### PR TITLE
S2 — mdux.evidence.digest (SHA-256)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,9 @@ target_sources(MduXCore
         FILES
             include/mdux/core/Units.cppm
             include/mdux/core/Result.cppm
+            include/mdux/evidence/Digest.cppm
+    PRIVATE
+        src/evidence/Digest.cpp
 )
 target_compile_features(MduXCore PUBLIC cxx_std_23)
 target_include_directories(MduXCore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)

--- a/include/mdux/evidence/Digest.cppm
+++ b/include/mdux/evidence/Digest.cppm
@@ -1,0 +1,71 @@
+/**
+ * @file Digest.cppm
+ * @brief Governed-zone SHA-256: the digest every evidence artifact is identified by.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (noexcept throughout, no throwing)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Part of MduXCore. Every `report.json` digest, every `package.json` sidecar reference, and
+ * the weight-blob verification in the planned `Classifier1D::create()` (issue #18) resolve to
+ * this implementation.
+ *
+ * Hand-written rather than taken as a dependency, which is the zero-SOUP position. SHA-256 is
+ * one of the few algorithms where that is uncontroversial: a fixed specification, ~200 lines,
+ * and an official test-vector suite to check against. There is no error path - a hash of any
+ * byte sequence is defined - so nothing here returns a Result.
+ *
+ * No allocation anywhere: the streaming state is a fixed 64-byte block buffer plus eight words.
+ */
+module;
+
+export module mdux.evidence.digest;
+
+import std;
+
+export namespace mdux::evidence {
+
+/// A SHA-256 digest: 32 bytes, most significant byte first.
+using Digest = std::array<std::uint8_t, 32>;
+
+/**
+ * @brief Streaming SHA-256, for inputs too large to hold in one span.
+ *
+ * Feed with any number of update() calls, then finish(). The digest of the concatenation of
+ * every update() is identical to sha256() over the same bytes contiguously - the streaming
+ * tests assert exactly that.
+ *
+ * finish() does not consume the object: it finalizes a copy of the internal state, so calling
+ * it twice yields the same digest, and update() may continue afterwards to extend the message.
+ * That costs one 96-byte copy and removes a whole class of misuse from a governed API.
+ */
+class Sha256 {
+public:
+    Sha256() noexcept = default;
+
+    /// Absorbs `data` into the running hash.
+    void update(std::span<const std::byte> data) noexcept;
+
+    /// Returns the digest of everything absorbed so far. Non-destructive; see the class note.
+    [[nodiscard]] Digest finish() const noexcept;
+
+    /// Discards all absorbed input, returning the object to its freshly-constructed state.
+    void reset() noexcept;
+
+private:
+    /// FIPS 180-4 initial hash value H(0): the first 32 bits of the fractional parts of the
+    /// square roots of the first eight primes.
+    std::array<std::uint32_t, 8> state_{0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+                                        0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u};
+    std::array<std::byte, 64> block_{};
+    std::size_t blockLen_{0};   ///< bytes currently buffered in block_, always < 64
+    std::uint64_t totalBytes_{0};
+};
+
+/// One-shot SHA-256 over a contiguous byte range.
+[[nodiscard]] Digest sha256(std::span<const std::byte> data) noexcept;
+
+/// Lowercase hex encoding of `digest`. Exactly 64 characters, not NUL-terminated.
+[[nodiscard]] std::array<char, 64> toHex(const Digest& digest) noexcept;
+
+}  // namespace mdux::evidence

--- a/src/evidence/Digest.cpp
+++ b/src/evidence/Digest.cpp
@@ -1,0 +1,205 @@
+/**
+ * @file Digest.cpp
+ * @brief FIPS 180-4 SHA-256 implementation for the governed evidence zone.
+ *
+ * @compliance ADR-004 Trust zones in C++
+ * @compliance ADR-005 Error handling and exceptions policy
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Straight transcription of the FIPS 180-4 compression function - no SIMD, no table
+ * generation at runtime, no allocation, no branching on message content. Deliberately
+ * unclever: this is code a manufacturer may have to read, and its test vectors are
+ * published, so clarity is worth more here than throughput.
+ */
+module;
+
+module mdux.evidence.digest;
+
+import std;
+
+namespace mdux::evidence {
+
+namespace {
+
+/// FIPS 180-4 K constants: the first 32 bits of the fractional parts of the cube roots of
+/// the first sixty-four primes.
+constexpr std::array<std::uint32_t, 64> kRoundConstants{
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu, 0x59f111f1u, 0x923f82a4u,
+    0xab1c5ed5u, 0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu,
+    0x9bdc06a7u, 0xc19bf174u, 0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu, 0x2de92c6fu,
+    0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau, 0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
+    0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u, 0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu,
+    0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u, 0xa2bfe8a1u, 0xa81a664bu,
+    0xc24b8b70u, 0xc76c51a3u, 0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u, 0x19a4c116u,
+    0x1e376c08u, 0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+    0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u, 0x90befffau, 0xa4506cebu, 0xbef9a3f7u,
+    0xc67178f2u};
+
+[[nodiscard]] constexpr std::uint32_t ch(std::uint32_t x, std::uint32_t y,
+                                          std::uint32_t z) noexcept {
+    return (x & y) ^ (~x & z);
+}
+
+[[nodiscard]] constexpr std::uint32_t maj(std::uint32_t x, std::uint32_t y,
+                                           std::uint32_t z) noexcept {
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+[[nodiscard]] constexpr std::uint32_t bigSigma0(std::uint32_t x) noexcept {
+    return std::rotr(x, 2) ^ std::rotr(x, 13) ^ std::rotr(x, 22);
+}
+
+[[nodiscard]] constexpr std::uint32_t bigSigma1(std::uint32_t x) noexcept {
+    return std::rotr(x, 6) ^ std::rotr(x, 11) ^ std::rotr(x, 25);
+}
+
+[[nodiscard]] constexpr std::uint32_t smallSigma0(std::uint32_t x) noexcept {
+    return std::rotr(x, 7) ^ std::rotr(x, 18) ^ (x >> 3);
+}
+
+[[nodiscard]] constexpr std::uint32_t smallSigma1(std::uint32_t x) noexcept {
+    return std::rotr(x, 17) ^ std::rotr(x, 19) ^ (x >> 10);
+}
+
+/// Big-endian load of the 32-bit word at `block[offset]`. Explicit shifts rather than
+/// std::bit_cast or memcpy so the byte order is the algorithm's, not the host's - this
+/// implementation must produce identical digests on a big-endian target.
+[[nodiscard]] std::uint32_t loadBigEndian32(std::span<const std::byte, 64> block,
+                                             std::size_t offset) noexcept {
+    return (static_cast<std::uint32_t>(block[offset]) << 24) |
+           (static_cast<std::uint32_t>(block[offset + 1]) << 16) |
+           (static_cast<std::uint32_t>(block[offset + 2]) << 8) |
+           static_cast<std::uint32_t>(block[offset + 3]);
+}
+
+/// The FIPS 180-4 compression function: absorbs exactly one 64-byte block into `state`.
+void compress(std::array<std::uint32_t, 8>& state,
+              std::span<const std::byte, 64> block) noexcept {
+    std::array<std::uint32_t, 64> w{};
+    for (std::size_t i = 0; i < 16; ++i) {
+        w[i] = loadBigEndian32(block, i * 4);
+    }
+    for (std::size_t i = 16; i < 64; ++i) {
+        w[i] = smallSigma1(w[i - 2]) + w[i - 7] + smallSigma0(w[i - 15]) + w[i - 16];
+    }
+
+    std::uint32_t a = state[0];
+    std::uint32_t b = state[1];
+    std::uint32_t c = state[2];
+    std::uint32_t d = state[3];
+    std::uint32_t e = state[4];
+    std::uint32_t f = state[5];
+    std::uint32_t g = state[6];
+    std::uint32_t h = state[7];
+
+    for (std::size_t i = 0; i < 64; ++i) {
+        const std::uint32_t t1 = h + bigSigma1(e) + ch(e, f, g) + kRoundConstants[i] + w[i];
+        const std::uint32_t t2 = bigSigma0(a) + maj(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = d + t1;
+        d = c;
+        c = b;
+        b = a;
+        a = t1 + t2;
+    }
+
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    state[5] += f;
+    state[6] += g;
+    state[7] += h;
+}
+
+}  // namespace
+
+void Sha256::update(std::span<const std::byte> data) noexcept {
+    totalBytes_ += data.size();
+
+    // Top off a partially-filled block first, so the fast path below always starts aligned.
+    if (blockLen_ > 0) {
+        const std::size_t wanted = 64 - blockLen_;
+        const std::size_t taken = std::min(wanted, data.size());
+        std::copy_n(data.begin(), taken, block_.begin() + static_cast<std::ptrdiff_t>(blockLen_));
+        blockLen_ += taken;
+        data = data.subspan(taken);
+        if (blockLen_ < 64) {
+            return;  // still short of a full block; nothing to compress yet
+        }
+        compress(state_, std::span<const std::byte, 64>{block_});
+        blockLen_ = 0;
+    }
+
+    // Whole blocks straight from the caller's buffer, no copy through block_.
+    while (data.size() >= 64) {
+        compress(state_, data.first<64>());
+        data = data.subspan(64);
+    }
+
+    // Retain the remainder for the next update() or for finish()'s padding.
+    std::copy(data.begin(), data.end(), block_.begin());
+    blockLen_ = data.size();
+}
+
+Digest Sha256::finish() const noexcept {
+    // Finalize on copies so the caller's object is untouched: finish() twice returns the same
+    // digest, and update() may legitimately continue after a finish().
+    std::array<std::uint32_t, 8> state = state_;
+    std::array<std::byte, 64> block = block_;
+    std::size_t blockLen = blockLen_;
+
+    // FIPS 180-4 padding: a single 0x80 byte, then zeros, then the message length in bits as a
+    // 64-bit big-endian integer, arranged so the total is a whole number of 64-byte blocks.
+    block[blockLen++] = std::byte{0x80};
+    if (blockLen > 56) {
+        // No room for the 8-byte length in this block: zero-fill, compress, continue in a new one.
+        std::fill(block.begin() + static_cast<std::ptrdiff_t>(blockLen), block.end(),
+                  std::byte{0});
+        compress(state, std::span<const std::byte, 64>{block});
+        blockLen = 0;
+    }
+    std::fill(block.begin() + static_cast<std::ptrdiff_t>(blockLen), block.end() - 8,
+              std::byte{0});
+
+    const std::uint64_t bitLength = totalBytes_ * 8;
+    for (std::size_t i = 0; i < 8; ++i) {
+        block[56 + i] = static_cast<std::byte>((bitLength >> (56 - 8 * i)) & 0xffu);
+    }
+    compress(state, std::span<const std::byte, 64>{block});
+
+    Digest digest{};
+    for (std::size_t i = 0; i < 8; ++i) {
+        digest[i * 4] = static_cast<std::uint8_t>((state[i] >> 24) & 0xffu);
+        digest[i * 4 + 1] = static_cast<std::uint8_t>((state[i] >> 16) & 0xffu);
+        digest[i * 4 + 2] = static_cast<std::uint8_t>((state[i] >> 8) & 0xffu);
+        digest[i * 4 + 3] = static_cast<std::uint8_t>(state[i] & 0xffu);
+    }
+    return digest;
+}
+
+void Sha256::reset() noexcept {
+    *this = Sha256{};
+}
+
+Digest sha256(std::span<const std::byte> data) noexcept {
+    Sha256 hasher;
+    hasher.update(data);
+    return hasher.finish();
+}
+
+std::array<char, 64> toHex(const Digest& digest) noexcept {
+    constexpr std::array<char, 16> digits{'0', '1', '2', '3', '4', '5', '6', '7',
+                                          '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    std::array<char, 64> hex{};
+    for (std::size_t i = 0; i < digest.size(); ++i) {
+        hex[i * 2] = digits[(digest[i] >> 4) & 0x0fu];
+        hex[i * 2 + 1] = digits[digest[i] & 0x0fu];
+    }
+    return hex;
+}
+
+}  // namespace mdux::evidence

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,36 @@ endif()
 
 mdux_discover_tests(core_tests)
 
+# Evidence-kernel tests (ADR-007). Links MduX::Core only, for the same reason core_tests does:
+# the evidence modules are governed, so a test that needed MduX::MduX to build them would mean
+# the trust-zone boundary had been crossed somewhere.
+add_executable(evidence_tests
+    evidence/EvidenceTestMain.cpp
+    evidence/DigestTests.cpp
+)
+
+target_sources(evidence_tests PRIVATE FILE_SET CXX_MODULES FILES framework/MduXTest.cppm)
+target_link_libraries(evidence_tests PRIVATE MduX::Core)
+target_include_directories(evidence_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(evidence_tests
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(evidence_tests PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(evidence_tests PRIVATE /experimental:module)
+    target_compile_options(evidence_tests PRIVATE /std:c++latest)
+endif()
+
+mdux_discover_tests(evidence_tests)
+
 # Basic unit tests
 add_executable(unit_tests
     TestMain.cpp

--- a/tests/evidence/DigestTests.cpp
+++ b/tests/evidence/DigestTests.cpp
@@ -1,0 +1,202 @@
+/**
+ * @file DigestTests.cpp
+ * @brief Tests for the governed-zone mdux.evidence.digest module.
+ *
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Every expected digest below is a published FIPS 180-4 value or was produced by an
+ * independent implementation, never by this one - a test that compares an implementation
+ * against itself proves only that it is deterministic, which is the weaker half of what
+ * this module has to be.
+ */
+
+import std;
+import mdux.evidence.digest;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+
+using namespace mdux::evidence;
+
+namespace {
+
+/// Hashes the bytes of an ASCII string literal, which is how every published vector is stated.
+[[nodiscard]] Digest hashText(std::string_view text) noexcept {
+    return sha256(std::as_bytes(std::span{text}));
+}
+
+[[nodiscard]] std::string hex(const Digest& digest) {
+    const std::array<char, 64> chars = toHex(digest);
+    return std::string{chars.data(), chars.size()};
+}
+
+/// n repetitions of `fill`, as bytes.
+[[nodiscard]] std::vector<std::byte> repeated(char fill, std::size_t n) {
+    return std::vector<std::byte>(n, static_cast<std::byte>(fill));
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Published FIPS 180-4 vectors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("SHA-256 empty input matches the published vector", "evidence-unit") {
+    CHECK(hex(hashText("")) ==
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+TEST_CASE("SHA-256 'abc' matches the published vector", "evidence-unit") {
+    CHECK(hex(hashText("abc")) ==
+          "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+TEST_CASE("SHA-256 448-bit vector matches", "evidence-unit") {
+    // 56 bytes: one byte short of needing a second block once padding is added, so this
+    // vector exercises the "no room for the length field" branch in finish().
+    constexpr std::string_view message =
+        "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    REQUIRE(message.size() == 56);
+    CHECK(hex(hashText(message)) ==
+          "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+}
+
+TEST_CASE("SHA-256 896-bit vector matches", "evidence-unit") {
+    constexpr std::string_view message =
+        "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno"
+        "ijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
+    REQUIRE(message.size() == 112);
+    CHECK(hex(hashText(message)) ==
+          "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1");
+}
+
+TEST_CASE("SHA-256 one million 'a' matches the published vector", "evidence-unit") {
+    const std::vector<std::byte> message = repeated('a', 1'000'000);
+    CHECK(hex(sha256(message)) ==
+          "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+}
+
+// ---------------------------------------------------------------------------
+// Block-boundary behaviour
+// ---------------------------------------------------------------------------
+
+TEST_CASE("SHA-256 is correct either side of the 64-byte block boundary", "evidence-unit") {
+    // 55/56 straddle the padding-length boundary; 63/64/65 straddle the block boundary;
+    // 119/120 and 127/128 repeat both one block further along, where an off-by-one in the
+    // multi-block loop rather than in finish() would show up.
+    struct Vector {
+        std::size_t length;
+        std::string_view expected;
+    };
+    constexpr std::array<Vector, 10> vectors{
+        Vector{55, "8963cc0afd622cc7574ac2011f93a3059b3d65548a77542a1559e3d202e6ab00"},
+        Vector{56, "6ea719cefa4b31862035a7fa606b7cc3602f46231117d135cc7119b3c1412314"},
+        Vector{57, "a00df74fbdadd9eb0e7742a019e5b2d77374de5417eba5b7a0730a60cce5e7bf"},
+        Vector{63, "1b58d00f5b1fbd2a1884d666a2be33c2fa7463dff32cd60ef200c0f750a6b70f"},
+        Vector{64, "d53eda7a637c99cc7fb566d96e9fa109bf15c478410a3f5eb4d4c4e26cd081f6"},
+        Vector{65, "836203944f4c0280461ad73d31457c22ba19d1d99e232dc231000085899e00a2"},
+        Vector{119, "17d2f0f7197a6612e311d141781f2b9539c4aef7affd729246c401890e000dde"},
+        Vector{120, "a4f4256159ea6fb23b27eb8c5eb9cfb9083475985f355a85c78de8f2fef2b3ac"},
+        Vector{127, "026134f6117e45a37c5c2dc2f330bdd274c6dc087526b91ecec4d6dac9bb7346"},
+        Vector{128, "b6ac3cc10386331c765f04f041c147d0f278f2aed8eaa021e2d0057fc6f6ff9e"},
+    };
+
+    for (const Vector& vector : vectors) {
+        const std::vector<std::byte> message = repeated('A', vector.length);
+        CHECK_MESSAGE(hex(sha256(message)) == vector.expected,
+                      "length " + std::to_string(vector.length) + " digest was " +
+                          hex(sha256(message)));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming equivalence
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Streaming update() in awkward chunks equals the one-shot digest", "evidence-unit") {
+    // 300 bytes is deliberately not a multiple of 64, and the chunk sizes below are chosen so
+    // that chunk boundaries fall inside, on, and either side of block boundaries.
+    std::vector<std::byte> message(300);
+    for (std::size_t i = 0; i < message.size(); ++i) {
+        message[i] = static_cast<std::byte>(i % 256);
+    }
+    const Digest expected = sha256(message);
+
+    for (std::size_t chunk : {std::size_t{1}, std::size_t{7}, std::size_t{63}, std::size_t{64},
+                              std::size_t{65}, std::size_t{128}, std::size_t{299}}) {
+        Sha256 hasher;
+        std::span<const std::byte> remaining{message};
+        while (!remaining.empty()) {
+            const std::size_t take = std::min(chunk, remaining.size());
+            hasher.update(remaining.first(take));
+            remaining = remaining.subspan(take);
+        }
+        CHECK_MESSAGE(hasher.finish() == expected,
+                      "chunk size " + std::to_string(chunk) + " diverged from the one-shot digest");
+    }
+}
+
+TEST_CASE("Streaming a multi-megabyte buffer equals the one-shot digest", "evidence-unit") {
+    // 4 MiB is the order of magnitude issue #18's weight blobs reach, which is the reason the
+    // streaming path exists at all - exercise it at that size rather than only on toy inputs.
+    // The modulus is 251 (prime, < 256) so the pattern does not align with the 64-byte block.
+    std::vector<std::byte> message(4 * 1024 * 1024);
+    for (std::size_t i = 0; i < message.size(); ++i) {
+        message[i] = static_cast<std::byte>(i % 251);
+    }
+
+    CHECK(hex(sha256(message)) ==
+          "a117210941a0b00dcb2d8577e680d84b6fa0eaf760d2afc654c953b9859d54fa");
+
+    Sha256 hasher;
+    std::span<const std::byte> remaining{message};
+    while (!remaining.empty()) {
+        const std::size_t take = std::min(std::size_t{7919}, remaining.size());
+        hasher.update(remaining.first(take));
+        remaining = remaining.subspan(take);
+    }
+    CHECK(hasher.finish() == sha256(message));
+}
+
+TEST_CASE("An empty update() does not change the digest", "evidence-unit") {
+    Sha256 hasher;
+    hasher.update({});
+    hasher.update(std::as_bytes(std::span{std::string_view{"abc"}}));
+    hasher.update({});
+    CHECK(hasher.finish() == hashText("abc"));
+}
+
+// ---------------------------------------------------------------------------
+// API contract
+// ---------------------------------------------------------------------------
+
+TEST_CASE("finish() is non-destructive and update() may continue after it", "evidence-unit") {
+    Sha256 hasher;
+    hasher.update(std::as_bytes(std::span{std::string_view{"abc"}}));
+
+    const Digest first = hasher.finish();
+    CHECK(first == hashText("abc"));
+    CHECK(hasher.finish() == first);  // repeatable, per the documented contract
+
+    hasher.update(std::as_bytes(std::span{std::string_view{"def"}}));
+    CHECK(hasher.finish() == hashText("abcdef"));
+}
+
+TEST_CASE("reset() returns the hasher to its initial state", "evidence-unit") {
+    Sha256 hasher;
+    hasher.update(std::as_bytes(std::span{std::string_view{"discard me"}}));
+    hasher.reset();
+    CHECK(hasher.finish() == hashText(""));
+}
+
+TEST_CASE("toHex is lowercase, 64 characters, and covers every nibble value", "evidence-unit") {
+    Digest digest{};
+    for (std::size_t i = 0; i < digest.size(); ++i) {
+        digest[i] = static_cast<std::uint8_t>(i * 8);
+    }
+    const std::string encoded = hex(digest);
+
+    REQUIRE(encoded.size() == 64);
+    CHECK(encoded == "0008101820283038404850586068707880889098a0a8b0b8c0c8d0d8e0e8f0f8");
+    CHECK(std::ranges::none_of(encoded, [](char c) { return std::isupper(static_cast<unsigned char>(c)) != 0; }));
+}

--- a/tests/evidence/EvidenceTestMain.cpp
+++ b/tests/evidence/EvidenceTestMain.cpp
@@ -1,0 +1,15 @@
+/**
+ * @brief Entry point for the evidence-kernel test executable (MduXTest framework).
+ *
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * One main() per executable, in its own translation unit, so each new evidence module can add a
+ * test file without touching this one. Registration order across files does not matter.
+ */
+
+import std;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+
+MDUX_TEST_MAIN("MduX Evidence Kernel Tests")


### PR DESCRIPTION
## Summary
- Adds `mdux.evidence.digest`: governed-zone (ADR-004), `noexcept`, allocation-free SHA-256 — `Digest = std::array<uint8_t,32>`, `sha256(span<const byte>)`, and a streaming `Sha256` class for inputs too large for one span.
- Hand-written rather than a dependency (the zero-SOUP position ADR-007 requires of anything the device build could link), which is uncontroversial for SHA-256 specifically: a fixed FIPS 180-4 specification, ~200 lines, an official test-vector suite.
- Wires `Digest.cppm`/`Digest.cpp` into `MduXCore`'s `FILE_SET`, and adds a new `evidence_tests` executable (own `MDUX_TEST_MAIN`, links `MduX::Core` only — same rationale as `core_tests`: a governed module must be usable without pulling in Vulkan).

## Test plan
12/12 pass, checked against **independently-known** digests (published FIPS 180-4 vectors, and Python's `hashlib.sha256` for the rest) — never against this implementation's own output:
- [x] Empty string, `"abc"`, the 448-bit and 896-bit standard vectors, one million `'a'`
- [x] Both sides of the 64-byte block boundary at nine lengths (55/56/57, 63/64/65, 119/120, 127/128)
- [x] Streaming in awkward chunk sizes (1, 7, 63, 64, 65, 128, 299 bytes) against the one-shot digest
- [x] A 4 MiB buffer — the order of magnitude issue #18's ML weight blobs will reach
- [x] `finish()` non-destructive / repeatable, `reset()`, `toHex()` lowercase/64-char

Verified by compiling directly with Clang 21 + libc++'s `std` module (this repo's CMake `import std` UUID is pinned to CMake 4.0.3 and this sandbox has 4.3.1 — pre-existing, unrelated to this change, confirmed it also blocks building master's own `Result.cppm`). Real CI is the first place the actual CMake/Vulkan build graph runs this.

Stacked on #79 (ADR-007). Part of the #12 Evidence kernel stack (issue #50).
