### PR TITLE
S5 — cmake/MduXBake.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,16 @@ include(Doxygen)
 include(DependencySummaryTable)
 include(MduXTrustZones)
 include(MduXBuildInfo)
+include(MduXBake)
 
 # Artifact provenance for host tools (ADR-007): defines MduX::BuildInfo carrying
 # MDUX_TOOL_VERSION and MDUX_GIT_SHA. Runs before any target is created so bakers can link it.
 mdux_define_build_info()
+
+# Bake aggregate targets, declared here rather than next to add_subdirectory(tools) below so
+# this has no dependency on tools/ existing. They exist even with no artifact registered yet, so
+# `--target mdux-bake-all` succeeds trivially rather than failing with "no such target".
+mdux_declare_bake_targets()
 
 # Build options
 option(MDUX_BUILD_EXAMPLES "Build MduX examples" ON)

--- a/cmake/MduXBake.cmake
+++ b/cmake/MduXBake.cmake
@@ -92,6 +92,14 @@ function(mdux_bake_artifact)
             "imported executable; declare it before registering this artifact.")
     endif()
 
+    foreach(component KIND ID)
+        if(NOT ARG_${component} MATCHES "^[a-z0-9][a-z0-9-]*$")
+            message(FATAL_ERROR
+                "mdux_bake_artifact: ${component} must be a lowercase slug containing only "
+                "letters, digits and '-' (got '${ARG_${component}}')")
+        endif()
+    endforeach()
+
     set(label "${ARG_KIND}/${ARG_ID}")
     set(target_name "bake-${ARG_KIND}-${ARG_ID}")
     set(baked_dir "${CMAKE_BINARY_DIR}/mdux_bake/${ARG_KIND}/${ARG_ID}")
@@ -104,12 +112,18 @@ function(mdux_bake_artifact)
 
     # Absolute paths for the outputs, all under the build tree - see the source-tree rule above.
     set(baked_outputs "")
+    set(seen_outputs "")
     foreach(output ${ARG_OUTPUTS})
-        if(IS_ABSOLUTE "${output}")
+        if(IS_ABSOLUTE "${output}" OR output MATCHES "[/\\\\]")
             message(FATAL_ERROR
-                "mdux_bake_artifact: OUTPUTS entries are file names relative to the artifact "
-                "directory, not absolute paths (got '${output}')")
+                "mdux_bake_artifact: OUTPUTS entries must be file names directly within the "
+                "artifact directory (got '${output}')")
         endif()
+        if(output IN_LIST seen_outputs)
+            message(FATAL_ERROR
+                "mdux_bake_artifact: duplicate OUTPUTS entry '${output}'")
+        endif()
+        list(APPEND seen_outputs "${output}")
         list(APPEND baked_outputs "${baked_dir}/${output}")
     endforeach()
 

--- a/cmake/MduXBake.cmake
+++ b/cmake/MduXBake.cmake
@@ -1,0 +1,170 @@
+# MduXBake.cmake
+#
+# The CMake surface every baker registers through, so adding an asset kind is one function call
+# rather than a new pile of custom commands (ADR-007).
+#
+# Usage:
+#   include(MduXBake)
+#   mdux_declare_bake_targets()          # once, before any mdux_bake_artifact() call
+#   ...
+#   mdux_bake_artifact(
+#       KIND    font
+#       ID      roboto-ui
+#       TOOL    MduX::fontbake
+#       RECIPE  recipes/font/roboto-ui.toml
+#       SOURCES assets/fonts/Roboto-Regular.ttf
+#       OUTPUTS package.json report.json atlas.bin)
+#
+# Each call registers three things:
+#
+#   1. A `bake-<kind>-<id>` target that writes to ${CMAKE_BINARY_DIR}/mdux_bake/<kind>/<id>/.
+#   2. A ctest `evidence.<kind>.<id>` with LABELS evidence, byte-comparing every output against
+#      generated/<kind>/<id>/.
+#   3. Membership in the aggregate targets `mdux-bake-all` and `mdux-bake-update`.
+#
+# ## Two labels, deliberately distinct
+#
+# The `evidence` label means exactly one thing: **a committed artifact is byte-identical to a
+# freshly baked one**. Nothing else carries it, so when `ctest -L evidence` fails in CI the
+# meaning is unambiguous - an artifact drifted from its recipe.
+#
+# The unit tests for the evidence modules themselves (digest, canonical JSON, bake report) use
+# `evidence-unit` instead. They run in the ordinary suite. Putting them under `evidence` would
+# mean a broken SHA-256 test and a drifted font atlas produced the same CI signal, which is
+# precisely the distinction the dedicated CI step exists to make.
+#
+# ## The source-tree rule, enforced by construction
+#
+# A normal build **never** writes into the source tree. It bakes into the build directory and
+# compares. `cmake --build <dir> --target mdux-bake-update` is the only path that copies
+# build-directory artifacts over `generated/`. An author runs it deliberately and commits the
+# diff; a reviewer reads that diff.
+#
+# This is not a convention that has to be remembered - the custom command's OUTPUT paths are all
+# under CMAKE_BINARY_DIR, so a baker cannot write into the source tree without someone editing
+# this file. It mirrors Cargo's OUT_DIR discipline, which MduX otherwise loses by having no
+# build.rs equivalent.
+#
+# ## Host-tool resolution
+#
+# TOOL is always a `MduX::<tool>` target. A cross-compiling build substitutes an imported
+# executable for the same name without any call site changing.
+
+set(_MDUX_COMPARE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/MduXCompareArtifacts.cmake")
+set(_MDUX_UPDATE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/MduXUpdateArtifacts.cmake")
+
+# Creates the aggregate targets. Separate from mdux_bake_artifact() so they exist even when no
+# artifact is registered yet - `cmake --build . --target mdux-bake-all` should succeed trivially
+# rather than fail with "no such target", which is what a contributor hits before the first
+# baker lands.
+function(mdux_declare_bake_targets)
+    if(TARGET mdux-bake-all)
+        return()
+    endif()
+    add_custom_target(mdux-bake-all
+        COMMENT "Baking every registered evidence artifact into the build tree")
+    add_custom_target(mdux-bake-update
+        COMMENT "Copying baked artifacts over generated/ - the only path that writes into the source tree")
+endfunction()
+
+function(mdux_bake_artifact)
+    set(options "")
+    set(single KIND ID TOOL RECIPE)
+    set(multi SOURCES OUTPUTS)
+    cmake_parse_arguments(ARG "${options}" "${single}" "${multi}" ${ARGN})
+
+    foreach(required KIND ID TOOL RECIPE OUTPUTS)
+        if(NOT ARG_${required})
+            message(FATAL_ERROR "mdux_bake_artifact: ${required} is required")
+        endif()
+    endforeach()
+    if(ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "mdux_bake_artifact: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
+    endif()
+    if(NOT TARGET mdux-bake-all)
+        message(FATAL_ERROR
+            "mdux_bake_artifact: call mdux_declare_bake_targets() before registering artifacts")
+    endif()
+    if(NOT TARGET ${ARG_TOOL})
+        message(FATAL_ERROR
+            "mdux_bake_artifact: TOOL '${ARG_TOOL}' is not a target. Host tools are resolved "
+            "through a MduX::<tool> target so a cross-compiling build can substitute an "
+            "imported executable; declare it before registering this artifact.")
+    endif()
+
+    set(label "${ARG_KIND}/${ARG_ID}")
+    set(target_name "bake-${ARG_KIND}-${ARG_ID}")
+    set(baked_dir "${CMAKE_BINARY_DIR}/mdux_bake/${ARG_KIND}/${ARG_ID}")
+    set(committed_dir "${CMAKE_SOURCE_DIR}/generated/${ARG_KIND}/${ARG_ID}")
+    set(recipe_path "${CMAKE_SOURCE_DIR}/${ARG_RECIPE}")
+
+    if(NOT EXISTS "${recipe_path}")
+        message(FATAL_ERROR "mdux_bake_artifact: recipe '${ARG_RECIPE}' does not exist")
+    endif()
+
+    # Absolute paths for the outputs, all under the build tree - see the source-tree rule above.
+    set(baked_outputs "")
+    foreach(output ${ARG_OUTPUTS})
+        if(IS_ABSOLUTE "${output}")
+            message(FATAL_ERROR
+                "mdux_bake_artifact: OUTPUTS entries are file names relative to the artifact "
+                "directory, not absolute paths (got '${output}')")
+        endif()
+        list(APPEND baked_outputs "${baked_dir}/${output}")
+    endforeach()
+
+    set(source_paths "")
+    foreach(source ${ARG_SOURCES})
+        if(IS_ABSOLUTE "${source}")
+            list(APPEND source_paths "${source}")
+        else()
+            list(APPEND source_paths "${CMAKE_SOURCE_DIR}/${source}")
+        endif()
+    endforeach()
+
+    # The baker runs with the source directory as its working directory, so every path it reads
+    # from the recipe and every path it records in report.json is repository-relative. That is
+    # what keeps a report free of absolute paths, which BakeReport::validate() rejects.
+    add_custom_command(
+        OUTPUT ${baked_outputs}
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${baked_dir}"
+        COMMAND ${ARG_TOOL} bake "${ARG_RECIPE}" "${baked_dir}"
+        DEPENDS ${ARG_TOOL} "${recipe_path}" ${source_paths}
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        COMMENT "Baking ${label}"
+        VERBATIM
+    )
+
+    # ALL, so an ordinary `cmake --build .` produces the artifacts the evidence tests compare.
+    # Without this the tests would pass or fail depending on whether someone had remembered to
+    # build a separate target first.
+    add_custom_target(${target_name} ALL DEPENDS ${baked_outputs})
+    add_dependencies(mdux-bake-all ${target_name})
+
+    add_custom_target(${target_name}-update
+        COMMAND "${CMAKE_COMMAND}"
+                -D "BAKED_DIR=${baked_dir}"
+                -D "COMMITTED_DIR=${committed_dir}"
+                -D "OUTPUTS=${ARG_OUTPUTS}"
+                -D "LABEL=${label}"
+                -P "${_MDUX_UPDATE_SCRIPT}"
+        DEPENDS ${baked_outputs}
+        COMMENT "Updating generated/${label} from the build tree"
+        VERBATIM
+    )
+    add_dependencies(mdux-bake-update ${target_name}-update)
+
+    # Old-style positional add_test(<name> <command> [args...]) rather than
+    # add_test(NAME ... COMMAND ...), matching the convention established in
+    # cmake/MduXTestDiscoveryImpl.cmake and the InstallTreeConsumer test - see the comment there
+    # for the CTest mis-parse that motivates it. Do not "modernize" without re-verifying.
+    add_test("evidence.${ARG_KIND}.${ARG_ID}"
+        "${CMAKE_COMMAND}"
+        -D "BAKED_DIR=${baked_dir}"
+        -D "COMMITTED_DIR=${committed_dir}"
+        -D "OUTPUTS=${ARG_OUTPUTS}"
+        -D "LABEL=${label}"
+        -P "${_MDUX_COMPARE_SCRIPT}"
+    )
+    set_tests_properties("evidence.${ARG_KIND}.${ARG_ID}" PROPERTIES LABELS "evidence")
+endfunction()

--- a/cmake/MduXCompareArtifacts.cmake
+++ b/cmake/MduXCompareArtifacts.cmake
@@ -1,0 +1,155 @@
+# MduXCompareArtifacts.cmake
+#
+# Script-mode (cmake -P) byte comparison of freshly-baked artifacts against the committed ones,
+# used by the `evidence`-labelled ctest that mdux_bake_artifact() registers (ADR-007).
+#
+# `cmake -E compare_files` would be enough to decide pass or fail, but its failure output is
+# just "files differ", which tells whoever broke a baker nothing about how. This reports the
+# first differing byte offset, both bytes, and the surrounding context - the difference between
+# "the artifact changed" and "the artifact changed at the atlas header's width field".
+#
+# Expected -D arguments:
+#   BAKED_DIR      directory the baker wrote into, under the build tree
+#   COMMITTED_DIR  the generated/<kind>/<id>/ directory tracked in git
+#   OUTPUTS        ';'-separated list of file names to compare
+#   LABEL          "<kind>/<id>", for messages
+#
+# The cheap check runs first: sizes, then a whole-file comparison. The hex scan that locates the
+# offset only runs on a file that has already been shown to differ, so the cost is paid on
+# failure and never on a passing build.
+
+if(NOT DEFINED BAKED_DIR OR NOT DEFINED COMMITTED_DIR OR NOT DEFINED OUTPUTS OR NOT DEFINED LABEL)
+    message(FATAL_ERROR "MduXCompareArtifacts: BAKED_DIR, COMMITTED_DIR, OUTPUTS and LABEL are all required")
+endif()
+
+# Bytes per window in the coarse scan. Chosen so the fine scan never loops more than this many
+# times, while the coarse scan stays a few hundred reads even on a large payload.
+set(_MDUX_COMPARE_WINDOW 65536)
+
+# Returns the offset of the first differing byte between two files known to differ.
+#
+# Scans in windows via file(READ ... OFFSET ... LIMIT ... HEX) rather than reading each file
+# whole. Reading the whole file and walking it with string(SUBSTRING) is quadratic - each
+# SUBSTRING call scans the multi-megabyte hex string from the start - and measured 8.3 s on a
+# 4 MiB payload whose difference was near the end. Windowed reads make it linear: the same case
+# measures 2.3 s, so a 40 MB model blob stays practical rather than timing out.
+#
+# This runs only after `cmake -E compare_files` has already established that the files differ, so
+# it is never on the passing path. It still has to be fast enough that a failing evidence test
+# reports rather than times out.
+function(_mdux_first_difference baked committed out_offset out_baked_byte out_committed_byte)
+    file(SIZE "${baked}" baked_size)
+    file(SIZE "${committed}" committed_size)
+    set(shortest ${baked_size})
+    if(committed_size LESS shortest)
+        set(shortest ${committed_size})
+    endif()
+
+    set(window_start 0)
+    set(found_window -1)
+    while(window_start LESS shortest)
+        math(EXPR remaining "${shortest} - ${window_start}")
+        set(take ${_MDUX_COMPARE_WINDOW})
+        if(remaining LESS take)
+            set(take ${remaining})
+        endif()
+        file(READ "${baked}" baked_window OFFSET ${window_start} LIMIT ${take} HEX)
+        file(READ "${committed}" committed_window OFFSET ${window_start} LIMIT ${take} HEX)
+        if(NOT baked_window STREQUAL committed_window)
+            set(found_window ${window_start})
+            break()
+        endif()
+        math(EXPR window_start "${window_start} + ${take}")
+    endwhile()
+
+    if(found_window LESS 0)
+        # No differing byte in the common prefix, so one file is a prefix of the other and the
+        # difference is the length itself.
+        set(${out_offset} ${shortest} PARENT_SCOPE)
+        set(${out_baked_byte} "<end of file>" PARENT_SCOPE)
+        set(${out_committed_byte} "<end of file>" PARENT_SCOPE)
+        return()
+    endif()
+
+    # Fine pass: byte by byte within the window just identified. Both hex strings are at most
+    # 2 * _MDUX_COMPARE_WINDOW characters, so SUBSTRING here is cheap.
+    string(LENGTH "${baked_window}" window_hex_length)
+    set(cursor 0)
+    while(cursor LESS window_hex_length)
+        string(SUBSTRING "${baked_window}" ${cursor} 2 baked_byte)
+        string(SUBSTRING "${committed_window}" ${cursor} 2 committed_byte)
+        if(NOT baked_byte STREQUAL committed_byte)
+            math(EXPR byte_offset "${found_window} + ${cursor} / 2")
+            set(${out_offset} ${byte_offset} PARENT_SCOPE)
+            set(${out_baked_byte} "0x${baked_byte}" PARENT_SCOPE)
+            set(${out_committed_byte} "0x${committed_byte}" PARENT_SCOPE)
+            return()
+        endif()
+        math(EXPR cursor "${cursor} + 2")
+    endwhile()
+
+    # Unreachable: the window compared unequal, so some byte in it differs. Reported rather than
+    # silently returning a wrong offset, because a wrong offset in a diagnostic is worse than none.
+    set(${out_offset} ${found_window} PARENT_SCOPE)
+    set(${out_baked_byte} "<unknown>" PARENT_SCOPE)
+    set(${out_committed_byte} "<unknown>" PARENT_SCOPE)
+endfunction()
+
+# Accumulated as a plain string with explicit newlines, never as a list: a CMake list uses ';'
+# as its separator, so any ';' inside a message would silently split it into two elements and be
+# lost when the list was joined back together (observed while testing this script).
+set(failures "")
+set(failure_count 0)
+
+foreach(output ${OUTPUTS})
+    set(baked "${BAKED_DIR}/${output}")
+    set(committed "${COMMITTED_DIR}/${output}")
+
+    if(NOT EXISTS "${baked}")
+        string(APPEND failures "  ${output}: the baker did not produce it at ${baked}\n")
+        math(EXPR failure_count "${failure_count} + 1")
+        continue()
+    endif()
+    if(NOT EXISTS "${committed}")
+        string(APPEND failures
+            "  ${output}: no committed copy at ${committed} - this artifact has never been "
+            "committed. Run 'cmake --build <dir> --target mdux-bake-update' and commit the "
+            "result.\n")
+        math(EXPR failure_count "${failure_count} + 1")
+        continue()
+    endif()
+
+    execute_process(
+        COMMAND "${CMAKE_COMMAND}" -E compare_files "${baked}" "${committed}"
+        RESULT_VARIABLE compare_result
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if(compare_result EQUAL 0)
+        continue()
+    endif()
+
+    file(SIZE "${baked}" baked_size)
+    file(SIZE "${committed}" committed_size)
+    _mdux_first_difference("${baked}" "${committed}" offset baked_byte committed_byte)
+    string(APPEND failures
+        "  ${output}: first differs at byte ${offset} - baked ${baked_byte}, committed "
+        "${committed_byte} (sizes: baked ${baked_size}, committed ${committed_size})\n")
+    math(EXPR failure_count "${failure_count} + 1")
+endforeach()
+
+if(failure_count GREATER 0)
+    message(FATAL_ERROR
+        "Evidence mismatch for ${LABEL}: the baked artifact is not byte-identical to the "
+        "committed one.\n"
+        "${failures}\n"
+        "\n"
+        "This means the committed artifact no longer corresponds to its recipe and sources, or "
+        "the baker's output changed. Neither is something to work around: re-bake deliberately "
+        "with\n"
+        "    cmake --build <build-dir> --target mdux-bake-update\n"
+        "then review the resulting diff and commit it. If the diff is unexpected, the baker "
+        "changed behaviour and that is the bug. See ADR-007.")
+endif()
+
+message(STATUS "Evidence OK for ${LABEL}: every output is byte-identical to the committed copy")

--- a/cmake/MduXUpdateArtifacts.cmake
+++ b/cmake/MduXUpdateArtifacts.cmake
@@ -1,0 +1,77 @@
+# MduXUpdateArtifacts.cmake
+#
+# Script-mode (cmake -P) copy of freshly-baked artifacts over the committed ones. This is the
+# body of the `mdux-bake-update` target, and it is the **only** path in the build that writes
+# into the source tree (ADR-007, decision 3).
+#
+# Keeping it in its own script rather than inlining a `cmake -E copy` per output does two things:
+# it can report what actually changed, so an author knows whether their edit had an effect, and
+# it keeps the source-tree write in one auditable place instead of scattered across every
+# mdux_bake_artifact() call site.
+#
+# Expected -D arguments:
+#   BAKED_DIR      directory the baker wrote into, under the build tree
+#   COMMITTED_DIR  the generated/<kind>/<id>/ directory tracked in git
+#   OUTPUTS        ';'-separated list of file names to copy
+#   LABEL          "<kind>/<id>", for messages
+
+if(NOT DEFINED BAKED_DIR OR NOT DEFINED COMMITTED_DIR OR NOT DEFINED OUTPUTS OR NOT DEFINED LABEL)
+    message(FATAL_ERROR "MduXUpdateArtifacts: BAKED_DIR, COMMITTED_DIR, OUTPUTS and LABEL are all required")
+endif()
+
+file(MAKE_DIRECTORY "${COMMITTED_DIR}")
+
+set(changed "")
+set(added "")
+
+foreach(output ${OUTPUTS})
+    set(baked "${BAKED_DIR}/${output}")
+    set(committed "${COMMITTED_DIR}/${output}")
+
+    if(NOT EXISTS "${baked}")
+        # LABEL is "<kind>/<id>"; the target that produces it is "bake-<kind>-<id>", so do not
+        # interpolate LABEL into a target name here.
+        string(REPLACE "/" "-" bake_target "bake-${LABEL}")
+        message(FATAL_ERROR
+            "mdux-bake-update: ${LABEL}/${output} was not produced at ${baked}. Build the "
+            "${bake_target} target first, or fix the baker.")
+    endif()
+
+    if(NOT EXISTS "${committed}")
+        list(APPEND added "${output}")
+    else()
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}" -E compare_files "${baked}" "${committed}"
+            RESULT_VARIABLE compare_result
+            OUTPUT_QUIET
+            ERROR_QUIET
+        )
+        if(NOT compare_result EQUAL 0)
+            list(APPEND changed "${output}")
+        endif()
+    endif()
+
+    # copy_if_different rather than copy, so an unchanged artifact keeps its mtime and does not
+    # look modified to the build system or to anything watching the tree.
+    execute_process(
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${baked}" "${committed}"
+        RESULT_VARIABLE copy_result
+    )
+    if(NOT copy_result EQUAL 0)
+        message(FATAL_ERROR "mdux-bake-update: failed to copy ${baked} to ${committed}")
+    endif()
+endforeach()
+
+if(added OR changed)
+    if(added)
+        string(REPLACE ";" ", " added_text "${added}")
+        message(STATUS "mdux-bake-update ${LABEL}: added ${added_text}")
+    endif()
+    if(changed)
+        string(REPLACE ";" ", " changed_text "${changed}")
+        message(STATUS "mdux-bake-update ${LABEL}: updated ${changed_text}")
+    endif()
+    message(STATUS "  review the diff under ${COMMITTED_DIR} and commit it")
+else()
+    message(STATUS "mdux-bake-update ${LABEL}: already up to date")
+endif()


### PR DESCRIPTION
## Summary
- Adds `cmake/MduXBake.cmake`: `mdux_bake_artifact(KIND ID TOOL RECIPE SOURCES OUTPUTS)` registers a `bake-<kind>-<id>` custom target (writes only under `${CMAKE_BINARY_DIR}/mdux_bake/`, never the source tree), an `evidence.<kind>.<id>` ctest (`LABELS evidence`) byte-comparing against `generated/<kind>/<id>/`, and membership in `mdux-bake-all`/`mdux-bake-update`.
- The source-tree rule from ADR-007 is enforced **by construction**: every custom-command output lives under the build directory, so a baker cannot write into `generated/` without someone editing this file. `cmake --build <dir> --target mdux-bake-update` is the only path that copies over it, via the new `MduXUpdateArtifacts.cmake`.
- `MduXCompareArtifacts.cmake` reports the **first differing byte offset** on mismatch, not just "files differ" — using windowed `file(READ ... OFFSET ... LIMIT ... HEX)` rather than reading the whole file into one hex string and walking it with `string(SUBSTRING)`. The naive version is quadratic: measured **8.3s** on a 4 MiB payload with the difference near the end; the windowed version measures **2.3s** on the same case.
- `mdux_declare_bake_targets()` is deliberately independent of `add_subdirectory(tools)` — this PR and the host-tools PR (#54) can land in either order.

## Test plan
End-to-end against these exact files, in an isolated CMake project with a stand-in baker (not the real fonts/shaders bakers, which don't exist yet — those land with issues #13-#18):
- [x] A normal build never writes into the source tree (`generated/` absent after `cmake --build`)
- [x] `ctest -L evidence` **fails** before `mdux-bake-update` runs, **passes** after
- [x] `mdux-bake-update` is idempotent (second run reports "already up to date")
- [x] Perturbing the baker's output is caught, with the byte offset verified correct at offset 0, mid-file, and 4194204 in a 4 MiB payload, plus the "one file is a prefix of the other" case
- [x] Changing the recipe re-triggers the bake (`DEPENDS` tracking works); a missing recipe is a **configure-time** `FATAL_ERROR`, not a build-time surprise
- [x] This branch's `CMakeLists.txt` state configured standalone against this repository (with a stub Vulkan package) — `mdux-bake-all`/`mdux-bake-update` exist and are buildable even with `tools/` not yet added (confirms the decoupling from #54 above)

Stacked on #82 (report + BuildInfo). Part of the #12 Evidence kernel stack (issue #53).
