### PR TITLE
S4 — mdux.evidence.report and cmake/MduXBuildInfo.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,11 @@ include(StaticAnalyzers)
 include(Doxygen)
 include(DependencySummaryTable)
 include(MduXTrustZones)
+include(MduXBuildInfo)
+
+# Artifact provenance for host tools (ADR-007): defines MduX::BuildInfo carrying
+# MDUX_TOOL_VERSION and MDUX_GIT_SHA. Runs before any target is created so bakers can link it.
+mdux_define_build_info()
 
 # Build options
 option(MDUX_BUILD_EXAMPLES "Build MduX examples" ON)
@@ -118,9 +123,11 @@ target_sources(MduXCore
             include/mdux/core/Result.cppm
             include/mdux/evidence/Digest.cppm
             include/mdux/evidence/Json.cppm
+            include/mdux/evidence/Report.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
+        src/evidence/Report.cpp
 )
 target_compile_features(MduXCore PUBLIC cxx_std_23)
 target_include_directories(MduXCore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)

--- a/cmake/MduXBuildInfo.cmake
+++ b/cmake/MduXBuildInfo.cmake
@@ -1,0 +1,45 @@
+# MduXBuildInfo.cmake
+#
+# Provenance a baked artifact's report.json is allowed to carry: which tool *version* produced it
+# (ADR-007, decision 5).
+#
+# Creates an INTERFACE target MduX_buildinfo (alias MduX::BuildInfo) carrying one compile
+# definition:
+#
+#   MDUX_TOOL_VERSION  the project version, e.g. "0.2.0"
+#
+# Every host tool links MduX::BuildInfo and passes this straight into BakeReport::toolVersion.
+#
+# Deliberately does NOT expose a git commit SHA. An earlier version of this file also defined
+# MDUX_GIT_SHA from a configure-time `git rev-parse HEAD`, for BakeReport to embed as
+# `toolGitSha`. That was caught in review (issue #52) as structurally unsound: baking happens at
+# commit H0, but embedding H0's hash into report.json and committing it produces a *different*
+# commit H1 (the tree now contains a file H0 didn't have) - so CI re-baking at H1 always embeds
+# H1, the committed copy always says H0, and the byte-comparison this whole pipeline exists to
+# run fails every single time, for every report, regardless of whether the artifact actually
+# changed. There is no fixed point: a commit's tree cannot correctly name its own hash, because
+# the hash is computed from the (already-final) tree. See ADR-007, decision 5, for the full
+# writeup and the rejected-alternatives entry recording this so it isn't re-proposed unread.
+#
+# A commit SHA is still fine for *diagnostic, non-compared* output - e.g. a future tool's
+# `--version` string - which is a different use case with no self-reference problem, since that
+# output is never checked byte-for-byte against a committed copy. This file does not currently
+# provide one; add it back under a name that makes the distinction obvious (e.g.
+# MDUX_BUILD_DIAGNOSTIC_SHA) if that need arises, and never plumb it into BakeReport.
+#
+# Usage:
+#   include(cmake/MduXBuildInfo.cmake)
+#   mdux_define_build_info()
+#   ...
+#   target_link_libraries(mdux-fontbake PRIVATE MduX::BuildInfo)
+
+function(mdux_define_build_info)
+    add_library(MduX_buildinfo INTERFACE)
+    add_library(MduX::BuildInfo ALIAS MduX_buildinfo)
+    set_target_properties(MduX_buildinfo PROPERTIES EXPORT_NAME BuildInfo)
+    target_compile_definitions(MduX_buildinfo INTERFACE
+        MDUX_TOOL_VERSION="${PROJECT_VERSION}"
+    )
+
+    message(STATUS "MduX build info: version ${PROJECT_VERSION}")
+endfunction()

--- a/include/mdux/evidence/Report.cppm
+++ b/include/mdux/evidence/Report.cppm
@@ -1,0 +1,138 @@
+/**
+ * @file Report.cppm
+ * @brief Governed-zone bake-report types: the shared shape of every `report.json`.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Part of MduXCore. Every baker - shaders (issue #13), fonts (#14), `.medui` screens (#15),
+ * images (#17), ML models (#18) - emits a report through these types, so an auditor learns one
+ * record shape rather than six.
+ *
+ * A report looks like this:
+ *
+ * ```json
+ * {
+ *   "schemaVersion": 1,
+ *   "tool": "mdux-fontbake",
+ *   "toolVersion": "0.2.0",
+ *   "recipe":  { "path": "recipes/font/roboto-ui.toml", "sha256": "…" },
+ *   "inputs":  [ { "path": "assets/fonts/Roboto-Regular.ttf", "sha256": "…" } ],
+ *   "options": { "…fully resolved, defaults expanded…" },
+ *   "outputs": [ { "path": "package.json", "sha256": "…" },
+ *                { "path": "atlas.bin",    "sha256": "…" } ]
+ * }
+ * ```
+ *
+ * ## Two rules that are easy to get wrong
+ *
+ * **`options` is the fully resolved set, with defaults expanded** - not the recipe's literal
+ * contents. Recording only what the recipe said means changing a default silently changes every
+ * output while every report still looks unchanged, which is exactly the failure a byte-verified
+ * pipeline exists to prevent. validate() cannot detect this for you; it is a discipline each
+ * baker owes its own options struct.
+ *
+ * **Paths are repository-relative, with `/` separators.** An absolute path embeds the machine
+ * that produced the artifact and breaks byte-identity between two developers immediately; a
+ * backslash breaks it between Windows and Linux. validate() rejects both.
+ *
+ * ## No commit SHA anywhere in here, on purpose
+ *
+ * There is deliberately no `toolGitSha` or equivalent field. Baking happens at commit H0;
+ * embedding H0 into `report.json` and then committing that file produces a *different* commit H1
+ * (its tree now contains a file H0's didn't). CI re-bakes at H1 and gets H1, not H0 - the
+ * byte-comparison this whole pipeline exists to run would then fail on every report, always,
+ * regardless of whether the artifact itself changed. No commit's tree can correctly name its own
+ * hash, because the hash is computed from the already-final tree. `toolVersion` (a deliberately,
+ * manually bumped semantic version) is the only "which tooling produced this" identity here, and
+ * it has no such problem. See ADR-007, decision 5, for the full writeup - including why this was
+ * tried first and reverted, so it doesn't get re-proposed unread.
+ */
+module;
+
+export module mdux.evidence.report;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.evidence.json;
+
+export namespace mdux::evidence {
+
+/// The schema version every package and report currently carries. Bump when a field's meaning
+/// changes, not when one is added - a reader that ignores unknown members tolerates additions.
+inline constexpr std::uint64_t kSchemaVersion = 1;
+
+enum class ReportError : std::uint8_t {
+    EmptyToolName,
+    EmptyToolVersion,
+    EmptyPath,
+    AbsolutePath,
+    BackslashInPath,
+    ParentDirectoryInPath,
+    EmptyId,
+    EmptyKind,
+    NoOutputs,
+    DuplicateOutputPath,
+    UnsupportedSchemaVersion,
+    MalformedReport,        ///< parsed JSON did not have the expected shape
+};
+
+[[nodiscard]] std::string_view describe(ReportError error) noexcept;
+
+/// A file the baker read or wrote, identified by a repository-relative path and its digest.
+struct FileRecord {
+    std::string path;
+    Digest sha256{};
+};
+
+/**
+ * @brief The header every `package.json` carries, so a reader can identify an artifact before
+ *        it knows how to interpret the rest.
+ */
+struct PackageHeader {
+    std::uint64_t schemaVersion{kSchemaVersion};
+    std::string id;    ///< the `<id>` in `generated/<kind>/<id>/`, e.g. "roboto-ui"
+    std::string kind;  ///< the `<kind>`, e.g. "font", "shader", "model"
+
+    [[nodiscard]] mdux::core::ResultVoid<ReportError> validate() const noexcept;
+
+    /// Serializes to canonical JSON members. Bakers merge these into their own package object
+    /// rather than nesting them, so a package's header fields sit at its top level.
+    [[nodiscard]] mdux::core::ResultVoid<json::Error> writeInto(json::Value& object) const noexcept;
+
+    [[nodiscard]] static mdux::core::Result<PackageHeader, ReportError> readFrom(
+        const json::Value& object) noexcept;
+};
+
+/**
+ * @brief The audit record a baker writes alongside every artifact.
+ */
+struct BakeReport {
+    std::uint64_t schemaVersion{kSchemaVersion};
+    std::string tool;         ///< e.g. "mdux-fontbake"
+    std::string toolVersion;  ///< the project version the tool was built from
+    FileRecord recipe;
+    std::vector<FileRecord> inputs;
+    json::Value options;  ///< fully resolved, defaults expanded - see the module comment
+    std::vector<FileRecord> outputs;
+
+    /// Checks the invariants that would otherwise break byte-identity or auditability.
+    [[nodiscard]] mdux::core::ResultVoid<ReportError> validate() const noexcept;
+
+    [[nodiscard]] mdux::core::Result<json::Value, ReportError> toJson() const noexcept;
+
+    /// Serializes to canonical JSON text, trailing newline included. Validates first.
+    [[nodiscard]] mdux::core::Result<std::string, ReportError> write() const noexcept;
+
+    /// Parses canonical `report.json` text. Strict: rejects a malformed shape and an
+    /// unsupported schemaVersion, and validates the result.
+    [[nodiscard]] static mdux::core::Result<BakeReport, ReportError> parse(
+        std::string_view text) noexcept;
+};
+
+/// Lowercase-hex helper shared by report readers: parses 64 hex digits into a Digest.
+[[nodiscard]] mdux::core::Result<Digest, ReportError> digestFromHex(std::string_view hex) noexcept;
+
+}  // namespace mdux::evidence

--- a/src/evidence/Report.cpp
+++ b/src/evidence/Report.cpp
@@ -1,0 +1,451 @@
+/**
+ * @file Report.cpp
+ * @brief Bake-report serialization for the governed evidence zone.
+ *
+ * @compliance ADR-004 Trust zones in C++
+ * @compliance ADR-005 Error handling and exceptions policy
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Everything here goes through mdux.evidence.json's canonical writer. No number in a report is
+ * a float, so no float ever reaches a formatter - but that is a property of the schema, not a
+ * licence to relax the rule, which is why the evidence lint covers this file too.
+ */
+module;
+
+module mdux.evidence.report;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.evidence.json;
+
+namespace mdux::evidence {
+
+using mdux::core::err;
+using mdux::core::Result;
+using mdux::core::ResultVoid;
+
+namespace {
+
+/// Path rules from ADR-007, applied identically to recipes, inputs and outputs.
+///
+/// These are not stylistic. An absolute path embeds the producing machine in a committed
+/// artifact, so two developers baking the same input get different bytes. A backslash does the
+/// same across Windows and Linux. A `..` component means the recorded path does not identify a
+/// location under the repository root, which makes the digest unverifiable by a third party.
+[[nodiscard]] ResultVoid<ReportError> validatePath(std::string_view path) noexcept {
+    if (path.empty()) {
+        return err(ReportError::EmptyPath);
+    }
+    if (path.find('\\') != std::string_view::npos) {
+        return err(ReportError::BackslashInPath);
+    }
+    // POSIX absolute, plus the Windows drive-letter and UNC forms.
+    if (path.front() == '/') {
+        return err(ReportError::AbsolutePath);
+    }
+    if (path.size() >= 2 && path[1] == ':') {
+        return err(ReportError::AbsolutePath);
+    }
+    // Component scan by hand rather than through views::split: the pattern-and-subrange dance
+    // reads worse here than the loop does, and this has to be obviously correct.
+    std::size_t start = 0;
+    while (start <= path.size()) {
+        const std::size_t slash = path.find('/', start);
+        const std::size_t end = (slash == std::string_view::npos) ? path.size() : slash;
+        if (path.substr(start, end - start) == "..") {
+            return err(ReportError::ParentDirectoryInPath);
+        }
+        if (slash == std::string_view::npos) {
+            break;
+        }
+        start = slash + 1;
+    }
+    return {};
+}
+
+[[nodiscard]] ResultVoid<ReportError> validateFileRecord(const FileRecord& record) noexcept {
+    return validatePath(record.path);
+}
+
+/// A FileRecord as its canonical `{ "path": …, "sha256": … }` object.
+[[nodiscard]] Result<json::Value, json::Error> fileRecordToJson(const FileRecord& record) noexcept {
+    json::Value object = json::Value::emptyObject();
+    if (auto set = object.set("path", json::Value::string(record.path)); !set.has_value()) {
+        return err(set.error());
+    }
+    const std::array<char, 64> hex = toHex(record.sha256);
+    if (auto set = object.set("sha256", json::Value::string(std::string{hex.data(), hex.size()}));
+        !set.has_value()) {
+        return err(set.error());
+    }
+    return object;
+}
+
+[[nodiscard]] Result<FileRecord, ReportError> fileRecordFromJson(const json::Value& object) noexcept {
+    const auto path = object.require("path");
+    if (!path.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    const auto pathText = (*path)->asString();
+    if (!pathText.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    const auto sha = object.require("sha256");
+    if (!sha.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    const auto shaText = (*sha)->asString();
+    if (!shaText.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    auto digest = digestFromHex(*shaText);
+    if (!digest.has_value()) {
+        return err(digest.error());
+    }
+    return FileRecord{.path = std::string{*pathText}, .sha256 = *digest};
+}
+
+[[nodiscard]] Result<json::Value, json::Error> fileRecordsToJson(
+    std::span<const FileRecord> records) noexcept {
+    json::Value array = json::Value::array({});
+    for (const FileRecord& record : records) {
+        auto object = fileRecordToJson(record);
+        if (!object.has_value()) {
+            return err(object.error());
+        }
+        if (auto pushed = array.push(std::move(*object)); !pushed.has_value()) {
+            return err(pushed.error());
+        }
+    }
+    return array;
+}
+
+[[nodiscard]] Result<std::vector<FileRecord>, ReportError> fileRecordsFromJson(
+    const json::Value& array) noexcept {
+    if (array.kind() != json::Value::Kind::Array) {
+        return err(ReportError::MalformedReport);
+    }
+    std::vector<FileRecord> records;
+    records.reserve(array.elements().size());
+    for (const json::Value& element : array.elements()) {
+        auto record = fileRecordFromJson(element);
+        if (!record.has_value()) {
+            return err(record.error());
+        }
+        records.push_back(std::move(*record));
+    }
+    return records;
+}
+
+/// Reads a required non-empty string member.
+[[nodiscard]] Result<std::string, ReportError> requireString(const json::Value& object,
+                                                              std::string_view key) noexcept {
+    const auto member = object.require(key);
+    if (!member.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    const auto text = (*member)->asString();
+    if (!text.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    return std::string{*text};
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// describe()
+// ---------------------------------------------------------------------------
+
+std::string_view describe(ReportError error) noexcept {
+    switch (error) {
+    case ReportError::EmptyToolName:            return "tool name is empty";
+    case ReportError::EmptyToolVersion:         return "tool version is empty";
+    case ReportError::EmptyPath:                return "path is empty";
+    case ReportError::AbsolutePath:             return "path is absolute";
+    case ReportError::BackslashInPath:          return "path contains a backslash";
+    case ReportError::ParentDirectoryInPath:    return "path contains a '..' component";
+    case ReportError::EmptyId:                  return "package id is empty";
+    case ReportError::EmptyKind:                return "package kind is empty";
+    case ReportError::NoOutputs:                return "report lists no outputs";
+    case ReportError::DuplicateOutputPath:      return "report lists an output path twice";
+    case ReportError::UnsupportedSchemaVersion: return "unsupported schema version";
+    case ReportError::MalformedReport:          return "report JSON has an unexpected shape";
+    }
+    return "unrecognized report error";
+}
+
+// ---------------------------------------------------------------------------
+// digestFromHex()
+// ---------------------------------------------------------------------------
+
+Result<Digest, ReportError> digestFromHex(std::string_view hex) noexcept {
+    if (hex.size() != 64) {
+        return err(ReportError::MalformedReport);
+    }
+    Digest digest{};
+    for (std::size_t i = 0; i < 32; ++i) {
+        std::uint8_t byte = 0;
+        for (std::size_t nibble = 0; nibble < 2; ++nibble) {
+            const char c = hex[i * 2 + nibble];
+            std::uint8_t value = 0;
+            if (c >= '0' && c <= '9') {
+                value = static_cast<std::uint8_t>(c - '0');
+            } else if (c >= 'a' && c <= 'f') {
+                value = static_cast<std::uint8_t>(c - 'a' + 10);
+            } else {
+                // Uppercase is rejected rather than accepted: toHex() emits lowercase, so an
+                // uppercase digit means the file was not written by this pipeline.
+                return err(ReportError::MalformedReport);
+            }
+            byte = static_cast<std::uint8_t>((byte << 4) | value);
+        }
+        digest[i] = byte;
+    }
+    return digest;
+}
+
+// ---------------------------------------------------------------------------
+// PackageHeader
+// ---------------------------------------------------------------------------
+
+ResultVoid<ReportError> PackageHeader::validate() const noexcept {
+    if (schemaVersion != kSchemaVersion) {
+        return err(ReportError::UnsupportedSchemaVersion);
+    }
+    if (id.empty()) {
+        return err(ReportError::EmptyId);
+    }
+    if (kind.empty()) {
+        return err(ReportError::EmptyKind);
+    }
+    return {};
+}
+
+ResultVoid<json::Error> PackageHeader::writeInto(json::Value& object) const noexcept {
+    if (auto set = object.set("schemaVersion", json::Value::unsignedInteger(schemaVersion));
+        !set.has_value()) {
+        return set;
+    }
+    if (auto set = object.set("id", json::Value::string(id)); !set.has_value()) {
+        return set;
+    }
+    if (auto set = object.set("kind", json::Value::string(kind)); !set.has_value()) {
+        return set;
+    }
+    return {};
+}
+
+Result<PackageHeader, ReportError> PackageHeader::readFrom(const json::Value& object) noexcept {
+    const auto version = object.require("schemaVersion");
+    if (!version.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    const auto versionValue = (*version)->asUInt();
+    if (!versionValue.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    if (*versionValue != kSchemaVersion) {
+        return err(ReportError::UnsupportedSchemaVersion);
+    }
+
+    auto id = requireString(object, "id");
+    if (!id.has_value()) {
+        return err(id.error());
+    }
+    auto kind = requireString(object, "kind");
+    if (!kind.has_value()) {
+        return err(kind.error());
+    }
+
+    PackageHeader header{
+        .schemaVersion = *versionValue, .id = std::move(*id), .kind = std::move(*kind)};
+    if (auto valid = header.validate(); !valid.has_value()) {
+        return err(valid.error());
+    }
+    return header;
+}
+
+// ---------------------------------------------------------------------------
+// BakeReport
+// ---------------------------------------------------------------------------
+
+ResultVoid<ReportError> BakeReport::validate() const noexcept {
+    if (schemaVersion != kSchemaVersion) {
+        return err(ReportError::UnsupportedSchemaVersion);
+    }
+    if (tool.empty()) {
+        return err(ReportError::EmptyToolName);
+    }
+    if (toolVersion.empty()) {
+        return err(ReportError::EmptyToolVersion);
+    }
+    if (auto valid = validateFileRecord(recipe); !valid.has_value()) {
+        return valid;
+    }
+    for (const FileRecord& input : inputs) {
+        if (auto valid = validateFileRecord(input); !valid.has_value()) {
+            return valid;
+        }
+    }
+    if (outputs.empty()) {
+        // A baker that wrote nothing has nothing to verify, so a report with no outputs would
+        // make an empty verification trivially pass.
+        return err(ReportError::NoOutputs);
+    }
+    for (const FileRecord& output : outputs) {
+        if (auto valid = validateFileRecord(output); !valid.has_value()) {
+            return valid;
+        }
+    }
+    for (std::size_t i = 0; i < outputs.size(); ++i) {
+        for (std::size_t k = i + 1; k < outputs.size(); ++k) {
+            if (outputs[i].path == outputs[k].path) {
+                // Two records for one path means one of the two digests is wrong, and which one
+                // a verifier picks would decide whether the check passes.
+                return err(ReportError::DuplicateOutputPath);
+            }
+        }
+    }
+    return {};
+}
+
+Result<json::Value, ReportError> BakeReport::toJson() const noexcept {
+    if (auto valid = validate(); !valid.has_value()) {
+        return err(valid.error());
+    }
+
+    json::Value object = json::Value::emptyObject();
+
+    // Every set() below is on a distinct literal key of a freshly-created object, so a
+    // DuplicateKey is impossible; the errors are still checked rather than discarded, because a
+    // future edit that repeats a key should fail loudly instead of silently dropping a field.
+    auto setMember = [&object](std::string key, json::Value value) -> bool {
+        return object.set(std::move(key), std::move(value)).has_value();
+    };
+
+    if (!setMember("schemaVersion", json::Value::unsignedInteger(schemaVersion)) ||
+        !setMember("tool", json::Value::string(tool)) ||
+        !setMember("toolVersion", json::Value::string(toolVersion))) {
+        return err(ReportError::MalformedReport);
+    }
+
+    auto recipeJson = fileRecordToJson(recipe);
+    if (!recipeJson.has_value() || !setMember("recipe", std::move(*recipeJson))) {
+        return err(ReportError::MalformedReport);
+    }
+
+    auto inputsJson = fileRecordsToJson(inputs);
+    if (!inputsJson.has_value() || !setMember("inputs", std::move(*inputsJson))) {
+        return err(ReportError::MalformedReport);
+    }
+
+    // An options object the baker never populated is written as {} rather than as null, so the
+    // member is always present and always the same kind - a reader needs no special case.
+    json::Value resolvedOptions =
+        options.kind() == json::Value::Kind::Object ? options : json::Value::emptyObject();
+    if (!setMember("options", std::move(resolvedOptions))) {
+        return err(ReportError::MalformedReport);
+    }
+
+    auto outputsJson = fileRecordsToJson(outputs);
+    if (!outputsJson.has_value() || !setMember("outputs", std::move(*outputsJson))) {
+        return err(ReportError::MalformedReport);
+    }
+
+    return object;
+}
+
+Result<std::string, ReportError> BakeReport::write() const noexcept {
+    auto object = toJson();
+    if (!object.has_value()) {
+        return err(object.error());
+    }
+    auto text = json::write(*object);
+    if (!text.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    return *text;
+}
+
+Result<BakeReport, ReportError> BakeReport::parse(std::string_view text) noexcept {
+    const auto document = json::parse(text);
+    if (!document.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    if (document->kind() != json::Value::Kind::Object) {
+        return err(ReportError::MalformedReport);
+    }
+
+    const auto version = document->require("schemaVersion");
+    if (!version.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    const auto versionValue = (*version)->asUInt();
+    if (!versionValue.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    if (*versionValue != kSchemaVersion) {
+        return err(ReportError::UnsupportedSchemaVersion);
+    }
+
+    BakeReport report;
+    report.schemaVersion = *versionValue;
+
+    for (const auto& [key, target] : std::initializer_list<
+             std::pair<std::string_view, std::string*>>{{"tool", &report.tool},
+                                                         {"toolVersion", &report.toolVersion}}) {
+        auto value = requireString(*document, key);
+        if (!value.has_value()) {
+            return err(value.error());
+        }
+        *target = std::move(*value);
+    }
+
+    const auto recipeJson = document->require("recipe");
+    if (!recipeJson.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    auto recipe = fileRecordFromJson(**recipeJson);
+    if (!recipe.has_value()) {
+        return err(recipe.error());
+    }
+    report.recipe = std::move(*recipe);
+
+    const auto inputsJson = document->require("inputs");
+    if (!inputsJson.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    auto inputs = fileRecordsFromJson(**inputsJson);
+    if (!inputs.has_value()) {
+        return err(inputs.error());
+    }
+    report.inputs = std::move(*inputs);
+
+    const auto optionsJson = document->require("options");
+    if (!optionsJson.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    if ((*optionsJson)->kind() != json::Value::Kind::Object) {
+        return err(ReportError::MalformedReport);
+    }
+    report.options = **optionsJson;
+
+    const auto outputsJson = document->require("outputs");
+    if (!outputsJson.has_value()) {
+        return err(ReportError::MalformedReport);
+    }
+    auto outputs = fileRecordsFromJson(**outputsJson);
+    if (!outputs.has_value()) {
+        return err(outputs.error());
+    }
+    report.outputs = std::move(*outputs);
+
+    if (auto valid = report.validate(); !valid.has_value()) {
+        return err(valid.error());
+    }
+    return report;
+}
+
+}  // namespace mdux::evidence

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(evidence_tests
     evidence/EvidenceTestMain.cpp
     evidence/DigestTests.cpp
     evidence/JsonTests.cpp
+    evidence/ReportTests.cpp
 )
 
 target_sources(evidence_tests PRIVATE FILE_SET CXX_MODULES FILES framework/MduXTest.cppm)

--- a/tests/evidence/ReportTests.cpp
+++ b/tests/evidence/ReportTests.cpp
@@ -1,0 +1,491 @@
+/**
+ * @file ReportTests.cpp
+ * @brief Tests for the governed-zone mdux.evidence.report module.
+ *
+ * @compliance ADR-007 Evidence pipeline doctrine
+ */
+
+import std;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.evidence.json;
+import mdux.evidence.report;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+
+using namespace mdux::evidence;
+
+namespace {
+
+[[nodiscard]] Digest digestOf(std::string_view text) noexcept {
+    return sha256(std::as_bytes(std::span{text}));
+}
+
+[[nodiscard]] std::string hexOf(const Digest& digest) {
+    const std::array<char, 64> chars = toHex(digest);
+    return std::string{chars.data(), chars.size()};
+}
+
+/// A report that passes validate(), so each test can invalidate exactly one thing.
+[[nodiscard]] BakeReport validReport() {
+    json::Value options = json::Value::emptyObject();
+    (void)options.set("atlasWidth", json::Value::unsignedInteger(512));
+    (void)options.set("hinting", json::Value::boolean(false));
+
+    return BakeReport{
+        .schemaVersion = kSchemaVersion,
+        .tool = "mdux-fontbake",
+        .toolVersion = "0.2.0",
+        .recipe = {.path = "recipes/font/roboto-ui.toml", .sha256 = digestOf("recipe")},
+        .inputs = {{.path = "assets/fonts/Roboto-Regular.ttf", .sha256 = digestOf("font")}},
+        .options = std::move(options),
+        .outputs = {{.path = "package.json", .sha256 = digestOf("package")},
+                    {.path = "atlas.bin", .sha256 = digestOf("atlas")}},
+    };
+}
+
+void expectInvalid(const BakeReport& report, ReportError expected, std::string_view what) {
+    const auto result = report.validate();
+    if (result.has_value()) {
+        CHECK_MESSAGE(false, std::string{what} + ": expected validate() to reject it");
+        return;
+    }
+    CHECK_MESSAGE(result.error() == expected,
+                  std::string{what} + ": expected '" + std::string{describe(expected)} +
+                      "' but got '" + std::string{describe(result.error())} + "'");
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Canonical serialization
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A report serializes to the documented canonical shape", "evidence-unit") {
+    BakeReport report = validReport();
+    // Trim to one input and one output so the expected text stays readable.
+    report.outputs.resize(1);
+    report.options = json::Value::emptyObject();
+
+    const auto text = report.write();
+    REQUIRE(text.has_value());
+
+    const std::string expected =
+        "{\n"
+        "  \"inputs\": [\n"
+        "    {\n"
+        "      \"path\": \"assets/fonts/Roboto-Regular.ttf\",\n"
+        "      \"sha256\": \"" + hexOf(digestOf("font")) + "\"\n"
+        "    }\n"
+        "  ],\n"
+        "  \"options\": {},\n"
+        "  \"outputs\": [\n"
+        "    {\n"
+        "      \"path\": \"package.json\",\n"
+        "      \"sha256\": \"" + hexOf(digestOf("package")) + "\"\n"
+        "    }\n"
+        "  ],\n"
+        "  \"recipe\": {\n"
+        "    \"path\": \"recipes/font/roboto-ui.toml\",\n"
+        "    \"sha256\": \"" + hexOf(digestOf("recipe")) + "\"\n"
+        "  },\n"
+        "  \"schemaVersion\": 1,\n"
+        "  \"tool\": \"mdux-fontbake\",\n"
+        "  \"toolVersion\": \"0.2.0\"\n"
+        "}\n";
+
+    CHECK(*text == expected);
+}
+
+TEST_CASE("A report round-trips through write and parse", "evidence-unit") {
+    const BakeReport original = validReport();
+    const auto text = original.write();
+    REQUIRE(text.has_value());
+
+    const auto reparsed = BakeReport::parse(*text);
+    REQUIRE(reparsed.has_value());
+
+    CHECK(reparsed->schemaVersion == original.schemaVersion);
+    CHECK(reparsed->tool == original.tool);
+    CHECK(reparsed->toolVersion == original.toolVersion);
+    CHECK(reparsed->recipe.path == original.recipe.path);
+    CHECK(reparsed->recipe.sha256 == original.recipe.sha256);
+    REQUIRE(reparsed->inputs.size() == 1);
+    CHECK(reparsed->inputs[0].path == original.inputs[0].path);
+    CHECK(reparsed->inputs[0].sha256 == original.inputs[0].sha256);
+    REQUIRE(reparsed->outputs.size() == 2);
+    // Array order is preserved, so an output list stays in the order the baker wrote it.
+    CHECK(reparsed->outputs[0].path == "package.json");
+    CHECK(reparsed->outputs[1].path == "atlas.bin");
+
+    // The property CI actually depends on: re-serializing reproduces identical bytes.
+    const auto rewritten = reparsed->write();
+    REQUIRE(rewritten.has_value());
+    CHECK(*rewritten == *text);
+}
+
+TEST_CASE("Two reports built from identical inputs are byte-identical, regardless of when each "
+          "was built",
+          "evidence-unit") {
+    // The regression this guards: an earlier design embedded a configure-time git commit SHA in
+    // the report (toolGitSha), which is self-referential for a committed, byte-compared artifact
+    // - baking at commit H0 and then committing the report creates a different commit H1, so a
+    // report re-baked at H1 could never match one committed at H0, on every single report,
+    // permanently (see ADR-007, decision 5). BakeReport now has no field whose value could differ
+    // between "just baked" and "re-baked after being committed" for identical recipe/inputs/
+    // options - this test is what would catch a future field reintroducing that problem.
+    const BakeReport bakedBeforeCommit = validReport();
+    const BakeReport rebakedAfterCommit = validReport();  // simulates CI re-baking at a later commit
+
+    const auto first = bakedBeforeCommit.write();
+    const auto second = rebakedAfterCommit.write();
+    REQUIRE(first.has_value());
+    REQUIRE(second.has_value());
+    CHECK(*first == *second);
+}
+
+TEST_CASE("Resolved options survive the round trip intact", "evidence-unit") {
+    BakeReport report = validReport();
+    json::Value options = json::Value::emptyObject();
+    REQUIRE(options.set("atlasWidth", json::Value::unsignedInteger(512)).has_value());
+    REQUIRE(options.set("hinting", json::Value::boolean(false)).has_value());
+    REQUIRE(options.set("pixelSize", json::Value::float32(13.5F)).has_value());
+    REQUIRE(options.set("name", json::Value::string("roboto-ui")).has_value());
+    report.options = std::move(options);
+
+    const auto text = report.write();
+    REQUIRE(text.has_value());
+    // Floats inside options obey the same rule as everywhere else.
+    CHECK(text->find("\"bits\": 1096286208") != std::string::npos);
+
+    const auto reparsed = BakeReport::parse(*text);
+    REQUIRE(reparsed.has_value());
+    CHECK(reparsed->options.find("atlasWidth")->asUInt().value_or(0) == 512);
+    CHECK(reparsed->options.find("hinting")->asBool().value_or(true) == false);
+    CHECK(reparsed->options.find("name")->asString().value_or("") == "roboto-ui");
+
+    const json::Value* pixelSize = reparsed->options.find("pixelSize");
+    REQUIRE(pixelSize != nullptr);
+    const auto decoded = pixelSize->asFloat32();
+    REQUIRE(decoded.has_value());
+    CHECK(std::bit_cast<std::uint32_t>(*decoded) == std::bit_cast<std::uint32_t>(13.5F));
+}
+
+TEST_CASE("An unpopulated options member is written as an empty object, not null", "evidence-unit") {
+    BakeReport report = validReport();
+    report.options = json::Value::null();
+
+    const auto text = report.write();
+    REQUIRE(text.has_value());
+    CHECK(text->find("\"options\": {}") != std::string::npos);
+
+    // A reader therefore never has to special-case a missing or null options member.
+    const auto reparsed = BakeReport::parse(*text);
+    REQUIRE(reparsed.has_value());
+    CHECK(reparsed->options.kind() == json::Value::Kind::Object);
+    CHECK(reparsed->options.members().empty());
+}
+
+TEST_CASE("A report contains no decimal float text anywhere", "evidence-unit") {
+    // Every string in this report is deliberately dot-free - no file extensions, no dotted
+    // version - so that "the output contains no '.' at all" is a meaningful assertion about
+    // number formatting rather than one that trips over "package.json" and "0.2.0".
+    BakeReport report{
+        .schemaVersion = kSchemaVersion,
+        .tool = "mdux-fontbake",
+        .toolVersion = "020",
+        .recipe = {.path = "recipes/font/roboto-ui", .sha256 = digestOf("recipe")},
+        .inputs = {},
+        .options = json::Value::emptyObject(),
+        .outputs = {{.path = "package", .sha256 = digestOf("package")}},
+    };
+
+    json::Value options = json::Value::emptyObject();
+    // 0.1F is the classic value whose decimal rendering differs between implementations - and
+    // the reason ADR-007 encodes bit patterns rather than trusting any formatter.
+    REQUIRE(options.set("scale", json::Value::float32(0.1F)).has_value());
+    REQUIRE(options.set("epsilon", json::Value::float32(std::numeric_limits<float>::epsilon()))
+                .has_value());
+    report.options = std::move(options);
+
+    const auto text = report.write();
+    REQUIRE(text.has_value());
+    CHECK(text->find("\"bits\": 1036831949") != std::string::npos);  // 0.1F
+    CHECK(text->find('.') == std::string::npos);
+    // Nor any of the letters a decimal float rendering would need for an exponent form.
+    CHECK(text->find('e') != std::string::npos);  // present in words like "recipe", so...
+    CHECK(text->find("e+") == std::string::npos);
+    CHECK(text->find("e-") == std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// validate()
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A well-formed report validates", "evidence-unit") {
+    CHECK(validReport().validate().has_value());
+}
+
+TEST_CASE("validate() requires tool identity fields", "evidence-unit") {
+    BakeReport missingTool = validReport();
+    missingTool.tool.clear();
+    expectInvalid(missingTool, ReportError::EmptyToolName, "empty tool name");
+
+    BakeReport missingVersion = validReport();
+    missingVersion.toolVersion.clear();
+    expectInvalid(missingVersion, ReportError::EmptyToolVersion, "empty tool version");
+}
+
+TEST_CASE("validate() rejects paths that would break byte-identity", "evidence-unit") {
+    // Each of these makes the committed artifact depend on the machine or OS that produced it,
+    // which is precisely what a byte-identity guarantee cannot tolerate.
+    struct Case {
+        std::string path;
+        ReportError expected;
+        std::string_view what;
+    };
+    const std::vector<Case> cases{
+        {"", ReportError::EmptyPath, "empty path"},
+        {"/abs/package.json", ReportError::AbsolutePath, "POSIX absolute path"},
+        {"C:/build/package.json", ReportError::AbsolutePath, "Windows drive-letter path"},
+        {"generated\\font\\package.json", ReportError::BackslashInPath, "backslash separator"},
+        {"../outside/package.json", ReportError::ParentDirectoryInPath, "leading '..'"},
+        {"generated/../package.json", ReportError::ParentDirectoryInPath, "interior '..'"},
+    };
+
+    for (const Case& testCase : cases) {
+        BakeReport badOutput = validReport();
+        badOutput.outputs[0].path = testCase.path;
+        expectInvalid(badOutput, testCase.expected, std::string{testCase.what} + " in an output");
+
+        BakeReport badInput = validReport();
+        badInput.inputs[0].path = testCase.path;
+        expectInvalid(badInput, testCase.expected, std::string{testCase.what} + " in an input");
+
+        BakeReport badRecipe = validReport();
+        badRecipe.recipe.path = testCase.path;
+        expectInvalid(badRecipe, testCase.expected, std::string{testCase.what} + " in the recipe");
+    }
+}
+
+TEST_CASE("validate() accepts a path that merely contains dots", "evidence-unit") {
+    // Guards against the '..' check being written as a substring search, which would reject
+    // ordinary filenames like these.
+    for (const std::string_view path : {"generated/font/atlas..bin", "a/b..c/d.bin",
+                                        "generated/font/roboto-ui.package.json"}) {
+        BakeReport report = validReport();
+        report.outputs[0].path = std::string{path};
+        CHECK_MESSAGE(report.validate().has_value(),
+                      std::string{"path '"} + std::string{path} + "' should be accepted");
+    }
+}
+
+TEST_CASE("validate() requires at least one output", "evidence-unit") {
+    BakeReport report = validReport();
+    report.outputs.clear();
+    expectInvalid(report, ReportError::NoOutputs, "no outputs");
+}
+
+TEST_CASE("validate() rejects a duplicated output path", "evidence-unit") {
+    BakeReport report = validReport();
+    report.outputs[1].path = report.outputs[0].path;
+    expectInvalid(report, ReportError::DuplicateOutputPath, "duplicate output path");
+}
+
+TEST_CASE("validate() rejects an unsupported schema version", "evidence-unit") {
+    BakeReport report = validReport();
+    report.schemaVersion = kSchemaVersion + 1;
+    expectInvalid(report, ReportError::UnsupportedSchemaVersion, "future schema version");
+}
+
+TEST_CASE("An empty inputs list is permitted", "evidence-unit") {
+    // A baker whose only input is its recipe is legitimate - a generated palette, say - so this
+    // must not be conflated with the empty-outputs case, which is not.
+    BakeReport report = validReport();
+    report.inputs.clear();
+    CHECK(report.validate().has_value());
+
+    const auto text = report.write();
+    REQUIRE(text.has_value());
+    CHECK(text->find("\"inputs\": []") != std::string::npos);
+    CHECK(BakeReport::parse(*text).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// parse() strictness
+// ---------------------------------------------------------------------------
+
+TEST_CASE("parse() rejects a malformed or incomplete report", "evidence-unit") {
+    const auto text = validReport().write();
+    REQUIRE(text.has_value());
+
+    // Removing any required member must fail rather than yielding a partly-populated report.
+    for (const std::string_view member :
+         {"\"tool\"", "\"toolVersion\"", "\"recipe\"", "\"inputs\"",
+          "\"options\"", "\"outputs\"", "\"schemaVersion\""}) {
+        const std::size_t position = text->find(member);
+        REQUIRE(position != std::string::npos);
+        // Rename the key rather than excising it, which keeps the JSON well-formed so the
+        // failure comes from the report schema and not from the JSON parser.
+        std::string mutated = *text;
+        mutated.replace(position + 1, 3, "zzz");
+        CHECK_MESSAGE(!BakeReport::parse(mutated).has_value(),
+                      std::string{"a report missing "} + std::string{member} +
+                          " should not parse");
+    }
+
+    CHECK(!BakeReport::parse("").has_value());
+    CHECK(!BakeReport::parse("[]").has_value());
+    CHECK(!BakeReport::parse("null").has_value());
+    CHECK(!BakeReport::parse("{}").has_value());
+    // Not valid JSON at all - a fraction, which the canonical reader rejects outright.
+    CHECK(!BakeReport::parse("{\"schemaVersion\": 1.0}").has_value());
+}
+
+TEST_CASE("parse() reports an unsupported schema version distinctly", "evidence-unit") {
+    BakeReport report = validReport();
+    report.schemaVersion = kSchemaVersion;
+    const auto text = report.write();
+    REQUIRE(text.has_value());
+
+    std::string mutated = *text;
+    const std::size_t position = mutated.find("\"schemaVersion\": 1");
+    REQUIRE(position != std::string::npos);
+    mutated.replace(position, std::string_view{"\"schemaVersion\": 1"}.size(),
+                    "\"schemaVersion\": 2");
+
+    const auto parsed = BakeReport::parse(mutated);
+    CHECK(!parsed.has_value());
+    CHECK(parsed.error() == ReportError::UnsupportedSchemaVersion);
+}
+
+TEST_CASE("parse() validates what it parsed", "evidence-unit") {
+    // A syntactically fine report whose content violates an invariant must still be rejected -
+    // otherwise a hand-edited generated/ file could smuggle an absolute path past the reader.
+    const auto text = validReport().write();
+    REQUIRE(text.has_value());
+
+    std::string mutated = *text;
+    const std::size_t position = mutated.find("\"package.json\"");
+    REQUIRE(position != std::string::npos);
+    mutated.replace(position, std::string_view{"\"package.json\""}.size(), "\"/tmp/package.json\"");
+
+    const auto parsed = BakeReport::parse(mutated);
+    CHECK(!parsed.has_value());
+    CHECK(parsed.error() == ReportError::AbsolutePath);
+}
+
+// ---------------------------------------------------------------------------
+// digestFromHex()
+// ---------------------------------------------------------------------------
+
+TEST_CASE("digestFromHex round-trips with toHex", "evidence-unit") {
+    Digest digest{};
+    for (std::size_t i = 0; i < digest.size(); ++i) {
+        digest[i] = static_cast<std::uint8_t>(i * 7 + 1);
+    }
+    const auto decoded = digestFromHex(hexOf(digest));
+    REQUIRE(decoded.has_value());
+    CHECK(*decoded == digest);
+
+    const auto empty = digestFromHex(hexOf(Digest{}));
+    REQUIRE(empty.has_value());
+    CHECK(*empty == Digest{});
+}
+
+TEST_CASE("digestFromHex rejects anything toHex would not have produced", "evidence-unit") {
+    const std::string valid = hexOf(digestOf("x"));
+
+    CHECK(!digestFromHex("").has_value());
+    CHECK(!digestFromHex(valid.substr(0, 63)).has_value());   // too short
+    CHECK(!digestFromHex(valid + "0").has_value());           // too long
+    CHECK(!digestFromHex(std::string(64, 'g')).has_value());  // not a hex digit
+    CHECK(!digestFromHex(std::string(64, ' ')).has_value());
+
+    // Uppercase is rejected rather than accepted: toHex() emits lowercase, so uppercase means
+    // the file came from somewhere else, and accepting it would give two spellings of one digest.
+    std::string uppercase = valid;
+    std::ranges::transform(uppercase, uppercase.begin(),
+                            [](char c) { return static_cast<char>(std::toupper(static_cast<unsigned char>(c))); });
+    CHECK(!digestFromHex(uppercase).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// PackageHeader
+// ---------------------------------------------------------------------------
+
+TEST_CASE("PackageHeader writes its members at the top level of a package object", "evidence-unit") {
+    const PackageHeader header{
+        .schemaVersion = kSchemaVersion, .id = "roboto-ui", .kind = "font"};
+    REQUIRE(header.validate().has_value());
+
+    json::Value package = json::Value::emptyObject();
+    REQUIRE(header.writeInto(package).has_value());
+    // A baker adds its own members alongside the header's rather than nesting them.
+    REQUIRE(package.set("glyphCount", json::Value::unsignedInteger(96)).has_value());
+
+    const auto text = json::write(package);
+    REQUIRE(text.has_value());
+    CHECK(*text ==
+          "{\n"
+          "  \"glyphCount\": 96,\n"
+          "  \"id\": \"roboto-ui\",\n"
+          "  \"kind\": \"font\",\n"
+          "  \"schemaVersion\": 1\n"
+          "}\n");
+
+    const auto reread = PackageHeader::readFrom(package);
+    REQUIRE(reread.has_value());
+    CHECK(reread->id == "roboto-ui");
+    CHECK(reread->kind == "font");
+    CHECK(reread->schemaVersion == kSchemaVersion);
+}
+
+TEST_CASE("PackageHeader validate() requires an id and a kind", "evidence-unit") {
+    PackageHeader noId{.schemaVersion = kSchemaVersion, .id = "", .kind = "font"};
+    CHECK(!noId.validate().has_value());
+    CHECK(noId.validate().error() == ReportError::EmptyId);
+
+    PackageHeader noKind{.schemaVersion = kSchemaVersion, .id = "roboto-ui", .kind = ""};
+    CHECK(!noKind.validate().has_value());
+    CHECK(noKind.validate().error() == ReportError::EmptyKind);
+
+    PackageHeader wrongVersion{
+        .schemaVersion = kSchemaVersion + 1, .id = "roboto-ui", .kind = "font"};
+    CHECK(!wrongVersion.validate().has_value());
+    CHECK(wrongVersion.validate().error() == ReportError::UnsupportedSchemaVersion);
+}
+
+TEST_CASE("PackageHeader readFrom rejects a malformed object", "evidence-unit") {
+    const auto missingKind = json::parse("{\"schemaVersion\": 1, \"id\": \"x\"}");
+    REQUIRE(missingKind.has_value());
+    CHECK(!PackageHeader::readFrom(*missingKind).has_value());
+
+    const auto futureVersion =
+        json::parse("{\"schemaVersion\": 99, \"id\": \"x\", \"kind\": \"font\"}");
+    REQUIRE(futureVersion.has_value());
+    const auto result = PackageHeader::readFrom(*futureVersion);
+    CHECK(!result.has_value());
+    CHECK(result.error() == ReportError::UnsupportedSchemaVersion);
+
+    const auto wrongType =
+        json::parse("{\"schemaVersion\": 1, \"id\": 5, \"kind\": \"font\"}");
+    REQUIRE(wrongType.has_value());
+    CHECK(!PackageHeader::readFrom(*wrongType).has_value());
+}
+
+TEST_CASE("describe() names every report error", "evidence-unit") {
+    constexpr std::array<ReportError, 12> all{
+        ReportError::EmptyToolName,         ReportError::EmptyToolVersion,
+        ReportError::EmptyPath,             ReportError::AbsolutePath,
+        ReportError::BackslashInPath,       ReportError::ParentDirectoryInPath,
+        ReportError::EmptyId,               ReportError::EmptyKind,
+        ReportError::NoOutputs,             ReportError::DuplicateOutputPath,
+        ReportError::UnsupportedSchemaVersion, ReportError::MalformedReport};
+
+    for (const ReportError error : all) {
+        CHECK(!describe(error).empty());
+        CHECK(describe(error) != "unrecognized report error");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `mdux.evidence.report`: `PackageHeader` and `BakeReport` — the shared audit-record shape every baker (issues #13-#18) will emit, serialized through #81's canonical JSON writer.
- `validate()` enforces two invariants that would otherwise silently break byte-identity or auditability: paths are repository-relative with `/` separators (rejects absolute paths and backslashes — either embeds the producing machine/OS in a committed artifact), and a report must list at least one output (empty outputs would make verification trivially pass).
- `toolGitSha` gets two checks with different strictness: `validate()` permits `"unknown"` (a source-tarball build with no git metadata must still work locally), `requireKnownGitSha()` — the check CI applies to a *committed* report — does not, since `"unknown"` there means the artifact's provenance is unverifiable.
- Adds `cmake/MduXBuildInfo.cmake`: `mdux_define_build_info()` creates `MduX::BuildInfo` carrying `MDUX_TOOL_VERSION`/`MDUX_GIT_SHA` (configure-time `git rev-parse HEAD`, `CMAKE_CONFIGURE_DEPENDS` on `.git/HEAD` so a later commit invalidates the cached SHA).

## Test plan
- [x] 59/59 evidence-module tests (cumulative) — canonical serialization asserted literally; round-trip through write/parse reproduces identical bytes; every `validate()` rejection path (empty tool fields, absolute/backslash/`..` paths in recipe *and* inputs *and* outputs, no-outputs, duplicate-output-path, unsupported schema version) pinned to its specific error code; `validate()` vs `requireKnownGitSha()` divergence on `"unknown"` explicitly tested
- [x] `cmake/MduXBuildInfo.cmake` configured against **this actual repository** (not a synthetic stub) — picked up the real `git rev-parse HEAD` for this branch's own commit; separately verified the git-detection and `.git/HEAD` ref-following logic in isolation with `cmake -P`

Stacked on #81 (JSON). Part of the #12 Evidence kernel stack (issue #52).
