### PR TITLE
Fix Windows CI: replace hardcoded vcvars64.bat path with ilammy/msvc-dev-cmd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,20 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
       
-    - name: Setup CMake (latest)
+    # Pinned, not 'latest': CMakeLists.txt hardcodes CMAKE_EXPERIMENTAL_CXX_IMPORT_STD
+    # to a specific UUID that only matches CMake's `import std` experimental-feature
+    # ABI as of 4.1.1 - CMake changes that UUID as the feature evolves release to
+    # release, so newer CMake versions reject it ("CMAKE_EXPERIMENTAL_CXX_IMPORT_STD
+    # is set to incorrect value") and import std silently stops working, cascading
+    # into hundreds of "could not find module 'std'" errors at compile time. Every
+    # other job in this workflow already pins 4.1.1 for the same reason (grep
+    # CMAKE_VERSION="4.1.1" below) - 'latest' here was the one job that floated,
+    # and it broke as soon as 'latest' moved past 4.1.1.
+    - name: Setup CMake (4.1.1, matching every other job in this workflow)
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: 'latest'
-        
+        cmake-version: '4.1.1'
+
     - name: Setup Vulkan SDK
       uses: humbletim/setup-vulkan-sdk@v1.2.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,24 +53,31 @@ jobs:
         Invoke-WebRequest -Uri $NINJA_URL -OutFile $NINJA_ZIP
         Expand-Archive -Path $NINJA_ZIP -DestinationPath $NINJA_DIR -Force
         echo "$NINJA_DIR" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        
+
+    # Locates whatever MSVC version is actually installed on the runner image via
+    # vswhere and exports its environment (INCLUDE/LIB/PATH/etc.) into GITHUB_ENV
+    # for every later step in this job. Replaces a hardcoded
+    # ".../Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat" call that
+    # broke silently when GitHub's windows-latest image moved to a newer Visual
+    # Studio release with a different install path - the failure mode was `call`
+    # failing to find the batch file, followed by a *different*, misleading error
+    # ("'#' is not recognized...") from the now-garbled command line, not a clear
+    # "path not found". Never hardcode a VS version/edition path here again.
+    - name: Setup MSVC environment
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+
     - name: Configure CMake (MSVC with Ninja)
-      run: |
-        # Setup MSVC environment and configure with explicit compiler paths
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        cmake -B build -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DMDUX_BUILD_EXAMPLES=ON -DMDUX_BUILD_TESTS=ON -DMDUX_BUILD_DOCS=OFF
+      run: cmake -B build -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DMDUX_BUILD_EXAMPLES=ON -DMDUX_BUILD_TESTS=ON -DMDUX_BUILD_DOCS=OFF
       shell: cmd
-      
+
     - name: Build
-      run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        cmake --build build --config ${{ env.BUILD_TYPE }}
+      run: cmake --build build --config ${{ env.BUILD_TYPE }}
       shell: cmd
-      
+
     - name: Run Tests
-      run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} --output-on-failure
+      run: ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} --output-on-failure
       shell: cmd
 
   # Linux Build with GCC 15 container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     # ("'#' is not recognized...") from the now-garbled command line, not a clear
     # "path not found". Never hardcode a VS version/edition path here again.
     - name: Setup MSVC environment
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: x64
 


### PR DESCRIPTION
Not stacked on the parity-programme PRs — this fixes a repo-wide CI break affecting every open PR identically (#6, #67, #68, and by extension #69-#77 once they rebase), so it should merge independently and as soon as possible.

## Root cause

`windows-build` called
`"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"`
directly, three times. GitHub's `windows-latest` runner image has since moved to a newer Visual Studio release at a different install path — a recent failing run shows `cl.exe` resolving under `Visual Studio\18\Enterprise\...`, not `2022`. The hardcoded `call` silently failed to find the batch file, and the resulting error was actively misleading: cmd's `call` on a missing file left a garbled command line that then printed `'#' is not recognized as an internal or external command` — masking the real cause behind what looks like an unrelated syntax error.

## Fix

Replaced the three inline `vcvars64.bat` calls with a single `ilammy/msvc-dev-cmd@v1` step. It locates whatever MSVC version is actually present via `vswhere` and exports the dev environment into `GITHUB_ENV` once, for every later step in the job — no hardcoded version or edition, so this survives future runner image upgrades without maintenance.

## Verification

- Workflow YAML parses.
- Watching this PR's own CI run below to confirm Windows actually goes green.