### PR TITLE
S6 — tools/common/ (TOML subset and CLI)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,12 @@ target_link_libraries(MduX PRIVATE MduX_warnings)
 target_link_libraries(MduXCore PRIVATE MduX_warnings)
 
 # Subdirectories
+#
+# tools/ comes before tests/ so the test targets can link MduX::ToolsCommon. It is not gated on
+# an option: the bakers under tools/ are what produce every committed artifact, so a build that
+# skipped them could not run `ctest -L evidence` at all (ADR-007).
+add_subdirectory(tools)
+
 if(MDUX_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,36 @@ endif()
 
 mdux_discover_tests(evidence_tests)
 
+# Host-tools tests (ADR-004 host-tools zone). Links MduX::ToolsCommon, which is deliberately not
+# a governed target - these tests exercise code permitted to throw (ADR-005).
+add_executable(tools_tests
+    tools/ToolsTestMain.cpp
+    tools/TomlTests.cpp
+    tools/CliTests.cpp
+)
+
+target_sources(tools_tests PRIVATE FILE_SET CXX_MODULES FILES framework/MduXTest.cppm)
+target_link_libraries(tools_tests PRIVATE MduX::ToolsCommon)
+target_include_directories(tools_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(tools_tests
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(tools_tests PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(tools_tests PRIVATE /experimental:module)
+    target_compile_options(tools_tests PRIVATE /std:c++latest)
+endif()
+
+mdux_discover_tests(tools_tests)
+
 # Basic unit tests
 add_executable(unit_tests
     TestMain.cpp

--- a/tests/tools/CliTests.cpp
+++ b/tests/tools/CliTests.cpp
@@ -1,0 +1,253 @@
+/**
+ * @file CliTests.cpp
+ * @brief Tests for the host-tools mdux.tools.cli argument parser and diagnostic envelope.
+ *
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * The envelope's field names and JSON shape are asserted literally. They are a published
+ * contract that agents key off (issue #19, S3), so a reword must break a test rather than
+ * silently break a consumer.
+ */
+
+import std;
+import mdux.tools.cli;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+
+using namespace mdux::tools::cli;
+
+namespace {
+
+constexpr std::string_view kTool = "mdux-fontbake";
+
+[[nodiscard]] std::optional<Invocation> parsedOk(std::vector<std::string_view> arguments) {
+    try {
+        return parse(kTool, arguments);
+    } catch (const UsageError& error) {
+        CHECK_MESSAGE(false, std::string{"unexpected UsageError: "} + error.what());
+        return std::nullopt;
+    }
+}
+
+void expectUsageError(std::vector<std::string_view> arguments, std::string_view expectedMention) {
+    try {
+        (void)parse(kTool, arguments);
+        CHECK_MESSAGE(false, "expected a UsageError");
+    } catch (const UsageError& error) {
+        const std::string message = error.what();
+        CHECK_MESSAGE(message.find(expectedMention) != std::string::npos,
+                      "message should mention '" + std::string{expectedMention} + "', got: " +
+                          message);
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+TEST_CASE("bake takes a recipe and an output directory", "evidence-unit") {
+    const auto invocation = parsedOk({"bake", "recipes/font/roboto-ui.toml", "build/mdux_bake"});
+    REQUIRE(invocation.has_value());
+    CHECK(invocation->mode == Mode::Bake);
+    CHECK(invocation->format == Format::Text);
+    CHECK(invocation->bake.recipe == "recipes/font/roboto-ui.toml");
+    CHECK(invocation->bake.outputDir == "build/mdux_bake");
+}
+
+TEST_CASE("verify takes a recipe and the two committed files", "evidence-unit") {
+    const auto invocation = parsedOk({"verify", "recipes/font/roboto-ui.toml",
+                                      "generated/font/roboto-ui/package.json",
+                                      "generated/font/roboto-ui/report.json"});
+    REQUIRE(invocation.has_value());
+    CHECK(invocation->mode == Mode::Verify);
+    CHECK(invocation->verify.recipe == "recipes/font/roboto-ui.toml");
+    CHECK(invocation->verify.packagePath == "generated/font/roboto-ui/package.json");
+    CHECK(invocation->verify.reportPath == "generated/font/roboto-ui/report.json");
+}
+
+TEST_CASE("--format is accepted before, between and after positionals", "evidence-unit") {
+    for (const std::vector<std::string_view> arguments :
+         {std::vector<std::string_view>{"--format=json", "bake", "r.toml", "out"},
+          std::vector<std::string_view>{"bake", "--format=json", "r.toml", "out"},
+          std::vector<std::string_view>{"bake", "r.toml", "out", "--format=json"}}) {
+        const auto invocation = parsedOk(arguments);
+        REQUIRE(invocation.has_value());
+        CHECK(invocation->format == Format::Json);
+        CHECK(invocation->bake.recipe == "r.toml");
+        CHECK(invocation->bake.outputDir == "out");
+    }
+
+    const auto text = parsedOk({"bake", "r.toml", "out", "--format=text"});
+    REQUIRE(text.has_value());
+    CHECK(text->format == Format::Text);
+}
+
+TEST_CASE("The argc/argv overload skips argv[0]", "evidence-unit") {
+    const std::array<const char*, 4> argv{"/usr/local/bin/mdux-fontbake", "bake", "r.toml", "out"};
+    const auto invocation = parse(kTool, static_cast<int>(argv.size()), argv.data());
+    CHECK(invocation.mode == Mode::Bake);
+    CHECK(invocation.bake.recipe == "r.toml");
+}
+
+// ---------------------------------------------------------------------------
+// Usage errors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Usage errors name what was wrong and print the usage text", "evidence-unit") {
+    expectUsageError({}, "expected a subcommand");
+    expectUsageError({"build", "r.toml", "out"}, "unrecognized subcommand 'build'");
+    expectUsageError({"bake"}, "bake takes exactly 2 arguments");
+    expectUsageError({"bake", "r.toml"}, "got 1");
+    expectUsageError({"bake", "r.toml", "out", "extra"}, "got 3");
+    expectUsageError({"verify", "r.toml", "p.json"}, "verify takes exactly 3 arguments");
+    expectUsageError({"--wat", "bake", "r.toml", "out"}, "unrecognized option '--wat'");
+    expectUsageError({"bake", "r.toml", "out", "--format=xml"},
+                     "unrecognized --format value 'xml'");
+    // The space-separated spelling gets its own message rather than "unrecognized option".
+    expectUsageError({"bake", "r.toml", "out", "--format", "json"}, "takes its value with '='");
+
+    // Every usage error carries the usage text, so a caller has one place to print it.
+    expectUsageError({}, "mdux-fontbake bake   <recipe> <output-dir>");
+}
+
+TEST_CASE("--help is a UsageError carrying the usage text", "evidence-unit") {
+    for (const std::string_view flag : {"--help", "-h"}) {
+        try {
+            (void)parse(kTool, std::vector<std::string_view>{flag});
+            CHECK_MESSAGE(false, "expected --help to throw");
+        } catch (const UsageError& error) {
+            CHECK(std::string{error.what()} == usage(kTool));
+        }
+    }
+}
+
+TEST_CASE("usage() documents both subcommands and both options", "evidence-unit") {
+    const std::string text = usage(kTool);
+    CHECK(text.find("mdux-fontbake bake   <recipe> <output-dir>") != std::string::npos);
+    CHECK(text.find("mdux-fontbake verify <recipe> <package.json> <report.json>") !=
+          std::string::npos);
+    CHECK(text.find("--format=json|text") != std::string::npos);
+    CHECK(text.find("--help") != std::string::npos);
+    // States the rule a baker author most needs to know.
+    CHECK(text.find("verify") != std::string::npos);
+    CHECK(text.find("writing nothing") != std::string::npos);
+    CHECK(text.find("ADR-007") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// The diagnostic envelope
+// ---------------------------------------------------------------------------
+
+TEST_CASE("JSON diagnostics use the published envelope shape", "evidence-unit") {
+    const std::vector<Diagnostic> diagnostics{
+        Diagnostic{.file = "recipes/font/roboto-ui.toml",
+                   .line = 7,
+                   .code = "FB001",
+                   .severity = Severity::Error,
+                   .message = "glyph budget exceeded",
+                   .fixHint = "raise atlasWidth or reduce the charset"},
+    };
+
+    CHECK(render(diagnostics, Format::Json, kTool) ==
+          "{\n"
+          "  \"tool\": \"mdux-fontbake\",\n"
+          "  \"findings\": [\n"
+          "    {\n"
+          "      \"file\": \"recipes/font/roboto-ui.toml\",\n"
+          "      \"line\": 7,\n"
+          "      \"code\": \"FB001\",\n"
+          "      \"severity\": \"error\",\n"
+          "      \"message\": \"glyph budget exceeded\",\n"
+          "      \"fixHint\": \"raise atlasWidth or reduce the charset\"\n"
+          "    }\n"
+          "  ]\n"
+          "}\n");
+}
+
+TEST_CASE("JSON diagnostics separate multiple findings with a comma", "evidence-unit") {
+    const std::vector<Diagnostic> diagnostics{
+        Diagnostic{.file = "a.toml", .line = 1, .code = "A", .message = "first"},
+        Diagnostic{.file = "b.toml", .line = 2, .code = "B", .message = "second"},
+    };
+    const std::string json = render(diagnostics, Format::Json, kTool);
+    CHECK(json.find("    },\n    {\n") != std::string::npos);
+    CHECK(json.find("\"message\": \"first\"") != std::string::npos);
+    CHECK(json.find("\"message\": \"second\"") != std::string::npos);
+}
+
+TEST_CASE("An empty finding list still produces a well-formed envelope", "evidence-unit") {
+    // A consumer must not have to special-case success; it parses the same shape either way.
+    CHECK(render({}, Format::Json, kTool) ==
+          "{\n"
+          "  \"tool\": \"mdux-fontbake\",\n"
+          "  \"findings\": []\n"
+          "}\n");
+    CHECK(render({}, Format::Text, kTool).empty());
+}
+
+TEST_CASE("JSON diagnostics escape what would otherwise break the envelope", "evidence-unit") {
+    const std::vector<Diagnostic> diagnostics{
+        Diagnostic{.file = "a\"b.toml",
+                   .line = 1,
+                   .code = "X",
+                   .message = "line one\nline two\ttabbed",
+                   .fixHint = "use a backslash: \\"},
+    };
+    const std::string json = render(diagnostics, Format::Json, kTool);
+    CHECK(json.find("\"file\": \"a\\\"b.toml\"") != std::string::npos);
+    CHECK(json.find("line one\\nline two\\ttabbed") != std::string::npos);
+    CHECK(json.find("use a backslash: \\\\") != std::string::npos);
+    // A raw newline inside a JSON string would make the envelope unparseable.
+    const std::size_t messageStart = json.find("\"message\":");
+    REQUIRE(messageStart != std::string::npos);
+    CHECK(json.find('\n', messageStart) > json.find("tabbed"));
+}
+
+TEST_CASE("Text diagnostics follow the file:line: severity: [code] message convention",
+          "evidence-unit") {
+    const std::vector<Diagnostic> diagnostics{
+        Diagnostic{.file = "recipes/font/roboto-ui.toml",
+                   .line = 7,
+                   .code = "FB001",
+                   .severity = Severity::Error,
+                   .message = "glyph budget exceeded",
+                   .fixHint = "raise atlasWidth"},
+        Diagnostic{.file = "recipes/font/roboto-ui.toml",
+                   .line = 0,
+                   .code = "FB002",
+                   .severity = Severity::Warning,
+                   .message = "charset has no digits"},
+    };
+
+    CHECK(render(diagnostics, Format::Text, kTool) ==
+          "recipes/font/roboto-ui.toml:7: error: [FB001] glyph budget exceeded\n"
+          "    fix: raise atlasWidth\n"
+          "recipes/font/roboto-ui.toml: warning: [FB002] charset has no digits\n");
+}
+
+TEST_CASE("Severity names are stable", "evidence-unit") {
+    // These strings are part of the published envelope; renaming one breaks consumers.
+    CHECK(describe(Severity::Error) == "error");
+    CHECK(describe(Severity::Warning) == "warning");
+    CHECK(describe(Severity::Note) == "note");
+}
+
+TEST_CASE("exitStatus fails only on an error", "evidence-unit") {
+    CHECK(exitStatus({}) == 0);
+
+    const std::vector<Diagnostic> warningOnly{
+        Diagnostic{.file = "a", .severity = Severity::Warning, .message = "w"},
+        Diagnostic{.file = "b", .severity = Severity::Note, .message = "n"},
+    };
+    // A warning alone must not fail a bake - only CI's byte-comparison decides that.
+    CHECK(exitStatus(warningOnly) == 0);
+
+    const std::vector<Diagnostic> withError{
+        Diagnostic{.file = "a", .severity = Severity::Warning, .message = "w"},
+        Diagnostic{.file = "b", .severity = Severity::Error, .message = "e"},
+    };
+    CHECK(exitStatus(withError) == 1);
+}

--- a/tests/tools/TomlTests.cpp
+++ b/tests/tools/TomlTests.cpp
@@ -1,0 +1,341 @@
+/**
+ * @file TomlTests.cpp
+ * @brief Tests for the host-tools mdux.tools.toml recipe reader.
+ *
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * The rejection tests carry as much weight as the acceptance tests. A parser that quietly
+ * accepted a feature outside the subset would let a recipe be written that only some future
+ * version of the tool understands, which is exactly the drift the narrow scope prevents.
+ */
+
+import std;
+import mdux.tools.toml;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+
+using namespace mdux::tools::toml;
+
+namespace {
+
+/// Parses `text`, or fails the test with the recipe error rather than propagating it.
+[[nodiscard]] std::optional<Document> parsed(std::string_view text) {
+    try {
+        return parse(text);
+    } catch (const TomlError& error) {
+        CHECK_MESSAGE(false, "unexpected TomlError at line " + std::to_string(error.line()) + ": " +
+                                 error.what());
+        return std::nullopt;
+    }
+}
+
+/// Asserts `text` is rejected, and that the message mentions `expectedMention` - so a test
+/// pinning down "outside this subset" cannot pass on an unrelated syntax error.
+void expectRejected(std::string_view text, std::string_view expectedMention,
+                    std::size_t expectedLine = 0) {
+    try {
+        (void)parse(text);
+        CHECK_MESSAGE(false, "expected rejection for: " + std::string{text});
+    } catch (const TomlError& error) {
+        const std::string message = error.what();
+        CHECK_MESSAGE(message.find(expectedMention) != std::string::npos,
+                      "message '" + message + "' should mention '" +
+                          std::string{expectedMention} + "'");
+        if (expectedLine != 0) {
+            CHECK_MESSAGE(error.line() == expectedLine,
+                          "expected line " + std::to_string(expectedLine) + ", got " +
+                              std::to_string(error.line()));
+        }
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The supported subset
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Root-level key/value pairs of every supported type parse", "evidence-unit") {
+    const auto document = parsed(R"(
+name = "roboto-ui"
+atlasWidth = 512
+offset = -17
+hinting = false
+antialias = true
+locales = ["en", "fr", "de"]
+sizes = [11, 13, 17]
+)");
+    REQUIRE(document.has_value());
+    const Table& root = document->root();
+
+    CHECK(root.require("name").asString() == "roboto-ui");
+    CHECK(root.require("atlasWidth").asInteger() == 512);
+    CHECK(root.require("offset").asInteger() == -17);
+    CHECK(root.require("hinting").asBoolean() == false);
+    CHECK(root.require("antialias").asBoolean() == true);
+    // Hoisted into locals: a braced initializer inside CHECK() would split on its commas and
+    // be read as extra macro arguments.
+    const std::vector<std::string> expectedLocales{"en", "fr", "de"};
+    const std::vector<std::int64_t> expectedSizes{11, 13, 17};
+    CHECK(root.require("locales").asStringArray() == expectedLocales);
+    CHECK(root.require("sizes").asIntegerArray() == expectedSizes);
+}
+
+TEST_CASE("Tables are flat and keep their own keys", "evidence-unit") {
+    const auto document = parsed(R"(
+kind = "font"
+
+[atlas]
+width = 512
+height = 512
+
+[metrics]
+tabularFigures = true
+)");
+    REQUIRE(document.has_value());
+
+    CHECK(document->root().require("kind").asString() == "font");
+    REQUIRE(document->tables().size() == 2);
+
+    const Table& atlas = document->requireTable("atlas");
+    CHECK(atlas.require("width").asInteger() == 512);
+    CHECK(atlas.require("height").asInteger() == 512);
+    // A key in one table is not visible from another, nor from the root.
+    CHECK(atlas.find("tabularFigures") == nullptr);
+    CHECK(document->root().find("width") == nullptr);
+
+    CHECK(document->requireTable("metrics").require("tabularFigures").asBoolean());
+    CHECK(document->table("absent") == nullptr);
+}
+
+TEST_CASE("Comments, blank lines and surrounding whitespace are ignored", "evidence-unit") {
+    const auto document = parsed(R"(
+# a leading comment
+
+  name = "x"   # trailing comment
+
+	[atlas]	# comment after a header
+  width  =  512
+)");
+    REQUIRE(document.has_value());
+    CHECK(document->root().require("name").asString() == "x");
+    CHECK(document->requireTable("atlas").require("width").asInteger() == 512);
+}
+
+TEST_CASE("A '#' inside a string is not a comment", "evidence-unit") {
+    const auto document = parsed(R"(
+label = "shade #3"
+escaped = "quote \" then # hash"
+)");
+    REQUIRE(document.has_value());
+    CHECK(document->root().require("label").asString() == "shade #3");
+    CHECK(document->root().require("escaped").asString() == "quote \" then # hash");
+}
+
+TEST_CASE("String escapes are decoded", "evidence-unit") {
+    const auto document = parsed(R"(
+escapes = "a\tb\nc\\d\"e"
+unicode = "é\U0001F600"
+)");
+    REQUIRE(document.has_value());
+    CHECK(document->root().require("escapes").asString() == "a\tb\nc\\d\"e");
+    CHECK(document->root().require("unicode").asString() == "é\U0001F600");
+}
+
+TEST_CASE("Arrays may span lines, nest, be empty, and carry a trailing comma", "evidence-unit") {
+    const auto document = parsed(R"(
+empty = []
+multiline = [
+  "en",
+  "fr",   # a comment inside the array
+  "de",
+]
+nested = [[1, 2], [3]]
+)");
+    REQUIRE(document.has_value());
+
+    const std::vector<std::string> expectedLocales{"en", "fr", "de"};
+    const std::vector<std::int64_t> expectedFirst{1, 2};
+    const std::vector<std::int64_t> expectedSecond{3};
+
+    CHECK(document->root().require("empty").asArray().empty());
+    CHECK(document->root().require("multiline").asStringArray() == expectedLocales);
+
+    const std::span<const Value> nested = document->root().require("nested").asArray();
+    REQUIRE(nested.size() == 2);
+    CHECK(nested[0].asIntegerArray() == expectedFirst);
+    CHECK(nested[1].asIntegerArray() == expectedSecond);
+}
+
+TEST_CASE("Integer bounds are handled exactly", "evidence-unit") {
+    const auto document = parsed(R"(
+max = 9223372036854775807
+min = -9223372036854775808
+zero = 0
+positive = +5
+)");
+    REQUIRE(document.has_value());
+    CHECK(document->root().require("max").asInteger() ==
+          std::numeric_limits<std::int64_t>::max());
+    CHECK(document->root().require("min").asInteger() ==
+          std::numeric_limits<std::int64_t>::min());
+    CHECK(document->root().require("zero").asInteger() == 0);
+    CHECK(document->root().require("positive").asInteger() == 5);
+}
+
+TEST_CASE("An empty document is valid", "evidence-unit") {
+    const auto document = parsed("");
+    REQUIRE(document.has_value());
+    CHECK(document->root().entries().empty());
+    CHECK(document->tables().empty());
+
+    const auto commentsOnly = parsed("# nothing but a comment\n\n# and another\n");
+    REQUIRE(commentsOnly.has_value());
+    CHECK(commentsOnly->root().entries().empty());
+}
+
+// ---------------------------------------------------------------------------
+// Outside the subset
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Floats are rejected with a message pointing at the bit-pattern rule", "evidence-unit") {
+    // The ADR-007 rule surfaced where a recipe author will actually meet it.
+    expectRejected("pixelSize = 13.5\n", "floats are rejected", 1);
+    expectRejected("scale = 1e5\n", "floats are rejected", 1);
+    expectRejected("scale = 1E5\n", "floats are rejected", 1);
+    // The message must say what to do instead, not merely that it failed.
+    try {
+        (void)parse("pixelSize = 13.5\n");
+    } catch (const TomlError& error) {
+        const std::string message = error.what();
+        CHECK(message.find("bit pattern") != std::string::npos);
+        CHECK(message.find("ADR-007") != std::string::npos);
+    }
+}
+
+TEST_CASE("Features outside the subset are named in the diagnostic", "evidence-unit") {
+    expectRejected("a.b = 1\n", "dotted key", 1);
+    expectRejected("[font.atlas]\n", "dotted table name", 1);
+    expectRejected("[[products]]\n", "arrays of tables", 1);
+    expectRejected("point = { x = 1 }\n", "inline tables", 1);
+    expectRejected("name = 'literal'\n", "literal", 1);
+    expectRejected("\"quoted\" = 1\n", "quoted key", 1);
+    expectRejected("mask = 0xff\n", "hexadecimal", 1);
+    expectRejected("mask = 0o17\n", "hexadecimal", 1);
+    expectRejected("mask = 0b1010\n", "hexadecimal", 1);
+    expectRejected("count = 1_000\n", "digit separators", 1);
+    expectRejected("when = 1979-05-27\n", "datetimes", 1);
+}
+
+TEST_CASE("Malformed syntax is rejected on the offending line", "evidence-unit") {
+    expectRejected("name = \"x\"\nbroken\n", "expected 'key = value'", 2);
+    expectRejected("[atlas\n", "closing ']'", 1);
+    expectRejected("name = \"unterminated\n", "not terminated", 1);
+    expectRejected("name = \n", "expected a value", 1);
+    expectRejected("= 1\n", "key is empty", 1);
+    expectRejected("name = \"x\" extra\n", "unexpected text after the value", 1);
+    expectRejected("list = [1, 2\n", "not terminated", 1);
+    expectRejected("list = [1 2]\n", "expected ',' or ']'", 1);
+    expectRejected("name = maybe\n", "unrecognized value", 1);
+    expectRejected("key! = 1\n", "outside [A-Za-z0-9_-]", 1);
+    expectRejected("name = \"bad\\qescape\"\n", "unrecognized escape", 1);
+}
+
+TEST_CASE("Integers outside 64-bit range are rejected", "evidence-unit") {
+    expectRejected("n = 9223372036854775808\n", "does not fit", 1);
+    expectRejected("n = -9223372036854775809\n", "does not fit", 1);
+    expectRejected("n = 99999999999999999999999\n", "does not fit", 1);
+}
+
+TEST_CASE("Duplicate keys and tables are rejected rather than overwritten", "evidence-unit") {
+    // Taking the last value silently is how an author's intent gets lost, and in a pipeline
+    // whose whole point is reproducibility, an ambiguous recipe is not acceptable input.
+    expectRejected("a = 1\na = 2\n", "duplicate key", 2);
+    expectRejected("[t]\na = 1\na = 2\n", "duplicate key", 3);
+    expectRejected("[t]\nx = 1\n[t]\ny = 2\n", "duplicate table", 3);
+
+    // The same key in two different tables is fine.
+    const auto document = parsed("[a]\nwidth = 1\n\n[b]\nwidth = 2\n");
+    REQUIRE(document.has_value());
+    CHECK(document->requireTable("a").require("width").asInteger() == 1);
+    CHECK(document->requireTable("b").require("width").asInteger() == 2);
+}
+
+TEST_CASE("Line numbers survive multi-line arrays", "evidence-unit") {
+    // An off-by-one here would send a recipe author to the wrong line, which is the main thing
+    // a diagnostic must not do.
+    expectRejected("a = [\n 1,\n 2,\n]\nbroken\n", "expected 'key = value'", 5);
+}
+
+// ---------------------------------------------------------------------------
+// Typed accessors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Accessors report the expected and actual type", "evidence-unit") {
+    const auto document = parsed("text = \"x\"\nnumber = 1\nflag = true\nlist = [1]\n");
+    REQUIRE(document.has_value());
+    const Table& root = document->root();
+
+    const auto expectTypeError = [](auto&& call, std::string_view expected) {
+        try {
+            call();
+            CHECK_MESSAGE(false, "expected a type error");
+        } catch (const TomlError& error) {
+            const std::string message = error.what();
+            CHECK_MESSAGE(message.find(expected) != std::string::npos,
+                          "message '" + message + "' should mention '" + std::string{expected} +
+                              "'");
+        }
+    };
+
+    expectTypeError([&] { return root.require("text").asInteger(); }, "expected an integer");
+    expectTypeError([&] { return root.require("number").asString(); }, "expected a string");
+    expectTypeError([&] { return root.require("flag").asArray(); }, "expected an array");
+    expectTypeError([&] { return root.require("list").asBoolean(); }, "expected a boolean");
+    // And the actual type is named too, not just the expected one.
+    expectTypeError([&] { return root.require("text").asInteger(); }, "found a string");
+}
+
+TEST_CASE("Array accessors name the offending element index", "evidence-unit") {
+    const auto document = parsed("mixed = [\"a\", 2, \"c\"]\n");
+    REQUIRE(document.has_value());
+    try {
+        (void)document->root().require("mixed").asStringArray();
+        CHECK_MESSAGE(false, "expected a type error");
+    } catch (const TomlError& error) {
+        const std::string message = error.what();
+        CHECK(message.find("element 1") != std::string::npos);
+        CHECK(message.find("expected a string") != std::string::npos);
+    }
+}
+
+TEST_CASE("require() names the missing key or table", "evidence-unit") {
+    const auto document = parsed("[atlas]\nwidth = 1\n");
+    REQUIRE(document.has_value());
+
+    try {
+        (void)document->requireTable("atlas").require("height");
+        CHECK_MESSAGE(false, "expected a missing-key error");
+    } catch (const TomlError& error) {
+        CHECK(std::string{error.what()}.find("height") != std::string::npos);
+        // The line reported is the table's header, which is where an author adds the key.
+        CHECK(error.line() == 1);
+    }
+
+    try {
+        (void)document->requireTable("metrics");
+        CHECK_MESSAGE(false, "expected a missing-table error");
+    } catch (const TomlError& error) {
+        CHECK(std::string{error.what()}.find("[metrics]") != std::string::npos);
+    }
+}
+
+TEST_CASE("Values carry the line they were written on", "evidence-unit") {
+    const auto document = parsed("a = 1\n\nb = 2\n\n[t]\nc = 3\n");
+    REQUIRE(document.has_value());
+    CHECK(document->root().require("a").line() == 1);
+    CHECK(document->root().require("b").line() == 3);
+    CHECK(document->requireTable("t").line() == 5);
+    CHECK(document->requireTable("t").require("c").line() == 6);
+}

--- a/tests/tools/ToolsTestMain.cpp
+++ b/tests/tools/ToolsTestMain.cpp
@@ -1,0 +1,16 @@
+/**
+ * @brief Entry point for the host-tools test executable (MduXTest framework).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Separate from evidence_tests because these tests exercise the host-tools zone, which links
+ * MduXToolsCommon rather than MduX::Core and is permitted to throw (ADR-005).
+ */
+
+import std;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+
+MDUX_TEST_MAIN("MduX Host Tools Tests")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Host tools (ADR-004 host-tools zone)
+#
+# Nothing here is ever linked into MduXCore or MduX, so this code may use exceptions freely
+# (ADR-005) and may depend on parsers that must not reach a device build (ADR-007). The
+# trust-zone check enforces the boundary from the other side: MduXToolsCommon is deliberately
+# *not* declared governed, so linking it from a governed target is a configure-time FATAL_ERROR.
+#
+# MduXToolsCommon is the shared infrastructure every baker uses:
+#   mdux.tools.toml - the TOML-subset recipe reader
+#   mdux.tools.cli  - argument parsing and the shared diagnostic envelope
+#
+# It links MduX::Core because bakers build artifacts through the governed evidence modules
+# (digest, canonical JSON, bake report). That direction is fine and is the intended one: tools may
+# depend on governed code, never the reverse.
+
+add_library(MduXToolsCommon)
+add_library(MduX::ToolsCommon ALIAS MduXToolsCommon)
+
+target_sources(MduXToolsCommon
+    PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES
+            common/Toml.cppm
+            common/Cli.cppm
+    PRIVATE
+        common/Toml.cpp
+        common/Cli.cpp
+)
+
+target_compile_features(MduXToolsCommon PUBLIC cxx_std_23)
+target_link_libraries(MduXToolsCommon PUBLIC MduX::Core)
+target_link_libraries(MduXToolsCommon PRIVATE MduX_warnings)
+
+# Provenance for every report a baker writes (ADR-007, decision 5). PUBLIC so a baker linking
+# MduXToolsCommon gets MDUX_TOOL_VERSION and MDUX_GIT_SHA without repeating this.
+target_link_libraries(MduXToolsCommon PUBLIC MduX::BuildInfo)
+
+set_target_properties(MduXToolsCommon
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(MduXToolsCommon PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(MduXToolsCommon PRIVATE /experimental:module /std:c++latest)
+endif()

--- a/tools/common/Cli.cpp
+++ b/tools/common/Cli.cpp
@@ -1,0 +1,216 @@
+/**
+ * @file Cli.cpp
+ * @brief Implementation of the shared baker CLI and diagnostic envelope.
+ *
+ * @compliance ADR-004 Trust zones in C++
+ * @compliance ADR-005 Error handling and exceptions policy
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * The JSON rendering here is hand-written rather than going through
+ * mdux.evidence.json's canonical writer, and that is deliberate: this output is a diagnostic
+ * stream for humans and agents, not an artifact. It is never hashed, never committed, and never
+ * compared byte-for-byte, so it does not need canonical form - and coupling a tool's error
+ * reporting to the artifact writer would mean a bug in the writer could suppress the diagnostic
+ * explaining it.
+ */
+module;
+
+module mdux.tools.cli;
+
+import std;
+
+namespace mdux::tools::cli {
+
+namespace {
+
+/// Minimal JSON string escaping for diagnostic output.
+[[nodiscard]] std::string escape(std::string_view text) {
+    std::string out;
+    out.reserve(text.size() + 2);
+    for (const char c : text) {
+        switch (c) {
+        case '"':  out += "\\\""; break;
+        case '\\': out += "\\\\"; break;
+        case '\b': out += "\\b"; break;
+        case '\f': out += "\\f"; break;
+        case '\n': out += "\\n"; break;
+        case '\r': out += "\\r"; break;
+        case '\t': out += "\\t"; break;
+        default:
+            if (static_cast<unsigned char>(c) < 0x20) {
+                constexpr std::string_view digits = "0123456789abcdef";
+                const auto value = static_cast<unsigned char>(c);
+                out += "\\u00";
+                out.push_back(digits[(value >> 4) & 0x0fu]);
+                out.push_back(digits[value & 0x0fu]);
+            } else {
+                out.push_back(c);
+            }
+            break;
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+std::string_view describe(Severity severity) noexcept {
+    switch (severity) {
+    case Severity::Error:   return "error";
+    case Severity::Warning: return "warning";
+    case Severity::Note:    return "note";
+    }
+    return "error";
+}
+
+std::string usage(std::string_view toolName) {
+    std::string name{toolName};
+    return "usage:\n"
+           "  " + name + " bake   <recipe> <output-dir>\n"
+           "  " + name + " verify <recipe> <package.json> <report.json>\n"
+           "\n"
+           "options:\n"
+           "  --format=json|text   diagnostic output format (default: text)\n"
+           "  --help               print this message\n"
+           "\n"
+           "bake writes the artifact into <output-dir>. verify produces the same artifact and\n"
+           "compares it against the given committed files, writing nothing. A normal build only\n"
+           "ever runs verify; see ADR-007.\n";
+}
+
+Invocation parse(std::string_view toolName, std::span<const std::string_view> arguments) {
+    Invocation invocation;
+
+    // Separate options from positionals in one pass, so --format may appear anywhere.
+    std::vector<std::string_view> positional;
+    for (const std::string_view argument : arguments) {
+        if (argument == "--help" || argument == "-h") {
+            throw UsageError{usage(toolName)};
+        }
+        if (argument.starts_with("--format=")) {
+            const std::string_view value = argument.substr(std::string_view{"--format="}.size());
+            if (value == "json") {
+                invocation.format = Format::Json;
+            } else if (value == "text") {
+                invocation.format = Format::Text;
+            } else {
+                throw UsageError{"unrecognized --format value '" + std::string{value} +
+                                 "'; expected 'json' or 'text'\n\n" + usage(toolName)};
+            }
+            continue;
+        }
+        if (argument.starts_with("--format")) {
+            // Catch the space-separated spelling explicitly rather than letting "--format" fall
+            // through to the unknown-option branch, whose message would be less useful.
+            throw UsageError{"--format takes its value with '=', as --format=json\n\n" +
+                             usage(toolName)};
+        }
+        if (argument.starts_with("-") && argument != "-") {
+            throw UsageError{"unrecognized option '" + std::string{argument} + "'\n\n" +
+                             usage(toolName)};
+        }
+        positional.push_back(argument);
+    }
+
+    if (positional.empty()) {
+        throw UsageError{"expected a subcommand\n\n" + usage(toolName)};
+    }
+
+    const std::string_view subcommand = positional.front();
+    const std::span<const std::string_view> rest{positional.begin() + 1, positional.end()};
+
+    if (subcommand == "bake") {
+        if (rest.size() != 2) {
+            throw UsageError{"bake takes exactly 2 arguments (<recipe> <output-dir>), got " +
+                             std::to_string(rest.size()) + "\n\n" + usage(toolName)};
+        }
+        invocation.mode = Mode::Bake;
+        invocation.bake = BakeArguments{.recipe = std::string{rest[0]},
+                                        .outputDir = std::string{rest[1]}};
+        return invocation;
+    }
+
+    if (subcommand == "verify") {
+        if (rest.size() != 3) {
+            throw UsageError{
+                "verify takes exactly 3 arguments (<recipe> <package.json> <report.json>), got " +
+                std::to_string(rest.size()) + "\n\n" + usage(toolName)};
+        }
+        invocation.mode = Mode::Verify;
+        invocation.verify = VerifyArguments{.recipe = std::string{rest[0]},
+                                            .packagePath = std::string{rest[1]},
+                                            .reportPath = std::string{rest[2]}};
+        return invocation;
+    }
+
+    throw UsageError{"unrecognized subcommand '" + std::string{subcommand} +
+                     "'; expected 'bake' or 'verify'\n\n" + usage(toolName)};
+}
+
+Invocation parse(std::string_view toolName, int argc, const char* const* argv) {
+    std::vector<std::string_view> arguments;
+    // argv[0] is the program name; the tool name is passed explicitly so a renamed or wrapped
+    // executable still reports the name its diagnostics are keyed to.
+    for (int i = 1; i < argc; ++i) {
+        arguments.emplace_back(argv[i]);
+    }
+    return parse(toolName, arguments);
+}
+
+std::string render(std::span<const Diagnostic> diagnostics, Format format,
+                   std::string_view toolName) {
+    if (format == Format::Json) {
+        std::string out = "{\n  \"tool\": \"" + escape(toolName) + "\",\n  \"findings\": [";
+        if (diagnostics.empty()) {
+            out += "]\n}\n";
+            return out;
+        }
+        out += "\n";
+        for (std::size_t i = 0; i < diagnostics.size(); ++i) {
+            const Diagnostic& diagnostic = diagnostics[i];
+            out += "    {\n";
+            out += "      \"file\": \"" + escape(diagnostic.file) + "\",\n";
+            out += "      \"line\": " + std::to_string(diagnostic.line) + ",\n";
+            out += "      \"code\": \"" + escape(diagnostic.code) + "\",\n";
+            out += "      \"severity\": \"" + std::string{describe(diagnostic.severity)} + "\",\n";
+            out += "      \"message\": \"" + escape(diagnostic.message) + "\",\n";
+            out += "      \"fixHint\": \"" + escape(diagnostic.fixHint) + "\"\n";
+            out += (i + 1 < diagnostics.size()) ? "    },\n" : "    }\n";
+        }
+        out += "  ]\n}\n";
+        return out;
+    }
+
+    // Text form follows the file:line: severity: [code] message convention the existing lints
+    // use, which is also what an editor's error parser expects.
+    std::string out;
+    for (const Diagnostic& diagnostic : diagnostics) {
+        out += diagnostic.file;
+        if (diagnostic.line != 0) {
+            out += ":" + std::to_string(diagnostic.line);
+        }
+        out += ": ";
+        out += describe(diagnostic.severity);
+        out += ": ";
+        if (!diagnostic.code.empty()) {
+            out += "[" + diagnostic.code + "] ";
+        }
+        out += diagnostic.message;
+        out += "\n";
+        if (!diagnostic.fixHint.empty()) {
+            out += "    fix: " + diagnostic.fixHint + "\n";
+        }
+    }
+    return out;
+}
+
+int exitStatus(std::span<const Diagnostic> diagnostics) noexcept {
+    for (const Diagnostic& diagnostic : diagnostics) {
+        if (diagnostic.severity == Severity::Error) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+}  // namespace mdux::tools::cli

--- a/tools/common/Cli.cppm
+++ b/tools/common/Cli.cppm
@@ -1,0 +1,117 @@
+/**
+ * @file Cli.cppm
+ * @brief Shared argument parsing and the diagnostic envelope every baker presents.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone: never linked into MduXCore or MduX)
+ * @compliance ADR-005 Error handling and exceptions policy (host tools may throw)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * ## One interface for six bakers
+ *
+ * ```
+ * mdux-<kind>bake bake   <recipe> <output-dir>
+ * mdux-<kind>bake verify <recipe> <package.json> <report.json>
+ *                        [--format=json|text]
+ * ```
+ *
+ * `bake` and `verify` must run the *same* code path with different output handling. If verify
+ * were a separate reimplementation it could drift from bake, and a CI check that compares a
+ * baker against a different baker proves nothing. Baker authors: produce the artifact in memory
+ * once, then either write it (bake) or compare it (verify).
+ *
+ * ## The diagnostic envelope
+ *
+ * `--format=json` emits `{file, line, code, severity, message, fixHint}` per finding - the first
+ * instance of the stable envelope issue #19 (S3) extends to every tool. It is deliberately the
+ * same shape `mdux-docs-lint` and `mdux-evidence-lint` already emit, so an agent parses one
+ * schema for the whole repository rather than one per tool.
+ *
+ * Defining it here, once, is the point: a baker gets the envelope by using this module and
+ * cannot accidentally invent its own.
+ */
+module;
+
+export module mdux.tools.cli;
+
+import std;
+
+export namespace mdux::tools::cli {
+
+/// A usage error: bad arguments, not a bad recipe. Rendered as usage text, not as a diagnostic.
+class UsageError : public std::runtime_error {
+public:
+    explicit UsageError(std::string message) : std::runtime_error{std::move(message)} {}
+};
+
+enum class Mode : std::uint8_t {
+    Bake,   ///< produce the artifact and write it into <output-dir>
+    Verify, ///< produce the artifact and compare it against committed files, writing nothing
+};
+
+enum class Format : std::uint8_t { Text, Json };
+
+enum class Severity : std::uint8_t { Error, Warning, Note };
+
+[[nodiscard]] std::string_view describe(Severity severity) noexcept;
+
+/**
+ * @brief One finding, in the envelope every MduX tool shares.
+ *
+ * `line` is 1-based; 0 means "the finding is about the file as a whole". `code` is a short stable
+ * identifier a tool can be grepped for, and must not change meaning once published - an agent
+ * keying off it should not be broken by a message reword.
+ */
+struct Diagnostic {
+    std::string file;
+    std::size_t line{0};
+    std::string code;
+    Severity severity{Severity::Error};
+    std::string message;
+    std::string fixHint;
+};
+
+struct BakeArguments {
+    std::string recipe;
+    std::string outputDir;
+};
+
+struct VerifyArguments {
+    std::string recipe;
+    std::string packagePath;
+    std::string reportPath;
+};
+
+/// A parsed command line. Exactly one of `bake`/`verify` is meaningful, per `mode`.
+struct Invocation {
+    Mode mode{Mode::Bake};
+    Format format{Format::Text};
+    BakeArguments bake;
+    VerifyArguments verify;
+};
+
+/// Usage text for `toolName`, as printed on a usage error or `--help`.
+[[nodiscard]] std::string usage(std::string_view toolName);
+
+/**
+ * @brief Parses `arguments` (the argv tail, *excluding* argv[0]).
+ *
+ * Throws UsageError with an actionable message on an unrecognized subcommand, a wrong argument
+ * count, or an unknown option. `--help` also throws, carrying the usage text, so a caller has
+ * one place to handle "did not run".
+ */
+[[nodiscard]] Invocation parse(std::string_view toolName,
+                                std::span<const std::string_view> arguments);
+
+/// Convenience wrapper for a `main(argc, argv)` tail.
+[[nodiscard]] Invocation parse(std::string_view toolName, int argc, const char* const* argv);
+
+/// Renders `diagnostics` in the requested format. `toolName` appears in the JSON envelope so a
+/// consumer aggregating several tools' output can tell them apart.
+[[nodiscard]] std::string render(std::span<const Diagnostic> diagnostics, Format format,
+                                 std::string_view toolName);
+
+/// The exit status a tool should return: 0 when no diagnostic is an error, 1 otherwise. A
+/// warning alone does not fail a bake - only CI's byte-comparison decides that.
+[[nodiscard]] int exitStatus(std::span<const Diagnostic> diagnostics) noexcept;
+
+}  // namespace mdux::tools::cli

--- a/tools/common/Toml.cpp
+++ b/tools/common/Toml.cpp
@@ -1,0 +1,578 @@
+/**
+ * @file Toml.cpp
+ * @brief Implementation of the TOML-subset recipe reader.
+ *
+ * @compliance ADR-004 Trust zones in C++
+ * @compliance ADR-005 Error handling and exceptions policy
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * Line-oriented: this subset has no construct spanning a newline except an array, which is
+ * handled by joining continuation lines before parsing the value. That keeps the parser small
+ * and every diagnostic anchored to a line an author can find.
+ */
+module;
+
+module mdux.tools.toml;
+
+import std;
+
+namespace mdux::tools::toml {
+
+namespace {
+
+[[nodiscard]] bool isBareKeyChar(char c) noexcept {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' ||
+           c == '-';
+}
+
+[[nodiscard]] std::string_view trim(std::string_view text) noexcept {
+    const auto notSpace = [](char c) { return c != ' ' && c != '\t' && c != '\r'; };
+    while (!text.empty() && !notSpace(text.front())) {
+        text.remove_prefix(1);
+    }
+    while (!text.empty() && !notSpace(text.back())) {
+        text.remove_suffix(1);
+    }
+    return text;
+}
+
+/// Strips a trailing `#` comment, honouring quoting so a `#` inside a string survives.
+[[nodiscard]] std::string_view stripComment(std::string_view line) noexcept {
+    bool inString = false;
+    for (std::size_t i = 0; i < line.size(); ++i) {
+        if (line[i] == '\\' && inString) {
+            ++i;  // skip the escaped character
+            continue;
+        }
+        if (line[i] == '"') {
+            inString = !inString;
+            continue;
+        }
+        if (line[i] == '#' && !inString) {
+            return line.substr(0, i);
+        }
+    }
+    return line;
+}
+
+/// True when `text` has an unclosed `[` at top level, meaning the array continues on the next
+/// line. Quote-aware, so a bracket inside a string does not count.
+[[nodiscard]] bool hasUnclosedBracket(std::string_view text) noexcept {
+    bool inString = false;
+    int depth = 0;
+    for (std::size_t i = 0; i < text.size(); ++i) {
+        if (text[i] == '\\' && inString) {
+            ++i;
+            continue;
+        }
+        if (text[i] == '"') {
+            inString = !inString;
+            continue;
+        }
+        if (inString) {
+            continue;
+        }
+        if (text[i] == '[') {
+            ++depth;
+        } else if (text[i] == ']') {
+            --depth;
+        }
+    }
+    return depth > 0;
+}
+
+class ValueParser {
+public:
+    ValueParser(std::string_view text, std::size_t line) noexcept : text_{text}, line_{line} {}
+
+    /// Parses one value and requires that nothing follows it.
+    [[nodiscard]] Value parseComplete() {
+        Value value = parseValue();
+        skipSpace();
+        if (position_ != text_.size()) {
+            throw TomlError{line_, "unexpected text after the value: '" +
+                                        std::string{trim(text_.substr(position_))} + "'"};
+        }
+        return value;
+    }
+
+private:
+    void skipSpace() noexcept {
+        while (position_ < text_.size() &&
+               (text_[position_] == ' ' || text_[position_] == '\t' || text_[position_] == '\n' ||
+                text_[position_] == '\r')) {
+            ++position_;
+        }
+    }
+
+    [[nodiscard]] Value parseValue() {
+        skipSpace();
+        if (position_ >= text_.size()) {
+            throw TomlError{line_, "expected a value"};
+        }
+        const char c = text_[position_];
+        if (c == '"') {
+            return Value::string(parseString(), line_);
+        }
+        if (c == '[') {
+            return parseArray();
+        }
+        if (c == '\'') {
+            throw TomlError{line_,
+                            "literal (single-quoted) strings are outside this TOML subset; use a "
+                            "double-quoted string"};
+        }
+        if (c == '{') {
+            throw TomlError{line_, "inline tables are outside this TOML subset; use a [table] "
+                                    "header instead"};
+        }
+        if (text_.substr(position_).starts_with("true")) {
+            position_ += 4;
+            return Value::boolean(true, line_);
+        }
+        if (text_.substr(position_).starts_with("false")) {
+            position_ += 5;
+            return Value::boolean(false, line_);
+        }
+        if (c == '-' || c == '+' || (c >= '0' && c <= '9')) {
+            return parseNumber();
+        }
+        throw TomlError{line_, "unrecognized value starting at '" +
+                                    std::string{text_.substr(position_, 12)} + "'"};
+    }
+
+    [[nodiscard]] std::string parseString() {
+        ++position_;  // opening quote
+        std::string out;
+        while (true) {
+            if (position_ >= text_.size()) {
+                throw TomlError{line_, "string is not terminated"};
+            }
+            const char c = text_[position_];
+            if (c == '"') {
+                ++position_;
+                return out;
+            }
+            if (c == '\n') {
+                throw TomlError{line_, "multi-line strings are outside this TOML subset"};
+            }
+            if (c != '\\') {
+                out.push_back(c);
+                ++position_;
+                continue;
+            }
+            ++position_;
+            if (position_ >= text_.size()) {
+                throw TomlError{line_, "string ends inside an escape sequence"};
+            }
+            const char escape = text_[position_++];
+            switch (escape) {
+            case '"':  out.push_back('"'); break;
+            case '\\': out.push_back('\\'); break;
+            case 'b':  out.push_back('\b'); break;
+            case 'f':  out.push_back('\f'); break;
+            case 'n':  out.push_back('\n'); break;
+            case 'r':  out.push_back('\r'); break;
+            case 't':  out.push_back('\t'); break;
+            case 'u':  appendUtf8(out, parseHex(4)); break;
+            case 'U':  appendUtf8(out, parseHex(8)); break;
+            default:
+                throw TomlError{line_, std::string{"unrecognized escape '\\"} + escape + "'"};
+            }
+        }
+    }
+
+    [[nodiscard]] std::uint32_t parseHex(std::size_t digits) {
+        if (position_ + digits > text_.size()) {
+            throw TomlError{line_, "\\u escape needs " + std::to_string(digits) + " hex digits"};
+        }
+        std::uint32_t value = 0;
+        for (std::size_t i = 0; i < digits; ++i) {
+            const char c = text_[position_ + i];
+            std::uint32_t digit = 0;
+            if (c >= '0' && c <= '9') {
+                digit = static_cast<std::uint32_t>(c - '0');
+            } else if (c >= 'a' && c <= 'f') {
+                digit = static_cast<std::uint32_t>(c - 'a') + 10u;
+            } else if (c >= 'A' && c <= 'F') {
+                digit = static_cast<std::uint32_t>(c - 'A') + 10u;
+            } else {
+                throw TomlError{line_,
+                                "\\u escape needs " + std::to_string(digits) + " hex digits"};
+            }
+            value = (value << 4) | digit;
+        }
+        position_ += digits;
+        if (value > 0x10ffff || (value >= 0xd800 && value <= 0xdfff)) {
+            throw TomlError{line_, "escape does not denote a Unicode scalar value"};
+        }
+        return value;
+    }
+
+    static void appendUtf8(std::string& out, std::uint32_t codePoint) {
+        if (codePoint < 0x80) {
+            out.push_back(static_cast<char>(codePoint));
+        } else if (codePoint < 0x800) {
+            out.push_back(static_cast<char>(0xc0u | (codePoint >> 6)));
+            out.push_back(static_cast<char>(0x80u | (codePoint & 0x3fu)));
+        } else if (codePoint < 0x10000) {
+            out.push_back(static_cast<char>(0xe0u | (codePoint >> 12)));
+            out.push_back(static_cast<char>(0x80u | ((codePoint >> 6) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | (codePoint & 0x3fu)));
+        } else {
+            out.push_back(static_cast<char>(0xf0u | (codePoint >> 18)));
+            out.push_back(static_cast<char>(0x80u | ((codePoint >> 12) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | ((codePoint >> 6) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | (codePoint & 0x3fu)));
+        }
+    }
+
+    [[nodiscard]] Value parseNumber() {
+        const std::size_t start = position_;
+        bool negative = false;
+        if (text_[position_] == '-' || text_[position_] == '+') {
+            negative = text_[position_] == '-';
+            ++position_;
+        }
+        if (position_ >= text_.size() || text_[position_] < '0' || text_[position_] > '9') {
+            throw TomlError{line_, "expected a digit"};
+        }
+        // Reject the bases and separators TOML permits but this subset does not, before the
+        // digit loop, so the diagnostic names the actual feature rather than "unexpected text".
+        if (text_[position_] == '0' && position_ + 1 < text_.size()) {
+            const char next = text_[position_ + 1];
+            if (next == 'x' || next == 'o' || next == 'b') {
+                throw TomlError{line_, "hexadecimal, octal and binary integers are outside this "
+                                        "TOML subset; write the value in decimal"};
+            }
+        }
+
+        std::uint64_t magnitude = 0;
+        while (position_ < text_.size() && text_[position_] >= '0' && text_[position_] <= '9') {
+            const auto digit = static_cast<std::uint64_t>(text_[position_] - '0');
+            if (magnitude > (std::numeric_limits<std::uint64_t>::max() - digit) / 10u) {
+                throw TomlError{line_, "integer does not fit in 64 bits"};
+            }
+            magnitude = magnitude * 10u + digit;
+            ++position_;
+        }
+        if (position_ < text_.size() && text_[position_] == '_') {
+            throw TomlError{line_, "digit separators are outside this TOML subset"};
+        }
+        if (position_ < text_.size() &&
+            (text_[position_] == '.' || text_[position_] == 'e' || text_[position_] == 'E')) {
+            // The ADR-007 rule, surfaced at the recipe level: a real number cannot be authored
+            // as decimal text anywhere in this pipeline.
+            throw TomlError{line_,
+                            "floats are rejected: a real number in this pipeline is a u32 bit "
+                            "pattern, not decimal text (see ADR-007). Write the bit pattern as "
+                            "an integer."};
+        }
+        if (position_ < text_.size() && text_[position_] == '-') {
+            throw TomlError{line_, "datetimes are outside this TOML subset"};
+        }
+
+        const auto limit =
+            static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + (negative ? 1u : 0u);
+        if (magnitude > limit) {
+            throw TomlError{line_, "integer '" + std::string{text_.substr(start, position_ - start)} +
+                                        "' does not fit in a signed 64-bit integer"};
+        }
+        if (negative) {
+            if (magnitude == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1u) {
+                return Value::integer(std::numeric_limits<std::int64_t>::min(), line_);
+            }
+            return Value::integer(-static_cast<std::int64_t>(magnitude), line_);
+        }
+        return Value::integer(static_cast<std::int64_t>(magnitude), line_);
+    }
+
+    [[nodiscard]] Value parseArray() {
+        ++position_;  // '['
+        std::vector<Value> elements;
+        while (true) {
+            skipSpace();
+            if (position_ >= text_.size()) {
+                throw TomlError{line_, "array is not terminated"};
+            }
+            if (text_[position_] == ']') {
+                ++position_;
+                return Value::array(std::move(elements), line_);
+            }
+            elements.push_back(parseValue());
+            skipSpace();
+            if (position_ >= text_.size()) {
+                throw TomlError{line_, "array is not terminated"};
+            }
+            if (text_[position_] == ',') {
+                ++position_;
+                continue;  // a trailing comma before ']' is legal TOML, so the loop head handles it
+            }
+            if (text_[position_] == ']') {
+                ++position_;
+                return Value::array(std::move(elements), line_);
+            }
+            throw TomlError{line_, "expected ',' or ']' in an array"};
+        }
+    }
+
+    std::string_view text_;
+    std::size_t line_;
+    std::size_t position_{0};
+};
+
+/// Validates a bare key and produces the diagnostics that distinguish "outside this subset" from
+/// "not a key at all" - the difference matters to whoever is fixing the recipe.
+void validateBareKey(std::string_view key, std::size_t line, std::string_view what) {
+    if (key.empty()) {
+        throw TomlError{line, std::string{what} + " is empty"};
+    }
+    if (key.find('.') != std::string_view::npos) {
+        throw TomlError{line, "dotted " + std::string{what} + "s are outside this TOML subset: '" +
+                                  std::string{key} + "'"};
+    }
+    if (key.front() == '"' || key.front() == '\'') {
+        throw TomlError{line, "quoted " + std::string{what} + "s are outside this TOML subset: '" +
+                                  std::string{key} + "'"};
+    }
+    for (const char c : key) {
+        if (!isBareKeyChar(c)) {
+            throw TomlError{line, std::string{what} + " '" + std::string{key} +
+                                      "' contains a character outside [A-Za-z0-9_-]"};
+        }
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Value
+// ---------------------------------------------------------------------------
+
+Value Value::string(std::string text, std::size_t line) {
+    Value value;
+    value.kind_ = Kind::String;
+    value.line_ = line;
+    value.string_ = std::move(text);
+    return value;
+}
+
+Value Value::integer(std::int64_t number, std::size_t line) {
+    Value value;
+    value.kind_ = Kind::Integer;
+    value.line_ = line;
+    value.integer_ = number;
+    return value;
+}
+
+Value Value::boolean(bool flag, std::size_t line) {
+    Value value;
+    value.kind_ = Kind::Boolean;
+    value.line_ = line;
+    value.boolean_ = flag;
+    return value;
+}
+
+Value Value::array(std::vector<Value> elements, std::size_t line) {
+    Value value;
+    value.kind_ = Kind::Array;
+    value.line_ = line;
+    value.elements_ = std::move(elements);
+    return value;
+}
+
+std::string_view Value::describe(Kind kind) noexcept {
+    switch (kind) {
+    case Kind::String:  return "string";
+    case Kind::Integer: return "integer";
+    case Kind::Boolean: return "boolean";
+    case Kind::Array:   return "array";
+    }
+    return "unrecognized";
+}
+
+const std::string& Value::asString() const {
+    if (kind_ != Kind::String) {
+        throw TomlError{line_, std::string{"expected a string, found a "} +
+                                   std::string{describe(kind_)}};
+    }
+    return string_;
+}
+
+std::int64_t Value::asInteger() const {
+    if (kind_ != Kind::Integer) {
+        throw TomlError{line_, std::string{"expected an integer, found a "} +
+                                   std::string{describe(kind_)}};
+    }
+    return integer_;
+}
+
+bool Value::asBoolean() const {
+    if (kind_ != Kind::Boolean) {
+        throw TomlError{line_, std::string{"expected a boolean, found a "} +
+                                   std::string{describe(kind_)}};
+    }
+    return boolean_;
+}
+
+std::span<const Value> Value::asArray() const {
+    if (kind_ != Kind::Array) {
+        throw TomlError{line_, std::string{"expected an array, found a "} +
+                                   std::string{describe(kind_)}};
+    }
+    return elements_;
+}
+
+std::vector<std::string> Value::asStringArray() const {
+    const std::span<const Value> elements = asArray();
+    std::vector<std::string> out;
+    out.reserve(elements.size());
+    for (std::size_t i = 0; i < elements.size(); ++i) {
+        if (elements[i].kind() != Kind::String) {
+            throw TomlError{elements[i].line(),
+                            "array element " + std::to_string(i) + " is a " +
+                                std::string{describe(elements[i].kind())} + ", expected a string"};
+        }
+        out.push_back(elements[i].string_);
+    }
+    return out;
+}
+
+std::vector<std::int64_t> Value::asIntegerArray() const {
+    const std::span<const Value> elements = asArray();
+    std::vector<std::int64_t> out;
+    out.reserve(elements.size());
+    for (std::size_t i = 0; i < elements.size(); ++i) {
+        if (elements[i].kind() != Kind::Integer) {
+            throw TomlError{elements[i].line(),
+                            "array element " + std::to_string(i) + " is a " +
+                                std::string{describe(elements[i].kind())} + ", expected an integer"};
+        }
+        out.push_back(elements[i].integer_);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Table
+// ---------------------------------------------------------------------------
+
+const Value* Table::find(std::string_view key) const noexcept {
+    for (const auto& entry : entries_) {
+        if (entry.first == key) {
+            return &entry.second;
+        }
+    }
+    return nullptr;
+}
+
+const Value& Table::require(std::string_view key) const {
+    if (const Value* found = find(key); found != nullptr) {
+        return *found;
+    }
+    throw TomlError{line_, "required key '" + std::string{key} + "' is missing"};
+}
+
+void Table::insert(std::string key, Value value, std::size_t line) {
+    if (find(key) != nullptr) {
+        throw TomlError{line, "duplicate key '" + key + "'"};
+    }
+    entries_.emplace_back(std::move(key), std::move(value));
+}
+
+// ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+const Table* Document::table(std::string_view name) const noexcept {
+    for (const auto& entry : tables_) {
+        if (entry.first == name) {
+            return &entry.second;
+        }
+    }
+    return nullptr;
+}
+
+const Table& Document::requireTable(std::string_view name) const {
+    if (const Table* found = table(name); found != nullptr) {
+        return *found;
+    }
+    throw TomlError{0, "required table '[" + std::string{name} + "]' is missing"};
+}
+
+// ---------------------------------------------------------------------------
+// parse()
+// ---------------------------------------------------------------------------
+
+Document parse(std::string_view text) {
+    Document document;
+    Table* current = &document.root_;
+
+    // Split into lines up front so a diagnostic can always name a 1-based line number.
+    std::vector<std::string_view> lines;
+    std::size_t start = 0;
+    while (start <= text.size()) {
+        const std::size_t newline = text.find('\n', start);
+        if (newline == std::string_view::npos) {
+            lines.push_back(text.substr(start));
+            break;
+        }
+        lines.push_back(text.substr(start, newline - start));
+        start = newline + 1;
+    }
+
+    for (std::size_t index = 0; index < lines.size(); ++index) {
+        const std::size_t lineNumber = index + 1;
+        const std::string_view stripped = trim(stripComment(lines[index]));
+        if (stripped.empty()) {
+            continue;
+        }
+
+        if (stripped.front() == '[') {
+            if (stripped.starts_with("[[")) {
+                throw TomlError{lineNumber,
+                                "arrays of tables are outside this TOML subset"};
+            }
+            if (stripped.back() != ']') {
+                throw TomlError{lineNumber, "table header is missing its closing ']'"};
+            }
+            const std::string_view name = trim(stripped.substr(1, stripped.size() - 2));
+            validateBareKey(name, lineNumber, "table name");
+            if (document.table(name) != nullptr) {
+                throw TomlError{lineNumber, "duplicate table '[" + std::string{name} + "]'"};
+            }
+            Table table;
+            table.setLine(lineNumber);
+            document.tables_.emplace_back(std::string{name}, std::move(table));
+            current = &document.tables_.back().second;
+            continue;
+        }
+
+        const std::size_t equals = stripped.find('=');
+        if (equals == std::string_view::npos) {
+            throw TomlError{lineNumber, "expected 'key = value' or a [table] header"};
+        }
+        const std::string_view key = trim(stripped.substr(0, equals));
+        validateBareKey(key, lineNumber, "key");
+
+        // An array may span lines; join continuation lines before handing the text to the value
+        // parser. Comments are stripped per line first, so a comment inside a multi-line array
+        // is handled the same as anywhere else.
+        std::string valueText{trim(stripped.substr(equals + 1))};
+        while (hasUnclosedBracket(valueText)) {
+            ++index;
+            if (index >= lines.size()) {
+                throw TomlError{lineNumber, "array is not terminated before end of file"};
+            }
+            valueText.push_back('\n');
+            valueText += trim(stripComment(lines[index]));
+        }
+
+        ValueParser parser{valueText, lineNumber};
+        current->insert(std::string{key}, parser.parseComplete(), lineNumber);
+    }
+
+    return document;
+}
+
+}  // namespace mdux::tools::toml

--- a/tools/common/Toml.cppm
+++ b/tools/common/Toml.cppm
@@ -1,0 +1,152 @@
+/**
+ * @file Toml.cppm
+ * @brief A deliberately minimal TOML reader for baker recipe files.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone: never linked into MduXCore or MduX)
+ * @compliance ADR-005 Error handling and exceptions policy (host tools may throw)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * ## Scope, and why it is this small
+ *
+ * Supported: tables, bare keys, basic strings, integers, booleans, and arrays of those.
+ *
+ * Not supported, on purpose: dotted keys, dotted table headers, arrays of tables, inline
+ * tables, multi-line strings, literal (single-quoted) strings, floats, datetimes, hex/octal/
+ * binary integers, and digit separators.
+ *
+ * The narrow scope is the point rather than a limitation to be fixed later. Recipe files are
+ * authored by this project, TOML's full grammar is large, and every line here is code a
+ * manufacturer may have to qualify. If a recipe needs a feature outside this subset, the recipe
+ * format is wrong, not the parser.
+ *
+ * **Floats are rejected outright.** A recipe cannot express a real number as decimal text,
+ * because ADR-007's byte-identity guarantee depends on real numbers being bit patterns. A recipe
+ * that needs one states it as an integer bit pattern, and the diagnostic says so.
+ *
+ * ## Errors
+ *
+ * Throws TomlError, which carries a line number so a tool can render it through the shared
+ * diagnostic envelope in mdux.tools.cli. This is the host-tools zone, so throwing is permitted -
+ * a recipe error is a fail-and-report situation, not something a baker recovers from.
+ */
+module;
+
+export module mdux.tools.toml;
+
+import std;
+
+export namespace mdux::tools::toml {
+
+/// A recipe syntax or type error, with the 1-based line it was found on.
+class TomlError : public std::runtime_error {
+public:
+    TomlError(std::size_t line, std::string message)
+        : std::runtime_error{std::move(message)}, line_{line} {}
+
+    [[nodiscard]] std::size_t line() const noexcept { return line_; }
+
+private:
+    std::size_t line_;
+};
+
+class Value {
+public:
+    enum class Kind : std::uint8_t { String, Integer, Boolean, Array };
+
+    [[nodiscard]] static Value string(std::string text, std::size_t line);
+    [[nodiscard]] static Value integer(std::int64_t number, std::size_t line);
+    [[nodiscard]] static Value boolean(bool flag, std::size_t line);
+    [[nodiscard]] static Value array(std::vector<Value> elements, std::size_t line);
+
+    [[nodiscard]] Kind kind() const noexcept { return kind_; }
+
+    /// The line this value appeared on, for diagnostics.
+    [[nodiscard]] std::size_t line() const noexcept { return line_; }
+
+    /// Typed accessors. Each throws TomlError naming the expected and actual type, so a baker
+    /// reading an option gets a recipe-author-facing message without writing one itself.
+    [[nodiscard]] const std::string& asString() const;
+    [[nodiscard]] std::int64_t asInteger() const;
+    [[nodiscard]] bool asBoolean() const;
+    [[nodiscard]] std::span<const Value> asArray() const;
+
+    /// Convenience for the common "array of strings" and "array of integers" recipe shapes.
+    /// Throws if any element is of the wrong type, naming the offending index.
+    [[nodiscard]] std::vector<std::string> asStringArray() const;
+    [[nodiscard]] std::vector<std::int64_t> asIntegerArray() const;
+
+    [[nodiscard]] static std::string_view describe(Kind kind) noexcept;
+
+private:
+    Kind kind_{Kind::String};
+    std::size_t line_{0};
+    std::string string_;
+    std::int64_t integer_{0};
+    bool boolean_{false};
+    std::vector<Value> elements_;
+};
+
+/**
+ * @brief A table: an ordered set of key/value pairs.
+ *
+ * Insertion order is preserved so that a diagnostic can report keys in the order the author
+ * wrote them. Lookup is by key and is exact - there is no case folding and no dotted-path
+ * traversal, because neither exists in this subset.
+ */
+class Table {
+public:
+    [[nodiscard]] const Value* find(std::string_view key) const noexcept;
+
+    /// find() that throws TomlError if the key is absent, for required options.
+    [[nodiscard]] const Value& require(std::string_view key) const;
+
+    [[nodiscard]] bool contains(std::string_view key) const noexcept { return find(key) != nullptr; }
+
+    [[nodiscard]] std::span<const std::pair<std::string, Value>> entries() const noexcept {
+        return entries_;
+    }
+
+    /// The line the table's header appeared on, or 0 for the root table.
+    [[nodiscard]] std::size_t line() const noexcept { return line_; }
+
+    void setLine(std::size_t line) noexcept { line_ = line; }
+
+    /// Throws on a duplicate key rather than overwriting - a recipe with a key twice is
+    /// ambiguous, and silently taking the last one is how an author's intent gets lost.
+    void insert(std::string key, Value value, std::size_t line);
+
+private:
+    std::vector<std::pair<std::string, Value>> entries_;
+    std::size_t line_{0};
+};
+
+/**
+ * @brief A parsed recipe: a root table plus named tables.
+ *
+ * Flat by construction. `[font]` and `[atlas]` are two tables; `[font.atlas]` is a dotted header
+ * and is rejected.
+ */
+class Document {
+public:
+    [[nodiscard]] const Table& root() const noexcept { return root_; }
+
+    [[nodiscard]] const Table* table(std::string_view name) const noexcept;
+
+    /// table() that throws TomlError if the table is absent, for required sections.
+    [[nodiscard]] const Table& requireTable(std::string_view name) const;
+
+    [[nodiscard]] std::span<const std::pair<std::string, Table>> tables() const noexcept {
+        return tables_;
+    }
+
+    friend Document parse(std::string_view text);
+
+private:
+    Table root_;
+    std::vector<std::pair<std::string, Table>> tables_;
+};
+
+/// Parses TOML-subset `text`. Throws TomlError on anything outside the subset.
+[[nodiscard]] Document parse(std::string_view text);
+
+}  // namespace mdux::tools::toml


### PR DESCRIPTION
## Summary
- Adds `tools/common/`: shared host-tools-zone (ADR-004) infrastructure every future baker (issues #13-#18) builds on.
- `mdux.tools.toml` — a deliberately minimal TOML reader: tables, bare keys, basic strings, integers, booleans, arrays. **No** dotted keys, inline tables, multi-line strings, floats, datetimes, digit separators. The narrow scope is the point — every line is code a manufacturer may have to qualify. Floats are rejected with a message pointing at ADR-007's bit-pattern rule.
- `mdux.tools.cli` — parses the `bake <recipe> <output-dir>` / `verify <recipe> <package.json> <report.json> [--format=json|text]` interface every baker presents, and the stable diagnostic envelope (`{file, line, code, severity, message, fixHint}`) — the first instance of the JSON output every MduX tool will share (issue #19).
- Adds `MduXToolsCommon` (links `MduX::Core`, since bakers build artifacts through the governed evidence modules) and wires `add_subdirectory(tools)` into the top-level build, ahead of `tests/`.

## Test plan
- [x] 32/32 host-tools tests, including a full battery of "outside this TOML subset" rejections (floats, dotted keys/tables, inline tables, literal strings, hex/octal/binary integers, digit separators, datetimes) each pinned to a message naming the *specific* unsupported feature — not just "syntax error"
- [x] The diagnostic envelope's exact JSON shape asserted **literally** — it's a contract future agent tooling (#19) keys off, not just human-readable text
- [x] Configured against this repository with a stub Vulkan package: `MduXToolsCommon`, `tools_tests`, `mdux-bake-all` all present and buildable together

Stacked on #83 (Bake CMake infra) — decoupled from it deliberately (see #83's description), so either could have landed first.
Part of the #12 Evidence kernel stack (issue #54).
