### PR TITLE
S1 — ADR-007: evidence pipeline doctrine

### DIFF
--- a/docs/adr/ADR-007-evidence-pipeline-doctrine.md
+++ b/docs/adr/ADR-007-evidence-pipeline-doctrine.md
@@ -1,0 +1,235 @@
+# ADR-007: Evidence pipeline doctrine
+
+## Status
+Accepted (2026-07-27)
+
+## Context
+MduX currently has no evidence pipeline at all. The committed SPIR-V under
+`examples/shaders/compiled/` has no consumer, no recorded provenance, and no check that it
+corresponds to the GLSL beside it — and `.gitignore` ignored `*.spv` until issue #43 fixed the
+negations. Nothing in the repository can answer "which tool, at which version, from which input,
+produced this binary artifact".
+
+Every asset kind still to be built needs that answer: shaders (issue #13), fonts and text packages
+(issue #14), compiled `.medui` screens (issue #15), images and traces (issue #17), and ML model
+packages (issue #18). Six bakers, six chances to invent a different provenance format. Deciding the
+shape once — before the first baker exists — is cheaper than reconciling six of them later, and it
+is the difference between artifacts an auditor can read uniformly and six bespoke conventions.
+
+The constraint that shapes the whole design is that authoring dependencies must not reach the device
+build. A font parser, a safetensors reader and a SPIR-V walker are exactly the kind of code a
+manufacturer would otherwise have to qualify as SOUP. If baking happens at build time on the host
+and the *result* is committed, the runtime build never links any of it.
+
+## Medical Device Considerations
+
+### IEC 62304 implications (software lifecycle)
+- **Configuration identification of every derived artifact.** A baked artifact is software the
+  device executes or reads. Committing it alongside a report naming its tool, tool version, tool git
+  SHA and input digests makes each artifact identifiable in the configuration-management sense
+  rather than an unexplained binary in the tree.
+- **Verification is re-derivation, not inspection.** CI re-runs the baker and asserts the output is
+  byte-identical to what is committed. That is a stronger and far cheaper verification argument than
+  reviewing a binary diff, which no reviewer can meaningfully do.
+- **SOUP avoidance is structural, not asserted.** Authoring-time parsers live in host tools that are
+  never linked into `MduXCore` or `MduX` (ADR-004), so they are absent from the device build by
+  construction — a property the trust-zone link-graph check already enforces mechanically.
+
+### Risk management considerations
+- An artifact that silently drifts from its source is a hazard: the reviewed source and the shipped
+  binary stop corresponding, and nothing detects it. Byte-identity verification in CI turns that
+  silent drift into a failed PR.
+- A baker whose resolved options are not recorded is the subtler version of the same hazard —
+  see the `options` rule under Decision.
+
+### Traceability requirements
+- `report.json` links each output digest back to a recipe digest and input digests, so the chain
+  from authored source to shipped bytes is machine-checkable rather than narrative.
+
+## Decision
+
+Every asset kind follows one pattern:
+
+```
+recipes/<kind>/<id>.toml + assets/…  ──[ mdux-<kind>bake ]──▶  generated/<kind>/<id>/
+                                                                 package.json
+                                                                 report.json
+                                                                 payload.bin
+```
+
+Host-only tools produce these files. They are **committed**. CI re-runs the baker in verify mode and
+asserts byte-identity against the committed copies. Runtime builds consume the committed artifact and
+never invoke a baker.
+
+### 1. Sidecar binaries — a deliberate deviation from TrustSC
+Bulk payloads go in `payload.bin` (or a kind-specific name such as `atlas.bin`), **not** base64
+inside `package.json`.
+
+TrustSC embeds payloads in the package JSON. Committing megabytes of base64 makes git history
+unusable, and the diff is meaningless either way — no reviewer reads a changed base64 blob. The
+guarantee is unchanged: `package.json` carries the sidecar's SHA-256, so verification covers two
+files instead of one, and a tampered sidecar fails against the digest in the package it belongs to.
+
+### 2. Floats as `u32` bit patterns in canonical JSON, never decimal text
+A float is encoded as `{"bits": 1065353216}`, never as `1.0`.
+
+`printf("%.9g")` and `std::format("{}", f)` are not guaranteed byte-identical across MSVC, glibc and
+libc++, and this pipeline crosses all three. Baked font metrics, layout bounds and ML golden vectors
+are all floats. This single rule is what makes cross-toolchain byte-identity achievable at all;
+without it the rest of the design cannot deliver its central guarantee.
+
+A CI lint bans `%f`, `%g`, `%e` and float `std::format` specifiers under `src/evidence/` and
+`tools/`, because one stray specifier in one baker breaks byte-identity in a way that only reproduces
+on someone else's operating system.
+
+### 3. Normal builds never write into the source tree
+Bakers write into `${CMAKE_BINARY_DIR}/mdux_bake/<kind>/<id>/` and the `evidence`-labelled ctest
+compares that against `generated/<kind>/<id>/`. `cmake --build build --target mdux-bake-update` is
+the **only** path that copies build-directory artifacts over `generated/`. An author runs it
+deliberately and commits the resulting diff; a reviewer reads that diff.
+
+This mirrors Cargo's `OUT_DIR` discipline, which MduX otherwise loses by having no `build.rs`
+equivalent.
+
+### 4. `options` in the report is the fully resolved set
+Not the recipe's literal contents — the resolved set with every default expanded. Otherwise changing
+a default silently changes every output while every report still looks unchanged, which is precisely
+the failure a byte-verified pipeline exists to prevent.
+
+### 5. No commit SHA in a byte-compared report — it cannot be made to work
+An earlier draft of this ADR had `BakeReport` carry `toolGitSha`, a configure-time `git rev-parse
+HEAD` baked in as a compile definition, with CI rejecting `"unknown"` in a committed report.
+**This is unsound and was removed before merge** (caught in review — see the PR discussion on
+issue #52).
+
+The problem is structural, not a flaky edge case: baking happens at commit H0 (whatever HEAD is
+*before* the artifact is committed). Embedding `H0` into `report.json` and committing it creates
+H1 — a *different* commit, because it now contains a file H0's tree didn't have. CI checks out H1
+(or GitHub's synthetic merge commit) and re-bakes; `git rev-parse HEAD` there returns H1, not H0.
+The freshly-baked report embeds H1, the committed one says H0, and the byte-comparison this whole
+pipeline exists to run **fails every single time**, for every report, regardless of whether
+anything about the actual artifact changed. There is no fixed point: no commit's tree can contain
+a file that correctly names that commit's own hash, because computing the hash requires the tree
+to already be final.
+
+**The fix is to not put self-referential, commit-dependent data inside a byte-compared artifact at
+all.** `BakeReport` has no `toolGitSha` field. `toolVersion` (the project's semantic version,
+bumped deliberately and manually) is the report's only "which tooling produced this" identity —
+and it is safe precisely because a version bump is a separate, intentional action, not something
+automatically derived from "whatever HEAD happens to be when this gets committed."
+
+This does not lose the audit trail it looked like it was buying: `git log --follow
+generated/<kind>/<id>/report.json` already tells an auditor exactly which commit(s) produced or
+changed a committed artifact, authoritatively, for free. Duplicating that inside the file itself
+was redundant even before it turned out to be broken.
+
+### 6. Two toolchains, in the same PR — a claim TrustSC cannot make
+The evidence tests run on Windows/MSVC **and** Linux/GCC (and Clang, now that issue #48 re-enabled
+that leg) in the same pull request. Byte-identity across independent toolchains, standard libraries
+and floating-point code generators is a strictly stronger determinism claim than TrustSC obtains from
+a single rustc, and it costs nothing extra because both legs already exist.
+
+This is written down here specifically so that a future change cannot "simplify" CI to one leg
+without knowingly discarding the claim.
+
+## Alternatives Considered
+
+### 1. Bake at build time, commit nothing (Rejected)
+**Pros:** No generated files in git; no `mdux-bake-update` step; no possibility of a stale artifact.
+**Cons:** Every authoring dependency — TrueType parser, safetensors reader, SPIR-V walker — becomes
+a build dependency of every consumer, including cross-compiled device builds. That is the SOUP
+surface this project's zero-SOUP direction exists to avoid, and it makes the device build depend on
+tools that would each need qualifying. It also gives up reproducibility as an observable property:
+there is no committed artifact to compare against, so "the baker is deterministic" becomes an
+assertion rather than a test.
+
+### 2. Commit artifacts but verify by digest only, not by re-baking (Rejected)
+**Pros:** Much faster CI; no need for bakers to be runnable in every leg.
+**Cons:** Proves only that the committed file matches a committed hash of itself — it detects
+corruption, not drift. It cannot detect that the artifact no longer corresponds to its source, which
+is the failure mode that matters.
+
+### 3. Base64 payloads inside `package.json`, as TrustSC does (Rejected)
+**Pros:** One file per artifact; one digest; nothing to keep in sync.
+**Cons:** Unusable git history at the sizes ML weight blobs and font atlases reach. See Decision 1;
+the digest in `package.json` recovers the integrity guarantee that the single-file layout provided.
+
+### 4. Decimal float text with a fixed `%.17g` format (Rejected)
+**Pros:** Human-readable diffs; obvious at a glance what a metric is.
+**Cons:** Not guaranteed byte-identical across the three standard libraries this project builds on,
+which defeats the entire purpose. Round-tripping is not the property needed here — *identical bytes*
+is, and only the bit pattern delivers that. A future tool may render bit patterns as decimal for
+human display; the committed form stays bits.
+
+### 5. Embed the commit SHA that produced the artifact in `report.json` (Rejected — see Decision 5)
+**Pros:** A single glance at the file tells you which commit built it, without a separate `git log`.
+**Cons:** Provably cannot work for anything that is committed and then byte-compared, for the
+structural reason in Decision 5: the SHA of the commit containing a file cannot be known while
+that file is being written, so the embedded value and the actual containing commit's hash can
+never agree once re-baked. `git log --follow` on the artifact path gives the same information
+without the self-reference. If a future need arises for "which exact toolchain build produced
+this" for *diagnostic, non-compared* output (e.g. a tool's `--version` string), that is a
+legitimate and different use of a commit SHA — the constraint here is specifically about
+byte-compared, committed artifacts.
+
+## Consequences
+
+### Positive
+- Six bakers produce one audit record shape, so an auditor learns it once.
+- Authoring dependencies are absent from the device build by construction, verified by the existing
+  trust-zone link-graph check rather than by convention.
+- Determinism becomes a test rather than a claim, on two toolchains at once.
+- The evidence kernel is reusable as-is by issue #18's `ml.determinism.crossToolchain` check, which
+  is the same comparison applied to a baked model package.
+
+### Negative
+- `generated/` grows in git, and every artifact change produces a binary diff a reviewer cannot read
+  directly — mitigated only partially by `report.json` making the *cause* of the change readable.
+- Contributors must remember `mdux-bake-update` after changing a recipe or an asset; forgetting it
+  produces a CI failure rather than a silent problem, but it is still an extra step to learn.
+- Bakers must be runnable in every CI leg, which constrains them to portable C++ with no
+  host-specific dependencies.
+
+### Risks and Mitigations
+- **A baker introduces nondeterminism** (hash-map iteration order, a timestamp, an absolute path, a
+  locale-dependent conversion). *Mitigation*: the canonical writer sorts keys and rejects
+  timestamps, absolute paths and decimal floats by construction; the two-leg CI check catches what
+  the writer cannot.
+- **Someone hand-edits a file under `generated/`.** *Mitigation*: the strict reader rejects
+  permissive JSON, and re-baking overwrites the edit while the byte-comparison fails the PR.
+- **CI is reduced to one leg for speed.** *Mitigation*: Decision 6 records why both legs exist;
+  removing one is then a documented reversal rather than an unnoticed regression.
+- **`generated/` is swallowed by `.gitignore` again.** *Mitigation*: the `git status --porcelain`
+  assertion that follows the evidence tests catches both an uncommitted artifact and a build that
+  wrote into the source tree.
+
+## Implementation Notes
+- `mdux.evidence.digest` (issue #50), `mdux.evidence.json` (#51) and `mdux.evidence.report` (#52)
+  are governed-zone modules: `std` only, `noexcept`, no allocation in the digest path. They are
+  consumed by host tools *and* by the device runtime, which is why they are governed rather than
+  living under `tools/`.
+- `cmake/MduXBake.cmake` (#53) provides `mdux_bake_artifact()`; every baker registers through it, so
+  adding an asset kind is one function call.
+- **Two ctest labels, kept distinct.** `evidence` means only "a committed artifact is byte-identical
+  to a freshly baked one", so a failure of `ctest -L evidence` has exactly one interpretation. The
+  evidence modules' own unit tests use `evidence-unit`. Merging them would make a broken SHA-256
+  test and a drifted font atlas indistinguishable in CI.
+- `tools/common/` (#54) holds the shared TOML-subset reader and CLI parser. It is host-tools zone and
+  may use exceptions freely (ADR-005).
+- Host-tool resolution goes through `MduX::<tool>` uniformly, so a cross-compiling build substitutes
+  an imported executable without any call site changing.
+
+## References
+- ADR-004: Trust zones in C++ (this repository) — the governed/adapter/tools boundary this doctrine
+  is scoped by, and the link-graph check that makes "absent from the device build" mechanical
+- ADR-005: Error handling and exceptions policy (this repository) — why the governed evidence modules
+  are `noexcept` and the host tools are not
+- ADR-006: No reproduction of normative standard text (this repository)
+- [TrustSC ADR-007](https://github.com/ambroise-leclerc/TrustSC/tree/main/docs/adr) — the pipeline
+  this doctrine mirrors, and the source of the two deviations recorded above
+
+## Approval
+- **Decision Date**: 2026-07-27
+- **Approved By**: Project maintainer
+- **Review Date**: when the second baker registers through `mdux_bake_artifact()` (issue #14), the
+  first point at which the shared shape is tested by more than one consumer

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ All ADRs in this project must consider:
 | [ADR-004](ADR-004-trust-zones-in-cpp.md) | Trust zones in C++ | Accepted | 2026-07-26 |
 | [ADR-005](ADR-005-error-handling-and-exceptions-policy.md) | Error handling and exceptions policy | Accepted | 2026-07-26 |
 | [ADR-006](ADR-006-no-reproduction-of-normative-standard-text.md) | No reproduction of normative standard text | Accepted | 2026-07-26 |
+| [ADR-007](ADR-007-evidence-pipeline-doctrine.md) | Evidence pipeline doctrine | Accepted | 2026-07-27 |
 
 Note: `ADR-002-implementation-plan.md` shares its number with `ADR-002-testing-framework-selection.md`
 (a pre-existing duplication in this directory) and is not an independently numbered ADR — it is the


### PR DESCRIPTION
## Summary
- Adds ADR-007, recording the evidence-pipeline doctrine every baker in the upcoming kernel (issues #50-#55) follows: `recipe+source -> host baker -> committed generated/<kind>/<id>/{package.json,report.json,payload.bin}`, verified in CI by re-baking and asserting byte-identity.
- Documents two deliberate deviations from TrustSC's equivalent decision: sidecar `.bin` payloads instead of base64-in-JSON (keeps git history usable at font-atlas/ML-weight sizes), and floats encoded as `u32` bit patterns rather than decimal text (`printf`/`std::format` are not byte-identical across MSVC/glibc/libc++, and this pipeline crosses all three in CI).
- Records the two-toolchain byte-identity claim (stronger than TrustSC's single-rustc guarantee) and the source-tree rule (`mdux-bake-update` is the only path that writes into `generated/`).

## Context
First of a stack of PRs implementing Epic #12 (Evidence kernel), the sole gate on Track C (#13) and Track D (#18) per the Wave 2 roadmap. This PR is documentation only — no code.

## Test plan
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 0 findings (citation format, justification schema, reproduced-text heuristics all pass)
- [x] `docs/adr/README.md` index updated

Stacked on top of this PR: #50 (digest), #51 (canonical JSON), #52 (bake report), #53 (CMake bake infra), #54 (host-tools TOML/CLI), #55 (CI wiring).