### PR TITLE
S4 — New docs/iec62366/ (IEC 62366-1) [confidence flag - see PR body]

### DIFF
--- a/docs/iec62366/01-scope-and-terms.md
+++ b/docs/iec62366/01-scope-and-terms.md
@@ -1,0 +1,34 @@
+# IEC 62366-1:2015 §1–§3 — Scope, normative references, terms and definitions
+
+## §1 Scope
+
+IEC 62366-1 specifies a process for a manufacturer to analyze, specify, design, verify, and
+validate the usability of a medical device's user interface, so far as usability relates to safety.
+It is explicitly scoped to *use-related* risk — errors and hazards arising from how a user
+interacts with the device — rather than the device's broader functional risk, which ISO 14971
+covers.
+
+MduX renders content described by a device's own UI design; it does not itself define what that
+device's users see or how they interact with it in a specific clinical context. This corpus
+documents where MduX's rendering and compilation mechanisms bear on use-related risk regardless of
+the device (chiefly, once built: a compile-time-enforced content budget that keeps critical
+information from being silently truncated or occluded) and states plainly where the process this
+standard describes remains entirely the integrating device's responsibility.
+
+## §2 Normative references
+
+IEC 62366-1 is written to be read alongside ISO 14971, for the risk-management framework its
+use-related risk analysis sits inside. See [`../iso14971/`](../iso14971/) for this project's
+treatment of that standard.
+
+## §3 Terms and definitions
+
+As elsewhere in this corpus, definitions are not restated. The terms below recur across this
+directory.
+
+| Term | Where MduX makes it concrete |
+|---|---|
+| User interface | For MduX, the concrete artifact is a compiled `.medui` screen — a `CompiledScreenPackage` (issue #15) — not the source `.medui` file, since the runtime only ever sees the compiled form. |
+| Use error | An error arising from user interaction with the interface, as distinct from a device malfunction. MduX has no mechanism addressing use error directly yet; the closest adjacent idea is rendered-truth verification (issue #16), which confirms *what is displayed* matches the compiled screen's specification, a precondition for a user being able to act on correct information at all. |
+| Formative evaluation | Evaluation performed during design, to identify use-related problems and inform further design iteration. No MduX mechanism yet — this belongs to a device's own UI design process, once `.medui` screens exist for a device to iterate on. |
+| Summative evaluation | Evaluation performed on the final user interface design, to confirm safe use has been achieved. Device-level; no MduX mechanism. |

--- a/docs/iec62366/02-general-requirements.md
+++ b/docs/iec62366/02-general-requirements.md
@@ -1,0 +1,13 @@
+# IEC 62366-1:2015 §4 — General requirements for the application of usability engineering to medical devices
+
+This clause establishes that a manufacturer must apply a usability engineering process to their
+device, document it, and integrate it with the device's overall risk management (ISO 14971) and
+quality management system (ISO 13485). It also permits a manufacturer to justify not applying the
+full process to interface elements with no bearing on safety — a scoping decision the manufacturer
+must document and defend, not skip silently.
+
+MduX has no device-level usability engineering process to establish, for the same reason it has no
+device-level risk analysis (see [`../iso14971/`](../iso14971/)): it is a UI SDK, not the device. The
+scoping judgment this clause asks a manufacturer to make — which interface elements are safety-
+relevant — is theirs to make about their own device's UI, informed by what MduX actually renders,
+not something MduX can pre-decide on their behalf.

--- a/docs/iec62366/03-usability-engineering-process.md
+++ b/docs/iec62366/03-usability-engineering-process.md
@@ -1,64 +1,97 @@
 # IEC 62366-1:2015 §5 — Usability engineering process
 
-See the confidence note in [`README.md`](README.md): the named steps below are described with
-higher confidence than their exact `§5.x` numbering, which should be checked against the actual
-standard before being cited elsewhere.
+§5 is the standard's process clause: the sequence of activities by which a manufacturer specifies,
+designs, evaluates and finally confirms a user interface against use-related risk.
 
-## §5.1 General
+**This file asserts no sub-clause numbers.** An earlier version headed each step below `§5.1`
+through `§5.9`. Those numbers were written from professional familiarity with the process rather
+than from the standard, which this project does not hold a copy of (see
+[ADR-006](../adr/ADR-006-no-reproduction-of-normative-standard-text.md)), and the citation
+convention requires a clause number to be confirmed before it is cited. They are therefore removed
+rather than caveated: a number carrying a warning label is still a citation, and a reader who
+copies it into a design history file has cited something nobody checked. The named steps below are
+the part this corpus does assert; the only citation key it uses is `IEC 62366-1:2015 §5 Usability
+engineering process`, at the level [`README.md`](README.md) explains is confirmed.
 
-Establishing that the usability engineering process runs across the device's life cycle, iterating
-as the design evolves. Device-level; no MduX mechanism.
+A maintainer with access to IEC 62366-1:2015 can restore the sub-clause numbering by checking each
+heading against the standard's §5 and adding the number back. That is a small, bounded task; it is
+tracked on issue #30 and is the only thing standing between this file and a full clause-accurate
+index entry.
 
-## §5.2 Establish application specification
+## Establish the application specification
 
-Documenting the device's intended medical indication, intended patient population, intended part
-of the body or tissue interacted with, intended use environment, and intended operator profile.
-Entirely device-level information MduX has no visibility into.
+Documenting the device's intended medical indication, intended patient population, intended part of
+the body or tissue interacted with, intended use environment, and intended operator profile.
 
-## §5.3 Establish user interface characteristics related to safety, hazards and hazardous situations
+Entirely device-level information MduX has no visibility into. A UI library is instantiated by a
+device; it does not know the patient population it will be read by.
+
+## Establish user interface characteristics related to safety
 
 Identifying which UI characteristics could contribute to a use error with safety consequences —
-frequently-used functions, and functions whose incorrect use could cause harm. This is the sub-clause
-where a future MduX mechanism is most plausible: once the `.medui` compiler (issue #15) and content
-budget validation exist, a compile-time-enforced limit on, say, how much text a safety-critical
-field may contain would be a concrete answer to *one* characteristic this sub-clause asks about.
-No such mechanism exists today — this corpus states the future shape rather than a present
-Justification.
+frequently-used functions, and functions whose incorrect use could cause harm.
 
-## §5.4 Establish user interface specification
+This is the step where MduX's planned mechanisms attach most directly, and it is worth being
+precise about which ones and what they would and would not establish:
+
+| Planned mechanism | Issue | What it would establish | What it would not |
+|---|---|---|---|
+| `@safety_critical` annotation on a `.medui` element | #15 | That an element the author considers safety-relevant is *marked*, so every other mechanism below can be scoped to it | Whether the author marked the right elements — that judgement is the device's |
+| `requirement:` binding on an annotated element | #15 | That every safety-critical element names the requirement it exists to satisfy, checked at compile time rather than in review | That the requirement is the correct one, or that it is met |
+| Text-budget validation against every approved locale | #15 | That an annotated field cannot overflow or truncate in any locale the device ships, in any build — a use-error mode (a value read as `12` when it is `120`) removed by construction | Anything about legibility, contrast, or comprehension |
+| Rendered-truth verification | #16 | That the compiled screen renders the values it was given — the pixels match the model | That the values themselves are correct, or that a clinician reads them correctly |
+
+None of these exist today: the `.medui` compiler has not been built. This corpus states the shape
+they would take rather than manufacturing a `Justification` for a mechanism that does not exist.
+The distinction matters more here than in most of this repository — a usability engineering file
+citing a control that is not implemented is exactly the failure mode this standard's evaluation
+steps exist to catch.
+
+## Establish the user interface specification
 
 Specifying the UI's design inputs: layout, information to be conveyed, and interaction requirements
-that follow from the application specification and identified hazards. Device-level; MduX provides
-the compiler and runtime a device's UI specification would be authored against, once built, not the
-specification itself.
+that follow from the application specification and the identified hazards.
 
-## §5.5 Establish user interface evaluation plan
+Device-level. Once issue #15 lands, a `.medui` source file is the artifact a device's UI
+specification is *authored against* and, in part, expressed in — but the specification itself,
+including what a screen must convey and why, remains the device manufacturer's.
 
-Planning what will be evaluated (formative and summative), against what criteria, and by what
-method. Device-level; no MduX mechanism.
+## Establish the user interface evaluation plan
 
-## §5.6 Perform user interface design and implementation
+Planning what will be evaluated — formatively and summatively — against what criteria and by what
+method. Device-level; no MduX mechanism, and none plausible: an evaluation plan is a statement
+about people and a use environment, neither of which a library has.
 
-For MduX, "implementation" of a device's UI *is* authoring and compiling a `.medui` screen (issue
-#15) — the point at which this corpus's future mechanisms would most directly apply. Today, there
-is no `.medui` compiler yet, so there is no implementation mechanism to cite.
+## Perform user interface design and implementation
 
-## §5.7 Perform formative evaluation
+For a device built on MduX, implementing a user interface *is* authoring and compiling `.medui`
+screens (issue #15). This is where the mechanisms tabulated above would run, at build time, on
+every change.
 
-Iteratively evaluating the UI during design to catch use-related problems before they reach a final
-design. Device-level, and dependent on a device's actual users; no MduX mechanism, and none
-plausible even once `.medui` exists — this step needs real user interaction, not a compiled
-artifact.
+Today there is no `.medui` compiler, so there is no implementation mechanism to cite.
 
-## §5.8 (further design iteration, as evaluation results require)
+## Perform formative evaluation
 
-Iterating §5.4 through §5.7 as formative evaluation results warrant. No MduX mechanism, for the
-same reasons as the steps it iterates.
+Iteratively evaluating the UI during design, to find use-related problems before the design is
+final.
 
-## §5.9 Perform summative evaluation
+Device-level and dependent on a device's actual users; no MduX mechanism, and none plausible even
+once `.medui` exists. This step needs real people interacting with a real device in a realistic
+environment. A compiler cannot substitute for that, and a corpus that implied otherwise would be
+describing a control the device does not have.
+
+## Iterate the design as evaluation results require
+
+Repeating specification, design, implementation and formative evaluation as the results warrant.
+No MduX mechanism, for the same reasons as the steps it iterates.
+
+## Perform summative evaluation
 
 Confirming, on the final design, that residual use-related risk is acceptable — the evidence a
-usability engineering file ultimately needs to support a device's release. Device-level; no MduX
-mechanism, and the rendered-truth verification epic (issue #16) is the closest MduX comes to an
-adjacent idea — confirming a compiled screen renders as specified — without being a substitute for
-evaluating actual use by real users.
+usability engineering file ultimately needs to support a device's release.
+
+Device-level. Rendered-truth verification (issue #16) is the closest adjacent idea MduX has, and it
+is worth naming the gap precisely: it confirms that a compiled screen renders the state it was
+given. Summative evaluation confirms that a clinician, under realistic conditions, reads that
+screen and acts correctly. The first is a property of the software; the second is a property of the
+software *and* its users, and only the second is what this step asks for.

--- a/docs/iec62366/03-usability-engineering-process.md
+++ b/docs/iec62366/03-usability-engineering-process.md
@@ -1,0 +1,64 @@
+# IEC 62366-1:2015 §5 — Usability engineering process
+
+See the confidence note in [`README.md`](README.md): the named steps below are described with
+higher confidence than their exact `§5.x` numbering, which should be checked against the actual
+standard before being cited elsewhere.
+
+## §5.1 General
+
+Establishing that the usability engineering process runs across the device's life cycle, iterating
+as the design evolves. Device-level; no MduX mechanism.
+
+## §5.2 Establish application specification
+
+Documenting the device's intended medical indication, intended patient population, intended part
+of the body or tissue interacted with, intended use environment, and intended operator profile.
+Entirely device-level information MduX has no visibility into.
+
+## §5.3 Establish user interface characteristics related to safety, hazards and hazardous situations
+
+Identifying which UI characteristics could contribute to a use error with safety consequences —
+frequently-used functions, and functions whose incorrect use could cause harm. This is the sub-clause
+where a future MduX mechanism is most plausible: once the `.medui` compiler (issue #15) and content
+budget validation exist, a compile-time-enforced limit on, say, how much text a safety-critical
+field may contain would be a concrete answer to *one* characteristic this sub-clause asks about.
+No such mechanism exists today — this corpus states the future shape rather than a present
+Justification.
+
+## §5.4 Establish user interface specification
+
+Specifying the UI's design inputs: layout, information to be conveyed, and interaction requirements
+that follow from the application specification and identified hazards. Device-level; MduX provides
+the compiler and runtime a device's UI specification would be authored against, once built, not the
+specification itself.
+
+## §5.5 Establish user interface evaluation plan
+
+Planning what will be evaluated (formative and summative), against what criteria, and by what
+method. Device-level; no MduX mechanism.
+
+## §5.6 Perform user interface design and implementation
+
+For MduX, "implementation" of a device's UI *is* authoring and compiling a `.medui` screen (issue
+#15) — the point at which this corpus's future mechanisms would most directly apply. Today, there
+is no `.medui` compiler yet, so there is no implementation mechanism to cite.
+
+## §5.7 Perform formative evaluation
+
+Iteratively evaluating the UI during design to catch use-related problems before they reach a final
+design. Device-level, and dependent on a device's actual users; no MduX mechanism, and none
+plausible even once `.medui` exists — this step needs real user interaction, not a compiled
+artifact.
+
+## §5.8 (further design iteration, as evaluation results require)
+
+Iterating §5.4 through §5.7 as formative evaluation results warrant. No MduX mechanism, for the
+same reasons as the steps it iterates.
+
+## §5.9 Perform summative evaluation
+
+Confirming, on the final design, that residual use-related risk is acceptable — the evidence a
+usability engineering file ultimately needs to support a device's release. Device-level; no MduX
+mechanism, and the rendered-truth verification epic (issue #16) is the closest MduX comes to an
+adjacent idea — confirming a compiled screen renders as specified — without being a substitute for
+evaluating actual use by real users.

--- a/docs/iec62366/README.md
+++ b/docs/iec62366/README.md
@@ -1,22 +1,29 @@
-# IEC 62366-1:2015 — clause-accurate reference
+# IEC 62366-1:2015 — clause reference, top-level clauses only
 
 New content, following the same convention as [`docs/iso14971/`](../iso14971/):
 [`docs/governance/citation-convention.md`](../governance/citation-convention.md)'s citation-key
 format, original prose only, `Justification` objects where a real MduX mechanism applies.
 
-## Confidence note — read before citing a sub-clause from this directory
+## What this directory cites, and what it does not
 
-This corpus's citations below the top level (`§5.1` through `§5.9`) are written from general
-professional familiarity with IEC 62366-1's usability engineering process, not from the standard
-text itself, which this project does not reproduce or hold a copy of (see
-[ADR-006](../adr/ADR-006-no-reproduction-of-normative-standard-text.md)). Confidence in the exact
-sub-clause numbering here is lower than for [`docs/iec62304/`](../iec62304/),
-[`docs/iso13485/`](../iso13485/), and [`docs/iso14971/`](../iso14971/), which this project's authors
-are more confident is accurate at the same depth. **Verify any `§5.x` citation from this directory
-against the actual standard before relying on it** — the named process steps (application
-specification, UI-related hazard identification, UI specification, evaluation planning, design and
-implementation, formative evaluation, summative evaluation) are the part of this corpus with higher
-confidence; their exact numeric position within §5 is the part that most needs checking.
+This corpus cites IEC 62366-1:2015 at the **top level only** — `§1` through `§5`. Those clause
+numbers are asserted; nothing below them is.
+
+An earlier version of [`03-usability-engineering-process.md`](03-usability-engineering-process.md)
+numbered the process steps `§5.1` through `§5.9`. Those numbers came from general professional
+familiarity with the usability engineering process rather than from the standard text, which this
+project does not hold a copy of (see
+[ADR-006](../adr/ADR-006-no-reproduction-of-normative-standard-text.md)). The citation convention
+requires a clause number to be confirmed before it is cited, so they have been **removed rather
+than caveated**: a warning label does not stop a number being copied into a design history file,
+and a reader who copies it has cited something nobody checked. The named process steps — application
+specification, UI characteristics related to safety, UI specification, evaluation planning, design
+and implementation, formative evaluation, iteration, summative evaluation — are what this corpus
+asserts, and they are stated as headings rather than citations.
+
+Restoring the sub-clause numbering needs one thing this repository cannot supply: a maintainer with
+access to IEC 62366-1:2015, checking each heading against the standard's §5. That is tracked on
+issue #30.
 
 ## What this is, and is not
 
@@ -37,5 +44,21 @@ have not been built.
 | [`02-general-requirements.md`](02-general-requirements.md) | §4 | General requirements for applying usability engineering |
 | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | §5 | Application specification through summative evaluation |
 
-A per-clause index (`AI-Reference.md`) and JSON Schemas are tracked separately as issues #32
-and #33.
+A per-clause index (`AI-Reference.md`) is tracked separately as issue #32.
+
+## Schemas
+
+[`schemas/usability-engineering-record.schema.json`](schemas/usability-engineering-record.schema.json)
+is one use-related risk, the UI characteristic it arises from, and the control that addresses it.
+
+Two things about it are deliberate. Its `process_step` is a set of **named** steps rather than
+clause numbers, for the reason above — putting unverified sub-clause numbers into machine-readable
+form would be worse than leaving them out of prose. And `control_status` is required with no
+default: a usability engineering file citing a control that is not implemented is the precise
+failure this standard's evaluation steps exist to catch, so a record cannot be written without
+saying whether its control exists today, and a `planned` one must name the issue that would build
+it.
+
+`requirement_id` and `hazard_id` use the same shapes as `mdux::governance::Requirement::id` and
+`Hazard::id`, so a usability control joins to the risk management file rather than sitting beside
+it — use-related risk is risk.

--- a/docs/iec62366/README.md
+++ b/docs/iec62366/README.md
@@ -1,0 +1,41 @@
+# IEC 62366-1:2015 — clause-accurate reference
+
+New content, following the same convention as [`docs/iso14971/`](../iso14971/):
+[`docs/governance/citation-convention.md`](../governance/citation-convention.md)'s citation-key
+format, original prose only, `Justification` objects where a real MduX mechanism applies.
+
+## Confidence note — read before citing a sub-clause from this directory
+
+This corpus's citations below the top level (`§5.1` through `§5.9`) are written from general
+professional familiarity with IEC 62366-1's usability engineering process, not from the standard
+text itself, which this project does not reproduce or hold a copy of (see
+[ADR-006](../adr/ADR-006-no-reproduction-of-normative-standard-text.md)). Confidence in the exact
+sub-clause numbering here is lower than for [`docs/iec62304/`](../iec62304/),
+[`docs/iso13485/`](../iso13485/), and [`docs/iso14971/`](../iso14971/), which this project's authors
+are more confident is accurate at the same depth. **Verify any `§5.x` citation from this directory
+against the actual standard before relying on it** — the named process steps (application
+specification, UI-related hazard identification, UI specification, evaluation planning, design and
+implementation, formative evaluation, summative evaluation) are the part of this corpus with higher
+confidence; their exact numeric position within §5 is the part that most needs checking.
+
+## What this is, and is not
+
+IEC 62366-1 specifies a usability engineering process for identifying and mitigating use-related
+risks for a medical device's user interface. MduX renders UI content but does not, itself, run a
+usability engineering process against a device's actual users and use environment — that remains a
+device integrator's responsibility. Where MduX's architecture bears directly on a use-related risk
+category regardless of the integrating device (a UI budget the compiler enforces at build time, for
+instance, once issue #15 exists), this corpus will say so; today, most of the process this standard
+describes has no MduX mechanism yet, because the `.medui` compiler and renderer it would apply to
+have not been built.
+
+## Structure
+
+| File | Clause(s) | Covers |
+|---|---|---|
+| [`01-scope-and-terms.md`](01-scope-and-terms.md) | §1–§3 | Scope, normative references, terms and definitions |
+| [`02-general-requirements.md`](02-general-requirements.md) | §4 | General requirements for applying usability engineering |
+| [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | §5 | Application specification through summative evaluation |
+
+A per-clause index (`AI-Reference.md`) and JSON Schemas are tracked separately as issues #32
+and #33.

--- a/docs/iec62366/schemas/usability-engineering-record.schema.json
+++ b/docs/iec62366/schemas/usability-engineering-record.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdux.dev/schemas/iec62366/usability-engineering-record.schema.json",
+  "title": "IEC 62366-1 usability engineering record",
+  "description": "One use-related risk, the user interface characteristic it arises from, and the control that addresses it. Two design choices are worth reading before using this schema. First, process_step is a set of named steps rather than clause numbers: this corpus asserts IEC 62366-1:2015 clause numbers at the top level only, and inventing sub-clause numbers here would put unverified citations into machine-readable form, which is worse than leaving them out of prose (see docs/iec62366/README.md). Second, control_status is required and has no default. A usability engineering file that cites a control which is not implemented is the precise failure this standard's evaluation steps exist to catch, so a record cannot be written without stating whether its control exists today - and 'planned' records carry the issue that would implement them.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["record_id", "process_step", "use_error", "harm", "ui_characteristic", "control", "control_status", "owner"],
+  "properties": {
+    "record_id": {
+      "type": "string",
+      "description": "Unique within docs/iec62366/.",
+      "pattern": "^UER-[0-9]{3,}$"
+    },
+    "process_step": {
+      "type": "string",
+      "description": "Which step of the §5 usability engineering process this record belongs to. Named, not numbered - see the schema description. The order here is the order the steps run in.",
+      "enum": [
+        "application_specification",
+        "ui_characteristics_related_to_safety",
+        "ui_specification",
+        "evaluation_plan",
+        "design_and_implementation",
+        "formative_evaluation",
+        "design_iteration",
+        "summative_evaluation"
+      ]
+    },
+    "use_error": {
+      "type": "string",
+      "description": "What the user does, or fails to do, that this record is about. Stated as an action rather than as a defect: 'reads a dose value truncated to two digits', not 'text overflows'.",
+      "minLength": 1
+    },
+    "harm": {
+      "type": "string",
+      "description": "The injury or damage that can follow from the use error.",
+      "minLength": 1
+    },
+    "ui_characteristic": {
+      "type": "string",
+      "description": "The user interface characteristic the use error arises from - the thing a manufacturer would change to remove it.",
+      "minLength": 1
+    },
+    "control": {
+      "type": "string",
+      "description": "The measure that addresses the use error. Where MduX supplies it, name the mechanism concretely (an annotation, a compile-time check, a verification pass) rather than describing an intent.",
+      "minLength": 1
+    },
+    "control_status": {
+      "type": "string",
+      "description": "Whether the control exists. 'implemented' requires evidence_refs to be present and non-empty; 'planned' requires planned_by_issue. There is no default: a record that did not have to say would let an unimplemented control read as an implemented one.",
+      "enum": ["implemented", "planned", "not_applicable"]
+    },
+    "owner": {
+      "type": "string",
+      "description": "Who the control belongs to. 'device_manufacturer' is the normal case - identifying use errors for an intended use and evaluating them with real users are device-level activities. 'mdux' is for controls this library enforces regardless of the integrating device.",
+      "enum": ["device_manufacturer", "mdux"]
+    },
+    "requirement_id": {
+      "type": "string",
+      "description": "The requirement this control satisfies, if one is bound. Same shape as mdux::governance::Requirement::id, so a usability control and a verification case can be joined on it.",
+      "pattern": "^REQ-[A-Z0-9-]+$"
+    },
+    "hazard_id": {
+      "type": "string",
+      "description": "The ISO 14971 hazard record this use-related risk feeds, if one exists. Same shape as mdux::governance::Hazard::id - use-related risk is risk, and IEC 62366-1's output belongs in the same risk management file.",
+      "pattern": "^HAZ-[A-Z0-9-]+$"
+    },
+    "planned_by_issue": {
+      "type": "integer",
+      "description": "The issue that would implement a planned control. Required when control_status is 'planned', so a planned control is traceable to work rather than to an intention.",
+      "minimum": 1
+    },
+    "evidence_refs": {
+      "type": "array",
+      "description": "Repository-relative paths showing the control exists. Required and non-empty when control_status is 'implemented'.",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "notes": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"control_status": {"const": "implemented"}},
+        "required": ["control_status"]
+      },
+      "then": {
+        "required": ["evidence_refs"],
+        "properties": {"evidence_refs": {"minItems": 1}}
+      }
+    },
+    {
+      "if": {
+        "properties": {"control_status": {"const": "planned"}},
+        "required": ["control_status"]
+      },
+      "then": {"required": ["planned_by_issue"]}
+    }
+  ],
+  "examples": [
+    {
+      "record_id": "UER-001",
+      "process_step": "ui_characteristics_related_to_safety",
+      "use_error": "A clinician reads a dose value that has been truncated by the field it is rendered in, and administers the truncated value.",
+      "harm": "Incorrect dose administered.",
+      "ui_characteristic": "A safety-critical numeric field whose width was validated in one locale but not in every locale the device ships.",
+      "control": "Text-budget validation over every approved locale, run by the .medui compiler at build time on every element carrying @safety_critical, so a build that could truncate does not link.",
+      "control_status": "planned",
+      "owner": "mdux",
+      "planned_by_issue": 15,
+      "requirement_id": "REQ-TEXT-BUDGET-001",
+      "hazard_id": "HAZ-DEVICE-014",
+      "notes": "The control removes one mechanism of this use error by construction. It says nothing about legibility or comprehension, which stay with the device's summative evaluation."
+    },
+    {
+      "record_id": "UER-002",
+      "process_step": "summative_evaluation",
+      "use_error": "A clinician misreads a waveform whose rendering differs from the state the device intended to display.",
+      "harm": "A clinical decision taken on a display that does not reflect the patient.",
+      "ui_characteristic": "The rendering path between the device's model state and the pixels on screen.",
+      "control": "Rendered-truth verification confirms a compiled screen renders the state it was given. This is a control on the software, not on the reading of it - the device's summative evaluation with real users is what covers the latter, and this record does not claim otherwise.",
+      "control_status": "planned",
+      "owner": "mdux",
+      "planned_by_issue": 16
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `docs/iec62366/` — new content covering IEC 62366-1's usability engineering process (§1–3 scope/terms, §4 general requirements, §5 the process itself, application specification through summative evaluation).
- **Confidence flag, stated prominently in the README**: sub-clause numbering here (`§5.1`–`§5.9`) is written from general professional familiarity with the process, not verified against the standard text (which this project doesn't hold a copy of). Confidence in the *named steps* is higher than in their *exact numeric position*. This is meaningfully lower confidence than #27–#29, and is flagged as needing follow-up verification rather than presented with false precision.
- No `Justification` objects: the process needs actual users and a specific device's UI, which MduX doesn't have. Every §5 sub-clause states plainly that no MduX mechanism exists yet.

## Test plan
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 0 findings, full repo (45 files)
- [x] All markdown links resolve

Stacked on #90 (issue #29). Part of #8, issue #30.

**Flagging for reviewer attention:** this PR's clause numbering should be checked against the actual IEC 62366-1 text before being relied on for anything compliance-facing — see the confidence note in the README for specifics.
