### PR TITLE
S1 — docs/governance/citation-convention.md and the shared Justification schema

### DIFF
--- a/docs/governance/citation-convention.md
+++ b/docs/governance/citation-convention.md
@@ -6,10 +6,13 @@ why. This is the replacement: how to cite a standard's clause without reproducin
 
 ## Status
 
-This is a minimal first version, landed alongside the removal it explains (issue #22) so the tree
-is never in a state where the reproduced material is gone and nothing describes what replaces it.
-The full convention — including the `Justification` object's JSON Schema and worked examples — is
-tracked as issue #8, S1, and will extend this document rather than replace it.
+Landed in two parts. The first (issue #22) shipped alongside the reproduced-text removal so the
+tree was never in a state where the material was gone and nothing described what replaces it. This
+version (issue #8, S1) adds the formal `Justification` schema and worked examples, completing it.
+
+`docs/iec62304/` and `docs/iso13485/` do not follow this convention yet — see "Known gap" below.
+Issues #27/#28 are the clause-accurate rewrite that fixes this; this document defines the target
+shape those rewrites write against.
 
 ## The rule
 
@@ -41,26 +44,50 @@ a `clause_ref` field — so it can eventually be checked mechanically (issue #7,
 MduX keeps IEC 62304 Class A in scope (its sibling project TrustSC models Class B/C only) — state
 this explicitly wherever safety classification is discussed, rather than assuming one or the other.
 
-## The `Justification` object (preview)
+## The `Justification` object
 
-Use this shape whenever a design decision needs a formal link to a clause. This is an illustrative
-example with placeholder values, not a binding Justification — fenced as `jsonc` rather than `json`
-so `mdux-docs-lint` doesn't validate it as one:
+Use this shape whenever a design decision needs a formal link to a clause. The schema is
+[`docs/governance/schemas/justification.schema.json`](schemas/justification.schema.json) —
+Draft 2020-12, `additionalProperties: false`, and it cross-checks that `clause_ref` actually starts
+with the same standard named in `standard` (a plain regex can't do that alone; the schema uses a
+per-standard `if`/`then` pair for it).
 
-```jsonc
+`justification_id` (`JUS-NNN`) must be unique across the whole corpus, not per standard.
+`evidence_refs[]` must be non-empty and contain real repository paths — the schema rejects an empty
+array, because a Justification with no evidence is exactly the decorative citation this convention
+exists to prevent.
+
+Two worked examples, both validated against the schema and pointing at mechanisms that exist in
+this repository today:
+
+```json
 {
   "justification_id": "JUS-001",
   "standard": "IEC 62304:2006",
-  "clause_ref": "IEC 62304:2006 §5.3.3 Identify segregation necessary for risk control",
-  "rationale": "One sentence explaining why the cited mechanism satisfies the clause's intent.",
-  "requirement_id": "REQ-EXAMPLE-001",
-  "evidence_refs": ["path/to/real/file.cppm"]
+  "clause_ref": "IEC 62304:2006 §5.3 Software architectural design",
+  "rationale": "MduXTrustZones.cmake mechanically walks a governed target's link graph and fails the configure step if it reaches Vulkan or a windowing library, which is how the trust-zone architecture (ADR-004) keeps risk-relevant segregation a build-time guarantee rather than a code-review convention.",
+  "evidence_refs": ["cmake/MduXTrustZones.cmake", "docs/adr/ADR-004-trust-zones-in-cpp.md"]
 }
 ```
 
-`justification_id` (`JUS-NNN`) must be unique across the whole corpus, not per standard.
-`evidence_refs[]` must contain real repository paths. The formal JSON Schema for this object lands
-with issue #8, S1 — this preview exists so early citations already use the right shape.
+```json
+{
+  "justification_id": "JUS-002",
+  "standard": "IEC 62304:2006",
+  "clause_ref": "IEC 62304:2006 §8 Software configuration management process",
+  "rationale": "Every baked artifact is identified by a report naming its recipe digest, input digests and resolved options, and CI re-derives the artifact from those inputs and asserts byte-identity - so an artifact's configuration is verified by re-derivation, not by inspecting a binary diff.",
+  "evidence_refs": [
+    "docs/adr/ADR-007-evidence-pipeline-doctrine.md",
+    "include/mdux/evidence/Report.cppm",
+    "cmake/MduXBake.cmake"
+  ]
+}
+```
+
+Precise sub-clause numbering (the digits after the first dot, e.g. exactly which `§5.x` a
+requirement falls under) should be checked against the actual standard by whoever writes a new
+Justification. The clause-accurate corpus landing with issues #27-#31 is the place that numbering
+gets fixed once, centrally, rather than re-verified ad hoc at every citation site.
 
 ## Known gap this document does not yet close
 

--- a/docs/governance/schemas/justification.schema.json
+++ b/docs/governance/schemas/justification.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdux.dev/schemas/governance/justification.schema.json",
+  "title": "MduX Justification",
+  "description": "Links a design decision to a specific standard's clause, in original prose, with the concrete repository mechanism that addresses the clause's intent. See docs/governance/citation-convention.md for the rule this schema formalizes: a Justification with no real evidence_refs is decorative, not load-bearing, and mdux-docs-lint treats it as an error rather than as valid metadata.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "justification_id",
+    "standard",
+    "clause_ref",
+    "rationale",
+    "evidence_refs"
+  ],
+  "properties": {
+    "justification_id": {
+      "type": "string",
+      "description": "Unique across the whole corpus, not just within one standard's documents.",
+      "pattern": "^JUS-[0-9]{3,}$"
+    },
+    "standard": {
+      "type": "string",
+      "description": "One of the five standards MduX cites against. Closed set, matching docs/governance/citation-convention.md's approved identifiers exactly.",
+      "enum": [
+        "IEC 62304:2006",
+        "ISO 13485:2016",
+        "ISO 14971:2019",
+        "IEC 62366-1:2015",
+        "IEC 81001-5-1:2021"
+      ]
+    },
+    "clause_ref": {
+      "type": "string",
+      "description": "The citation-key format from docs/governance/citation-convention.md: '<Standard> §<clause> <Short clause title>'. Must start with the same value as `standard` - enforced below by the per-standard if/then pairs, since a plain pattern here cannot cross-reference a sibling property.",
+      "pattern": "^(IEC 62304:2006|ISO 13485:2016|ISO 14971:2019|IEC 62366-1:2015|IEC 81001-5-1:2021) §[0-9]+(\\.[0-9]+)* .+$"
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Original prose explaining why the cited mechanism satisfies the clause's intent. Never a quotation or close paraphrase of the standard's own wording (ADR-006) - mdux-docs-lint's reproduction heuristic runs over this field along with everything else in the corpus.",
+      "minLength": 1
+    },
+    "requirement_id": {
+      "type": "string",
+      "description": "Optional link to a tracked requirement, when one exists independently of this justification.",
+      "pattern": "^REQ-[A-Z0-9-]+$"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "description": "Repository-relative paths to the concrete mechanism - a module, an ADR, a CI step, a test - that addresses the clause's intent. Never empty: a Justification with no evidence is exactly the 'decorative citation' the citation convention rejects.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "standard": { "const": "IEC 62304:2006" } } },
+      "then": { "properties": { "clause_ref": { "pattern": "^IEC 62304:2006 " } } }
+    },
+    {
+      "if": { "properties": { "standard": { "const": "ISO 13485:2016" } } },
+      "then": { "properties": { "clause_ref": { "pattern": "^ISO 13485:2016 " } } }
+    },
+    {
+      "if": { "properties": { "standard": { "const": "ISO 14971:2019" } } },
+      "then": { "properties": { "clause_ref": { "pattern": "^ISO 14971:2019 " } } }
+    },
+    {
+      "if": { "properties": { "standard": { "const": "IEC 62366-1:2015" } } },
+      "then": { "properties": { "clause_ref": { "pattern": "^IEC 62366-1:2015 " } } }
+    },
+    {
+      "if": { "properties": { "standard": { "const": "IEC 81001-5-1:2021" } } },
+      "then": { "properties": { "clause_ref": { "pattern": "^IEC 81001-5-1:2021 " } } }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Completes `docs/governance/citation-convention.md`, which shipped with #22 as an explicitly-deferred "minimal first version".
- Adds `docs/governance/schemas/justification.schema.json` (Draft 2020-12, `additionalProperties: false`) and replaces the illustrative (unvalidated `jsonc`) preview block with two real worked examples that validate against it and against `mdux-docs-lint`'s existing justification checks.
- The schema cross-checks that `clause_ref` actually starts with the same standard named in `standard`, via a per-standard `if`/`then` pair — a plain regex on `clause_ref` alone can't reference a sibling property.

## Test plan
- [x] Schema validated as well-formed Draft 2020-12 (`jsonschema.Draft202012Validator.check_schema`)
- [x] 10 cases tested with `jsonschema`: the valid example, the same example with its optional field omitted, and 8 rejection cases (empty `evidence_refs`, missing `rationale`, unapproved standard, malformed `justification_id`, unknown extra field, duplicate `evidence_refs`, malformed `clause_ref`, and — the one that actually caught a real bug in my first draft — **`clause_ref` naming a different standard than `standard`**, which a regex-only version silently accepted
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 0 findings on both new files
- [x] Both worked examples' `evidence_refs` paths verified to exist in the repository before committing

Part of #8. Issue #26 complete.
