### PR TITLE
S3 — mdux.evidence.json (canonical writer + strict reader) and mdux-evidence-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,8 @@ CLAUDE.md
 .roo/
 GEMINI.md
 .github/copilot-instructions.md
+
+# Python bytecode from the host-only lint tools (tools/docs-lint, tools/evidence-lint).
+# CI sets PYTHONDONTWRITEBYTECODE=1, but a local run of the self-tests still leaves these behind.
+__pycache__/
+*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,10 @@ target_sources(MduXCore
             include/mdux/core/Units.cppm
             include/mdux/core/Result.cppm
             include/mdux/evidence/Digest.cppm
+            include/mdux/evidence/Json.cppm
     PRIVATE
         src/evidence/Digest.cpp
+        src/evidence/Json.cpp
 )
 target_compile_features(MduXCore PUBLIC cxx_std_23)
 target_include_directories(MduXCore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)

--- a/include/mdux/evidence/Json.cppm
+++ b/include/mdux/evidence/Json.cppm
@@ -1,0 +1,208 @@
+/**
+ * @file Json.cppm
+ * @brief Governed-zone canonical JSON: the writer byte-identity depends on, and a reader
+ *        strict enough that a hand-edited artifact cannot pass verification.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-007 Evidence pipeline doctrine (canonical form, floats as bit patterns)
+ *
+ * Part of MduXCore. This is the component that makes byte-identity across MSVC, glibc and
+ * libc++ possible - or, if it gets one rule wrong, impossible.
+ *
+ * ## Canonical form
+ *
+ * - object keys sorted lexicographically by UTF-8 code unit
+ * - two-space indent, LF line endings, UTF-8 without a byte-order mark, trailing newline
+ * - no timestamps, no absolute paths, no environment-dependent values anywhere
+ * - `f32` encoded as its `u32` bit pattern, `{"bits": 1065353216}`, never as decimal text
+ *
+ * That last rule is the whole ballgame. `printf("%.9g")` and `std::format("{}", f)` are not
+ * guaranteed byte-identical across the three standard libraries this project builds on, and
+ * baked font metrics, layout bounds and ML golden vectors are all floats. A CI lint bans float
+ * format specifiers under `src/evidence/` and `tools/` so a stray one cannot reintroduce the
+ * problem on someone else's operating system only.
+ *
+ * ## Deliberate strictness
+ *
+ * The reader rejects duplicate keys, trailing commas, comments, `NaN`/`Infinity`, byte-order
+ * marks, unescaped control characters, invalid UTF-8, trailing content after the top-level
+ * value, and nesting past kMaxDepth.
+ *
+ * It also rejects **any** number carrying a fraction or exponent. Canonical MduX JSON never
+ * contains one - a real number is always `{"bits": N}` - so a decimal float in a `generated/`
+ * file means the file was hand-edited or written by something other than this writer. Accepting
+ * it would let exactly the artifact this pipeline exists to catch pass verification. The
+ * consequence is that this is a reader for canonical MduX JSON, not a general-purpose JSON
+ * parser, which is the intended scope.
+ *
+ * ## Allocation and noexcept
+ *
+ * Building and parsing JSON allocates, so these functions are not allocation-free the way
+ * mdux.evidence.digest is. They are still `noexcept`: under the `-fno-exceptions` builds
+ * ADR-005 requires the governed zone to support, an allocation failure terminates regardless,
+ * and terminating is the fail-closed outcome for a device that cannot record its own evidence.
+ * `noexcept` here states that actual behaviour rather than papering over it. Every *logical*
+ * failure is a `Result`, never a termination.
+ */
+module;
+
+export module mdux.evidence.json;
+
+import std;
+import mdux.core.result;
+
+export namespace mdux::evidence::json {
+
+/// Maximum object/array nesting the reader accepts. Evidence artifacts are shallow - the
+/// deepest shape any baker produces is a handful of levels - so this is a generous bound whose
+/// only job is to stop a malformed or hostile file from exhausting the stack.
+inline constexpr std::size_t kMaxDepth = 64;
+
+enum class ErrorCode : std::uint8_t {
+    UnexpectedEnd,
+    UnexpectedCharacter,
+    InvalidNumber,
+    FractionalNumberRejected,   ///< a fraction or exponent, which canonical form never emits
+    NumberOutOfRange,
+    NonFiniteLiteralRejected,   ///< NaN, Infinity, -Infinity
+    DuplicateKey,
+    TrailingComma,
+    CommentRejected,
+    InvalidEscape,
+    UnescapedControlCharacter,
+    InvalidUtf8,
+    ByteOrderMarkRejected,
+    TrailingContent,
+    DepthExceeded,
+    WrongKind,                  ///< accessor asked for a type the value does not hold
+    MissingMember,
+    NotExactlyRepresentable,    ///< e.g. asUInt() on a negative integer
+};
+
+/// A parse or serialization failure. `offset` is a byte offset into the input for reader
+/// errors and is 0 for writer and accessor errors, where there is no input to point at.
+struct Error {
+    ErrorCode code{};
+    std::size_t offset{0};
+    std::string detail;
+};
+
+/// Human-readable name for an ErrorCode, for diagnostics. Stable across platforms.
+[[nodiscard]] std::string_view describe(ErrorCode code) noexcept;
+
+class Value;
+
+/// One object member. Objects hold these sorted by `key`.
+struct Member;
+
+/**
+ * @brief A JSON value in canonical MduX form.
+ *
+ * Deliberately not a `std::variant`: the alternatives would include `std::vector<Value>` at a
+ * point where `Value` is still incomplete, and while vector tolerates that, variant's
+ * completeness requirements are murkier than is worth relying on in governed code. Explicit
+ * members cost roughly a hundred bytes per value, which is irrelevant at evidence-artifact
+ * sizes and buys a type whose validity nobody has to argue about.
+ */
+class Value {
+public:
+    enum class Kind : std::uint8_t { Null, Bool, Int, UInt, Float32, String, Array, Object };
+
+    Value() noexcept = default;  ///< null
+
+    [[nodiscard]] static Value null() noexcept;
+    [[nodiscard]] static Value boolean(bool value) noexcept;
+    [[nodiscard]] static Value integer(std::int64_t value) noexcept;
+    [[nodiscard]] static Value unsignedInteger(std::uint64_t value) noexcept;
+    [[nodiscard]] static Value string(std::string value) noexcept;
+    [[nodiscard]] static Value array(std::vector<Value> elements) noexcept;
+    [[nodiscard]] static Value emptyObject() noexcept;
+
+    /**
+     * @brief A 32-bit float, stored and emitted as its bit pattern.
+     *
+     * Every float in an evidence artifact goes through here. There is no overload taking a
+     * `double`, on purpose: a `double` written as bits would be a `u64`, and no baker has a
+     * reason to emit one. Adding that overload later is a schema decision, not a convenience.
+     */
+    [[nodiscard]] static Value float32(float value) noexcept;
+
+    [[nodiscard]] Kind kind() const noexcept { return kind_; }
+
+    [[nodiscard]] mdux::core::Result<bool, Error> asBool() const noexcept;
+    [[nodiscard]] mdux::core::Result<std::int64_t, Error> asInt() const noexcept;
+    [[nodiscard]] mdux::core::Result<std::uint64_t, Error> asUInt() const noexcept;
+    [[nodiscard]] mdux::core::Result<std::string_view, Error> asString() const noexcept;
+
+    /**
+     * @brief Decodes a float from the canonical `{"bits": N}` encoding.
+     *
+     * Accepts either a Float32 value built by float32(), or - which is the case after parsing -
+     * an Object with exactly one member named `bits` holding an integer in `[0, 2^32)`.
+     *
+     * Float-ness is decided by the caller asking for a float, never by the parser guessing from
+     * shape. An object that happens to have a `bits` member stays an object until something
+     * asks it to be a float, which keeps the reader free of a heuristic that could
+     * misinterpret a future schema.
+     */
+    [[nodiscard]] mdux::core::Result<float, Error> asFloat32() const noexcept;
+
+    /// Elements of an Array. Empty span for any other kind - check kind() first if that matters.
+    [[nodiscard]] std::span<const Value> elements() const noexcept;
+
+    /// Members of an Object, sorted by key. Empty span for any other kind.
+    [[nodiscard]] std::span<const Member> members() const noexcept;
+
+    /// The member named `key`, or nullptr if absent or if this is not an Object.
+    [[nodiscard]] const Value* find(std::string_view key) const noexcept;
+
+    /// find() with a MissingMember error instead of a null pointer, for chained access.
+    [[nodiscard]] mdux::core::Result<const Value*, Error> require(std::string_view key) const noexcept;
+
+    /**
+     * @brief Inserts a member, keeping members sorted by key.
+     *
+     * Fails with DuplicateKey rather than overwriting, and with WrongKind if this is not an
+     * Object. Rejecting duplicates here rather than at write time means a baker that builds a
+     * malformed object learns about it at the call site that caused it.
+     */
+    [[nodiscard]] mdux::core::ResultVoid<Error> set(std::string key, Value value) noexcept;
+
+    /// Appends to an Array. Fails with WrongKind if this is not an Array.
+    [[nodiscard]] mdux::core::ResultVoid<Error> push(Value value) noexcept;
+
+private:
+    Kind kind_{Kind::Null};
+    bool boolean_{false};
+    std::int64_t int_{0};
+    std::uint64_t uint_{0};
+    std::uint32_t floatBits_{0};
+    std::string string_;
+    std::vector<Value> elements_;
+    std::vector<Member> members_;
+};
+
+struct Member {
+    std::string key;
+    Value value;
+};
+
+/**
+ * @brief Serializes `value` in canonical form, trailing newline included.
+ *
+ * Object members are sorted by key regardless of insertion order, so the output depends only
+ * on the value's content. Fails with InvalidUtf8 on a malformed string or key, and with
+ * DuplicateKey if an object somehow holds two members with the same key.
+ */
+[[nodiscard]] mdux::core::Result<std::string, Error> write(const Value& value) noexcept;
+
+/**
+ * @brief Parses canonical MduX JSON strictly. See the module comment for what it rejects.
+ *
+ * `text` must be UTF-8 without a byte-order mark. A trailing newline is permitted (the writer
+ * emits one); any other trailing content is TrailingContent.
+ */
+[[nodiscard]] mdux::core::Result<Value, Error> parse(std::string_view text) noexcept;
+
+}  // namespace mdux::evidence::json

--- a/src/evidence/Json.cpp
+++ b/src/evidence/Json.cpp
@@ -1,0 +1,958 @@
+/**
+ * @file Json.cpp
+ * @brief Canonical JSON writer and strict reader for the governed evidence zone.
+ *
+ * @compliance ADR-004 Trust zones in C++
+ * @compliance ADR-005 Error handling and exceptions policy
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Two halves that must agree exactly: write() produces canonical form, parse() accepts
+ * canonical form and very little else. Any divergence between them shows up as a round-trip
+ * test failure, which is why the tests round-trip every shape rather than checking each half
+ * in isolation.
+ */
+module;
+
+module mdux.evidence.json;
+
+import std;
+import mdux.core.result;
+
+namespace mdux::evidence::json {
+
+using mdux::core::err;
+using mdux::core::Result;
+using mdux::core::ResultVoid;
+
+namespace {
+
+[[nodiscard]] Error makeError(ErrorCode code, std::size_t offset, std::string detail) noexcept {
+    return Error{.code = code, .offset = offset, .detail = std::move(detail)};
+}
+
+// ---------------------------------------------------------------------------
+// UTF-8 validation
+// ---------------------------------------------------------------------------
+
+/// Validates `text` as UTF-8, rejecting overlong encodings, surrogates and out-of-range code
+/// points - the three classes a naive length-driven decoder waves through. Returns the byte
+/// offset of the first invalid sequence, or npos if the whole string is well-formed.
+///
+/// This matters for byte-identity as much as for correctness: a writer that emits an invalid
+/// sequence produces a file whose bytes depend on whatever produced the bad input, and the
+/// promise is UTF-8 without a byte-order mark, not "whatever bytes were handed to us".
+[[nodiscard]] std::size_t findInvalidUtf8(std::string_view text) noexcept {
+    std::size_t i = 0;
+    while (i < text.size()) {
+        const auto byte0 = static_cast<unsigned char>(text[i]);
+        std::size_t length = 0;
+        std::uint32_t codePoint = 0;
+
+        if (byte0 < 0x80) {
+            i += 1;
+            continue;
+        }
+        if ((byte0 & 0xe0u) == 0xc0u) {
+            length = 2;
+            codePoint = byte0 & 0x1fu;
+        } else if ((byte0 & 0xf0u) == 0xe0u) {
+            length = 3;
+            codePoint = byte0 & 0x0fu;
+        } else if ((byte0 & 0xf8u) == 0xf0u) {
+            length = 4;
+            codePoint = byte0 & 0x07u;
+        } else {
+            return i;  // continuation byte or 0xf8+ as a lead byte
+        }
+
+        if (i + length > text.size()) {
+            return i;
+        }
+        for (std::size_t k = 1; k < length; ++k) {
+            const auto continuation = static_cast<unsigned char>(text[i + k]);
+            if ((continuation & 0xc0u) != 0x80u) {
+                return i;
+            }
+            codePoint = (codePoint << 6) | (continuation & 0x3fu);
+        }
+
+        // Overlong: a code point encodable in fewer bytes than were used.
+        static constexpr std::array<std::uint32_t, 5> minimum{0, 0, 0x80, 0x800, 0x10000};
+        if (codePoint < minimum[length]) {
+            return i;
+        }
+        // UTF-16 surrogate halves are not valid scalar values in UTF-8.
+        if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
+            return i;
+        }
+        if (codePoint > 0x10ffff) {
+            return i;
+        }
+        i += length;
+    }
+    return std::string_view::npos;
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/// JSON string escaping, fixed so that the same input always produces the same bytes.
+///
+/// Escapes exactly what RFC 8259 requires - quote, backslash, and everything below 0x20 -
+/// using the two-character shorthand where one exists and \u00XX otherwise. Notably does *not*
+/// escape `/` (legal but optional, and escaping it is a common source of two writers
+/// disagreeing) and does not escape non-ASCII, which stays raw UTF-8.
+void appendEscaped(std::string& out, std::string_view text) noexcept {
+    out.push_back('"');
+    for (const char c : text) {
+        switch (c) {
+        case '"':  out += "\\\""; break;
+        case '\\': out += "\\\\"; break;
+        case '\b': out += "\\b"; break;
+        case '\f': out += "\\f"; break;
+        case '\n': out += "\\n"; break;
+        case '\r': out += "\\r"; break;
+        case '\t': out += "\\t"; break;
+        default:
+            if (static_cast<unsigned char>(c) < 0x20) {
+                constexpr std::string_view digits = "0123456789abcdef";
+                const auto value = static_cast<unsigned char>(c);
+                out += "\\u00";
+                out.push_back(digits[(value >> 4) & 0x0fu]);
+                out.push_back(digits[value & 0x0fu]);
+            } else {
+                out.push_back(c);
+            }
+            break;
+        }
+    }
+    out.push_back('"');
+}
+
+/// Integers are rendered by hand rather than through std::format, so that no locale, no
+/// formatting library version and no floating-point path can influence the bytes. std::to_chars
+/// would also be correct here; doing it manually keeps the whole writer free of any
+/// number-formatting facility, which is easier to state as an invariant than to audit for.
+void appendUnsigned(std::string& out, std::uint64_t value) noexcept {
+    std::array<char, 20> buffer{};
+    std::size_t length = 0;
+    do {
+        buffer[length++] = static_cast<char>('0' + (value % 10));
+        value /= 10;
+    } while (value != 0);
+    for (std::size_t i = length; i > 0; --i) {
+        out.push_back(buffer[i - 1]);
+    }
+}
+
+void appendSigned(std::string& out, std::int64_t value) noexcept {
+    if (value < 0) {
+        out.push_back('-');
+        // Negate through the unsigned domain so INT64_MIN does not overflow.
+        appendUnsigned(out, ~static_cast<std::uint64_t>(value) + 1u);
+    } else {
+        appendUnsigned(out, static_cast<std::uint64_t>(value));
+    }
+}
+
+void appendIndent(std::string& out, std::size_t depth) noexcept {
+    out.append(depth * 2, ' ');
+}
+
+ResultVoid<Error> writeValue(std::string& out, const Value& value, std::size_t depth) noexcept;
+
+/// Emits a float as the canonical `{"bits": N}` object, laid out exactly as a hand-built object
+/// of the same shape would be, so the two are indistinguishable in the output.
+void writeFloat32(std::string& out, std::uint32_t bits, std::size_t depth) noexcept {
+    out += "{\n";
+    appendIndent(out, depth + 1);
+    out += "\"bits\": ";
+    appendUnsigned(out, bits);
+    out.push_back('\n');
+    appendIndent(out, depth);
+    out.push_back('}');
+}
+
+ResultVoid<Error> writeValue(std::string& out, const Value& value, std::size_t depth) noexcept {
+    if (depth > kMaxDepth) {
+        return err(makeError(ErrorCode::DepthExceeded, 0,
+                              "value nests deeper than " + std::to_string(kMaxDepth) + " levels"));
+    }
+
+    switch (value.kind()) {
+    case Value::Kind::Null:
+        out += "null";
+        return {};
+
+    case Value::Kind::Bool:
+        out += value.asBool().value_or(false) ? "true" : "false";
+        return {};
+
+    case Value::Kind::Int: {
+        const auto result = value.asInt();
+        if (!result.has_value()) {
+            return err(result.error());
+        }
+        appendSigned(out, *result);
+        return {};
+    }
+
+    case Value::Kind::UInt: {
+        const auto result = value.asUInt();
+        if (!result.has_value()) {
+            return err(result.error());
+        }
+        appendUnsigned(out, *result);
+        return {};
+    }
+
+    case Value::Kind::Float32: {
+        const auto result = value.asFloat32();
+        if (!result.has_value()) {
+            return err(result.error());
+        }
+        writeFloat32(out, std::bit_cast<std::uint32_t>(*result), depth);
+        return {};
+    }
+
+    case Value::Kind::String: {
+        const auto result = value.asString();
+        if (!result.has_value()) {
+            return err(result.error());
+        }
+        if (const std::size_t bad = findInvalidUtf8(*result); bad != std::string_view::npos) {
+            return err(makeError(ErrorCode::InvalidUtf8, 0,
+                                  "string contains invalid UTF-8 at byte " + std::to_string(bad)));
+        }
+        appendEscaped(out, *result);
+        return {};
+    }
+
+    case Value::Kind::Array: {
+        const std::span<const Value> elements = value.elements();
+        if (elements.empty()) {
+            out += "[]";
+            return {};
+        }
+        out += "[\n";
+        for (std::size_t i = 0; i < elements.size(); ++i) {
+            appendIndent(out, depth + 1);
+            if (auto written = writeValue(out, elements[i], depth + 1); !written.has_value()) {
+                return written;
+            }
+            out += (i + 1 < elements.size()) ? ",\n" : "\n";
+        }
+        appendIndent(out, depth);
+        out.push_back(']');
+        return {};
+    }
+
+    case Value::Kind::Object: {
+        const std::span<const Member> members = value.members();
+        if (members.empty()) {
+            out += "{}";
+            return {};
+        }
+        // Members are kept sorted by set(), but sort a local index here anyway rather than
+        // trusting that invariant: a Value produced by parse() or by a future construction path
+        // must serialize canonically too, and the cost is negligible at these sizes.
+        std::vector<const Member*> ordered;
+        ordered.reserve(members.size());
+        for (const Member& member : members) {
+            ordered.push_back(&member);
+        }
+        std::ranges::stable_sort(ordered, [](const Member* a, const Member* b) {
+            // std::string_view's comparison is by unsigned char value, which for UTF-8 is the
+            // same order as by code point - so "sorted by UTF-8 code unit" needs no special
+            // collation, and must not acquire any.
+            return std::string_view{a->key} < std::string_view{b->key};
+        });
+        for (std::size_t i = 1; i < ordered.size(); ++i) {
+            if (ordered[i - 1]->key == ordered[i]->key) {
+                return err(makeError(ErrorCode::DuplicateKey, 0,
+                                      "object holds two members named '" + ordered[i]->key + "'"));
+            }
+        }
+
+        out += "{\n";
+        for (std::size_t i = 0; i < ordered.size(); ++i) {
+            const Member& member = *ordered[i];
+            if (const std::size_t bad = findInvalidUtf8(member.key);
+                bad != std::string_view::npos) {
+                return err(makeError(ErrorCode::InvalidUtf8, 0,
+                                      "object key contains invalid UTF-8 at byte " +
+                                          std::to_string(bad)));
+            }
+            appendIndent(out, depth + 1);
+            appendEscaped(out, member.key);
+            out += ": ";
+            if (auto written = writeValue(out, member.value, depth + 1); !written.has_value()) {
+                return written;
+            }
+            out += (i + 1 < ordered.size()) ? ",\n" : "\n";
+        }
+        appendIndent(out, depth);
+        out.push_back('}');
+        return {};
+    }
+    }
+
+    return err(makeError(ErrorCode::WrongKind, 0, "value has no recognized kind"));
+}
+
+// ---------------------------------------------------------------------------
+// Reader
+// ---------------------------------------------------------------------------
+
+/// Recursive-descent parser over a string_view. Holds no allocation of its own beyond the Values
+/// it builds, and every failure path produces an offset so a diagnostic can point at the byte.
+class Parser {
+public:
+    explicit Parser(std::string_view text) noexcept : text_{text} {}
+
+    [[nodiscard]] Result<Value, Error> run() noexcept {
+        // A byte-order mark is valid UTF-8 and invisible in an editor, which makes it exactly
+        // the kind of difference that would break byte-identity while looking like nothing.
+        if (text_.starts_with("\xef\xbb\xbf")) {
+            return err(makeError(ErrorCode::ByteOrderMarkRejected, 0,
+                                  "input begins with a UTF-8 byte-order mark"));
+        }
+        if (const std::size_t bad = findInvalidUtf8(text_); bad != std::string_view::npos) {
+            return err(makeError(ErrorCode::InvalidUtf8, bad, "invalid UTF-8 sequence"));
+        }
+
+        skipWhitespace();
+        auto value = parseValue(0);
+        if (!value.has_value()) {
+            return value;
+        }
+        skipWhitespace();
+        if (position_ != text_.size()) {
+            return err(makeError(ErrorCode::TrailingContent, position_,
+                                  "unexpected content after the top-level value"));
+        }
+        return value;
+    }
+
+private:
+    [[nodiscard]] bool atEnd() const noexcept { return position_ >= text_.size(); }
+    [[nodiscard]] char peek() const noexcept { return text_[position_]; }
+
+    /// Skips space, tab, CR and LF. Deliberately not a general "skip anything non-token" - a
+    /// comment must reach parseValue() so it can be reported as CommentRejected rather than
+    /// silently ignored.
+    void skipWhitespace() noexcept {
+        while (!atEnd()) {
+            const char c = peek();
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+                ++position_;
+            } else {
+                return;
+            }
+        }
+    }
+
+    [[nodiscard]] Error unexpected(std::string detail) const noexcept {
+        if (position_ >= text_.size()) {
+            return makeError(ErrorCode::UnexpectedEnd, position_, std::move(detail));
+        }
+        return makeError(ErrorCode::UnexpectedCharacter, position_, std::move(detail));
+    }
+
+    /// Rejects both comment syntaxes explicitly. JSON has no comments; a file containing one was
+    /// written or edited by hand, which is the case this reader exists to catch.
+    [[nodiscard]] std::optional<Error> rejectComment() const noexcept {
+        if (!atEnd() && peek() == '/') {
+            return makeError(ErrorCode::CommentRejected, position_,
+                              "comments are not valid JSON and are rejected");
+        }
+        return std::nullopt;
+    }
+
+    [[nodiscard]] Result<Value, Error> parseValue(std::size_t depth) noexcept {
+        if (depth > kMaxDepth) {
+            return err(makeError(ErrorCode::DepthExceeded, position_,
+                                  "nesting exceeds " + std::to_string(kMaxDepth) + " levels"));
+        }
+        if (atEnd()) {
+            return err(makeError(ErrorCode::UnexpectedEnd, position_, "expected a value"));
+        }
+        if (auto comment = rejectComment(); comment.has_value()) {
+            return err(*comment);
+        }
+
+        switch (peek()) {
+        case '{': return parseObject(depth);
+        case '[': return parseArray(depth);
+        case '"': {
+            auto text = parseString();
+            if (!text.has_value()) {
+                return err(text.error());
+            }
+            return Value::string(std::move(*text));
+        }
+        case 't':
+            return expectLiteral("true", Value::boolean(true));
+        case 'f':
+            return expectLiteral("false", Value::boolean(false));
+        case 'n':
+            // Distinguish `null` from `nan` before the generic literal check, so the nonfinite
+            // case gets its own error code rather than a confusing "expected null".
+            if (text_.substr(position_).starts_with("nan")) {
+                return err(makeError(ErrorCode::NonFiniteLiteralRejected, position_,
+                                      "NaN is not valid JSON and is rejected"));
+            }
+            return expectLiteral("null", Value::null());
+        case 'N':
+            return err(makeError(ErrorCode::NonFiniteLiteralRejected, position_,
+                                  "NaN is not valid JSON and is rejected"));
+        case 'I':
+            return err(makeError(ErrorCode::NonFiniteLiteralRejected, position_,
+                                  "Infinity is not valid JSON and is rejected"));
+        default:
+            if (peek() == '-' && text_.substr(position_).starts_with("-Infinity")) {
+                return err(makeError(ErrorCode::NonFiniteLiteralRejected, position_,
+                                      "-Infinity is not valid JSON and is rejected"));
+            }
+            return parseNumber();
+        }
+    }
+
+    [[nodiscard]] Result<Value, Error> expectLiteral(std::string_view literal,
+                                                      Value result) noexcept {
+        if (!text_.substr(position_).starts_with(literal)) {
+            return err(unexpected("expected '" + std::string{literal} + "'"));
+        }
+        position_ += literal.size();
+        return result;
+    }
+
+    [[nodiscard]] Result<Value, Error> parseNumber() noexcept {
+        const std::size_t start = position_;
+        const bool negative = !atEnd() && peek() == '-';
+        if (negative) {
+            ++position_;
+        }
+        if (atEnd() || peek() < '0' || peek() > '9') {
+            return err(unexpected("expected a digit"));
+        }
+        // Leading zeros are invalid JSON and would also break byte-identity, since "01" and "1"
+        // denote the same number but differ as bytes.
+        if (peek() == '0' && position_ + 1 < text_.size()) {
+            const char next = text_[position_ + 1];
+            if (next >= '0' && next <= '9') {
+                return err(makeError(ErrorCode::InvalidNumber, position_,
+                                      "number has a leading zero"));
+            }
+        }
+        const std::size_t digitsStart = position_;
+        while (!atEnd() && peek() >= '0' && peek() <= '9') {
+            ++position_;
+        }
+        if (!atEnd() && (peek() == '.' || peek() == 'e' || peek() == 'E')) {
+            return err(makeError(ErrorCode::FractionalNumberRejected, position_,
+                                  "canonical form encodes real numbers as {\"bits\": N}; a "
+                                  "fraction or exponent here means the file was not written by "
+                                  "this writer"));
+        }
+
+        const std::string_view digits = text_.substr(digitsStart, position_ - digitsStart);
+        std::uint64_t magnitude = 0;
+        for (const char c : digits) {
+            const auto digit = static_cast<std::uint64_t>(c - '0');
+            // Overflow check before multiplying, so an oversized literal is a clean error
+            // rather than a wrapped value that would silently corrupt an artifact.
+            if (magnitude > (std::numeric_limits<std::uint64_t>::max() - digit) / 10u) {
+                return err(makeError(ErrorCode::NumberOutOfRange, start,
+                                      "integer does not fit in 64 bits"));
+            }
+            magnitude = magnitude * 10u + digit;
+        }
+
+        if (!negative) {
+            return Value::unsignedInteger(magnitude);
+        }
+        // -0 is representable but denotes the same value as 0 and would give two byte sequences
+        // for one number, so canonical form has no place for it.
+        if (magnitude == 0) {
+            return err(makeError(ErrorCode::InvalidNumber, start,
+                                  "negative zero has no canonical representation"));
+        }
+        constexpr auto minMagnitude =
+            static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1u;
+        if (magnitude > minMagnitude) {
+            return err(makeError(ErrorCode::NumberOutOfRange, start,
+                                  "negative integer does not fit in 64 bits"));
+        }
+        if (magnitude == minMagnitude) {
+            return Value::integer(std::numeric_limits<std::int64_t>::min());
+        }
+        return Value::integer(-static_cast<std::int64_t>(magnitude));
+    }
+
+    [[nodiscard]] Result<std::string, Error> parseString() noexcept {
+        if (atEnd() || peek() != '"') {
+            return err(unexpected("expected '\"'"));
+        }
+        ++position_;
+        std::string out;
+        while (true) {
+            if (atEnd()) {
+                return err(makeError(ErrorCode::UnexpectedEnd, position_,
+                                      "string is not terminated"));
+            }
+            const char c = peek();
+            if (c == '"') {
+                ++position_;
+                return out;
+            }
+            if (static_cast<unsigned char>(c) < 0x20) {
+                return err(makeError(ErrorCode::UnescapedControlCharacter, position_,
+                                      "control character in a string must be escaped"));
+            }
+            if (c != '\\') {
+                out.push_back(c);
+                ++position_;
+                continue;
+            }
+
+            ++position_;  // consume the backslash
+            if (atEnd()) {
+                return err(makeError(ErrorCode::UnexpectedEnd, position_,
+                                      "string ends inside an escape sequence"));
+            }
+            const char escape = peek();
+            ++position_;
+            switch (escape) {
+            case '"':  out.push_back('"'); break;
+            case '\\': out.push_back('\\'); break;
+            case '/':  out.push_back('/'); break;
+            case 'b':  out.push_back('\b'); break;
+            case 'f':  out.push_back('\f'); break;
+            case 'n':  out.push_back('\n'); break;
+            case 'r':  out.push_back('\r'); break;
+            case 't':  out.push_back('\t'); break;
+            case 'u': {
+                auto decoded = parseUnicodeEscape();
+                if (!decoded.has_value()) {
+                    return err(decoded.error());
+                }
+                appendUtf8(out, *decoded);
+                break;
+            }
+            default:
+                return err(makeError(ErrorCode::InvalidEscape, position_ - 1,
+                                      "unrecognized escape '\\" + std::string(1, escape) + "'"));
+            }
+        }
+    }
+
+    /// Reads the four hex digits after `\u`, handling a surrogate pair as one code point. The
+    /// writer never emits `\u` above 0x1f, but a hand-written recipe or a third-party tool might,
+    /// and rejecting it outright would be stricter than the format requires.
+    [[nodiscard]] Result<std::uint32_t, Error> parseUnicodeEscape() noexcept {
+        auto readFourHex = [this]() -> Result<std::uint32_t, Error> {
+            if (position_ + 4 > text_.size()) {
+                return err(makeError(ErrorCode::InvalidEscape, position_,
+                                      "\\u needs four hexadecimal digits"));
+            }
+            std::uint32_t value = 0;
+            for (std::size_t i = 0; i < 4; ++i) {
+                const char c = text_[position_ + i];
+                std::uint32_t digit = 0;
+                if (c >= '0' && c <= '9') {
+                    digit = static_cast<std::uint32_t>(c - '0');
+                } else if (c >= 'a' && c <= 'f') {
+                    digit = static_cast<std::uint32_t>(c - 'a') + 10u;
+                } else if (c >= 'A' && c <= 'F') {
+                    digit = static_cast<std::uint32_t>(c - 'A') + 10u;
+                } else {
+                    return err(makeError(ErrorCode::InvalidEscape, position_ + i,
+                                          "\\u needs four hexadecimal digits"));
+                }
+                value = (value << 4) | digit;
+            }
+            position_ += 4;
+            return value;
+        };
+
+        auto high = readFourHex();
+        if (!high.has_value()) {
+            return high;
+        }
+        if (*high < 0xd800 || *high > 0xdbff) {
+            if (*high >= 0xdc00 && *high <= 0xdfff) {
+                return err(makeError(ErrorCode::InvalidEscape, position_,
+                                      "unpaired low surrogate in a \\u escape"));
+            }
+            return high;
+        }
+        if (!text_.substr(position_).starts_with("\\u")) {
+            return err(makeError(ErrorCode::InvalidEscape, position_,
+                                  "high surrogate is not followed by a low surrogate"));
+        }
+        position_ += 2;
+        auto low = readFourHex();
+        if (!low.has_value()) {
+            return low;
+        }
+        if (*low < 0xdc00 || *low > 0xdfff) {
+            return err(makeError(ErrorCode::InvalidEscape, position_,
+                                  "high surrogate is not followed by a low surrogate"));
+        }
+        return 0x10000u + ((*high - 0xd800u) << 10) + (*low - 0xdc00u);
+    }
+
+    static void appendUtf8(std::string& out, std::uint32_t codePoint) noexcept {
+        if (codePoint < 0x80) {
+            out.push_back(static_cast<char>(codePoint));
+        } else if (codePoint < 0x800) {
+            out.push_back(static_cast<char>(0xc0u | (codePoint >> 6)));
+            out.push_back(static_cast<char>(0x80u | (codePoint & 0x3fu)));
+        } else if (codePoint < 0x10000) {
+            out.push_back(static_cast<char>(0xe0u | (codePoint >> 12)));
+            out.push_back(static_cast<char>(0x80u | ((codePoint >> 6) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | (codePoint & 0x3fu)));
+        } else {
+            out.push_back(static_cast<char>(0xf0u | (codePoint >> 18)));
+            out.push_back(static_cast<char>(0x80u | ((codePoint >> 12) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | ((codePoint >> 6) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | (codePoint & 0x3fu)));
+        }
+    }
+
+    [[nodiscard]] Result<Value, Error> parseArray(std::size_t depth) noexcept {
+        ++position_;  // consume '['
+        std::vector<Value> elements;
+        skipWhitespace();
+        if (!atEnd() && peek() == ']') {
+            ++position_;
+            return Value::array(std::move(elements));
+        }
+        while (true) {
+            skipWhitespace();
+            if (!atEnd() && peek() == ']') {
+                return err(makeError(ErrorCode::TrailingComma, position_,
+                                      "trailing comma before ']'"));
+            }
+            auto element = parseValue(depth + 1);
+            if (!element.has_value()) {
+                return element;
+            }
+            elements.push_back(std::move(*element));
+
+            skipWhitespace();
+            if (atEnd()) {
+                return err(makeError(ErrorCode::UnexpectedEnd, position_,
+                                      "array is not terminated"));
+            }
+            if (peek() == ',') {
+                ++position_;
+                continue;
+            }
+            if (peek() == ']') {
+                ++position_;
+                return Value::array(std::move(elements));
+            }
+            return err(unexpected("expected ',' or ']'"));
+        }
+    }
+
+    [[nodiscard]] Result<Value, Error> parseObject(std::size_t depth) noexcept {
+        ++position_;  // consume '{'
+        Value object = Value::emptyObject();
+        skipWhitespace();
+        if (!atEnd() && peek() == '}') {
+            ++position_;
+            return object;
+        }
+        while (true) {
+            skipWhitespace();
+            if (!atEnd() && peek() == '}') {
+                return err(makeError(ErrorCode::TrailingComma, position_,
+                                      "trailing comma before '}'"));
+            }
+            if (auto comment = rejectComment(); comment.has_value()) {
+                return err(*comment);
+            }
+            const std::size_t keyOffset = position_;
+            auto key = parseString();
+            if (!key.has_value()) {
+                return err(key.error());
+            }
+
+            skipWhitespace();
+            if (atEnd() || peek() != ':') {
+                return err(unexpected("expected ':' after an object key"));
+            }
+            ++position_;
+            skipWhitespace();
+
+            auto value = parseValue(depth + 1);
+            if (!value.has_value()) {
+                return value;
+            }
+            // set() rejects duplicates, which is where DuplicateKey comes from - but its error
+            // has no offset, so re-report with the offending key's position.
+            if (auto inserted = object.set(*key, std::move(*value)); !inserted.has_value()) {
+                if (inserted.error().code == ErrorCode::DuplicateKey) {
+                    return err(makeError(ErrorCode::DuplicateKey, keyOffset,
+                                          "duplicate key '" + *key + "'"));
+                }
+                return err(inserted.error());
+            }
+
+            skipWhitespace();
+            if (atEnd()) {
+                return err(makeError(ErrorCode::UnexpectedEnd, position_,
+                                      "object is not terminated"));
+            }
+            if (peek() == ',') {
+                ++position_;
+                continue;
+            }
+            if (peek() == '}') {
+                ++position_;
+                return object;
+            }
+            return err(unexpected("expected ',' or '}'"));
+        }
+    }
+
+    std::string_view text_;
+    std::size_t position_{0};
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// describe()
+// ---------------------------------------------------------------------------
+
+std::string_view describe(ErrorCode code) noexcept {
+    switch (code) {
+    case ErrorCode::UnexpectedEnd:            return "unexpected end of input";
+    case ErrorCode::UnexpectedCharacter:      return "unexpected character";
+    case ErrorCode::InvalidNumber:            return "invalid number";
+    case ErrorCode::FractionalNumberRejected: return "fractional number rejected";
+    case ErrorCode::NumberOutOfRange:         return "number out of range";
+    case ErrorCode::NonFiniteLiteralRejected: return "non-finite literal rejected";
+    case ErrorCode::DuplicateKey:             return "duplicate object key";
+    case ErrorCode::TrailingComma:            return "trailing comma";
+    case ErrorCode::CommentRejected:          return "comment rejected";
+    case ErrorCode::InvalidEscape:            return "invalid escape sequence";
+    case ErrorCode::UnescapedControlCharacter: return "unescaped control character";
+    case ErrorCode::InvalidUtf8:              return "invalid UTF-8";
+    case ErrorCode::ByteOrderMarkRejected:    return "byte-order mark rejected";
+    case ErrorCode::TrailingContent:          return "trailing content";
+    case ErrorCode::DepthExceeded:            return "nesting too deep";
+    case ErrorCode::WrongKind:                return "wrong value kind";
+    case ErrorCode::MissingMember:            return "missing object member";
+    case ErrorCode::NotExactlyRepresentable:  return "not exactly representable";
+    }
+    return "unrecognized error";
+}
+
+// ---------------------------------------------------------------------------
+// Value
+// ---------------------------------------------------------------------------
+
+Value Value::null() noexcept {
+    return Value{};
+}
+
+Value Value::boolean(bool value) noexcept {
+    Value result;
+    result.kind_ = Kind::Bool;
+    result.boolean_ = value;
+    return result;
+}
+
+Value Value::integer(std::int64_t value) noexcept {
+    Value result;
+    result.kind_ = Kind::Int;
+    result.int_ = value;
+    return result;
+}
+
+Value Value::unsignedInteger(std::uint64_t value) noexcept {
+    Value result;
+    result.kind_ = Kind::UInt;
+    result.uint_ = value;
+    return result;
+}
+
+Value Value::float32(float value) noexcept {
+    Value result;
+    result.kind_ = Kind::Float32;
+    result.floatBits_ = std::bit_cast<std::uint32_t>(value);
+    return result;
+}
+
+Value Value::string(std::string value) noexcept {
+    Value result;
+    result.kind_ = Kind::String;
+    result.string_ = std::move(value);
+    return result;
+}
+
+Value Value::array(std::vector<Value> elements) noexcept {
+    Value result;
+    result.kind_ = Kind::Array;
+    result.elements_ = std::move(elements);
+    return result;
+}
+
+Value Value::emptyObject() noexcept {
+    Value result;
+    result.kind_ = Kind::Object;
+    return result;
+}
+
+Result<bool, Error> Value::asBool() const noexcept {
+    if (kind_ != Kind::Bool) {
+        return err(makeError(ErrorCode::WrongKind, 0, "value is not a boolean"));
+    }
+    return boolean_;
+}
+
+Result<std::int64_t, Error> Value::asInt() const noexcept {
+    if (kind_ == Kind::Int) {
+        return int_;
+    }
+    if (kind_ == Kind::UInt) {
+        // A parsed non-negative literal arrives as UInt; converting is legitimate exactly when
+        // the value fits, which is the "exactly representable in the declared type" rule.
+        if (uint_ > static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())) {
+            return err(makeError(ErrorCode::NotExactlyRepresentable, 0,
+                                  "unsigned value does not fit in a signed 64-bit integer"));
+        }
+        return static_cast<std::int64_t>(uint_);
+    }
+    return err(makeError(ErrorCode::WrongKind, 0, "value is not an integer"));
+}
+
+Result<std::uint64_t, Error> Value::asUInt() const noexcept {
+    if (kind_ == Kind::UInt) {
+        return uint_;
+    }
+    if (kind_ == Kind::Int) {
+        if (int_ < 0) {
+            return err(makeError(ErrorCode::NotExactlyRepresentable, 0,
+                                  "negative value is not representable as unsigned"));
+        }
+        return static_cast<std::uint64_t>(int_);
+    }
+    return err(makeError(ErrorCode::WrongKind, 0, "value is not an integer"));
+}
+
+Result<std::string_view, Error> Value::asString() const noexcept {
+    if (kind_ != Kind::String) {
+        return err(makeError(ErrorCode::WrongKind, 0, "value is not a string"));
+    }
+    return std::string_view{string_};
+}
+
+Result<float, Error> Value::asFloat32() const noexcept {
+    if (kind_ == Kind::Float32) {
+        return std::bit_cast<float>(floatBits_);
+    }
+    if (kind_ != Kind::Object) {
+        return err(makeError(ErrorCode::WrongKind, 0,
+                              "value is neither a float nor a {\"bits\": N} object"));
+    }
+    if (members_.size() != 1 || members_.front().key != "bits") {
+        return err(makeError(ErrorCode::WrongKind, 0,
+                              "a canonical float is an object with exactly one member 'bits'"));
+    }
+    const auto bits = members_.front().value.asUInt();
+    if (!bits.has_value()) {
+        return err(bits.error());
+    }
+    if (*bits > std::numeric_limits<std::uint32_t>::max()) {
+        return err(makeError(ErrorCode::NumberOutOfRange, 0,
+                              "float bit pattern does not fit in 32 bits"));
+    }
+    return std::bit_cast<float>(static_cast<std::uint32_t>(*bits));
+}
+
+std::span<const Value> Value::elements() const noexcept {
+    if (kind_ != Kind::Array) {
+        return {};
+    }
+    return elements_;
+}
+
+std::span<const Member> Value::members() const noexcept {
+    if (kind_ != Kind::Object) {
+        return {};
+    }
+    return members_;
+}
+
+const Value* Value::find(std::string_view key) const noexcept {
+    if (kind_ != Kind::Object) {
+        return nullptr;
+    }
+    // members_ is kept sorted by set(), so a binary search is correct here.
+    const auto position = std::ranges::lower_bound(
+        members_, key, {}, [](const Member& member) { return std::string_view{member.key}; });
+    if (position == members_.end() || std::string_view{position->key} != key) {
+        return nullptr;
+    }
+    return &position->value;
+}
+
+Result<const Value*, Error> Value::require(std::string_view key) const noexcept {
+    if (kind_ != Kind::Object) {
+        return err(makeError(ErrorCode::WrongKind, 0, "value is not an object"));
+    }
+    if (const Value* found = find(key); found != nullptr) {
+        return found;
+    }
+    return err(makeError(ErrorCode::MissingMember, 0,
+                          "object has no member '" + std::string{key} + "'"));
+}
+
+ResultVoid<Error> Value::set(std::string key, Value value) noexcept {
+    if (kind_ != Kind::Object) {
+        return err(makeError(ErrorCode::WrongKind, 0, "value is not an object"));
+    }
+    const auto position = std::ranges::lower_bound(
+        members_, std::string_view{key}, {},
+        [](const Member& member) { return std::string_view{member.key}; });
+    if (position != members_.end() && std::string_view{position->key} == std::string_view{key}) {
+        return err(makeError(ErrorCode::DuplicateKey, 0, "object already has a member '" + key + "'"));
+    }
+    members_.insert(position, Member{.key = std::move(key), .value = std::move(value)});
+    return {};
+}
+
+ResultVoid<Error> Value::push(Value value) noexcept {
+    if (kind_ != Kind::Array) {
+        return err(makeError(ErrorCode::WrongKind, 0, "value is not an array"));
+    }
+    elements_.push_back(std::move(value));
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// write() / parse()
+// ---------------------------------------------------------------------------
+
+Result<std::string, Error> write(const Value& value) noexcept {
+    std::string out;
+    if (auto written = writeValue(out, value, 0); !written.has_value()) {
+        return err(written.error());
+    }
+    out.push_back('\n');  // canonical form ends with exactly one LF
+    return out;
+}
+
+Result<Value, Error> parse(std::string_view text) noexcept {
+    Parser parser{text};
+    return parser.run();
+}
+
+}  // namespace mdux::evidence::json

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ mdux_discover_tests(core_tests)
 add_executable(evidence_tests
     evidence/EvidenceTestMain.cpp
     evidence/DigestTests.cpp
+    evidence/JsonTests.cpp
 )
 
 target_sources(evidence_tests PRIVATE FILE_SET CXX_MODULES FILES framework/MduXTest.cppm)

--- a/tests/evidence/JsonTests.cpp
+++ b/tests/evidence/JsonTests.cpp
@@ -1,0 +1,485 @@
+/**
+ * @file JsonTests.cpp
+ * @brief Tests for the governed-zone mdux.evidence.json module.
+ *
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Two things are being established here, and they are not the same thing:
+ *
+ * 1. The writer emits exactly one byte sequence for a given value - asserted against literal
+ *    expected strings, not against a re-serialization, because a test that compares the writer
+ *    to itself cannot detect that the canonical form changed.
+ * 2. The reader accepts that byte sequence and rejects everything a hand-edited or
+ *    foreign-written artifact would contain.
+ */
+
+import std;
+import mdux.evidence.json;
+import mdux.core.result;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+
+using namespace mdux::evidence::json;
+
+namespace {
+
+/// Builds an object from members in the order given, so a test can vary insertion order.
+[[nodiscard]] Value objectOf(std::vector<std::pair<std::string, Value>> members) {
+    Value object = Value::emptyObject();
+    for (auto& [key, value] : members) {
+        // A duplicate here is a bug in the test, not in the code under test. Throwing surfaces
+        // it through MduXTest's fatal-error path, which names the test case; an assert would
+        // take the whole run down without saying which one.
+        if (const auto inserted = object.set(key, std::move(value)); !inserted.has_value()) {
+            throw std::runtime_error{"test bug: duplicate key '" + key + "' in objectOf"};
+        }
+    }
+    return object;
+}
+
+[[nodiscard]] std::string written(const Value& value) {
+    const auto result = write(value);
+    if (!result.has_value()) {
+        return "<write failed: " + std::string{describe(result.error().code)} + ">";
+    }
+    return *result;
+}
+
+/// Asserts that `text` is rejected, and rejected with the expected code - a strictness test that
+/// only checked "it failed" would pass for the wrong reason after a refactor.
+void expectRejected(std::string_view text, ErrorCode expected, std::string_view what) {
+    const auto result = parse(text);
+    if (result.has_value()) {
+        CHECK_MESSAGE(false, std::string{what} + ": expected rejection, but it parsed");
+        return;
+    }
+    CHECK_MESSAGE(result.error().code == expected,
+                  std::string{what} + ": expected '" + std::string{describe(expected)} +
+                      "' but got '" + std::string{describe(result.error().code)} + "'");
+}
+
+[[nodiscard]] std::uint32_t bitsOf(float value) {
+    return std::bit_cast<std::uint32_t>(value);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Canonical form, asserted literally
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Canonical writer emits two-space indent, sorted keys and a trailing newline",
+          "evidence-unit") {
+    const Value value = objectOf({{"tool", Value::string("mdux-fontbake")},
+                                  {"schemaVersion", Value::unsignedInteger(1)}});
+
+    CHECK(written(value) ==
+          "{\n"
+          "  \"schemaVersion\": 1,\n"
+          "  \"tool\": \"mdux-fontbake\"\n"
+          "}\n");
+}
+
+TEST_CASE("Canonical writer nests arrays and objects at the right depth", "evidence-unit") {
+    Value input = objectOf({{"path", Value::string("assets/fonts/Roboto-Regular.ttf")},
+                            {"sha256", Value::string("abc123")}});
+    const Value value = objectOf({{"inputs", Value::array({std::move(input)})}});
+
+    CHECK(written(value) ==
+          "{\n"
+          "  \"inputs\": [\n"
+          "    {\n"
+          "      \"path\": \"assets/fonts/Roboto-Regular.ttf\",\n"
+          "      \"sha256\": \"abc123\"\n"
+          "    }\n"
+          "  ]\n"
+          "}\n");
+}
+
+TEST_CASE("Empty containers are written compactly", "evidence-unit") {
+    const Value value = objectOf({{"outputs", Value::array({})},
+                                  {"options", Value::emptyObject()}});
+
+    CHECK(written(value) ==
+          "{\n"
+          "  \"options\": {},\n"
+          "  \"outputs\": []\n"
+          "}\n");
+}
+
+TEST_CASE("A float is written as its u32 bit pattern, never as decimal text", "evidence-unit") {
+    const Value value = objectOf({{"advance", Value::float32(1.0F)}});
+
+    CHECK(written(value) ==
+          "{\n"
+          "  \"advance\": {\n"
+          "    \"bits\": 1065353216\n"
+          "  }\n"
+          "}\n");
+
+    // The point of the rule, stated as a test: no decimal point reaches the output.
+    CHECK(written(value).find('.') == std::string::npos);
+}
+
+TEST_CASE("Scalars and escapes are written canonically", "evidence-unit") {
+    CHECK(written(Value::null()) == "null\n");
+    CHECK(written(Value::boolean(true)) == "true\n");
+    CHECK(written(Value::boolean(false)) == "false\n");
+    CHECK(written(Value::unsignedInteger(0)) == "0\n");
+    CHECK(written(Value::integer(-42)) == "-42\n");
+    CHECK(written(Value::unsignedInteger(std::numeric_limits<std::uint64_t>::max())) ==
+          "18446744073709551615\n");
+    CHECK(written(Value::integer(std::numeric_limits<std::int64_t>::min())) ==
+          "-9223372036854775808\n");
+
+    // Shorthand escapes where one exists, \u00XX otherwise, and `/` deliberately left alone.
+    CHECK(written(Value::string("a\"b\\c\nd\te/f")) == "\"a\\\"b\\\\c\\nd\\te/f\"\n");
+    CHECK(written(Value::string(std::string{"x\x01y"})) == "\"x\\u0001y\"\n");
+    // Non-ASCII stays raw UTF-8 rather than being escaped.
+    CHECK(written(Value::string("mm\u00b2")) == "\"mm\u00b2\"\n");
+}
+
+TEST_CASE("Key ordering does not depend on insertion order", "evidence-unit") {
+    const std::vector<std::string> keys{"zebra", "alpha", "Zulu", "beta", "ALPHA", "a"};
+
+    // Insert the same keys in several different orders; every one must serialize identically.
+    std::string reference;
+    for (std::size_t rotation = 0; rotation < keys.size(); ++rotation) {
+        std::vector<std::pair<std::string, Value>> members;
+        for (std::size_t i = 0; i < keys.size(); ++i) {
+            const std::string& key = keys[(i + rotation) % keys.size()];
+            members.emplace_back(key, Value::unsignedInteger(i));
+        }
+        // The values differ between rotations, so compare only the key sequence.
+        const Value object = objectOf(std::move(members));
+        std::string order;
+        for (const Member& member : object.members()) {
+            order += member.key;
+            order.push_back('|');
+        }
+        if (rotation == 0) {
+            reference = order;
+        }
+        CHECK_MESSAGE(order == reference, "rotation " + std::to_string(rotation) +
+                                              " produced key order " + order);
+    }
+
+    // Sorted by UTF-8 code unit, so uppercase sorts before lowercase - not a locale collation.
+    CHECK(reference == "ALPHA|Zulu|a|alpha|beta|zebra|");
+}
+
+// ---------------------------------------------------------------------------
+// Round-tripping
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A report-shaped value round-trips through write and parse", "evidence-unit") {
+    Value recipe = objectOf({{"path", Value::string("recipes/font/roboto-ui.toml")},
+                             {"sha256", Value::string("11aa")}});
+    Value input = objectOf({{"path", Value::string("assets/fonts/Roboto-Regular.ttf")},
+                            {"sha256", Value::string("22bb")}});
+    Value outputPackage = objectOf({{"path", Value::string("package.json")},
+                                    {"sha256", Value::string("33cc")}});
+    Value outputAtlas = objectOf({{"path", Value::string("atlas.bin")},
+                                  {"sha256", Value::string("44dd")}});
+    Value options = objectOf({{"atlasWidth", Value::unsignedInteger(512)},
+                              {"hinting", Value::boolean(false)},
+                              {"pixelSize", Value::float32(13.5F)}});
+
+    const Value report =
+        objectOf({{"schemaVersion", Value::unsignedInteger(1)},
+                  {"tool", Value::string("mdux-fontbake")},
+                  {"toolVersion", Value::string("0.2.0")},
+                  {"toolGitSha", Value::string("a1b2c3d")},
+                  {"recipe", std::move(recipe)},
+                  {"inputs", Value::array({std::move(input)})},
+                  {"options", std::move(options)},
+                  {"outputs", Value::array({std::move(outputPackage), std::move(outputAtlas)})}});
+
+    const std::string text = written(report);
+    const auto reparsed = parse(text);
+    REQUIRE(reparsed.has_value());
+
+    // The real property: re-serializing the parsed value reproduces the identical bytes. That is
+    // byte-identity in miniature, and it is what CI asserts at file scale.
+    CHECK(written(*reparsed) == text);
+
+    // Spot-check that the structure actually survived, not just the byte count.
+    const auto tool = reparsed->require("tool");
+    REQUIRE(tool.has_value());
+    CHECK((*tool)->asString().value_or("") == "mdux-fontbake");
+
+    const auto outputs = reparsed->require("outputs");
+    REQUIRE(outputs.has_value());
+    REQUIRE((*outputs)->elements().size() == 2);
+    // Array order is preserved; only object keys are sorted.
+    CHECK((*outputs)->elements()[0].find("path")->asString().value_or("") == "package.json");
+    CHECK((*outputs)->elements()[1].find("path")->asString().value_or("") == "atlas.bin");
+
+    const auto options2 = reparsed->require("options");
+    REQUIRE(options2.has_value());
+    const Value* pixelSize = (*options2)->find("pixelSize");
+    REQUIRE(pixelSize != nullptr);
+    const auto decoded = pixelSize->asFloat32();
+    REQUIRE(decoded.has_value());
+    CHECK(bitsOf(*decoded) == bitsOf(13.5F));
+}
+
+TEST_CASE("Every notable f32 bit pattern survives a round trip bit-exactly", "evidence-unit") {
+    const std::vector<float> values{
+        0.0F,
+        -0.0F,
+        1.0F,
+        -1.0F,
+        std::numeric_limits<float>::min(),             // smallest positive normal
+        std::numeric_limits<float>::denorm_min(),      // smallest positive denormal
+        -std::numeric_limits<float>::denorm_min(),
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::epsilon(),
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+        std::numeric_limits<float>::quiet_NaN(),
+        13.5F,
+        3.14159265F,
+    };
+
+    for (const float value : values) {
+        const Value wrapped = objectOf({{"v", Value::float32(value)}});
+        const std::string text = written(wrapped);
+
+        const auto reparsed = parse(text);
+        REQUIRE(reparsed.has_value());
+        const Value* member = reparsed->find("v");
+        REQUIRE(member != nullptr);
+        const auto decoded = member->asFloat32();
+        REQUIRE(decoded.has_value());
+
+        // Compared as bit patterns, not as floats: NaN != NaN, and -0.0 == 0.0, so a float
+        // comparison would pass for two of these while the bytes differed.
+        CHECK_MESSAGE(bitsOf(*decoded) == bitsOf(value),
+                      "bit pattern " + std::to_string(bitsOf(value)) + " came back as " +
+                          std::to_string(bitsOf(*decoded)));
+        CHECK(written(*reparsed) == text);
+    }
+}
+
+TEST_CASE("Infinity and NaN are representable as bit patterns even though the literals are not",
+          "evidence-unit") {
+    // Worth stating explicitly: rejecting the `NaN` *literal* does not mean a baker cannot record
+    // a NaN. It records the bit pattern, which is exactly representable and portable.
+    const Value value = objectOf({{"v", Value::float32(std::numeric_limits<float>::quiet_NaN())}});
+    CHECK(written(value).find("NaN") == std::string::npos);
+
+    const auto reparsed = parse(written(value));
+    REQUIRE(reparsed.has_value());
+    const auto decoded = reparsed->find("v")->asFloat32();
+    REQUIRE(decoded.has_value());
+    CHECK(std::isnan(*decoded));
+}
+
+TEST_CASE("Unicode escapes and surrogate pairs decode correctly", "evidence-unit") {
+    const auto basic = parse("\"\\u00e9\"");
+    REQUIRE(basic.has_value());
+    CHECK(basic->asString().value_or("") == "\u00e9");
+
+    // U+1F600, which requires a surrogate pair in the \u form.
+    const auto astral = parse("\"\\ud83d\\ude00\"");
+    REQUIRE(astral.has_value());
+    CHECK(astral->asString().value_or("") == "\U0001F600");
+
+    // Round-tripping re-emits it as raw UTF-8, since the writer escapes only what it must.
+    CHECK(written(*astral) == "\"\U0001F600\"\n");
+}
+
+TEST_CASE("Whitespace between tokens is accepted, and a trailing newline is fine", "evidence-unit") {
+    const auto spaced = parse("{\n  \"a\" :  1 ,\n  \"b\" : [ 1 , 2 ]\n}\n");
+    REQUIRE(spaced.has_value());
+    CHECK(written(*spaced) ==
+          "{\n"
+          "  \"a\": 1,\n"
+          "  \"b\": [\n"
+          "    1,\n"
+          "    2\n"
+          "  ]\n"
+          "}\n");
+}
+
+// ---------------------------------------------------------------------------
+// Strictness
+// ---------------------------------------------------------------------------
+
+TEST_CASE("The reader rejects what a hand-edited artifact would contain", "evidence-unit") {
+    expectRejected("{\"a\": 1, \"a\": 2}", ErrorCode::DuplicateKey, "duplicate key");
+    expectRejected("{\"a\": 1,}", ErrorCode::TrailingComma, "trailing comma in an object");
+    expectRejected("[1, 2,]", ErrorCode::TrailingComma, "trailing comma in an array");
+    expectRejected("{\"a\": 1} // note", ErrorCode::TrailingContent, "line comment after a value");
+    expectRejected("{// note\n\"a\": 1}", ErrorCode::CommentRejected, "line comment in an object");
+    expectRejected("/* note */ 1", ErrorCode::CommentRejected, "block comment before a value");
+    expectRejected("NaN", ErrorCode::NonFiniteLiteralRejected, "NaN literal");
+    expectRejected("nan", ErrorCode::NonFiniteLiteralRejected, "lowercase nan literal");
+    expectRejected("Infinity", ErrorCode::NonFiniteLiteralRejected, "Infinity literal");
+    expectRejected("-Infinity", ErrorCode::NonFiniteLiteralRejected, "-Infinity literal");
+    expectRejected("\xef\xbb\xbf{}", ErrorCode::ByteOrderMarkRejected, "byte-order mark");
+    expectRejected("{} {}", ErrorCode::TrailingContent, "a second top-level value");
+    expectRejected("\"a\x01\"", ErrorCode::UnescapedControlCharacter, "raw control character");
+    expectRejected("\"\\q\"", ErrorCode::InvalidEscape, "unrecognized escape");
+    expectRejected("\"\\u00\"", ErrorCode::InvalidEscape, "truncated \\u escape");
+    expectRejected("\"\\ud83d\"", ErrorCode::InvalidEscape, "unpaired high surrogate");
+    expectRejected("\"\\udc00\"", ErrorCode::InvalidEscape, "unpaired low surrogate");
+    expectRejected("\"\xc3\"", ErrorCode::InvalidUtf8, "truncated UTF-8 sequence");
+    expectRejected("\"\xc0\xaf\"", ErrorCode::InvalidUtf8, "overlong UTF-8 encoding");
+    expectRejected("\"\xed\xa0\x80\"", ErrorCode::InvalidUtf8, "UTF-8-encoded surrogate");
+    expectRejected("{\"a\" 1}", ErrorCode::UnexpectedCharacter, "missing colon");
+    expectRejected("{\"a\": 1", ErrorCode::UnexpectedEnd, "unterminated object");
+    expectRejected("[1", ErrorCode::UnexpectedEnd, "unterminated array");
+    expectRejected("\"abc", ErrorCode::UnexpectedEnd, "unterminated string");
+    expectRejected("", ErrorCode::UnexpectedEnd, "empty input");
+}
+
+TEST_CASE("The reader rejects any number carrying a fraction or exponent", "evidence-unit") {
+    // Canonical form encodes real numbers as {"bits": N}, so a decimal float in a generated/
+    // file means it was not written by this writer - which is precisely what must not pass.
+    expectRejected("1.5", ErrorCode::FractionalNumberRejected, "fraction");
+    expectRejected("1.0", ErrorCode::FractionalNumberRejected, "fraction with a zero part");
+    expectRejected("1e5", ErrorCode::FractionalNumberRejected, "lowercase exponent");
+    expectRejected("1E5", ErrorCode::FractionalNumberRejected, "uppercase exponent");
+    expectRejected("{\"pixelSize\": 13.5}", ErrorCode::FractionalNumberRejected,
+                   "fraction inside an object");
+}
+
+TEST_CASE("The reader rejects non-canonical integer spellings", "evidence-unit") {
+    expectRejected("01", ErrorCode::InvalidNumber, "leading zero");
+    expectRejected("-0", ErrorCode::InvalidNumber, "negative zero");
+    expectRejected("+1", ErrorCode::UnexpectedCharacter, "leading plus");
+    expectRejected("-", ErrorCode::UnexpectedEnd, "bare minus");
+    expectRejected("18446744073709551616", ErrorCode::NumberOutOfRange, "u64 overflow");
+    expectRejected("-9223372036854775809", ErrorCode::NumberOutOfRange, "i64 underflow");
+}
+
+TEST_CASE("The reader rejects nesting past the depth limit", "evidence-unit") {
+    const std::string tooDeep = std::string(kMaxDepth + 2, '[') + std::string(kMaxDepth + 2, ']');
+    expectRejected(tooDeep, ErrorCode::DepthExceeded, "excessive nesting");
+
+    // The limit is generous, not tight: a shape well past anything a baker emits still parses.
+    const std::string acceptable = std::string(8, '[') + "1" + std::string(8, ']');
+    CHECK(parse(acceptable).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// Accessors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Accessors report the wrong kind rather than guessing", "evidence-unit") {
+    const Value text = Value::string("1");
+    CHECK(!text.asUInt().has_value());
+    CHECK(text.asUInt().error().code == ErrorCode::WrongKind);
+    CHECK(!text.asBool().has_value());
+    CHECK(!text.asFloat32().has_value());
+
+    const Value number = Value::unsignedInteger(1);
+    CHECK(!number.asString().has_value());
+    CHECK(number.asString().error().code == ErrorCode::WrongKind);
+}
+
+TEST_CASE("Integer accessors enforce exact representability", "evidence-unit") {
+    const Value negative = Value::integer(-1);
+    CHECK(!negative.asUInt().has_value());
+    CHECK(negative.asUInt().error().code == ErrorCode::NotExactlyRepresentable);
+    CHECK(negative.asInt().value_or(0) == -1);
+
+    const Value huge = Value::unsignedInteger(
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1u);
+    CHECK(!huge.asInt().has_value());
+    CHECK(huge.asInt().error().code == ErrorCode::NotExactlyRepresentable);
+    CHECK(huge.asUInt().has_value());
+}
+
+TEST_CASE("asFloat32 accepts only a single-member bits object", "evidence-unit") {
+    const auto twoMembers = parse("{\"bits\": 1, \"extra\": 2}");
+    REQUIRE(twoMembers.has_value());
+    CHECK(!twoMembers->asFloat32().has_value());
+    CHECK(twoMembers->asFloat32().error().code == ErrorCode::WrongKind);
+
+    const auto wrongName = parse("{\"bytes\": 1}");
+    REQUIRE(wrongName.has_value());
+    CHECK(!wrongName->asFloat32().has_value());
+
+    const auto tooLarge = parse("{\"bits\": 4294967296}");
+    REQUIRE(tooLarge.has_value());
+    CHECK(!tooLarge->asFloat32().has_value());
+    CHECK(tooLarge->asFloat32().error().code == ErrorCode::NumberOutOfRange);
+
+    const auto valid = parse("{\"bits\": 1065353216}");
+    REQUIRE(valid.has_value());
+    REQUIRE(valid->asFloat32().has_value());
+    CHECK(bitsOf(valid->asFloat32().value()) == bitsOf(1.0F));
+}
+
+TEST_CASE("set() rejects a duplicate key instead of overwriting", "evidence-unit") {
+    Value object = Value::emptyObject();
+    REQUIRE(object.set("a", Value::unsignedInteger(1)).has_value());
+
+    const auto again = object.set("a", Value::unsignedInteger(2));
+    CHECK(!again.has_value());
+    CHECK(again.error().code == ErrorCode::DuplicateKey);
+    // The original value is intact - a rejected set() is not a partial one.
+    CHECK(object.find("a")->asUInt().value_or(0) == 1);
+}
+
+TEST_CASE("set() and push() reject the wrong container kind", "evidence-unit") {
+    Value array = Value::array({});
+    CHECK(!array.set("a", Value::null()).has_value());
+    CHECK(array.set("a", Value::null()).error().code == ErrorCode::WrongKind);
+    CHECK(array.push(Value::unsignedInteger(1)).has_value());
+
+    Value object = Value::emptyObject();
+    CHECK(!object.push(Value::null()).has_value());
+    CHECK(object.push(Value::null()).error().code == ErrorCode::WrongKind);
+}
+
+TEST_CASE("find() and require() agree, and require() names the missing member", "evidence-unit") {
+    const Value object = objectOf({{"present", Value::unsignedInteger(1)}});
+
+    CHECK(object.find("present") != nullptr);
+    CHECK(object.find("absent") == nullptr);
+    CHECK(object.require("present").has_value());
+
+    const auto missing = object.require("absent");
+    CHECK(!missing.has_value());
+    CHECK(missing.error().code == ErrorCode::MissingMember);
+    CHECK(missing.error().detail.find("absent") != std::string::npos);
+}
+
+TEST_CASE("The writer rejects invalid UTF-8 rather than emitting it", "evidence-unit") {
+    const Value badString = Value::string(std::string{"\xc3"});
+    const auto result = write(badString);
+    CHECK(!result.has_value());
+    CHECK(result.error().code == ErrorCode::InvalidUtf8);
+
+    Value object = Value::emptyObject();
+    REQUIRE(object.set(std::string{"\xff"}, Value::null()).has_value());
+    const auto keyResult = write(object);
+    CHECK(!keyResult.has_value());
+    CHECK(keyResult.error().code == ErrorCode::InvalidUtf8);
+}
+
+TEST_CASE("describe() names every error code", "evidence-unit") {
+    // Guards against a new ErrorCode being added without a diagnostic string, which would
+    // otherwise surface as "unrecognized error" in a baker's output.
+    constexpr std::array<ErrorCode, 18> all{
+        ErrorCode::UnexpectedEnd,            ErrorCode::UnexpectedCharacter,
+        ErrorCode::InvalidNumber,            ErrorCode::FractionalNumberRejected,
+        ErrorCode::NumberOutOfRange,         ErrorCode::NonFiniteLiteralRejected,
+        ErrorCode::DuplicateKey,             ErrorCode::TrailingComma,
+        ErrorCode::CommentRejected,          ErrorCode::InvalidEscape,
+        ErrorCode::UnescapedControlCharacter, ErrorCode::InvalidUtf8,
+        ErrorCode::ByteOrderMarkRejected,    ErrorCode::TrailingContent,
+        ErrorCode::DepthExceeded,            ErrorCode::WrongKind,
+        ErrorCode::MissingMember,            ErrorCode::NotExactlyRepresentable};
+
+    for (const ErrorCode code : all) {
+        CHECK(!describe(code).empty());
+        CHECK(describe(code) != "unrecognized error");
+    }
+}

--- a/tools/evidence-lint/mdux_evidence_lint.py
+++ b/tools/evidence-lint/mdux_evidence_lint.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""mdux-evidence-lint: bans decimal float formatting in the evidence pipeline.
+
+Host-only tool (see ADR-004's trust-zone model) - never built into MduXCore or MduX, no
+third-party dependencies, standard library only, so it runs anywhere Python 3.9+ runs without
+a build.
+
+## Why this exists
+
+ADR-007 encodes every real number in an evidence artifact as its `u32` bit pattern,
+`{"bits": 1065353216}`, never as decimal text. The reason is narrow and load-bearing:
+`printf("%.9g")` and `std::format("{}", f)` are not guaranteed byte-identical across MSVC,
+glibc and libc++, and the evidence pipeline crosses all three. Byte-identity across toolchains
+is the pipeline's central guarantee, and a single stray float specifier in a single baker
+breaks it - in a way that reproduces only on someone else's operating system, which is the
+worst possible failure mode to debug.
+
+Code review cannot be relied on to catch a `%g` buried in a diagnostic string. This can.
+
+## What it checks
+
+Over C++ sources under the scanned roots, **inside string literals only**:
+
+1. printf-family float conversions: `%f`, `%e`, `%g`, `%a` and their uppercase forms, with any
+   flags, width or precision in between.
+2. `std::format`/`std::print` replacement fields with a float presentation type: `{:.3f}`,
+   `{:e}`, `{:g}`, `{:a}` and uppercase equivalents.
+
+Scanning only string literals is what makes this precise. A format specifier can only ever
+appear in one, and the alternative - scanning whole lines - produces false positives that are
+not fixable by rewording: `Mode mode{Mode::Bake};` looks exactly like a `{:...e}` field, and
+`a %factor` looks exactly like `%f`. Restricting to literals also means prose *explaining* this
+rule, including the `%.9g` in ADR-007 and in the Json module's own documentation, is never
+scanned at all.
+
+One acknowledged blind spot: a specifier split across adjacent concatenated literals, as in
+`"%" "f"`, is not detected. Nobody writes that, and detecting it would mean modelling
+concatenation for no practical gain.
+
+## Escape hatch
+
+A line ending with `mdux-evidence-lint:allow` is exempt. Intended for the rare case of a
+host-only tool rendering a float for human display, where the output is not part of any
+artifact. It is reviewed, not routine - a baker never needs it.
+
+Usage:
+    python3 tools/evidence-lint/mdux_evidence_lint.py [--format text|json] [paths...]
+
+Exit status 0 if no findings, 1 otherwise. With no paths, scans the default roots below.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_SCAN_DIRS = (
+    "src/evidence",
+    "include/mdux/evidence",
+    "tools",
+)
+
+SOURCE_SUFFIXES = (".cpp", ".cppm", ".hpp", ".h", ".ixx", ".cc", ".cxx")
+
+# printf-family float conversion. `%%` is an escaped percent and must not match, so a percent
+# preceded by another percent is excluded via the leading (?<!%) guard.
+PRINTF_FLOAT_RE = re.compile(r"(?<!%)%[-+ #0']*[0-9*]*(?:\.[0-9*]+)?[aAeEfFgG]")
+
+# std::format replacement field with a float presentation type. Matches "{:", an optional
+# fill/align/sign/width/precision run that contains no braces, then a float type before "}".
+FORMAT_FLOAT_RE = re.compile(r"\{[^{}]*:[^{}]*[aAeEfFgG]\}")
+
+SUPPRESS_MARKER = "mdux-evidence-lint:allow"
+
+
+@dataclass
+class Finding:
+    path: str
+    line: int
+    code: str
+    severity: str
+    message: str
+    fix_hint: str = ""
+
+    def to_json(self) -> dict:
+        return {
+            "file": self.path,
+            "line": self.line,
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "fixHint": self.fix_hint,
+        }
+
+
+def extract_string_literals(text: str) -> list[tuple[int, str]]:
+    """Returns (1-based start line, literal body) for every string and character literal.
+
+    Comments are skipped entirely - a `%.9g` in a comment is documentation, not a format string.
+    Raw string literals are returned with their body intact and no escape processing, which is
+    what `R"(%.3f)"` needs. A literal that spans lines is reported at its first line.
+    """
+    literals: list[tuple[int, str]] = []
+    i = 0
+    n = len(text)
+    line = 1
+    while i < n:
+        c = text[i]
+
+        if text[i : i + 2] == "//":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if text[i : i + 2] == "/*":
+            i += 2
+            while i < n and text[i : i + 2] != "*/":
+                if text[i] == "\n":
+                    line += 1
+                i += 1
+            i += 2
+            continue
+
+        # Raw string literal: R"delim(body)delim", no escape processing inside.
+        if c == "R" and text[i + 1 : i + 2] == '"':
+            open_paren = text.find("(", i + 2)
+            if open_paren != -1:
+                delim = text[i + 2 : open_paren]
+                terminator = ")" + delim + '"'
+                end = text.find(terminator, open_paren + 1)
+                if end != -1:
+                    body = text[open_paren + 1 : end]
+                    literals.append((line, body))
+                    line += text.count("\n", i, end + len(terminator))
+                    i = end + len(terminator)
+                    continue
+
+        if c in ('"', "'"):
+            quote = c
+            start_line = line
+            i += 1
+            body_start = i
+            while i < n:
+                if text[i] == "\\" and i + 1 < n:
+                    if text[i + 1] == "\n":
+                        line += 1
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    break
+                if text[i] == "\n":  # unterminated literal; let the compiler complain about it
+                    line += 1
+                    break
+                i += 1
+            literals.append((start_line, text[body_start:i]))
+            i += 1
+            continue
+
+        if c == "\n":
+            line += 1
+        i += 1
+    return literals
+
+
+def check_file(path: Path, root: Path, findings: list[Finding]) -> None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        findings.append(
+            Finding(
+                path=str(path.relative_to(root)),
+                line=0,
+                code="EVL000",
+                severity="error",
+                message=f"could not read file: {exc}",
+            )
+        )
+        return
+
+    original_lines = text.splitlines()
+
+    for number, literal in extract_string_literals(text):
+        original = original_lines[number - 1] if number <= len(original_lines) else ""
+        if original.rstrip().endswith(SUPPRESS_MARKER):
+            continue
+
+        relative = str(path.relative_to(root))
+        for match in PRINTF_FLOAT_RE.finditer(literal):
+            findings.append(
+                Finding(
+                    path=relative,
+                    line=number,
+                    code="EVL001",
+                    severity="error",
+                    message=(
+                        f"printf-family float conversion {match.group(0)!r} in the evidence "
+                        "pipeline. Decimal float text is not byte-identical across MSVC, glibc "
+                        "and libc++, which breaks the cross-toolchain byte-identity guarantee."
+                    ),
+                    fix_hint=(
+                        "Encode the value as its u32 bit pattern via "
+                        "mdux::evidence::json::Value::float32(), which writes {\"bits\": N}. "
+                        "See ADR-007."
+                    ),
+                )
+            )
+        for match in FORMAT_FLOAT_RE.finditer(literal):
+            findings.append(
+                Finding(
+                    path=relative,
+                    line=number,
+                    code="EVL002",
+                    severity="error",
+                    message=(
+                        f"std::format float presentation type {match.group(0)!r} in the "
+                        "evidence pipeline. std::format's float output is not guaranteed "
+                        "byte-identical across standard libraries."
+                    ),
+                    fix_hint=(
+                        "Encode the value as its u32 bit pattern via "
+                        "mdux::evidence::json::Value::float32(). See ADR-007."
+                    ),
+                )
+            )
+
+
+def find_repository_root() -> Path:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / ".git").exists():
+            return candidate
+    return here.parents[2]
+
+
+def collect_sources(paths: list[Path]) -> list[Path]:
+    sources: list[Path] = []
+    for path in paths:
+        if path.is_file():
+            if path.suffix in SOURCE_SUFFIXES:
+                sources.append(path)
+        elif path.is_dir():
+            for suffix in SOURCE_SUFFIXES:
+                sources.extend(path.rglob(f"*{suffix}"))
+    return sorted(set(sources))
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Ban decimal float formatting in the MduX evidence pipeline (ADR-007)."
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("paths", nargs="*", type=Path)
+    args = parser.parse_args(argv)
+
+    root = find_repository_root()
+    if args.paths:
+        targets = [p if p.is_absolute() else (Path.cwd() / p) for p in args.paths]
+    else:
+        targets = [root / d for d in DEFAULT_SCAN_DIRS]
+    targets = [t for t in targets if t.exists()]
+
+    findings: list[Finding] = []
+    sources = collect_sources(targets)
+    for source in sources:
+        check_file(source, root, findings)
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "tool": "mdux-evidence-lint",
+                    "filesChecked": len(sources),
+                    "findings": [f.to_json() for f in findings],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for finding in findings:
+            print(
+                f"{finding.path}:{finding.line}: {finding.severity}: "
+                f"[{finding.code}] {finding.message}"
+            )
+            if finding.fix_hint:
+                print(f"    fix: {finding.fix_hint}")
+        if findings:
+            print(f"mdux-evidence-lint: {len(findings)} finding(s) in {len(sources)} file(s)")
+        else:
+            print(f"mdux-evidence-lint: OK ({len(sources)} files checked, 0 findings)")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/evidence-lint/test_mdux_evidence_lint.py
+++ b/tools/evidence-lint/test_mdux_evidence_lint.py
@@ -1,0 +1,220 @@
+"""Self-tests for mdux-evidence-lint.
+
+A lint that never fires is indistinguishable from no lint at all, so the cases below are
+weighted towards proving it *does* fire on each banned construct - and, just as importantly,
+that it stays quiet on the prose that explains why the construct is banned.
+"""
+import tempfile
+import unittest
+from pathlib import Path
+
+import mdux_evidence_lint as lint
+
+
+class CheckFileTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def check(self, source, name="Baker.cpp"):
+        path = self.root / name
+        path.write_text(source, encoding="utf-8")
+        findings = []
+        lint.check_file(path, self.root, findings)
+        return findings
+
+    def codes(self, source, name="Baker.cpp"):
+        return sorted(finding.code for finding in self.check(source, name))
+
+    # --- printf-family conversions (EVL001) ---------------------------------
+
+    def test_flags_printf_float_conversions(self):
+        for specifier in ("%f", "%e", "%g", "%a", "%F", "%E", "%G", "%A"):
+            with self.subTest(specifier=specifier):
+                self.assertEqual(
+                    ["EVL001"],
+                    self.codes(f'void f() {{ std::printf("value {specifier}", x); }}'),
+                )
+
+    def test_flags_printf_float_with_precision_and_flags(self):
+        for specifier in ("%.9g", "%-12.4f", "%+.3e", "%0*.*f", "%'.2f", "% .1f", "%#.2g"):
+            with self.subTest(specifier=specifier):
+                self.assertEqual(
+                    ["EVL001"],
+                    self.codes(f'void f() {{ std::printf("{specifier}", x); }}'),
+                )
+
+    def test_ignores_non_float_conversions(self):
+        source = 'void f() { std::printf("%d %s %u %zu %x %p %c %%", a, b, c, d, e, g, h); }'
+        self.assertEqual([], self.codes(source))
+
+    def test_escaped_percent_before_float_letter_is_not_a_conversion(self):
+        # "%%f" is a literal percent followed by the letter f, not a float conversion.
+        self.assertEqual([], self.codes('void f() { std::printf("100%%free"); }'))
+        self.assertEqual([], self.codes('void f() { std::printf("%%f"); }'))
+
+    # --- std::format presentation types (EVL002) ----------------------------
+
+    def test_flags_format_float_presentation_types(self):
+        for field in ("{:f}", "{:e}", "{:g}", "{:a}", "{:.3f}", "{:>10.2e}", "{:+.6g}", "{:E}"):
+            with self.subTest(field=field):
+                self.assertEqual(
+                    ["EVL002"],
+                    self.codes(f'void f() {{ auto s = std::format("{field}", x); }}'),
+                )
+
+    def test_ignores_format_fields_without_a_float_type(self):
+        source = 'void f() { auto s = std::format("{} {:d} {:>8} {:#x} {:s}", a, b, c, d, e); }'
+        self.assertEqual([], self.codes(source))
+
+    def test_ignores_plain_braces(self):
+        self.assertEqual([], self.codes("struct S { float f; };"))
+        self.assertEqual([], self.codes("void f() { if (a) { b(); } }"))
+
+    # --- literals only, not whole lines -------------------------------------
+
+    def test_prose_explaining_the_rule_does_not_fire(self):
+        # This is the exact shape of the comment in Json.cppm and ADR-007. Comments are not
+        # literals, so the module documenting the rule is never scanned.
+        source = """
+// printf("%.9g") is not byte-identical across MSVC, glibc and libc++.
+/* Nor is std::format("{:.9g}", value) - hence the {"bits": N} encoding. */
+void f() { }
+"""
+        self.assertEqual([], self.codes(source))
+
+    def test_brace_initializer_is_not_a_format_field(self):
+        # Regression: an earlier whole-line version of this lint flagged these, and no rewording
+        # could have fixed them - they are ordinary C++ that happens to look like "{:...e}".
+        for source in (
+            "struct S { Mode mode{Mode::Bake}; };",
+            "struct S { Format format{Format::Text}; };",
+            "auto x = Value{Kind::String};",
+            "std::map<int, float> m{{1, 2}};",
+        ):
+            with self.subTest(source=source):
+                self.assertEqual([], self.codes(source))
+
+    def test_modulo_expression_is_not_a_printf_conversion(self):
+        # Same class of regression: "a %factor" is a modulo, not a "%f".
+        for source in (
+            "int r = a %factor;",
+            "int r = total %gridWidth;",
+            "int r = i %entries;",
+        ):
+            with self.subTest(source=source):
+                self.assertEqual([], self.codes(source))
+
+    def test_violation_inside_a_string_still_fires(self):
+        self.assertEqual(["EVL001"], self.codes('const char* k = "%.9g";'))
+
+    def test_double_slash_inside_a_string_is_not_a_comment(self):
+        # If "//" inside this literal were treated as a comment start, the real violation later
+        # on the line would be missed.
+        source = 'void f() { log("http://x"); std::printf("%f", v); }'
+        self.assertEqual(["EVL001"], self.codes(source))
+
+    def test_raw_string_literal_contents_are_scanned(self):
+        self.assertEqual(["EVL001"], self.codes('const char* k = R"(%.3f)";'))
+
+    def test_line_numbers_survive_comments_and_multi_line_literals(self):
+        source = "\n".join(
+            [
+                "/* line one",
+                "   line two",
+                "   line three */",
+                'void f() { std::printf("%f", v); }',
+            ]
+        )
+        findings = self.check(source)
+        self.assertEqual(1, len(findings))
+        self.assertEqual(4, findings[0].line)
+
+    def test_line_numbers_survive_a_multi_line_raw_string(self):
+        source = "\n".join(
+            [
+                "const char* doc = R\"(",
+                "  line one",
+                "  line two",
+                ")\";",
+                'void f() { std::printf("%g", v); }',
+            ]
+        )
+        findings = self.check(source)
+        self.assertEqual(1, len(findings))
+        self.assertEqual(5, findings[0].line)
+
+    def test_a_violation_in_a_multi_line_raw_string_reports_its_start_line(self):
+        source = "\n".join(
+            [
+                "void f() {",
+                "  const char* fmt = R\"(",
+                "    %.3f",
+                "  )\";",
+                "}",
+            ]
+        )
+        findings = self.check(source)
+        self.assertEqual(1, len(findings))
+        self.assertEqual(2, findings[0].line)
+
+    # --- suppression --------------------------------------------------------
+
+    def test_suppression_marker_exempts_a_line(self):
+        source = 'void f() { std::printf("%.3f", v); }  // mdux-evidence-lint:allow'
+        self.assertEqual([], self.codes(source))
+
+    def test_suppression_marker_only_exempts_its_own_line(self):
+        source = "\n".join(
+            [
+                'void a() { std::printf("%.3f", v); }  // mdux-evidence-lint:allow',
+                'void b() { std::printf("%.3f", v); }',
+            ]
+        )
+        findings = self.check(source)
+        self.assertEqual(1, len(findings))
+        self.assertEqual(2, findings[0].line)
+
+    # --- reporting ----------------------------------------------------------
+
+    def test_finding_names_the_offending_text_and_points_at_the_fix(self):
+        findings = self.check('void f() { std::printf("%.9g", v); }')
+        self.assertEqual(1, len(findings))
+        self.assertIn("%.9g", findings[0].message)
+        self.assertIn("float32", findings[0].fix_hint)
+        self.assertIn("ADR-007", findings[0].fix_hint)
+        self.assertEqual("error", findings[0].severity)
+
+    def test_reports_every_violation_on_a_line(self):
+        self.assertEqual(
+            ["EVL001", "EVL001"], self.codes('void f() { std::printf("%f %e", a, b); }')
+        )
+
+
+class CollectSourcesTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_collects_cpp_sources_recursively_and_skips_other_files(self):
+        (self.root / "nested").mkdir()
+        for name in ("a.cpp", "b.cppm", "c.hpp", "nested/d.cpp", "notes.md", "data.json"):
+            (self.root / name).write_text("", encoding="utf-8")
+
+        collected = {p.name for p in lint.collect_sources([self.root])}
+        self.assertEqual({"a.cpp", "b.cppm", "c.hpp", "d.cpp"}, collected)
+
+    def test_accepts_an_explicit_file_path(self):
+        target = self.root / "one.cpp"
+        target.write_text("", encoding="utf-8")
+        self.assertEqual([target], lint.collect_sources([target]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `mdux.evidence.json`: canonical JSON writer + strict reader, the component byte-identity across MSVC/glibc/libc++ depends on. Canonical form — keys sorted by UTF-8 code unit, 2-space indent, LF, no BOM, trailing newline, floats as `{"bits": N}` never decimal text.
- The reader is deliberately stricter than general JSON: rejects duplicate keys, trailing commas, comments, `NaN`/`Infinity`, BOM, invalid UTF-8, trailing content, excessive nesting — and **any number with a fraction or exponent**, since canonical form never emits one.
- Adds `tools/evidence-lint/` banning printf/`std::format` float conversions inside string literals under `src/evidence/` and `tools/` — the CI-enforced half of the same rule.

## Test plan
- [x] 23 new JSON module tests (35/35 cumulative in `evidence_tests`) — canonical form asserted against **literal expected byte strings**, not re-serialization; every notable `f32` bit pattern (±0, denormals, NaN, ∞) round-trips bit-exactly; 20+ rejection cases each pinned to the specific expected error code
- [x] 22 lint self-tests, including two regression cases from my own false positives caught during development: `Mode mode{Mode::Bake}` and `int r = a %factor` both looked like format specifiers to an earlier whole-line version of this lint — fixed by scanning string literals only, which is the only fix that doesn't require impossible rewording of ordinary C++
- [x] `python3 tools/evidence-lint/mdux_evidence_lint.py` — 0 findings

Same sandbox caveat as #80 (no local `import std` due to the CMake UUID pin) — verified with Clang 21 + libc++'s `std` module directly.

Stacked on #80 (digest). Part of the #12 Evidence kernel stack (issue #51).
