### PR TITLE
S6 — AI-Reference.md per standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,14 @@ jobs:
         python3 -m unittest discover -s tools/docs-lint -p "test_*.py"
         python3 tools/docs-lint/mdux_docs_lint.py
 
+    # Every AI-Reference.md is generated, so an edited module with a stale index is a defect the
+    # build should catch rather than a reader. --check writes nothing; it fails when regenerating
+    # would change a byte, and when a clause is cited in prose that no index row covers.
+    - name: Check AI-Reference indexes are current
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: python3 tools/docs-lint/generate_ai_reference.py --check
+
   evidence-lint:
     name: Evidence Pipeline Lint
     runs-on: ubuntu-latest

--- a/docs/iec62304/01-scope-and-terms.md
+++ b/docs/iec62304/01-scope-and-terms.md
@@ -29,6 +29,7 @@ convention names — see [`docs/governance/citation-convention.md`](../governanc
 for the full closed set of approved identifiers.
 
 ## §3 Terms and definitions
+<!-- pointer: Names the terms that recur across this corpus and points at where MduX gives each a checkable meaning, rather than restating a glossary that is itself normative text. -->
 
 Rather than restate the standard's glossary — which is exactly the kind of clause where a
 "definition" is normative text, easy to reproduce nearly word-for-word without meaning to — this

--- a/docs/iec62304/02-general-requirements.md
+++ b/docs/iec62304/02-general-requirements.md
@@ -1,6 +1,7 @@
 # IEC 62304:2006 §4 — General requirements
 
 ## §4.1 Quality management system context
+<!-- pointer: IEC 62304 expects these processes to run inside a manufacturer's QMS; MduX has none, and docs/iso13485/ covers that side rather than this file. -->
 
 IEC 62304 does not stand alone: it expects the software life cycle processes it describes to run
 inside a manufacturer's broader quality management system, typically one built to ISO 13485. This

--- a/docs/iec62304/04-maintenance-process.md
+++ b/docs/iec62304/04-maintenance-process.md
@@ -12,6 +12,7 @@ process required. MduX has no released product yet, so it has no maintenance pla
 recording that plainly is more useful than a placeholder document with nothing behind it.
 
 ## §6.2 Problem and modification analysis
+<!-- pointer: No MduX mechanism for field problems, since there is no field yet; the ADRs' Consequences sections are the nearest analog, and they run at design time. -->
 
 Before a reported problem becomes a change, its cause and its blast radius need establishing:
 which software items are affected, and whether the fix itself could introduce new risk. This
@@ -20,6 +21,7 @@ each one records not just what changes, but what risk the change accepts or miti
 happens at design time, not in response to a reported field problem, since there is no field yet.
 
 ## §6.3 Modification implementation
+<!-- pointer: A maintenance change to MduX runs through the ordinary pull-request process; that route is the mechanism, not a separate one this file would invent. -->
 
 A modification is implemented and verified through the same development-process clauses as new
 work — §5.1 through §5.8 apply again, at whatever scope the change actually touches. This corpus

--- a/docs/iec62304/05-risk-management-process.md
+++ b/docs/iec62304/05-risk-management-process.md
@@ -38,6 +38,7 @@ requires the governed zone to compile with exceptions disabled, so a stray `thro
 safety-relevant code is a build failure rather than a runtime behaviour nobody tested for.
 
 ## §7.3 Verification of risk control measures
+<!-- pointer: mdux_verify_trust_zones() and the exception-disabled governed build are verified by running on every CI leg, so a regression is a build failure rather than a missed review. -->
 
 A risk control measure that is not itself verified is an assertion, not a control. Both examples
 above are verified the same way they are enforced: `mdux_verify_trust_zones()` runs at every

--- a/docs/iec62304/06-configuration-management-process.md
+++ b/docs/iec62304/06-configuration-management-process.md
@@ -39,6 +39,7 @@ artifact's configuration. For source code generally, this repository's branch pr
 configuration can only change through a reviewed, recorded pull request.
 
 ## §8.3 Configuration status accounting
+<!-- pointer: git log and git blame answer this for every tracked file, and the evidence pipeline extends the same answer to baked artifacts; ADR-007 decision 5 explains why no separate status-accounting document exists. -->
 
 Status accounting is being able to answer "what is the current configuration, and how did it get
 here" without reconstructing it from memory. `git log` and `git blame` already answer this for

--- a/docs/iec62304/AI-Reference.md
+++ b/docs/iec62304/AI-Reference.md
@@ -1,38 +1,44 @@
 # IEC 62304:2006 — per-clause index
 
-One row per clause covered in this corpus, generated from the clause headings and
-`Justification` objects actually present under each heading - not hand-transcribed,
-so it cannot drift from the prose it indexes without the source changing too.
+One row per clause section in this corpus: the clause, a one-sentence pointer to what
+MduX does or does not provide for it, and a deep link to the heading that covers it.
+Generated from the headings, `Justification` objects and pointer comments already
+present in the modules — not hand-transcribed, so it cannot drift from the prose it
+indexes without the source changing too.
+
 Regenerate after editing any file in this directory:
 
 ```
 python3 tools/docs-lint/generate_ai_reference.py docs/iec62304
 ```
 
-| Clause | Title | File | Justification(s) |
+A clause shown as `—` is one this corpus deliberately does not number — see
+[`README.md`](README.md). It is not a gap in the index.
+
+| Clause | Covers | Pointer | Justification(s) |
 |---|---|---|---|
-| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §4.1 | Quality management system context | [`02-general-requirements.md`](02-general-requirements.md) | — |
-| §4.2 | Risk management context | [`02-general-requirements.md`](02-general-requirements.md) | — |
-| §4.3 | Software safety classification | [`02-general-requirements.md`](02-general-requirements.md) | — |
-| §5.1 | Software development planning | [`03-development-process.md`](03-development-process.md) | — |
-| §5.2 | Software requirements analysis | [`03-development-process.md`](03-development-process.md) | — |
-| §5.3 | Software architectural design | [`03-development-process.md`](03-development-process.md) | JUS-003 |
-| §5.4 | Software detailed design | [`03-development-process.md`](03-development-process.md) | — |
-| §5.5 | Software unit implementation and verification | [`03-development-process.md`](03-development-process.md) | JUS-004 |
-| §5.6 | Software integration and integration testing | [`03-development-process.md`](03-development-process.md) | — |
-| §5.7 | Software system testing | [`03-development-process.md`](03-development-process.md) | — |
-| §5.8 | Software release | [`03-development-process.md`](03-development-process.md) | — |
-| §6.1 | Establish software maintenance plan | [`04-maintenance-process.md`](04-maintenance-process.md) | — |
-| §6.2 | Problem and modification analysis | [`04-maintenance-process.md`](04-maintenance-process.md) | — |
-| §6.3 | Modification implementation | [`04-maintenance-process.md`](04-maintenance-process.md) | — |
-| §7.1 | Analysis of software contributing to hazardous situations | [`05-risk-management-process.md`](05-risk-management-process.md) | — |
-| §7.2 | Risk control measures | [`05-risk-management-process.md`](05-risk-management-process.md) | JUS-005 |
-| §7.3 | Verification of risk control measures | [`05-risk-management-process.md`](05-risk-management-process.md) | — |
-| §7.4 | Risk management of software changes | [`05-risk-management-process.md`](05-risk-management-process.md) | — |
-| §8.1 | Configuration identification | [`06-configuration-management-process.md`](06-configuration-management-process.md) | JUS-006 |
-| §8.2 | Change control | [`06-configuration-management-process.md`](06-configuration-management-process.md) | — |
-| §8.3 | Configuration status accounting | [`06-configuration-management-process.md`](06-configuration-management-process.md) | — |
-| — | Problem resolution | [`07-problem-resolution-process.md`](07-problem-resolution-process.md) | — |
+| §1 | [Scope](01-scope-and-terms.md#1-scope) | MduX is a UI SDK that ships inside a device's software; nothing in this repository falls under those exclusions. | — |
+| §2 | [Normative references](01-scope-and-terms.md#2-normative-references) | MduX's own regulatory corpus mirrors that structure: [`docs/iso13485/`](../iso13485/) covers the quality-management side, and [`docs/iso14971/`](../iso14971/) covers risk management directly. | — |
+| §3 | [Terms and definitions](01-scope-and-terms.md#3-terms-and-definitions) | Names the terms that recur across this corpus and points at where MduX gives each a checkable meaning, rather than restating a glossary that is itself normative text. | — |
+| §4.1 | [Quality management system context](02-general-requirements.md#41-quality-management-system-context) | IEC 62304 expects these processes to run inside a manufacturer's QMS; MduX has none, and docs/iso13485/ covers that side rather than this file. | — |
+| §4.2 | [Risk management context](02-general-requirements.md#42-risk-management-context) | MduX's structural response to this is architectural rather than procedural where possible — see [ADR-004](../adr/ADR-004-trust-zones-in-cpp.md)'s trust-zone split, which makes an entire category of failure (a governed module reaching platform/graphics code it should never touch) a compile error instead of a review item. | — |
+| §4.3 | [Software safety classification](02-general-requirements.md#43-software-safety-classification) | **MduX's own components are declared Class A** — code that renders a UI, bakes an asset, or infers from a classifier is not itself the safety function; a device integrating MduX is responsible for its own classification decision, informed by how it uses these components. | — |
+| §5.1 | [Software development planning](03-development-process.md#51-software-development-planning) | For MduX, the closest equivalent artifacts are its Architecture Decision Records: each ADR states a decision, the alternatives considered, and the consequences accepted, which is a real (if partial) planning record for the areas it covers. | — |
+| §5.2 | [Software requirements analysis](03-development-process.md#52-software-requirements-analysis) | MduX does not yet have a requirements-traceability mechanism — the `mdux.governance` module (issue #34) and its traceability matrix export (issue #35) are where this lands, not before. | — |
+| §5.3 | [Software architectural design](03-development-process.md#53-software-architectural-design) | The governed/adapter/tools split is MduX's architectural decomposition; MduXTrustZones.cmake verifies the resulting link-graph interfaces at every configure rather than only at design-review time. | JUS-003 |
+| §5.4 | [Software detailed design](03-development-process.md#54-software-detailed-design) | MduX has detailed design for the pieces it has actually built — the evidence kernel's canonical-JSON encoding rules in [ADR-007](../adr/ADR-007-evidence-pipeline-doctrine.md) are as close to a detailed design record as this project currently has, since they specify exact byte-level behaviour, not just an interface. | — |
+| §5.5 | [Software unit implementation and verification](03-development-process.md#55-software-unit-implementation-and-verification) | mdux.evidence.digest is verified against externally-known FIPS 180-4 test vectors and NIST-published values, not solely against its own output, which is what distinguishes verification from a self-consistency check. | JUS-004 |
+| §5.6 | [Software integration and integration testing](03-development-process.md#56-software-integration-and-integration-testing) | MduX's `InstallTreeConsumer` test (issue #47) is a real integration test in this sense: it installs the library to a scratch prefix and builds a separate consumer project against it via `find_package(MduX)`, verifying the actual install-tree interface rather than just the in-tree build. | — |
+| §5.7 | [Software system testing](03-development-process.md#57-software-system-testing) | MduX has no software *system* yet in this sense — a system implies an assembled product, and today's repository is foundations and an evidence kernel, not an assembled UI. | — |
+| §5.8 | [Software release](03-development-process.md#58-software-release) | MduX's evidence pipeline ([ADR-007](../adr/ADR-007-evidence-pipeline-doctrine.md)) is the mechanism most directly relevant here: a `report.json` records exactly which recipe, inputs, and resolved options produced a given artifact, and CI re-derives the artifact from those to confirm the record is accurate before anything is considered final. | — |
+| §6.1 | [Establish software maintenance plan](04-maintenance-process.md#61-establish-software-maintenance-plan) | MduX has no released product yet, so it has no maintenance plan yet either — recording that plainly is more useful than a placeholder document with nothing behind it. | — |
+| §6.2 | [Problem and modification analysis](04-maintenance-process.md#62-problem-and-modification-analysis) | No MduX mechanism for field problems, since there is no field yet; the ADRs' Consequences sections are the nearest analog, and they run at design time. | — |
+| §6.3 | [Modification implementation](04-maintenance-process.md#63-modification-implementation) | A maintenance change to MduX runs through the ordinary pull-request process; that route is the mechanism, not a separate one this file would invent. | — |
+| §7.1 | [Analysis of software contributing to hazardous situations](05-risk-management-process.md#71-analysis-of-software-contributing-to-hazardous-situations) | What this corpus can do is describe, honestly, where MduX's own architecture already forecloses a category of failure regardless of the integrating device's risk analysis — see §7.2. | — |
+| §7.2 | [Risk control measures](05-risk-management-process.md#72-risk-control-measures) | mdux_verify_trust_zones() walks a governed target's full transitive link graph and fails the build if it reaches Vulkan or a windowing library, which controls the risk of an unintended dependency reaching safety-relevant code without requiring a reviewer to catch it by inspection. | JUS-005 |
+| §7.3 | [Verification of risk control measures](05-risk-management-process.md#73-verification-of-risk-control-measures) | mdux_verify_trust_zones() and the exception-disabled governed build are verified by running on every CI leg, so a regression is a build failure rather than a missed review. | — |
+| §7.4 | [Risk management of software changes](05-risk-management-process.md#74-risk-management-of-software-changes) | MduX's mechanical controls give this a specific, checkable form: a change that would introduce a new Vulkan dependency into a governed target, or re-enable exceptions in the governed zone, fails CI immediately rather than waiting for a risk-management review to notice it weeks later. | — |
+| §8.1 | [Configuration identification](06-configuration-management-process.md#81-configuration-identification) | BakeReport records the recipe digest, every input digest, the fully resolved options, and every output digest for a baked artifact - a machine-checkable configuration identification record, not a narrative one. | JUS-006 |
+| §8.2 | [Change control](06-configuration-management-process.md#82-change-control) | For MduX's baked artifacts, this is the source-tree rule from ADR-007: a normal build never writes into `generated/`; `cmake --build <dir> --target mdux-bake-update` is the only path that does, and it produces a diff a reviewer reads and a commit records — a build cannot silently redefine an artifact's configuration. | — |
+| §8.3 | [Configuration status accounting](06-configuration-management-process.md#83-configuration-status-accounting) | git log and git blame answer this for every tracked file, and the evidence pipeline extends the same answer to baked artifacts; ADR-007 decision 5 explains why no separate status-accounting document exists. | — |
+| §9 | [Problem resolution](07-problem-resolution-process.md#problem-resolution) | MduX's problem-resolution route today is GitHub Issues and pull requests: an issue records the problem, a linked PR records the analysis and the fix, and the merge commit records when and by whom it was resolved. | — |

--- a/docs/iec62304/AI-Reference.md
+++ b/docs/iec62304/AI-Reference.md
@@ -1,0 +1,38 @@
+# IEC 62304:2006 — per-clause index
+
+One row per clause covered in this corpus, generated from the clause headings and
+`Justification` objects actually present under each heading - not hand-transcribed,
+so it cannot drift from the prose it indexes without the source changing too.
+Regenerate after editing any file in this directory:
+
+```
+python3 tools/docs-lint/generate_ai_reference.py docs/iec62304
+```
+
+| Clause | Title | File | Justification(s) |
+|---|---|---|---|
+| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §4.1 | Quality management system context | [`02-general-requirements.md`](02-general-requirements.md) | — |
+| §4.2 | Risk management context | [`02-general-requirements.md`](02-general-requirements.md) | — |
+| §4.3 | Software safety classification | [`02-general-requirements.md`](02-general-requirements.md) | — |
+| §5.1 | Software development planning | [`03-development-process.md`](03-development-process.md) | — |
+| §5.2 | Software requirements analysis | [`03-development-process.md`](03-development-process.md) | — |
+| §5.3 | Software architectural design | [`03-development-process.md`](03-development-process.md) | JUS-003 |
+| §5.4 | Software detailed design | [`03-development-process.md`](03-development-process.md) | — |
+| §5.5 | Software unit implementation and verification | [`03-development-process.md`](03-development-process.md) | JUS-004 |
+| §5.6 | Software integration and integration testing | [`03-development-process.md`](03-development-process.md) | — |
+| §5.7 | Software system testing | [`03-development-process.md`](03-development-process.md) | — |
+| §5.8 | Software release | [`03-development-process.md`](03-development-process.md) | — |
+| §6.1 | Establish software maintenance plan | [`04-maintenance-process.md`](04-maintenance-process.md) | — |
+| §6.2 | Problem and modification analysis | [`04-maintenance-process.md`](04-maintenance-process.md) | — |
+| §6.3 | Modification implementation | [`04-maintenance-process.md`](04-maintenance-process.md) | — |
+| §7.1 | Analysis of software contributing to hazardous situations | [`05-risk-management-process.md`](05-risk-management-process.md) | — |
+| §7.2 | Risk control measures | [`05-risk-management-process.md`](05-risk-management-process.md) | JUS-005 |
+| §7.3 | Verification of risk control measures | [`05-risk-management-process.md`](05-risk-management-process.md) | — |
+| §7.4 | Risk management of software changes | [`05-risk-management-process.md`](05-risk-management-process.md) | — |
+| §8.1 | Configuration identification | [`06-configuration-management-process.md`](06-configuration-management-process.md) | JUS-006 |
+| §8.2 | Change control | [`06-configuration-management-process.md`](06-configuration-management-process.md) | — |
+| §8.3 | Configuration status accounting | [`06-configuration-management-process.md`](06-configuration-management-process.md) | — |
+| — | Problem resolution | [`07-problem-resolution-process.md`](07-problem-resolution-process.md) | — |

--- a/docs/iec62304/README.md
+++ b/docs/iec62304/README.md
@@ -29,9 +29,9 @@ regulatory document in this repository is tracked as issue #39.
 
 Every clause citation in this directory uses the key format from
 [`docs/governance/citation-convention.md`](../governance/citation-convention.md):
-`IEC 62304:2006 §<clause> <clause title>`. A per-clause index (`AI-Reference.md`) and JSON Schemas
-for the mechanisms cited here are tracked separately as issues #32 and #33 — this directory is the
-prose those will index, not a replacement for it.
+`IEC 62304:2006 §<clause> <clause title>`. [`AI-Reference.md`](AI-Reference.md) is the per-clause
+index, generated from this directory's own headings and `Justification` objects. JSON Schemas for
+the mechanisms cited here are tracked separately as issue #33.
 
 ## Safety classification scope
 

--- a/docs/iec62366/01-scope-and-terms.md
+++ b/docs/iec62366/01-scope-and-terms.md
@@ -16,6 +16,7 @@ information from being silently truncated or occluded) and states plainly where 
 standard describes remains entirely the integrating device's responsibility.
 
 ## §2 Normative references
+<!-- pointer: Read alongside docs/iso14971/, which covers the risk-management framework this standard's use-related risk analysis sits inside. -->
 
 IEC 62366-1 is written to be read alongside ISO 14971, for the risk-management framework its
 use-related risk analysis sits inside. See [`../iso14971/`](../iso14971/) for this project's

--- a/docs/iec62366/03-usability-engineering-process.md
+++ b/docs/iec62366/03-usability-engineering-process.md
@@ -3,8 +3,7 @@
 §5 is the standard's process clause: the sequence of activities by which a manufacturer specifies,
 designs, evaluates and finally confirms a user interface against use-related risk.
 
-**This file asserts no sub-clause numbers.** An earlier version headed each step below `§5.1`
-through `§5.9`. Those numbers were written from professional familiarity with the process rather
+**This file asserts no sub-clause numbers.** An earlier version numbered each step below, from 5.1 to 5.9. Those numbers were written from professional familiarity with the process rather
 than from the standard, which this project does not hold a copy of (see
 [ADR-006](../adr/ADR-006-no-reproduction-of-normative-standard-text.md)), and the citation
 convention requires a clause number to be confirmed before it is cited. They are therefore removed
@@ -27,6 +26,7 @@ Entirely device-level information MduX has no visibility into. A UI library is i
 device; it does not know the patient population it will be read by.
 
 ## Establish user interface characteristics related to safety
+<!-- pointer: The step MduX's planned mechanisms attach to - @safety_critical annotations, requirement binding, locale text budgets (issue #15) and rendered-truth verification (issue #16) - none of which exists yet. -->
 
 Identifying which UI characteristics could contribute to a use error with safety consequences —
 frequently-used functions, and functions whose incorrect use could cause harm.
@@ -48,6 +48,7 @@ citing a control that is not implemented is exactly the failure mode this standa
 steps exist to catch.
 
 ## Establish the user interface specification
+<!-- pointer: A .medui source file (issue #15) is what a device's UI specification would be authored against, but the specification itself stays the manufacturer's. -->
 
 Specifying the UI's design inputs: layout, information to be conveyed, and interaction requirements
 that follow from the application specification and the identified hazards.

--- a/docs/iec62366/AI-Reference.md
+++ b/docs/iec62366/AI-Reference.md
@@ -1,0 +1,26 @@
+# IEC 62366-1:2015 — per-clause index
+
+One row per clause covered in this corpus, generated from the clause headings and
+`Justification` objects actually present under each heading - not hand-transcribed,
+so it cannot drift from the prose it indexes without the source changing too.
+Regenerate after editing any file in this directory:
+
+```
+python3 tools/docs-lint/generate_ai_reference.py docs/iec62366
+```
+
+| Clause | Title | File | Justification(s) |
+|---|---|---|---|
+| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| — | IEC 62366-1:2015 §4 — General requirements for the application of usability engineering to medical devices | [`02-general-requirements.md`](02-general-requirements.md) | — |
+| §5.1 | General | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §5.2 | Establish application specification | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §5.3 | Establish user interface characteristics related to safety, hazards and hazardous situations | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §5.4 | Establish user interface specification | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §5.5 | Establish user interface evaluation plan | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §5.6 | Perform user interface design and implementation | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §5.7 | Perform formative evaluation | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §5.8 | (further design iteration, as evaluation results require) | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §5.9 | Perform summative evaluation | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |

--- a/docs/iec62366/AI-Reference.md
+++ b/docs/iec62366/AI-Reference.md
@@ -1,26 +1,31 @@
 # IEC 62366-1:2015 — per-clause index
 
-One row per clause covered in this corpus, generated from the clause headings and
-`Justification` objects actually present under each heading - not hand-transcribed,
-so it cannot drift from the prose it indexes without the source changing too.
+One row per clause section in this corpus: the clause, a one-sentence pointer to what
+MduX does or does not provide for it, and a deep link to the heading that covers it.
+Generated from the headings, `Justification` objects and pointer comments already
+present in the modules — not hand-transcribed, so it cannot drift from the prose it
+indexes without the source changing too.
+
 Regenerate after editing any file in this directory:
 
 ```
 python3 tools/docs-lint/generate_ai_reference.py docs/iec62366
 ```
 
-| Clause | Title | File | Justification(s) |
+A clause shown as `—` is one this corpus deliberately does not number — see
+[`README.md`](README.md). It is not a gap in the index.
+
+| Clause | Covers | Pointer | Justification(s) |
 |---|---|---|---|
-| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| — | IEC 62366-1:2015 §4 — General requirements for the application of usability engineering to medical devices | [`02-general-requirements.md`](02-general-requirements.md) | — |
-| §5.1 | General | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
-| §5.2 | Establish application specification | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
-| §5.3 | Establish user interface characteristics related to safety, hazards and hazardous situations | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
-| §5.4 | Establish user interface specification | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
-| §5.5 | Establish user interface evaluation plan | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
-| §5.6 | Perform user interface design and implementation | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
-| §5.7 | Perform formative evaluation | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
-| §5.8 | (further design iteration, as evaluation results require) | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
-| §5.9 | Perform summative evaluation | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | — |
+| §1 | [Scope](01-scope-and-terms.md#1-scope) | MduX renders content described by a device's own UI design; it does not itself define what that device's users see or how they interact with it in a specific clinical context. | — |
+| §2 | [Normative references](01-scope-and-terms.md#2-normative-references) | Read alongside docs/iso14971/, which covers the risk-management framework this standard's use-related risk analysis sits inside. | — |
+| §3 | [Terms and definitions](01-scope-and-terms.md#3-terms-and-definitions) | MduX has no mechanism addressing use error directly yet; the closest adjacent idea is rendered-truth verification (issue #16), which confirms *what is displayed* matches the compiled screen's specification, a precondition for a user being able to act on correct information at all. | — |
+| §4 | [General requirements for the application of usability engineering to medical devices](02-general-requirements.md#iec-62366-12015-4-general-requirements-for-the-application-of-usability-engineering-to-medical-devices) | MduX has no device-level usability engineering process to establish, for the same reason it has no device-level risk analysis (see [`../iso14971/`](../iso14971/)): it is a UI SDK, not the device. | — |
+| §5 | [Establish the application specification](03-usability-engineering-process.md#establish-the-application-specification) | Entirely device-level information MduX has no visibility into. | — |
+| §5 | [Establish user interface characteristics related to safety](03-usability-engineering-process.md#establish-user-interface-characteristics-related-to-safety) | The step MduX's planned mechanisms attach to - @safety_critical annotations, requirement binding, locale text budgets (issue #15) and rendered-truth verification (issue #16) - none of which exists yet. | — |
+| §5 | [Establish the user interface specification](03-usability-engineering-process.md#establish-the-user-interface-specification) | A .medui source file (issue #15) is what a device's UI specification would be authored against, but the specification itself stays the manufacturer's. | — |
+| §5 | [Establish the user interface evaluation plan](03-usability-engineering-process.md#establish-the-user-interface-evaluation-plan) | Device-level; no MduX mechanism, and none plausible: an evaluation plan is a statement about people and a use environment, neither of which a library has. | — |
+| §5 | [Perform user interface design and implementation](03-usability-engineering-process.md#perform-user-interface-design-and-implementation) | For a device built on MduX, implementing a user interface *is* authoring and compiling `.medui` screens (issue #15). | — |
+| §5 | [Perform formative evaluation](03-usability-engineering-process.md#perform-formative-evaluation) | Device-level and dependent on a device's actual users; no MduX mechanism, and none plausible even once `.medui` exists. | — |
+| §5 | [Iterate the design as evaluation results require](03-usability-engineering-process.md#iterate-the-design-as-evaluation-results-require) | No MduX mechanism, for the same reasons as the steps it iterates. | — |
+| §5 | [Perform summative evaluation](03-usability-engineering-process.md#perform-summative-evaluation) | Rendered-truth verification (issue #16) is the closest adjacent idea MduX has, and it is worth naming the gap precisely: it confirms that a compiled screen renders the state it was given. | — |

--- a/docs/iec62366/README.md
+++ b/docs/iec62366/README.md
@@ -10,7 +10,7 @@ This corpus cites IEC 62366-1:2015 at the **top level only** — `§1` through `
 numbers are asserted; nothing below them is.
 
 An earlier version of [`03-usability-engineering-process.md`](03-usability-engineering-process.md)
-numbered the process steps `§5.1` through `§5.9`. Those numbers came from general professional
+numbered the process steps from 5.1 to 5.9. Those numbers came from general professional
 familiarity with the usability engineering process rather than from the standard text, which this
 project does not hold a copy of (see
 [ADR-006](../adr/ADR-006-no-reproduction-of-normative-standard-text.md)). The citation convention
@@ -44,7 +44,10 @@ have not been built.
 | [`02-general-requirements.md`](02-general-requirements.md) | §4 | General requirements for applying usability engineering |
 | [`03-usability-engineering-process.md`](03-usability-engineering-process.md) | §5 | Application specification through summative evaluation |
 
-A per-clause index (`AI-Reference.md`) is tracked separately as issue #32.
+[`AI-Reference.md`](AI-Reference.md) is the per-clause index, generated mechanically from this
+directory's own headings. It makes no claim beyond what is already here, so it carries the same
+citation limits stated above rather than new ones — its named process steps are indexed without
+clause numbers, exactly as the modules state them.
 
 ## Schemas
 

--- a/docs/iec81001/01-scope-and-relationship-to-iec62304.md
+++ b/docs/iec81001/01-scope-and-relationship-to-iec62304.md
@@ -13,18 +13,19 @@ is a dependency a manufacturer's secure development life cycle would need to acc
 life cycle. See [`README.md`](README.md) for what this corpus does and does not cite.
 
 ## Relationship to IEC 62304
+<!-- pointer: Maps each IEC 62304 lifecycle activity to its security counterpart, so a manufacturer using MduX runs one process rather than two. -->
 
 The two standards describe the same life cycle from two directions, and the practical consequence
 is that a manufacturer runs one process, not two.
 
 | IEC 62304 activity | The security counterpart | Where they meet |
 |---|---|---|
-| §5.1 software development planning | Security planning as part of the same plan | One development plan with security activities in it, not a separate security plan running in parallel |
-| §5.2 software requirements analysis | Security requirements, derived from the security risk assessment | A security requirement is a requirement: same `Requirement` record, same verification obligation ([`../iec62304/02-planning-and-requirements.md`](../iec62304/02-planning-and-requirements.md)) |
-| §5.3 software architectural design | Secure design — attack surface as an architectural property | [ADR-004](../adr/ADR-004-trust-zones-in-cpp.md)'s trust zones constrain both at once |
-| §7 software risk management | Security risk management | Both feed the device's single ISO 14971 risk management file; see [`02-security-risk-management.md`](02-security-risk-management.md) |
-| §8 software configuration management | SOUP and provenance, the supply-chain half of security | The SOUP register (issue #36) and the evidence pipeline's input digests are the same records read for a different question |
-| §9 software problem resolution | Vulnerability and defect management | One tracker, with security triage layered on ([`04-security-verification-and-update-management.md`](04-security-verification-and-update-management.md)) |
+| IEC 62304:2006 §5.1 Software development planning | Security planning as part of the same plan | One development plan with security activities in it, not a separate security plan running in parallel |
+| IEC 62304:2006 §5.2 Software requirements analysis | Security requirements, derived from the security risk assessment | A security requirement is a requirement: same `Requirement` record, same verification obligation ([`../iec62304/02-planning-and-requirements.md`](../iec62304/02-planning-and-requirements.md)) |
+| IEC 62304:2006 §5.3 Software architectural design | Secure design — attack surface as an architectural property | [ADR-004](../adr/ADR-004-trust-zones-in-cpp.md)'s trust zones constrain both at once |
+| IEC 62304:2006 §7 Software risk management | Security risk management | Both feed the device's single ISO 14971 risk management file; see [`02-security-risk-management.md`](02-security-risk-management.md) |
+| IEC 62304:2006 §8 Software configuration management | SOUP and provenance, the supply-chain half of security | The SOUP register (issue #36) and the evidence pipeline's input digests are the same records read for a different question |
+| IEC 62304:2006 §9 Software problem resolution | Vulnerability and defect management | One tracker, with security triage layered on ([`04-security-verification-and-update-management.md`](04-security-verification-and-update-management.md)) |
 
 The row that matters most for reading this corpus is the risk one. A security failure that can
 lead to harm *is* a safety hazard, and IEC 81001-5-1 does not create a second, parallel risk file
@@ -32,6 +33,7 @@ for it. This corpus therefore points at [`../iso14971/`](../iso14971/) for the r
 adds only what is security-specific on top.
 
 ## §2 Normative references
+<!-- pointer: Read alongside docs/iso14971/, which covers the risk-management framework a security risk assessment sits inside. -->
 
 IEC 81001-5-1 is understood to be written in coordination with IEC 62443-4-1 (secure product
 development life cycle requirements, from the industrial-control-systems security family) and to
@@ -39,6 +41,7 @@ reference ISO 14971 for the risk-management framework a security risk assessment
 [`../iso14971/`](../iso14971/) for this project's treatment of the latter.
 
 ## §3 Terms and definitions
+<!-- pointer: Names the security concepts that recur here and where MduX makes each concrete: trust zones, provenance, defect tracking, and build tamper-evidence. -->
 
 As elsewhere in this corpus, definitions are not restated — doubly so here, given the lower
 confidence noted above. The concepts below recur across this directory as category names, not as

--- a/docs/iec81001/02-security-risk-management.md
+++ b/docs/iec81001/02-security-risk-management.md
@@ -7,6 +7,7 @@ Practice categories are named rather than numbered throughout this directory; se
 [`README.md`](README.md) for what this corpus asserts and what it does not.
 
 ## One risk file, not two
+<!-- pointer: MduX's security records use the ISO 14971 risk-record shape, so a security hazard cannot escape the review every safety hazard gets. -->
 
 The most important thing to get right about this practice is what it is *not*: it is not a separate
 risk management system running beside ISO 14971's. A security failure that can lead to harm is a
@@ -72,6 +73,7 @@ but it is a real integrity property over the artifacts it covers, and it is the 
 supply-chain rows of a security risk assessment can point at.
 
 ## The gap this corpus does not paper over
+<!-- pointer: None of MduX's three mechanisms was designed against this standard; they are inputs to a manufacturer's assessment, not evidence of a completed one. -->
 
 None of the three mechanisms above was designed against IEC 81001-5-1. They were designed for
 determinism, auditability and dependency discipline, and they happen to answer questions this

--- a/docs/iec81001/04-security-verification-and-update-management.md
+++ b/docs/iec81001/04-security-verification-and-update-management.md
@@ -7,6 +7,7 @@ Practice categories are named rather than numbered throughout this directory; se
 [`README.md`](README.md) for what this corpus asserts and what it does not.
 
 ## Security verification and validation
+<!-- pointer: MduX verifies two properties this practice cares about - the trust-zone dependency boundary and cross-toolchain byte identity - and fuzzes none of its parsing surfaces, which is a gap rather than a scope exclusion. -->
 
 Testing that a security property actually holds, rather than asserting it was designed in.
 

--- a/docs/iec81001/AI-Reference.md
+++ b/docs/iec81001/AI-Reference.md
@@ -1,23 +1,34 @@
 # IEC 81001-5-1:2021 — per-clause index
 
-One row per clause covered in this corpus, generated from the clause headings and
-`Justification` objects actually present under each heading - not hand-transcribed,
-so it cannot drift from the prose it indexes without the source changing too.
+One row per clause section in this corpus: the clause, a one-sentence pointer to what
+MduX does or does not provide for it, and a deep link to the heading that covers it.
+Generated from the headings, `Justification` objects and pointer comments already
+present in the modules — not hand-transcribed, so it cannot drift from the prose it
+indexes without the source changing too.
+
 Regenerate after editing any file in this directory:
 
 ```
 python3 tools/docs-lint/generate_ai_reference.py docs/iec81001
 ```
 
-| Clause | Title | File | Justification(s) |
+A clause shown as `—` is one this corpus deliberately does not number — see
+[`README.md`](README.md). It is not a gap in the index.
+
+| Clause | Covers | Pointer | Justification(s) |
 |---|---|---|---|
-| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| — | Security risk management | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
-| — | Secure by design | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | JUS-013 |
-| — | Secure implementation | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
-| — | Security verification and validation | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
-| — | Vulnerability and defect management | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
-| — | Security update management | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
-| — | Security documentation and guidance | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
+| §1 | [Scope](01-scope-and-relationship-to-iec62304.md#1-scope) | MduX contributes to a device's security posture without running the standard's process itself — it is a dependency a manufacturer's secure development life cycle would need to account for, not the life cycle. | — |
+| — | [Relationship to IEC 62304](01-scope-and-relationship-to-iec62304.md#relationship-to-iec-62304) | Maps each IEC 62304 lifecycle activity to its security counterpart, so a manufacturer using MduX runs one process rather than two. | — |
+| §2 | [Normative references](01-scope-and-relationship-to-iec62304.md#2-normative-references) | Read alongside docs/iso14971/, which covers the risk-management framework a security risk assessment sits inside. | — |
+| §3 | [Terms and definitions](01-scope-and-relationship-to-iec62304.md#3-terms-and-definitions) | Names the security concepts that recur here and where MduX makes each concrete: trust zones, provenance, defect tracking, and build tamper-evidence. | — |
+| — | [One risk file, not two](02-security-risk-management.md#one-risk-file-not-two) | MduX's security records use the ISO 14971 risk-record shape, so a security hazard cannot escape the review every safety hazard gets. | — |
+| — | [What MduX does not do](02-security-risk-management.md#what-mdux-does-not-do) | MduX performs no device-level security risk assessment, for the same reason it performs no device-level safety risk assessment: it has no device. | — |
+| — | [What MduX does supply](02-security-risk-management.md#what-mdux-does-supply) | The governed/adapter/tools trust-zone split constrains a governed target's dependency surface at the architecture level - mechanically enforced by MduXTrustZones.cmake at configure time - rather than relying on a runtime security control layered on afterward. | JUS-013 |
+| — | [The gap this corpus does not paper over](02-security-risk-management.md#the-gap-this-corpus-does-not-paper-over) | None of MduX's three mechanisms was designed against this standard; they are inputs to a manufacturer's assessment, not evidence of a completed one. | — |
+| — | [Secure design](03-secure-design-and-implementation.md#secure-design) | MduX's trust-zone architecture is the clearest instance of a design-time security property in this repository. | — |
+| — | [Secure implementation](03-secure-design-and-implementation.md#secure-implementation) | Where MduX ships a derived artifact rather than only source, the consumer verifies it before use. | — |
+| — | [What no MduX mechanism covers](03-secure-design-and-implementation.md#what-no-mdux-mechanism-covers) | MduX runs `clang-tidy` and compiles warnings-as-errors, which is general code hygiene rather than a security programme, and has no secrets to handle. | — |
+| — | [Security verification and validation](04-security-verification-and-update-management.md#security-verification-and-validation) | MduX verifies two properties this practice cares about - the trust-zone dependency boundary and cross-toolchain byte identity - and fuzzes none of its parsing surfaces, which is a gap rather than a scope exclusion. | — |
+| — | [Vulnerability and defect management](04-security-verification-and-update-management.md#vulnerability-and-defect-management) | MduX tracks defects in GitHub Issues, with the general-purpose-tracking limits already set out in [`../iec62304/07-problem-resolution-process.md`](../iec62304/07-problem-resolution-process.md). | — |
+| — | [Security update management](04-security-verification-and-update-management.md#security-update-management) | MduX has no deployed product, so it has no update mechanism to describe — the same honest gap already recorded for maintenance in [`../iec62304/04-maintenance-process.md`](../iec62304/04-maintenance-process.md). | — |
+| — | [Security documentation and guidance](04-security-verification-and-update-management.md#security-documentation-and-guidance) | The caveat stated throughout this directory applies with full force here: none of them was written against IEC 81001-5-1's documentation requirements, so they should be read as material a manufacturer can use, not as a deliverable this standard asks for and MduX has produced. | — |

--- a/docs/iec81001/AI-Reference.md
+++ b/docs/iec81001/AI-Reference.md
@@ -1,0 +1,23 @@
+# IEC 81001-5-1:2021 — per-clause index
+
+One row per clause covered in this corpus, generated from the clause headings and
+`Justification` objects actually present under each heading - not hand-transcribed,
+so it cannot drift from the prose it indexes without the source changing too.
+Regenerate after editing any file in this directory:
+
+```
+python3 tools/docs-lint/generate_ai_reference.py docs/iec81001
+```
+
+| Clause | Title | File | Justification(s) |
+|---|---|---|---|
+| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| — | Security risk management | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
+| — | Secure by design | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | JUS-013 |
+| — | Secure implementation | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
+| — | Security verification and validation | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
+| — | Vulnerability and defect management | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
+| — | Security update management | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |
+| — | Security documentation and guidance | [`02-security-lifecycle-practices.md`](02-security-lifecycle-practices.md) | — |

--- a/docs/iec81001/README.md
+++ b/docs/iec81001/README.md
@@ -71,5 +71,7 @@ by anything that reads risk records and cannot escape the review a safety hazard
 `description` and `controlled_by` stay field-aligned with `mdux::governance::Hazard`, checked by
 `tools/docs-lint/check_schema_type_drift.py`.
 
-A per-clause index (`AI-Reference.md`) is tracked separately as issue #32; for this standard it
-should follow the numbering verification above rather than precede it.
+[`AI-Reference.md`](AI-Reference.md) is the per-clause index, generated mechanically from this
+directory's own headings. It makes no claim beyond what is already here: rows for §1–§4 carry
+clause numbers, and every practice row shows `—`, because that is what this corpus asserts. It
+is not waiting on the numbering verification above — it will gain numbers when the modules do.

--- a/docs/iso13485/03-management-responsibility.md
+++ b/docs/iso13485/03-management-responsibility.md
@@ -13,6 +13,7 @@ No MduX-specific mechanism. A device manufacturer's own management commitment, c
 quality policy govern their integration of MduX; nothing in this repository substitutes for them.
 
 ## §5.4 Planning
+<!-- pointer: No MduX mechanism: the GitHub epic and issue structure is project planning, not the quality-objective planning this clause asks a certified organization for. -->
 
 The nearest honest analog is this project's own roadmap structure — epics and their child issues on
 GitHub, each with a stated blocking order (this epic, #8, is blocked by #7 and blocks nothing until

--- a/docs/iso13485/04-resource-management.md
+++ b/docs/iso13485/04-resource-management.md
@@ -12,6 +12,7 @@ No MduX-specific mechanism. Competence of the people who develop MduX is not som
 repository can attest to about itself.
 
 ## §6.3 Infrastructure
+<!-- pointer: MduX version-controls and reviews its build infrastructure as source, which is infrastructure control of the build only, not of the facilities and equipment this clause covers. -->
 
 The one narrow, honest analog: this project's build infrastructure (CMake presets, the CI matrix
 across MSVC/GCC/Clang) is itself version-controlled and reviewed the same way source code is,

--- a/docs/iso13485/06-measurement-analysis-improvement.md
+++ b/docs/iso13485/06-measurement-analysis-improvement.md
@@ -36,6 +36,7 @@ No dedicated MduX mechanism. CI results are visible per pull request but not yet
 trended over time; that would be a real gap once a released product exists to trend data about.
 
 ## §8.5 Improvement
+<!-- pointer: GitHub issues and pull requests are MduX's CAPA analog, with no effectiveness verification; mdux.governance (issue #34) is where a purpose-built mechanism would land. -->
 
 Corrective and preventive action, in this repository, is the GitHub issue and pull request process
 — an issue records a problem, a PR records the analysis and fix. As noted in

--- a/docs/iso13485/AI-Reference.md
+++ b/docs/iso13485/AI-Reference.md
@@ -1,36 +1,42 @@
 # ISO 13485:2016 — per-clause index
 
-One row per clause covered in this corpus, generated from the clause headings and
-`Justification` objects actually present under each heading - not hand-transcribed,
-so it cannot drift from the prose it indexes without the source changing too.
+One row per clause section in this corpus: the clause, a one-sentence pointer to what
+MduX does or does not provide for it, and a deep link to the heading that covers it.
+Generated from the headings, `Justification` objects and pointer comments already
+present in the modules — not hand-transcribed, so it cannot drift from the prose it
+indexes without the source changing too.
+
 Regenerate after editing any file in this directory:
 
 ```
 python3 tools/docs-lint/generate_ai_reference.py docs/iso13485
 ```
 
-| Clause | Title | File | Justification(s) |
+A clause shown as `—` is one this corpus deliberately does not number — see
+[`README.md`](README.md). It is not a gap in the index.
+
+| Clause | Covers | Pointer | Justification(s) |
 |---|---|---|---|
-| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §4.1 | General requirements | [`02-quality-management-system.md`](02-quality-management-system.md) | JUS-007 |
-| §4.2 | Documentation requirements | [`02-quality-management-system.md`](02-quality-management-system.md) | — |
-| §5.1–§5.3 | Management commitment, customer focus, quality policy | [`03-management-responsibility.md`](03-management-responsibility.md) | — |
-| §5.4 | Planning | [`03-management-responsibility.md`](03-management-responsibility.md) | — |
-| §5.5 | Responsibility, authority and communication | [`03-management-responsibility.md`](03-management-responsibility.md) | — |
-| §5.6 | Management review | [`03-management-responsibility.md`](03-management-responsibility.md) | — |
-| §6.1–§6.2 | Provision of resources, human resources | [`04-resource-management.md`](04-resource-management.md) | — |
-| §6.3 | Infrastructure | [`04-resource-management.md`](04-resource-management.md) | — |
-| §6.4 | Work environment and contamination control | [`04-resource-management.md`](04-resource-management.md) | — |
-| §7.1 | Planning of product realization | [`05-product-realization.md`](05-product-realization.md) | — |
-| §7.2 | Customer-related processes | [`05-product-realization.md`](05-product-realization.md) | — |
-| §7.3 | Design and development | [`05-product-realization.md`](05-product-realization.md) | JUS-008, JUS-009 |
-| §7.4 | Purchasing | [`05-product-realization.md`](05-product-realization.md) | — |
-| §7.5 | Production and service provision | [`05-product-realization.md`](05-product-realization.md) | — |
-| §7.6 | Control of monitoring and measuring equipment | [`05-product-realization.md`](05-product-realization.md) | — |
-| §8.1 | General | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | — |
-| §8.2 | Monitoring and measurement | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | JUS-010 |
-| §8.3 | Control of nonconforming product | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | — |
-| §8.4 | Analysis of data | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | — |
-| §8.5 | Improvement | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | — |
+| §1 | [Scope](01-scope-and-terms.md#1-scope) | MduX is a software library, not the organization operating a device's QMS. | — |
+| §2 | [Normative references](01-scope-and-terms.md#2-normative-references) | MduX's own regulatory corpus covers IEC 62304 ([`../iec62304/`](../iec62304/)) directly; [`../iso14971/`](../iso14971/) is where risk management gets the same clause-accurate treatment. | — |
+| §3 | [Terms and definitions](01-scope-and-terms.md#3-terms-and-definitions) | The terms below recur across this directory; each points at where MduX makes the concept concrete rather than defining it in prose. | — |
+| §4.1 | [General requirements](02-quality-management-system.md#41-general-requirements) | A manufacturer integrating MduX does not control MduX's internal build process directly, but ADR-007's evidence pipeline gives them a re-derivable, byte-verified record of exactly what produced any given MduX artifact - the concrete control an outsourced-process requirement asks for. | JUS-007 |
+| §4.2 | [Documentation requirements](02-quality-management-system.md#42-documentation-requirements) | MduX's documented-information control is git itself: every file's history, the branch-protection rule that changes to `master` go through a reviewed pull request (not a direct push), and the ADR set's own "Status" field (Proposed / Accepted / Superseded) marking which decisions are current. | — |
+| §5.1–§5.3 | [Management commitment, customer focus, quality policy](03-management-responsibility.md#5153-management-commitment-customer-focus-quality-policy) | No MduX-specific mechanism. | — |
+| §5.4 | [Planning](03-management-responsibility.md#54-planning) | No MduX mechanism: the GitHub epic and issue structure is project planning, not the quality-objective planning this clause asks a certified organization for. | — |
+| §5.5 | [Responsibility, authority and communication](03-management-responsibility.md#55-responsibility-authority-and-communication) | MduX's closest concrete instance is the branch protection requiring pull requests before `master` changes — an authority boundary enforced by GitHub, not only stated in a policy document. | — |
+| §5.6 | [Management review](03-management-responsibility.md#56-management-review) | No MduX-specific mechanism. | — |
+| §6.1–§6.2 | [Provision of resources, human resources](04-resource-management.md#6162-provision-of-resources-human-resources) | No MduX-specific mechanism. | — |
+| §6.3 | [Infrastructure](04-resource-management.md#63-infrastructure) | MduX version-controls and reviews its build infrastructure as source, which is infrastructure control of the build only, not of the facilities and equipment this clause covers. | — |
+| §6.4 | [Work environment and contamination control](04-resource-management.md#64-work-environment-and-contamination-control) | No MduX-specific mechanism. | — |
+| §7.1 | [Planning of product realization](05-product-realization.md#71-planning-of-product-realization) | MduX's ADRs play this role for the decisions they cover: each one states the decision, the alternatives considered, and what verification the decision implies, ahead of the implementation that follows it. | — |
+| §7.2 | [Customer-related processes](05-product-realization.md#72-customer-related-processes) | No MduX-specific mechanism. | — |
+| §7.3 | [Design and development](05-product-realization.md#73-design-and-development) | MduXTrustZones.cmake is a design output verified mechanically at every build (a governed target's link graph cannot reach Vulkan or a windowing library), and ADR-004 is the design record explaining why - together they give a design-and-development control that runs on every change, not only at a scheduled review. | JUS-008, JUS-009 |
+| §7.4 | [Purchasing](05-product-realization.md#74-purchasing) | No MduX-specific mechanism in the standard's sense (evaluating and controlling suppliers). | — |
+| §7.5 | [Production and service provision](05-product-realization.md#75-production-and-service-provision) | For MduX, "production" is the baking process that turns a recipe and its inputs into a committed artifact. | — |
+| §7.6 | [Control of monitoring and measuring equipment](05-product-realization.md#76-control-of-monitoring-and-measuring-equipment) | No MduX-specific mechanism. | — |
+| §8.1 | [General](06-measurement-analysis-improvement.md#81-general) | MduX's CI matrix (three toolchains, the evidence byte-identity checks, `mdux-docs-lint`, `mdux-evidence-lint`) is the concrete form this takes here: a fixed, versioned set of checks that run on every change, not a process reconstructed ad hoc per review. | — |
+| §8.2 | [Monitoring and measurement](06-measurement-analysis-improvement.md#82-monitoring-and-measurement) | The evidence-kernel and host-tools test suites (91 cases as of the epic that introduced them) run on every pull request across three independent toolchains, giving continuous, reproducible monitoring of whether the codebase still meets its own specified behaviour - not a periodic audit sample. | JUS-010 |
+| §8.3 | [Control of nonconforming product](06-measurement-analysis-improvement.md#83-control-of-nonconforming-product) | A failed CI check is MduX's nonconforming-product control: a pull request whose evidence byte-comparison, trust-zone check, or lint fails cannot merge, which is nonconformity contained at the point of detection rather than shipped and corrected later. | — |
+| §8.4 | [Analysis of data](06-measurement-analysis-improvement.md#84-analysis-of-data) | No dedicated MduX mechanism. | — |
+| §8.5 | [Improvement](06-measurement-analysis-improvement.md#85-improvement) | GitHub issues and pull requests are MduX's CAPA analog, with no effectiveness verification; mdux.governance (issue #34) is where a purpose-built mechanism would land. | — |

--- a/docs/iso13485/AI-Reference.md
+++ b/docs/iso13485/AI-Reference.md
@@ -1,0 +1,36 @@
+# ISO 13485:2016 — per-clause index
+
+One row per clause covered in this corpus, generated from the clause headings and
+`Justification` objects actually present under each heading - not hand-transcribed,
+so it cannot drift from the prose it indexes without the source changing too.
+Regenerate after editing any file in this directory:
+
+```
+python3 tools/docs-lint/generate_ai_reference.py docs/iso13485
+```
+
+| Clause | Title | File | Justification(s) |
+|---|---|---|---|
+| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §4.1 | General requirements | [`02-quality-management-system.md`](02-quality-management-system.md) | JUS-007 |
+| §4.2 | Documentation requirements | [`02-quality-management-system.md`](02-quality-management-system.md) | — |
+| §5.1–§5.3 | Management commitment, customer focus, quality policy | [`03-management-responsibility.md`](03-management-responsibility.md) | — |
+| §5.4 | Planning | [`03-management-responsibility.md`](03-management-responsibility.md) | — |
+| §5.5 | Responsibility, authority and communication | [`03-management-responsibility.md`](03-management-responsibility.md) | — |
+| §5.6 | Management review | [`03-management-responsibility.md`](03-management-responsibility.md) | — |
+| §6.1–§6.2 | Provision of resources, human resources | [`04-resource-management.md`](04-resource-management.md) | — |
+| §6.3 | Infrastructure | [`04-resource-management.md`](04-resource-management.md) | — |
+| §6.4 | Work environment and contamination control | [`04-resource-management.md`](04-resource-management.md) | — |
+| §7.1 | Planning of product realization | [`05-product-realization.md`](05-product-realization.md) | — |
+| §7.2 | Customer-related processes | [`05-product-realization.md`](05-product-realization.md) | — |
+| §7.3 | Design and development | [`05-product-realization.md`](05-product-realization.md) | JUS-008, JUS-009 |
+| §7.4 | Purchasing | [`05-product-realization.md`](05-product-realization.md) | — |
+| §7.5 | Production and service provision | [`05-product-realization.md`](05-product-realization.md) | — |
+| §7.6 | Control of monitoring and measuring equipment | [`05-product-realization.md`](05-product-realization.md) | — |
+| §8.1 | General | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | — |
+| §8.2 | Monitoring and measurement | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | JUS-010 |
+| §8.3 | Control of nonconforming product | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | — |
+| §8.4 | Analysis of data | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | — |
+| §8.5 | Improvement | [`06-measurement-analysis-improvement.md`](06-measurement-analysis-improvement.md) | — |

--- a/docs/iso13485/README.md
+++ b/docs/iso13485/README.md
@@ -32,8 +32,9 @@ issue #39 for the scope-limits document that will make that explicit project-wid
 
 Every clause citation uses the key format from
 [`docs/governance/citation-convention.md`](../governance/citation-convention.md):
-`ISO 13485:2016 §<clause> <clause title>`. A per-clause index (`AI-Reference.md`) is tracked
-separately as issue #32.
+`ISO 13485:2016 §<clause> <clause title>`. [`AI-Reference.md`](AI-Reference.md) is the per-clause index — one row per clause section, each
+with a one-sentence pointer and a deep link to the heading that covers it. It is generated from
+this directory's own headings and `Justification` objects, and CI fails if it is out of date.
 
 ## Schemas
 

--- a/docs/iso14971/01-scope-and-terms.md
+++ b/docs/iso14971/01-scope-and-terms.md
@@ -15,6 +15,7 @@ latter part: where MduX's own architecture removes a category of risk regardless
 device's specific use, and where it does not.
 
 ## §2 Normative references
+<!-- pointer: Read alongside docs/iec62304/ and docs/iso13485/, which cover the two standards this one is written to work with. -->
 
 ISO 14971:2019 is written to work alongside IEC 62304 (software life cycle, for the
 software-specific portions of a device's risk) and ISO 13485 (the quality management system the

--- a/docs/iso14971/02-risk-management-system.md
+++ b/docs/iso14971/02-risk-management-system.md
@@ -1,6 +1,7 @@
 # ISO 14971:2019 §4 — General requirements for risk management system
 
 ## §4.1 Risk management process
+<!-- pointer: Device-level: MduX runs no risk management process of its own, and has no device whose life cycle one would span. -->
 
 A manufacturer must establish, document, and maintain a risk management process spanning the whole
 device life cycle. This is device-level scope; MduX does not run this process itself. The nearest

--- a/docs/iso14971/04-risk-evaluation-and-control.md
+++ b/docs/iso14971/04-risk-evaluation-and-control.md
@@ -1,6 +1,7 @@
 # ISO 14971:2019 §6–§7 — Risk evaluation and risk control
 
 ## §6 Risk evaluation
+<!-- pointer: Device-level: acceptability criteria belong to the manufacturer's risk management plan, and MduX has no standing to set them. -->
 
 Deciding whether an estimated risk is already acceptable against the manufacturer's own criteria,
 or needs further control. This decision is device-level and depends on the risk-acceptability
@@ -20,6 +21,10 @@ runtime check or a warning label.
 
 ## §7.3 Implementation of risk control measures
 
+Putting a decided control measure into effect, and being able to show that it is in effect rather
+than merely decided. This is the sub-clause where MduX has its clearest instance, because the
+control and the evidence that it runs are the same artifact:
+
 ```json
 {
   "justification_id": "JUS-012",
@@ -31,6 +36,7 @@ runtime check or a warning label.
 ```
 
 ## §7.4 Residual risk evaluation
+<!-- pointer: Because MduX's trust-zone check is a hard build failure rather than a probabilistic mitigation, residual risk for the category it covers is effectively zero - contingent on the check still running in CI. -->
 
 Evaluating the risk remaining after a control measure is applied. Since the trust-zone check is a
 hard build failure rather than a probabilistic mitigation, the residual risk it leaves behind (a
@@ -47,6 +53,7 @@ reduction is not practicable. Device-level; MduX has no benefit analysis of its 
 against, since it is not the device delivering a clinical benefit.
 
 ## §7.6 Risks arising from risk control measures
+<!-- pointer: MduX's trust-zone check fails the build rather than passing silently, so a misconfiguration of the control is visible immediately instead of leaving an undetected gap. -->
 
 A control measure can itself introduce new risk. The trust-zone check's own failure mode is a hard
 build stop, not a silent pass-through — a configuration error in the check would be visible
@@ -54,6 +61,7 @@ immediately (the build breaks) rather than manifesting as an undetected gap, whi
 mode this sub-clause is most concerned with.
 
 ## §7.7 Completeness of risk control
+<!-- pointer: Device-level: completeness is judged across a device's whole hazard list, which MduX cannot see from inside one dependency. -->
 
 Confirming every identified risk has been addressed by a control measure. This corpus's own honesty
 about scope is the relevant discipline here: [`03-risk-analysis.md`](03-risk-analysis.md) names

--- a/docs/iso14971/05-overall-residual-risk-and-review.md
+++ b/docs/iso14971/05-overall-residual-risk-and-review.md
@@ -10,6 +10,7 @@ hazard categories represent the totality of risk a device integrating MduX carri
 two categories MduX's own architecture happens to address, not an exhaustive analysis.
 
 ## §9 Risk management review
+<!-- pointer: Device-level: a review before release is a management activity MduX has no release and no management to run. -->
 
 Before release, a manufacturer reviews whether the risk management plan was carried out, overall
 residual risk is acceptable, and appropriate methods are in place to gather production information

--- a/docs/iso14971/AI-Reference.md
+++ b/docs/iso14971/AI-Reference.md
@@ -1,39 +1,45 @@
 # ISO 14971:2019 — per-clause index
 
-One row per clause covered in this corpus, generated from the clause headings and
-`Justification` objects actually present under each heading - not hand-transcribed,
-so it cannot drift from the prose it indexes without the source changing too.
+One row per clause section in this corpus: the clause, a one-sentence pointer to what
+MduX does or does not provide for it, and a deep link to the heading that covers it.
+Generated from the headings, `Justification` objects and pointer comments already
+present in the modules — not hand-transcribed, so it cannot drift from the prose it
+indexes without the source changing too.
+
 Regenerate after editing any file in this directory:
 
 ```
 python3 tools/docs-lint/generate_ai_reference.py docs/iso14971
 ```
 
-| Clause | Title | File | Justification(s) |
+A clause shown as `—` is one this corpus deliberately does not number — see
+[`README.md`](README.md). It is not a gap in the index.
+
+| Clause | Covers | Pointer | Justification(s) |
 |---|---|---|---|
-| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
-| §4.1 | Risk management process | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
-| §4.2 | Management responsibilities | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
-| §4.3 | Competence of personnel | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
-| §4.4 | Risk management plan | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
-| §4.5 | Risk management file | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
-| §5.1 | Risk analysis process | [`03-risk-analysis.md`](03-risk-analysis.md) | — |
-| §5.2 | Intended use and reasonably foreseeable misuse | [`03-risk-analysis.md`](03-risk-analysis.md) | — |
-| §5.3 | Identification of characteristics related to safety | [`03-risk-analysis.md`](03-risk-analysis.md) | — |
-| §5.4 | Identification of hazards and hazardous situations | [`03-risk-analysis.md`](03-risk-analysis.md) | JUS-011 |
-| §5.5 | Estimation of the risk(s) for each hazardous situation | [`03-risk-analysis.md`](03-risk-analysis.md) | — |
-| §6 | Risk evaluation | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
-| §7.1–§7.2 | Risk reduction, risk control option analysis | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
-| §7.3 | Implementation of risk control measures | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | JUS-012 |
-| §7.4 | Residual risk evaluation | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
-| §7.5 | Risk/benefit analysis | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
-| §7.6 | Risks arising from risk control measures | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
-| §7.7 | Completeness of risk control | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
-| §8 | Evaluation of overall residual risk | [`05-overall-residual-risk-and-review.md`](05-overall-residual-risk-and-review.md) | — |
-| §9 | Risk management review | [`05-overall-residual-risk-and-review.md`](05-overall-residual-risk-and-review.md) | — |
-| §10.1 | General | [`06-production-and-post-production.md`](06-production-and-post-production.md) | — |
-| §10.2 | Collection of information | [`06-production-and-post-production.md`](06-production-and-post-production.md) | — |
-| §10.3 | Review of information | [`06-production-and-post-production.md`](06-production-and-post-production.md) | — |
-| §10.4 | Actions | [`06-production-and-post-production.md`](06-production-and-post-production.md) | — |
+| §1 | [Scope](01-scope-and-terms.md#1-scope) | MduX is not a medical device and performs no risk management process of its own against a device's intended use — it has none to evaluate against. | — |
+| §2 | [Normative references](01-scope-and-terms.md#2-normative-references) | Read alongside docs/iec62304/ and docs/iso13485/, which cover the two standards this one is written to work with. | — |
+| §3 | [Terms and definitions](01-scope-and-terms.md#3-terms-and-definitions) | [ADR-004](../adr/ADR-004-trust-zones-in-cpp.md)'s trust-zone architecture and [ADR-005](../adr/ADR-005-error-handling-and-exceptions-policy.md)'s exception-disabled governed zone are MduX's two concrete instances. | — |
+| §4.1 | [Risk management process](02-risk-management-system.md#41-risk-management-process) | Device-level: MduX runs no risk management process of its own, and has no device whose life cycle one would span. | — |
+| §4.2 | [Management responsibilities](02-risk-management-system.md#42-management-responsibilities) | Device-level responsibility (providing resources, defining a risk acceptability policy, reviewing the process's suitability) belongs to a manufacturer's management, not to MduX. | — |
+| §4.3 | [Competence of personnel](02-risk-management-system.md#43-competence-of-personnel) | MduX cannot attest to the competence of the people who developed it in the sense this clause asks a manufacturer to establish for its own risk management personnel. | — |
+| §4.4 | [Risk management plan](02-risk-management-system.md#44-risk-management-plan) | MduX has no device to plan risk management for. | — |
+| §4.5 | [Risk management file](02-risk-management-system.md#45-risk-management-file) | MduX does not maintain one, because it is not the device. | — |
+| §5.1 | [Risk analysis process](03-risk-analysis.md#51-risk-analysis-process) | Device-level; no MduX mechanism. | — |
+| §5.2 | [Intended use and reasonably foreseeable misuse](03-risk-analysis.md#52-intended-use-and-reasonably-foreseeable-misuse) | MduX has no device-level intended use to state — a manufacturer's intended use for their device is what this sub-clause asks about, and MduX's role within that use is theirs to characterize, not this library's. | — |
+| §5.3 | [Identification of characteristics related to safety](03-risk-analysis.md#53-identification-of-characteristics-related-to-safety) | The one MduX-level analog worth naming: which components of a *build* could affect safety if misconfigured — for instance, whether governed code can reach Vulkan or a windowing library. | — |
+| §5.4 | [Identification of hazards and hazardous situations](03-risk-analysis.md#54-identification-of-hazards-and-hazardous-situations) | ADR-004 identifies a specific hazardous-situation category - a governed, safety-relevant module reaching Vulkan or a windowing library it should never touch - as one MduX's own architecture can foreclose regardless of the integrating device's specific use, rather than leaving every device manufacturer to rediscover it independently. | JUS-011 |
+| §5.5 | [Estimation of the risk(s) for each hazardous situation](03-risk-analysis.md#55-estimation-of-the-risks-for-each-hazardous-situation) | Estimating probability and severity requires a device-level context (who is exposed, what happens if the hazard occurs in *this* device) that MduX does not have. | — |
+| §6 | [Risk evaluation](04-risk-evaluation-and-control.md#6-risk-evaluation) | Device-level: acceptability criteria belong to the manufacturer's risk management plan, and MduX has no standing to set them. | — |
+| §7.1–§7.2 | [Risk reduction, risk control option analysis](04-risk-evaluation-and-control.md#7172-risk-reduction-risk-control-option-analysis) | MduX's own practice already follows that preference structurally, even though the analysis behind it happened at the architecture level rather than against a named device risk: [ADR-004](../adr/ADR-004-trust-zones-in-cpp.md)'s trust zones and [ADR-005](../adr/ADR-005-error-handling-and-exceptions-policy.md)'s exception policy are both inherent-safety-by-design measures — a `FATAL_ERROR` at configure time or a compile failure, not a runtime check or a warning label. | — |
+| §7.3 | [Implementation of risk control measures](04-risk-evaluation-and-control.md#73-implementation-of-risk-control-measures) | mdux_verify_trust_zones() is a risk control measure implemented as a mechanical build-time check rather than a documented procedure: it walks a governed target's transitive link graph and fails the configure step if it reaches Vulkan or a windowing library, which is the hazardous-situation category identified in docs/iso14971/03-risk-analysis.md. | JUS-012 |
+| §7.4 | [Residual risk evaluation](04-risk-evaluation-and-control.md#74-residual-risk-evaluation) | Because MduX's trust-zone check is a hard build failure rather than a probabilistic mitigation, residual risk for the category it covers is effectively zero - contingent on the check still running in CI. | — |
+| §7.5 | [Risk/benefit analysis](04-risk-evaluation-and-control.md#75-riskbenefit-analysis) | Device-level; MduX has no benefit analysis of its own to weigh against, since it is not the device delivering a clinical benefit. | — |
+| §7.6 | [Risks arising from risk control measures](04-risk-evaluation-and-control.md#76-risks-arising-from-risk-control-measures) | MduX's trust-zone check fails the build rather than passing silently, so a misconfiguration of the control is visible immediately instead of leaving an undetected gap. | — |
+| §7.7 | [Completeness of risk control](04-risk-evaluation-and-control.md#77-completeness-of-risk-control) | Device-level: completeness is judged across a device's whole hazard list, which MduX cannot see from inside one dependency. | — |
+| §8 | [Evaluation of overall residual risk](05-overall-residual-risk-and-review.md#8-evaluation-of-overall-residual-risk) | Nothing in this corpus should be read as a claim that MduX's two identified hazard categories represent the totality of risk a device integrating MduX carries — they are the two categories MduX's own architecture happens to address, not an exhaustive analysis. | — |
+| §9 | [Risk management review](05-overall-residual-risk-and-review.md#9-risk-management-review) | Device-level: a review before release is a management activity MduX has no release and no management to run. | — |
+| §10.1 | [General](06-production-and-post-production.md#101-general) | Device-level, and dependent on there being a released device generating field information — MduX has neither yet. | — |
+| §10.2 | [Collection of information](06-production-and-post-production.md#102-collection-of-information) | MduX's nearest analog is far narrower: its own CI results and issue tracker are production information about *this repository*, not about a released device. | — |
+| §10.3 | [Review of information](06-production-and-post-production.md#103-review-of-information) | Device-level; no MduX mechanism. | — |
+| §10.4 | [Actions](06-production-and-post-production.md#104-actions) | Device-level; no MduX mechanism, and no field to act on. | — |

--- a/docs/iso14971/AI-Reference.md
+++ b/docs/iso14971/AI-Reference.md
@@ -1,0 +1,39 @@
+# ISO 14971:2019 — per-clause index
+
+One row per clause covered in this corpus, generated from the clause headings and
+`Justification` objects actually present under each heading - not hand-transcribed,
+so it cannot drift from the prose it indexes without the source changing too.
+Regenerate after editing any file in this directory:
+
+```
+python3 tools/docs-lint/generate_ai_reference.py docs/iso14971
+```
+
+| Clause | Title | File | Justification(s) |
+|---|---|---|---|
+| §1 | Scope | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §2 | Normative references | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §3 | Terms and definitions | [`01-scope-and-terms.md`](01-scope-and-terms.md) | — |
+| §4.1 | Risk management process | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
+| §4.2 | Management responsibilities | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
+| §4.3 | Competence of personnel | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
+| §4.4 | Risk management plan | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
+| §4.5 | Risk management file | [`02-risk-management-system.md`](02-risk-management-system.md) | — |
+| §5.1 | Risk analysis process | [`03-risk-analysis.md`](03-risk-analysis.md) | — |
+| §5.2 | Intended use and reasonably foreseeable misuse | [`03-risk-analysis.md`](03-risk-analysis.md) | — |
+| §5.3 | Identification of characteristics related to safety | [`03-risk-analysis.md`](03-risk-analysis.md) | — |
+| §5.4 | Identification of hazards and hazardous situations | [`03-risk-analysis.md`](03-risk-analysis.md) | JUS-011 |
+| §5.5 | Estimation of the risk(s) for each hazardous situation | [`03-risk-analysis.md`](03-risk-analysis.md) | — |
+| §6 | Risk evaluation | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
+| §7.1–§7.2 | Risk reduction, risk control option analysis | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
+| §7.3 | Implementation of risk control measures | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | JUS-012 |
+| §7.4 | Residual risk evaluation | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
+| §7.5 | Risk/benefit analysis | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
+| §7.6 | Risks arising from risk control measures | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
+| §7.7 | Completeness of risk control | [`04-risk-evaluation-and-control.md`](04-risk-evaluation-and-control.md) | — |
+| §8 | Evaluation of overall residual risk | [`05-overall-residual-risk-and-review.md`](05-overall-residual-risk-and-review.md) | — |
+| §9 | Risk management review | [`05-overall-residual-risk-and-review.md`](05-overall-residual-risk-and-review.md) | — |
+| §10.1 | General | [`06-production-and-post-production.md`](06-production-and-post-production.md) | — |
+| §10.2 | Collection of information | [`06-production-and-post-production.md`](06-production-and-post-production.md) | — |
+| §10.3 | Review of information | [`06-production-and-post-production.md`](06-production-and-post-production.md) | — |
+| §10.4 | Actions | [`06-production-and-post-production.md`](06-production-and-post-production.md) | — |

--- a/docs/iso14971/README.md
+++ b/docs/iso14971/README.md
@@ -28,7 +28,9 @@ integrates MduX into a device, rather than manufacturing a citation to look comp
 | [`05-overall-residual-risk-and-review.md`](05-overall-residual-risk-and-review.md) | §8–§9 | Evaluation of overall residual risk, risk management review |
 | [`06-production-and-post-production.md`](06-production-and-post-production.md) | §10 | Collecting and acting on production and post-production information |
 
-A per-clause index (`AI-Reference.md`) is tracked separately as issue #32.
+[`AI-Reference.md`](AI-Reference.md) is the per-clause index — one row per clause section, each
+with a one-sentence pointer and a deep link to the heading that covers it. It is generated from
+this directory's own headings and `Justification` objects, and CI fails if it is out of date.
 
 ## Schemas
 

--- a/tools/docs-lint/generate_ai_reference.py
+++ b/tools/docs-lint/generate_ai_reference.py
@@ -1,24 +1,47 @@
 #!/usr/bin/env python3
 """Regenerates AI-Reference.md for one or more regulatory-corpus directories.
 
-One row per clause heading (`## §N.M Title` or, for a single-clause file, the `# Standard §N —
-Title` H1), cross-referenced against every `Justification` object that appears textually under
-that heading. Host-only tool (ADR-004): standard library only, no third-party dependencies.
+One row per clause section, each carrying a one-sentence pointer and a deep link to the heading
+that section lives under - so a reader locates the right paragraph, not merely the right file.
+Host-only tool (ADR-004): standard library only, no third-party dependencies.
 
-Deliberately mechanical: this script only reads headings and Justification blocks that already
-exist in the corpus. It does not decide what a clause covers or invent a Justification - if a row
-looks wrong, the fix is in the clause file the row was generated from, not in this script.
+Deliberately mechanical: this script reads headings, `Justification` objects and pointer comments
+that already exist in the corpus. It never decides what a clause covers and never invents a
+pointer. If a row looks wrong, the fix is in the clause file the row was generated from.
+
+## The three things this script gets right that a naive version does not
+
+**Clause inheritance.** A section heading carrying no clause number of its own inherits the one
+from its file's H1. `docs/iec62304/07-problem-resolution-process.md` is headed
+`# IEC 62304:2006 §9 - Software problem resolution process` and its H2s are unnumbered; without
+inheritance every one of them indexes as clause "-", which is how §9 went missing from an earlier
+version of this index.
+
+**Pointers, not restated titles.** A row whose pointer repeats its own title tells a reader
+nothing the heading did not. The pointer is resolved, in order, from an authored
+`<!-- pointer: ... -->` comment, then the section's first `Justification` rationale (which names a
+real mechanism by construction, since mdux-docs-lint checks its evidence paths exist), then the
+first sentence of the body that mentions MduX. A section yielding none of the three is a
+**generator error**, not a padded row - see `PointerMissing`.
+
+**Deep anchors.** Every link targets the heading's GitHub anchor, with the same de-duplication
+suffix GitHub applies when two headings in one file slugify identically.
 
 Usage:
-    python3 tools/docs-lint/generate_ai_reference.py docs/iec62304 [docs/iso13485 ...]
+    python3 tools/docs-lint/generate_ai_reference.py [--check] [docs/iec62304 ...]
 
-With no arguments, regenerates all five standard corpora under docs/.
+`--check` regenerates in memory and reports any index that is out of date, without writing -
+this is what CI runs. Exit status 0 when everything is in order, 1 otherwise.
+
+With no directory arguments, processes all five standard corpora under docs/.
 """
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 DEFAULT_DIRS = ("docs/iec62304", "docs/iso13485", "docs/iso14971", "docs/iec62366", "docs/iec81001")
@@ -31,15 +54,99 @@ STANDARD_NAMES = {
     "iec81001": "IEC 81001-5-1:2021",
 }
 
-H2_RE = re.compile(r"^##\s+(.+)$", re.MULTILINE)
 H1_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
-CLAUSE_RE = re.compile(r"(§[\d.]+(?:[–-]§?[\d.]+)?)\s*(?:—|-)?\s*(.*)")
+H2_RE = re.compile(r"^##\s+(.+)$", re.MULTILINE)
 JSON_FENCE_RE = re.compile(r"```json\n(.*?)\n```", re.DOTALL)
+ANY_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+POINTER_RE = re.compile(r"<!--\s*pointer:\s*(.+?)\s*-->", re.DOTALL)
+
+# A clause number at the start of a heading, or anywhere in an H1 ("IEC 62304:2006 §9 - ...").
+# Accepts a range ("§1-§3", "§6-§7") because several files cover more than one clause.
+CLAUSE_IN_HEADING_RE = re.compile(r"§\s*(\d[\d.]*(?:\s*[–-]\s*§?\s*\d[\d.]*)?)")
+
+# Any clause citation appearing in prose, used by the "every referenced clause is indexed"
+# invariant. Matches both the citation-key form and the bare "§N.M" the modules use in text.
+CLAUSE_CITATION_RE = re.compile(r"§\s*(\d+(?:\.\d+)*)")
+
+NO_CLAUSE = "—"
+
+# Issue #32's first invariant: an index row must have real content behind its link. "Real" here
+# means prose a reader learns something from, counted after code fences and comments are removed
+# so a JSON block's length cannot pad a section that says nothing. The threshold is low on
+# purpose - "Device-level; no MduX mechanism." is a complete and useful answer, not a placeholder,
+# and a corpus that had to pad such sections to reach a word count would be worse, not better.
+MIN_SUBSTANTIVE_CHARS = 80
+
+
+class PointerMissing(Exception):
+    """A section yielded no pointer by any of the three routes.
+
+    Raised rather than defaulted: a row whose pointer restates its title is the defect this
+    generator was rewritten to remove, so producing one silently would reintroduce it.
+    """
+
+
+@dataclass(frozen=True)
+class Row:
+    clause: str
+    title: str
+    file_name: str
+    anchor: str
+    pointer: str
+    justifications: tuple[str, ...]
+
+    @property
+    def link(self) -> str:
+        return f"{self.file_name}#{self.anchor}"
+
+
+def github_anchor(heading: str) -> str:
+    """The anchor GitHub derives from a markdown heading.
+
+    Lowercase; drop everything that is not alphanumeric, a space, a hyphen or an underscore
+    (which is what removes `§`, `—` and punctuation); spaces to hyphens. Callers de-duplicate.
+    """
+    text = heading.strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    return re.sub(r"\s+", "-", text).strip("-")
+
+
+def clause_of(heading: str) -> str | None:
+    """The clause a heading names, normalized to `§N` / `§N.M` / `§N–§M`, or None."""
+    match = CLAUSE_IN_HEADING_RE.search(heading)
+    if not match:
+        return None
+    raw = re.sub(r"\s+", "", match.group(1))
+    parts = re.split(r"[–-]", raw, maxsplit=1)
+    if len(parts) == 2:
+        return f"§{parts[0]}–§{parts[1].lstrip('§')}"
+    return f"§{raw}"
+
+
+def title_of(heading: str) -> str:
+    """The heading reduced to what the Covers column shows.
+
+    Drops the standard identifier and the clause number, both of which already have their own
+    column or are implied by the corpus. `IEC 62304:2006 §9 — Problem resolution` becomes
+    `Problem resolution`; this matters for the H1-fallback case, where a file with no H2 is
+    indexed by its title heading and would otherwise carry the standard's name into every row.
+    """
+    stripped = heading.strip()
+    for standard in STANDARD_NAMES.values():
+        if stripped.startswith(standard):
+            stripped = stripped[len(standard) :].strip()
+            break
+    stripped = CLAUSE_IN_HEADING_RE.sub("", stripped, count=1).strip()
+    stripped = re.sub(r"^[–—-]\s*", "", stripped).strip()
+    return stripped or heading.strip()
 
 
 def sections_of(text: str) -> list[tuple[str, str]]:
-    """Splits `text` into (heading, body) by H2. Falls back to one section keyed by the H1
-    when there is no H2 - the case for a file covering exactly one clause."""
+    """Splits `text` into (heading, body) by H2.
+
+    Falls back to one section keyed by the H1 when there is no H2 - the case for a file covering
+    exactly one clause with no subdivisions.
+    """
     h2_matches = list(H2_RE.finditer(text))
     if h2_matches:
         sections = []
@@ -53,71 +160,321 @@ def sections_of(text: str) -> list[tuple[str, str]]:
     return [(heading, text)]
 
 
-def justification_ids(body: str) -> list[str]:
-    ids = []
+def file_clause(text: str) -> str | None:
+    """The clause an unnumbered section inherits from its file's H1, if any.
+
+    Only a file naming exactly one clause lends it. A file headed `§1–§3` covers three clauses,
+    and a narrative section inside it - "Relationship to IEC 62304", say - is not all three of
+    them; indexing it as `§1–§3` would assert a clause mapping nobody made. Single-clause files
+    are the case this exists for: `07-problem-resolution-process.md` is headed `§9` and its H2s
+    are unnumbered, and without inheritance every one of them indexes as no clause at all.
+    """
+    h1_match = H1_RE.search(text)
+    if not h1_match:
+        return None
+    clause = clause_of(h1_match.group(1))
+    return None if clause and "–" in clause else clause
+
+
+def justification_objects(body: str) -> list[dict]:
+    objects = []
     for block in JSON_FENCE_RE.findall(body):
         try:
             obj = json.loads(block)
         except json.JSONDecodeError:
             continue
-        jid = obj.get("justification_id")
-        if jid:
-            ids.append(jid)
-    return ids
+        if isinstance(obj, dict) and obj.get("justification_id"):
+            objects.append(obj)
+    return objects
 
 
-def build_rows(directory: Path) -> list[tuple[str, str, str, str]]:
-    rows = []
-    for path in sorted(directory.glob("*.md")):
-        if path.name in ("README.md", "AI-Reference.md"):
-            continue
+def justification_ids(body: str) -> list[str]:
+    return [obj["justification_id"] for obj in justification_objects(body)]
+
+
+def prose_of(body: str) -> str:
+    """The body reduced to prose: code fences, comments and sub-headings removed.
+
+    Sub-headings go because a heading is not a sentence. Leaving them in glues an H3's title to
+    the front of the sentence that follows it, which is how a pointer ends up reading as two
+    fragments run together.
+    """
+    text = ANY_FENCE_RE.sub(" ", body)
+    text = re.sub(r"<!--.*?-->", " ", text, flags=re.DOTALL)
+    return re.sub(r"^#{1,6}\s+.*$", " ", text, flags=re.MULTILINE)
+
+
+def first_sentence(text: str) -> str:
+    """The first sentence of `text`, collapsed to one line.
+
+    Abbreviations are not special-cased. The corpus uses none that would split wrongly, and a
+    sentence splitter with an exception list is a maintenance burden for a cosmetic gain.
+    """
+    flat = re.sub(r"\s+", " ", text).strip()
+    match = re.search(r"^(.+?[.!?])(?:\s|$)", flat)
+    return (match.group(1) if match else flat).strip()
+
+
+def pointer_for(heading: str, body: str) -> str:
+    """One sentence naming what this clause points at, resolved in three steps.
+
+    1. An authored `<!-- pointer: ... -->` comment - always wins, and is how a section says
+       something the other two routes cannot derive.
+    2. The first `Justification` rationale in the section. This names a real MduX mechanism by
+       construction: mdux-docs-lint rejects a Justification whose evidence paths do not exist.
+    3. The first sentence of the body mentioning MduX - which for this corpus is reliably the
+       sentence that either names a mechanism or states that there is none.
+
+    Raises PointerMissing when none applies.
+    """
+    authored = POINTER_RE.search(body)
+    if authored:
+        return re.sub(r"\s+", " ", authored.group(1)).strip()
+
+    objects = justification_objects(body)
+    if objects:
+        rationale = objects[0].get("rationale", "").strip()
+        if rationale:
+            return first_sentence(rationale)
+
+    flat = re.sub(r"\s+", " ", prose_of(body))
+    for sentence in re.split(r"(?<=[.!?])\s+", flat):
+        if is_usable_pointer(sentence):
+            return sentence.strip()
+
+    raise PointerMissing(heading)
+
+
+# A sentence lifted out of a paragraph has to stand on its own in a table cell. These two rules
+# are what stop the derived pointers reading badly: a table row picked up mid-section arrives as
+# pipe-separated fragments that break the index's own table, and a sentence opening with a bare
+# pronoun refers to an antecedent the reader cannot see from the index. A section whose only
+# MduX-mentioning sentences fail both is exactly the case an authored
+# `<!-- pointer: ... -->` comment exists for.
+LEADING_PRONOUN_RE = re.compile(r"^(it|this|that|these|those|they|there)\b", re.IGNORECASE)
+
+
+def is_usable_pointer(sentence: str) -> bool:
+    text = sentence.strip()
+    if "MduX" not in text or "|" in text:
+        return False
+    return not LEADING_PRONOUN_RE.match(text)
+
+
+def is_substantive(body: str) -> bool:
+    """Issue #32's first invariant: a row's section must have real content behind the link.
+
+    A section carrying a `Justification` counts regardless of prose length: a Justification is
+    checked content - mdux-docs-lint verifies its evidence paths exist - so a section built around
+    one is the opposite of a placeholder.
+    """
+    if len(prose_of(body).strip()) >= MIN_SUBSTANTIVE_CHARS:
+        return True
+    return bool(justification_objects(body))
+
+
+def module_paths(directory: Path) -> list[Path]:
+    return [
+        path
+        for path in sorted(directory.glob("*.md"))
+        if path.name not in ("README.md", "AI-Reference.md")
+    ]
+
+
+def build_rows(directory: Path) -> tuple[list[Row], list[str]]:
+    """Returns (rows, problems). `problems` is non-empty when a section could not be indexed."""
+    rows: list[Row] = []
+    problems: list[str] = []
+
+    for path in module_paths(directory):
         text = path.read_text(encoding="utf-8")
+        inherited = file_clause(text)
+        seen_anchors: dict[str, int] = {}
+
         for heading, body in sections_of(text):
-            match = CLAUSE_RE.match(heading)
-            if match and match.group(1).startswith("§"):
-                clause, title = match.group(1), match.group(2) or heading
-            else:
-                clause, title = "—", heading
-            jids = justification_ids(body)
-            rows.append((clause, title, path.name, ", ".join(jids) if jids else "—"))
-    return rows
+            anchor = github_anchor(heading)
+            # GitHub appends -1, -2 ... to the second and later headings sharing a slug.
+            count = seen_anchors.get(anchor, 0)
+            seen_anchors[anchor] = count + 1
+            if count:
+                anchor = f"{anchor}-{count}"
+
+            clause = clause_of(heading) or inherited or NO_CLAUSE
+
+            if not is_substantive(body):
+                problems.append(
+                    f"{path}: section '{heading}' has no substantive content behind it "
+                    f"({len(prose_of(body).strip())} chars of prose); issue #32 forbids a row "
+                    f"pointing at a stub"
+                )
+                continue
+
+            try:
+                pointer = pointer_for(heading, body)
+            except PointerMissing:
+                problems.append(
+                    f"{path}: section '{heading}' yields no pointer. Add a "
+                    f"<!-- pointer: ... --> comment under the heading, or a sentence naming "
+                    f"what MduX does or does not provide for this clause"
+                )
+                continue
+
+            rows.append(
+                Row(
+                    clause=clause,
+                    title=title_of(heading),
+                    file_name=path.name,
+                    anchor=anchor,
+                    pointer=pointer,
+                    justifications=tuple(justification_ids(body)),
+                )
+            )
+
+    return rows, problems
 
 
-def render(standard_name: str, directory: Path, rows: list[tuple[str, str, str, str]]) -> str:
+def referenced_clauses(directory: Path) -> set[str]:
+    """Every clause number cited in this corpus's own modules, in headings or prose.
+
+    Issue #32's second invariant: each must appear in the index. Only same-standard citations
+    count - a module citing `ISO 14971:2019 §7` from inside docs/iec62304/ is pointing at another
+    corpus, and requiring an index row for it here would be wrong.
+    """
+    standard = STANDARD_NAMES.get(directory.name)
+    found: set[str] = set()
+    for path in module_paths(directory):
+        text = ANY_FENCE_RE.sub(" ", path.read_text(encoding="utf-8"))
+        # Drop citations that name a different standard before scanning for bare clause numbers.
+        for other in STANDARD_NAMES.values():
+            if other != standard:
+                text = re.sub(re.escape(other) + r"\s*§\s*\d+(?:\.\d+)*", " ", text)
+        for match in CLAUSE_CITATION_RE.finditer(text):
+            found.add(f"§{match.group(1)}")
+    return found
+
+
+def indexed_clauses(rows: list[Row]) -> set[str]:
+    """The clauses an index covers, with ranges expanded and parents implied by their children.
+
+    A row for §7.3 makes §7 indexed: a reader looking for §7 finds it. The reverse is not true,
+    which is why a §7.4 cited in prose with no §7.4 row is a finding.
+    """
+    covered: set[str] = set()
+    for row in rows:
+        if row.clause == NO_CLAUSE:
+            continue
+        parts = [p.strip().lstrip("§") for p in row.clause.split("–")]
+        if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+            for number in range(int(parts[0]), int(parts[1]) + 1):
+                covered.add(f"§{number}")
+            continue
+        for part in parts:
+            segments = part.split(".")
+            for i in range(1, len(segments) + 1):
+                covered.add("§" + ".".join(segments[:i]))
+    return covered
+
+
+def clause_sort_key(clause: str) -> list[int]:
+    return [int(n) for n in clause.lstrip("§").split(".") if n.isdigit()]
+
+
+def unindexed_clauses(directory: Path, rows: list[Row]) -> list[str]:
+    missing = referenced_clauses(directory) - indexed_clauses(rows)
+    return sorted(missing, key=clause_sort_key)
+
+
+def display_path(directory: Path) -> str:
+    """The path to print inside a generated index: `docs/<corpus>`, however it was invoked.
+
+    The regenerate command is part of the file's bytes, so deriving it from the argument as given
+    would make `--check` fail purely because CI passed an absolute path and a developer passed a
+    relative one. Taking the last two components is enough - every corpus lives at docs/<name>.
+    """
+    return "/".join(directory.parts[-2:])
+
+
+def render(standard_name: str, directory: Path, rows: list[Row]) -> str:
     lines = [
         f"# {standard_name} — per-clause index",
         "",
-        "One row per clause covered in this corpus, generated from the clause headings and",
-        "`Justification` objects actually present under each heading - not hand-transcribed,",
-        "so it cannot drift from the prose it indexes without the source changing too.",
+        "One row per clause section in this corpus: the clause, a one-sentence pointer to what",
+        "MduX does or does not provide for it, and a deep link to the heading that covers it.",
+        "Generated from the headings, `Justification` objects and pointer comments already",
+        "present in the modules — not hand-transcribed, so it cannot drift from the prose it",
+        "indexes without the source changing too.",
+        "",
         "Regenerate after editing any file in this directory:",
         "",
         "```",
-        f"python3 tools/docs-lint/generate_ai_reference.py {directory}",
+        f"python3 tools/docs-lint/generate_ai_reference.py {display_path(directory)}",
         "```",
         "",
-        "| Clause | Title | File | Justification(s) |",
+        f"A clause shown as `{NO_CLAUSE}` is one this corpus deliberately does not number — see",
+        "[`README.md`](README.md). It is not a gap in the index.",
+        "",
+        "| Clause | Covers | Pointer | Justification(s) |",
         "|---|---|---|---|",
     ]
-    for clause, title, fname, jids in rows:
-        title_escaped = title.replace("|", "\\|")
-        lines.append(f"| {clause} | {title_escaped} | [`{fname}`]({fname}) | {jids} |")
+    for row in rows:
+        title = row.title.replace("|", "\\|")
+        pointer = row.pointer.replace("|", "\\|")
+        jids = ", ".join(row.justifications) if row.justifications else NO_CLAUSE
+        lines.append(f"| {row.clause} | [{title}]({row.link}) | {pointer} | {jids} |")
     lines.append("")
     return "\n".join(lines)
 
 
+def process(directory: Path, check_only: bool) -> tuple[bool, list[str]]:
+    """Returns (ok, messages)."""
+    standard_name = STANDARD_NAMES.get(directory.name, directory.name)
+    rows, problems = build_rows(directory)
+    problems.extend(
+        f"{directory}: clause {clause} is cited in the prose but has no index row"
+        for clause in unindexed_clauses(directory, rows)
+    )
+    if problems:
+        return False, problems
+
+    output = render(standard_name, directory, rows)
+    target = directory / "AI-Reference.md"
+    if check_only:
+        current = target.read_text(encoding="utf-8") if target.exists() else None
+        if current != output:
+            return False, [f"{target} is out of date; run generate_ai_reference.py to regenerate"]
+        return True, [f"{target} up to date ({len(rows)} rows)"]
+
+    target.write_text(output, encoding="utf-8")
+    return True, [f"wrote {target} ({len(rows)} rows)"]
+
+
 def main(argv: list[str]) -> int:
-    targets = [Path(p) for p in argv] if argv else [Path(p) for p in DEFAULT_DIRS]
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report out-of-date indexes without writing (what CI runs)",
+    )
+    parser.add_argument("directories", nargs="*", help="corpus directories; default is all five")
+    args = parser.parse_args(argv)
+
+    targets = (
+        [Path(p) for p in args.directories]
+        if args.directories
+        else [Path(p) for p in DEFAULT_DIRS]
+    )
+
+    ok = True
     for directory in targets:
         if not directory.is_dir():
             print(f"skip: {directory} is not a directory", file=sys.stderr)
             continue
-        standard_name = STANDARD_NAMES.get(directory.name, directory.name)
-        rows = build_rows(directory)
-        output = render(standard_name, directory, rows)
-        (directory / "AI-Reference.md").write_text(output, encoding="utf-8")
-        print(f"wrote {directory / 'AI-Reference.md'} ({len(rows)} rows)")
-    return 0
+        succeeded, messages = process(directory, args.check)
+        stream = sys.stdout if succeeded else sys.stderr
+        for message in messages:
+            print(message, file=stream)
+        ok = ok and succeeded
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/tools/docs-lint/generate_ai_reference.py
+++ b/tools/docs-lint/generate_ai_reference.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Regenerates AI-Reference.md for one or more regulatory-corpus directories.
+
+One row per clause heading (`## §N.M Title` or, for a single-clause file, the `# Standard §N —
+Title` H1), cross-referenced against every `Justification` object that appears textually under
+that heading. Host-only tool (ADR-004): standard library only, no third-party dependencies.
+
+Deliberately mechanical: this script only reads headings and Justification blocks that already
+exist in the corpus. It does not decide what a clause covers or invent a Justification - if a row
+looks wrong, the fix is in the clause file the row was generated from, not in this script.
+
+Usage:
+    python3 tools/docs-lint/generate_ai_reference.py docs/iec62304 [docs/iso13485 ...]
+
+With no arguments, regenerates all five standard corpora under docs/.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_DIRS = ("docs/iec62304", "docs/iso13485", "docs/iso14971", "docs/iec62366", "docs/iec81001")
+
+STANDARD_NAMES = {
+    "iec62304": "IEC 62304:2006",
+    "iso13485": "ISO 13485:2016",
+    "iso14971": "ISO 14971:2019",
+    "iec62366": "IEC 62366-1:2015",
+    "iec81001": "IEC 81001-5-1:2021",
+}
+
+H2_RE = re.compile(r"^##\s+(.+)$", re.MULTILINE)
+H1_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+CLAUSE_RE = re.compile(r"(§[\d.]+(?:[–-]§?[\d.]+)?)\s*(?:—|-)?\s*(.*)")
+JSON_FENCE_RE = re.compile(r"```json\n(.*?)\n```", re.DOTALL)
+
+
+def sections_of(text: str) -> list[tuple[str, str]]:
+    """Splits `text` into (heading, body) by H2. Falls back to one section keyed by the H1
+    when there is no H2 - the case for a file covering exactly one clause."""
+    h2_matches = list(H2_RE.finditer(text))
+    if h2_matches:
+        sections = []
+        for i, match in enumerate(h2_matches):
+            start = match.end()
+            end = h2_matches[i + 1].start() if i + 1 < len(h2_matches) else len(text)
+            sections.append((match.group(1), text[start:end]))
+        return sections
+    h1_match = H1_RE.search(text)
+    heading = h1_match.group(1) if h1_match else ""
+    return [(heading, text)]
+
+
+def justification_ids(body: str) -> list[str]:
+    ids = []
+    for block in JSON_FENCE_RE.findall(body):
+        try:
+            obj = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        jid = obj.get("justification_id")
+        if jid:
+            ids.append(jid)
+    return ids
+
+
+def build_rows(directory: Path) -> list[tuple[str, str, str, str]]:
+    rows = []
+    for path in sorted(directory.glob("*.md")):
+        if path.name in ("README.md", "AI-Reference.md"):
+            continue
+        text = path.read_text(encoding="utf-8")
+        for heading, body in sections_of(text):
+            match = CLAUSE_RE.match(heading)
+            if match and match.group(1).startswith("§"):
+                clause, title = match.group(1), match.group(2) or heading
+            else:
+                clause, title = "—", heading
+            jids = justification_ids(body)
+            rows.append((clause, title, path.name, ", ".join(jids) if jids else "—"))
+    return rows
+
+
+def render(standard_name: str, directory: Path, rows: list[tuple[str, str, str, str]]) -> str:
+    lines = [
+        f"# {standard_name} — per-clause index",
+        "",
+        "One row per clause covered in this corpus, generated from the clause headings and",
+        "`Justification` objects actually present under each heading - not hand-transcribed,",
+        "so it cannot drift from the prose it indexes without the source changing too.",
+        "Regenerate after editing any file in this directory:",
+        "",
+        "```",
+        f"python3 tools/docs-lint/generate_ai_reference.py {directory}",
+        "```",
+        "",
+        "| Clause | Title | File | Justification(s) |",
+        "|---|---|---|---|",
+    ]
+    for clause, title, fname, jids in rows:
+        title_escaped = title.replace("|", "\\|")
+        lines.append(f"| {clause} | {title_escaped} | [`{fname}`]({fname}) | {jids} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    targets = [Path(p) for p in argv] if argv else [Path(p) for p in DEFAULT_DIRS]
+    for directory in targets:
+        if not directory.is_dir():
+            print(f"skip: {directory} is not a directory", file=sys.stderr)
+            continue
+        standard_name = STANDARD_NAMES.get(directory.name, directory.name)
+        rows = build_rows(directory)
+        output = render(standard_name, directory, rows)
+        (directory / "AI-Reference.md").write_text(output, encoding="utf-8")
+        print(f"wrote {directory / 'AI-Reference.md'} ({len(rows)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/docs-lint/test_generate_ai_reference.py
+++ b/tools/docs-lint/test_generate_ai_reference.py
@@ -1,0 +1,116 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import generate_ai_reference as gen
+
+
+class SectionsOfTests(unittest.TestCase):
+    def test_splits_on_h2(self):
+        text = "# Title\n\nintro\n\n## §1 First\n\nbody one\n\n## §2 Second\n\nbody two\n"
+        sections = gen.sections_of(text)
+        self.assertEqual([h for h, _ in sections], ["§1 First", "§2 Second"])
+        self.assertIn("body one", sections[0][1])
+        self.assertIn("body two", sections[1][1])
+        self.assertNotIn("body two", sections[0][1])
+
+    def test_falls_back_to_h1_when_no_h2(self):
+        text = "# IEC 62366-1:2015 §4 — General requirements\n\nsome prose\n"
+        sections = gen.sections_of(text)
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0][0], "IEC 62366-1:2015 §4 — General requirements")
+
+
+class JustificationIdsTests(unittest.TestCase):
+    def test_extracts_id_from_fenced_json(self):
+        body = (
+            "prose\n\n```json\n"
+            '{"justification_id": "JUS-099", "standard": "IEC 62304:2006"}'
+            "\n```\nmore prose\n"
+        )
+        self.assertEqual(["JUS-099"], gen.justification_ids(body))
+
+    def test_ignores_non_json_fences_and_malformed_json(self):
+        body = "```text\nnot json\n```\n```json\n{not valid json\n```\n"
+        self.assertEqual([], gen.justification_ids(body))
+
+    def test_returns_multiple_ids_in_order(self):
+        body = (
+            '```json\n{"justification_id": "JUS-001"}\n```\n'
+            '```json\n{"justification_id": "JUS-002"}\n```\n'
+        )
+        self.assertEqual(["JUS-001", "JUS-002"], gen.justification_ids(body))
+
+
+class BuildRowsTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.directory = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def write(self, name: str, content: str) -> None:
+        (self.directory / name).write_text(content, encoding="utf-8")
+
+    def test_skips_readme_and_existing_ai_reference(self):
+        self.write("README.md", "# README\n\n## §1 Ignored\n")
+        self.write("AI-Reference.md", "# stale index\n\n## §9 Ignored\n")
+        self.write(
+            "01-real.md",
+            "# Real file\n\n## §1 Real clause\n\nprose\n",
+        )
+        rows = gen.build_rows(self.directory)
+        self.assertEqual([r[1] for r in rows], ["Real clause"])
+
+    def test_attributes_justification_to_the_heading_it_appears_under(self):
+        self.write(
+            "01-file.md",
+            "# Title\n\n"
+            "## §1 First\n\nno justification here\n\n"
+            "## §2 Second\n\n"
+            '```json\n{"justification_id": "JUS-005", "standard": "IEC 62304:2006"}\n```\n',
+        )
+        rows = gen.build_rows(self.directory)
+        by_title = {title: jids for _, title, _, jids in rows}
+        self.assertEqual(by_title["First"], "—")
+        self.assertEqual(by_title["Second"], "JUS-005")
+
+    def test_clause_extracted_from_heading_prefix(self):
+        self.write("01-file.md", "# Title\n\n## §5.3 Some clause title\n\nprose\n")
+        rows = gen.build_rows(self.directory)
+        clause, title, fname, _ = rows[0]
+        self.assertEqual(clause, "§5.3")
+        self.assertEqual(title, "Some clause title")
+        self.assertEqual(fname, "01-file.md")
+
+    def test_heading_without_clause_number_gets_em_dash(self):
+        self.write("01-file.md", "# Title\n\n## Not clause-numbered\n\nprose\n")
+        rows = gen.build_rows(self.directory)
+        clause, title, _, _ = rows[0]
+        self.assertEqual(clause, "—")
+        self.assertEqual(title, "Not clause-numbered")
+
+    def test_multiple_files_processed_in_sorted_order(self):
+        self.write("02-b.md", "# B\n\n## §2 In B\n")
+        self.write("01-a.md", "# A\n\n## §1 In A\n")
+        rows = gen.build_rows(self.directory)
+        self.assertEqual([r[2] for r in rows], ["01-a.md", "02-b.md"])
+
+
+class RenderTests(unittest.TestCase):
+    def test_render_includes_regenerate_command_and_table(self):
+        rows = [("§1", "Scope", "01-scope.md", "—")]
+        output = gen.render("IEC 62304:2006", Path("docs/iec62304"), rows)
+        self.assertIn("# IEC 62304:2006 — per-clause index", output)
+        self.assertIn("python3 tools/docs-lint/generate_ai_reference.py docs/iec62304", output)
+        self.assertIn("| §1 | Scope | [`01-scope.md`](01-scope.md) | — |", output)
+
+    def test_render_escapes_pipe_in_title(self):
+        rows = [("§7.5", "Risk/benefit | analysis", "04-file.md", "—")]
+        output = gen.render("ISO 14971:2019", Path("docs/iso14971"), rows)
+        self.assertIn("Risk/benefit \\| analysis", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/docs-lint/test_generate_ai_reference.py
+++ b/tools/docs-lint/test_generate_ai_reference.py
@@ -1,8 +1,42 @@
+"""Tests for generate_ai_reference.
+
+The last two classes are the ones that matter most. `InvariantTests` checks issue #32's two
+invariants on synthetic corpora, and `RealCorpusInvariantTests` checks them against the corpora
+actually in this repository - so a module edited without regenerating its index, or a clause cited
+in prose that no row covers, fails here rather than being noticed by a reader six months later.
+"""
+
+import re
 import tempfile
 import unittest
 from pathlib import Path
 
 import generate_ai_reference as gen
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A section body long enough to clear MIN_SUBSTANTIVE_CHARS, naming MduX so a pointer derives.
+BODY = (
+    "MduX supplies a mechanical check here rather than a documented procedure, which is the "
+    "distinction this clause turns on for a library with no quality system of its own.\n"
+)
+
+
+def write_corpus(directory: Path, files: dict) -> None:
+    for name, text in files.items():
+        (directory / name).write_text(text, encoding="utf-8")
+
+
+def anchors_in(path: Path) -> list:
+    """Every anchor GitHub would generate for `path`, de-duplicated the way GitHub does."""
+    anchors = []
+    seen = {}
+    for heading in re.findall(r"^#{1,6}\s+(.+)$", path.read_text(encoding="utf-8"), re.MULTILINE):
+        anchor = gen.github_anchor(heading)
+        count = seen.get(anchor, 0)
+        seen[anchor] = count + 1
+        anchors.append(f"{anchor}-{count}" if count else anchor)
+    return anchors
 
 
 class SectionsOfTests(unittest.TestCase):
@@ -42,74 +76,332 @@ class JustificationIdsTests(unittest.TestCase):
         self.assertEqual(["JUS-001", "JUS-002"], gen.justification_ids(body))
 
 
-class BuildRowsTests(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.directory = Path(self.temp_dir.name)
-
-    def tearDown(self):
-        self.temp_dir.cleanup()
-
-    def write(self, name: str, content: str) -> None:
-        (self.directory / name).write_text(content, encoding="utf-8")
-
-    def test_skips_readme_and_existing_ai_reference(self):
-        self.write("README.md", "# README\n\n## §1 Ignored\n")
-        self.write("AI-Reference.md", "# stale index\n\n## §9 Ignored\n")
-        self.write(
-            "01-real.md",
-            "# Real file\n\n## §1 Real clause\n\nprose\n",
-        )
-        rows = gen.build_rows(self.directory)
-        self.assertEqual([r[1] for r in rows], ["Real clause"])
-
-    def test_attributes_justification_to_the_heading_it_appears_under(self):
-        self.write(
-            "01-file.md",
-            "# Title\n\n"
-            "## §1 First\n\nno justification here\n\n"
-            "## §2 Second\n\n"
-            '```json\n{"justification_id": "JUS-005", "standard": "IEC 62304:2006"}\n```\n',
-        )
-        rows = gen.build_rows(self.directory)
-        by_title = {title: jids for _, title, _, jids in rows}
-        self.assertEqual(by_title["First"], "—")
-        self.assertEqual(by_title["Second"], "JUS-005")
-
+class ClauseTests(unittest.TestCase):
     def test_clause_extracted_from_heading_prefix(self):
-        self.write("01-file.md", "# Title\n\n## §5.3 Some clause title\n\nprose\n")
-        rows = gen.build_rows(self.directory)
-        clause, title, fname, _ = rows[0]
-        self.assertEqual(clause, "§5.3")
-        self.assertEqual(title, "Some clause title")
-        self.assertEqual(fname, "01-file.md")
+        self.assertEqual("§5.2", gen.clause_of("§5.2 Software requirements analysis"))
+        self.assertEqual("§9", gen.clause_of("IEC 62304:2006 §9 — Problem resolution"))
 
-    def test_heading_without_clause_number_gets_em_dash(self):
-        self.write("01-file.md", "# Title\n\n## Not clause-numbered\n\nprose\n")
-        rows = gen.build_rows(self.directory)
-        clause, title, _, _ = rows[0]
-        self.assertEqual(clause, "—")
-        self.assertEqual(title, "Not clause-numbered")
+    def test_clause_range_is_normalized(self):
+        self.assertEqual("§1–§3", gen.clause_of("IEC 62304:2006 §1–§3 — Scope and terms"))
 
-    def test_multiple_files_processed_in_sorted_order(self):
-        self.write("02-b.md", "# B\n\n## §2 In B\n")
-        self.write("01-a.md", "# A\n\n## §1 In A\n")
-        rows = gen.build_rows(self.directory)
-        self.assertEqual([r[2] for r in rows], ["01-a.md", "02-b.md"])
+    def test_heading_without_a_clause_has_none(self):
+        self.assertIsNone(gen.clause_of("Perform summative evaluation"))
+
+    def test_title_drops_the_clause_and_separator(self):
+        self.assertEqual("Software release", gen.title_of("§5.8 Software release"))
+        self.assertEqual(
+            "Problem resolution", gen.title_of("IEC 62304:2006 §9 — Problem resolution")
+        )
+
+
+class ClauseInheritanceTests(unittest.TestCase):
+    """The defect that made IEC 62304 §9 vanish from an earlier version of the index."""
+
+    def test_unnumbered_sections_inherit_a_single_clause_h1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {
+                    "07-problem-resolution.md": "# IEC 62304:2006 §9 — Problem resolution\n\n"
+                    f"## Reporting a problem\n\n{BODY}\n## Resolving it\n\n{BODY}"
+                },
+            )
+            rows, problems = gen.build_rows(directory)
+        self.assertEqual([], problems)
+        self.assertEqual(["§9", "§9"], [row.clause for row in rows])
+
+    def test_a_clause_range_is_not_inherited(self):
+        # A narrative section inside a §1–§3 file is not all three of those clauses.
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {
+                    "01-scope.md": "# ISO 14971:2019 §1–§3 — Scope and terms\n\n"
+                    f"## §1 Scope\n\n{BODY}\n## Relationship to another standard\n\n{BODY}"
+                },
+            )
+            rows, _ = gen.build_rows(directory)
+        self.assertEqual(["§1", gen.NO_CLAUSE], [row.clause for row in rows])
+
+
+class AnchorTests(unittest.TestCase):
+    def test_anchor_matches_github_slugging(self):
+        self.assertEqual(
+            "52-software-requirements-analysis",
+            gen.github_anchor("§5.2 Software requirements analysis"),
+        )
+        self.assertEqual("one-risk-file-not-two", gen.github_anchor("One risk file, not two"))
+
+    def test_repeated_headings_get_githubs_suffix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {"a.md": f"# ISO 14971:2019 §4 — Title\n\n## Notes\n\n{BODY}\n## Notes\n\n{BODY}"},
+            )
+            rows, _ = gen.build_rows(directory)
+        self.assertEqual(["notes", "notes-1"], [row.anchor for row in rows])
+
+    def test_rows_link_to_the_anchor_not_just_the_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory, {"a.md": f"# ISO 14971:2019 §4 — Title\n\n## §4.1 Sub\n\n{BODY}"}
+            )
+            rows, _ = gen.build_rows(directory)
+        self.assertEqual("a.md#41-sub", rows[0].link)
+
+
+class PointerTests(unittest.TestCase):
+    def test_authored_comment_wins(self):
+        body = "<!-- pointer: The authored one. -->\n\n" + BODY
+        self.assertEqual("The authored one.", gen.pointer_for("§1 X", body))
+
+    def test_justification_rationale_is_used_when_there_is_no_comment(self):
+        body = (
+            BODY
+            + '\n```json\n{"justification_id": "JUS-001", '
+            '"rationale": "MduXTrustZones.cmake fails the configure step. More detail follows."}'
+            "\n```\n"
+        )
+        # The Justification outranks the prose sentence, and only its first sentence is used.
+        self.assertEqual(
+            "MduXTrustZones.cmake fails the configure step.", gen.pointer_for("§1 X", body)
+        )
+
+    def test_falls_back_to_the_first_usable_mdux_sentence(self):
+        body = "A clause paraphrase with no mechanism in it. MduX has no mechanism here.\n"
+        self.assertEqual("MduX has no mechanism here.", gen.pointer_for("§1 X", body))
+
+    def test_table_rows_and_bare_pronouns_are_not_usable_pointers(self):
+        # Both would produce a row that either breaks the index's own table or refers to an
+        # antecedent a reader of the index cannot see.
+        self.assertFalse(gen.is_usable_pointer("| MduX | something |"))
+        self.assertFalse(gen.is_usable_pointer("It is MduX's mechanism."))
+        self.assertFalse(gen.is_usable_pointer("A sentence not naming the library."))
+        self.assertTrue(gen.is_usable_pointer("MduX has no mechanism here."))
+
+    def test_sub_headings_do_not_leak_into_a_pointer(self):
+        body = "### Attack surface\n\nMduX constrains the link graph at configure time.\n"
+        self.assertEqual(
+            "MduX constrains the link graph at configure time.",
+            gen.pointer_for("Secure design", body),
+        )
+
+    def test_a_section_with_no_pointer_raises(self):
+        with self.assertRaises(gen.PointerMissing):
+            gen.pointer_for("§1 X", "Prose that never names the library at all.\n")
+
+
+class BuildRowsTests(unittest.TestCase):
+    def test_skips_readme_and_existing_ai_reference(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {
+                    "README.md": f"# Readme\n\n## §1 Not indexed\n\n{BODY}",
+                    "AI-Reference.md": f"# Index\n\n## §2 Not indexed\n\n{BODY}",
+                    "01-real.md": f"# ISO 14971:2019 §4 — Title\n\n## §4.1 Indexed\n\n{BODY}",
+                },
+            )
+            rows, _ = gen.build_rows(directory)
+        self.assertEqual(["§4.1"], [row.clause for row in rows])
+
+    def test_attributes_a_justification_to_the_heading_it_appears_under(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {
+                    "a.md": "# ISO 14971:2019 §4 — Title\n\n"
+                    f"## §4.1 First\n\n{BODY}\n"
+                    f"## §4.2 Second\n\n{BODY}\n"
+                    '```json\n{"justification_id": "JUS-007"}\n```\n'
+                },
+            )
+            rows, _ = gen.build_rows(directory)
+        self.assertEqual((), rows[0].justifications)
+        self.assertEqual(("JUS-007",), rows[1].justifications)
+
+    def test_files_are_processed_in_sorted_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {
+                    "02-b.md": f"# ISO 14971:2019 §5 — B\n\n## §5.1 B\n\n{BODY}",
+                    "01-a.md": f"# ISO 14971:2019 §4 — A\n\n## §4.1 A\n\n{BODY}",
+                },
+            )
+            rows, _ = gen.build_rows(directory)
+        self.assertEqual(["01-a.md", "02-b.md"], [row.file_name for row in rows])
+
+
+class InvariantTests(unittest.TestCase):
+    """Issue #32's two invariants, on synthetic corpora."""
+
+    def test_invariant_one_a_stub_section_is_reported_not_indexed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {
+                    "a.md": "# ISO 14971:2019 §4 — Title\n\n"
+                    f"## §4.1 Real\n\n{BODY}\n## §4.2 Stub\n\nTBD.\n"
+                },
+            )
+            rows, problems = gen.build_rows(directory)
+        self.assertEqual(["§4.1"], [row.clause for row in rows])
+        self.assertTrue(any("no substantive content" in p for p in problems), problems)
+
+    def test_invariant_one_a_justification_makes_a_short_section_substantive(self):
+        # A checked Justification is content: mdux-docs-lint verifies its evidence paths exist.
+        body = '```json\n{"justification_id": "JUS-001", "rationale": "MduX does the thing."}\n```\n'
+        self.assertTrue(gen.is_substantive(body))
+        self.assertFalse(gen.is_substantive("TBD.\n"))
+
+    def test_invariant_two_a_clause_cited_in_prose_with_no_row_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {
+                    "a.md": "# ISO 14971:2019 §4 — Title\n\n## §4.1 Covered\n\n"
+                    + BODY
+                    + "\nThis also depends on §4.9, which has no section of its own.\n"
+                },
+            )
+            rows, _ = gen.build_rows(directory)
+            missing = gen.unindexed_clauses(directory, rows)
+        self.assertEqual(["§4.9"], missing)
+
+    def test_invariant_two_a_parent_clause_is_covered_by_its_children(self):
+        rows = [
+            gen.Row("§7.3", "t", "a.md", "a", "p", ()),
+            gen.Row("§1–§3", "t", "a.md", "b", "p", ()),
+        ]
+        covered = gen.indexed_clauses(rows)
+        self.assertIn("§7", covered)
+        self.assertIn("§7.3", covered)
+        self.assertIn("§2", covered)
+        self.assertNotIn("§7.4", covered)
+
+    def test_invariant_two_ignores_another_standards_clauses(self):
+        # A module citing "IEC 62304:2006 §5.1" from inside docs/iso14971/ points at a different
+        # corpus; demanding an ISO 14971 §5.1 row for it would be wrong.
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp) / "iso14971"
+            directory.mkdir()
+            write_corpus(
+                directory,
+                {
+                    "a.md": "# ISO 14971:2019 §4 — Title\n\n## §4.1 Covered\n\n"
+                    + BODY
+                    + "\nSee IEC 62304:2006 §5.1 Software development planning for that side.\n"
+                },
+            )
+            rows, _ = gen.build_rows(directory)
+            self.assertEqual([], gen.unindexed_clauses(directory, rows))
 
 
 class RenderTests(unittest.TestCase):
-    def test_render_includes_regenerate_command_and_table(self):
-        rows = [("§1", "Scope", "01-scope.md", "—")]
-        output = gen.render("IEC 62304:2006", Path("docs/iec62304"), rows)
-        self.assertIn("# IEC 62304:2006 — per-clause index", output)
-        self.assertIn("python3 tools/docs-lint/generate_ai_reference.py docs/iec62304", output)
-        self.assertIn("| §1 | Scope | [`01-scope.md`](01-scope.md) | — |", output)
+    def test_render_includes_regenerate_command_and_table_header(self):
+        output = gen.render("ISO 14971:2019", Path("docs/iso14971"), [])
+        self.assertIn("python3 tools/docs-lint/generate_ai_reference.py docs/iso14971", output)
+        self.assertIn("| Clause | Covers | Pointer | Justification(s) |", output)
 
-    def test_render_escapes_pipe_in_title(self):
-        rows = [("§7.5", "Risk/benefit | analysis", "04-file.md", "—")]
-        output = gen.render("ISO 14971:2019", Path("docs/iso14971"), rows)
-        self.assertIn("Risk/benefit \\| analysis", output)
+    def test_render_escapes_pipes_in_title_and_pointer(self):
+        row = gen.Row("§1", "a|b", "f.md", "anchor", "p|q", ("JUS-001",))
+        output = gen.render("S", Path("d"), [row])
+        self.assertIn("a\\|b", output)
+        self.assertIn("p\\|q", output)
+        self.assertIn("[a\\|b](f.md#anchor)", output)
+
+
+class CheckModeTests(unittest.TestCase):
+    def test_check_reports_an_out_of_date_index_without_writing_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            write_corpus(
+                directory,
+                {
+                    "a.md": f"# ISO 14971:2019 §4 — Title\n\n## §4.1 Sub\n\n{BODY}",
+                    "AI-Reference.md": "stale\n",
+                },
+            )
+            ok, messages = gen.process(directory, check_only=True)
+            self.assertFalse(ok)
+            self.assertIn("out of date", messages[0])
+            self.assertEqual("stale\n", (directory / "AI-Reference.md").read_text())
+
+            self.assertTrue(gen.process(directory, check_only=False)[0])
+            self.assertTrue(gen.process(directory, check_only=True)[0])
+
+
+class RealCorpusInvariantTests(unittest.TestCase):
+    """The same invariants, against the corpora actually in this repository."""
+
+    def corpora(self):
+        for name in gen.DEFAULT_DIRS:
+            directory = REPO_ROOT / name
+            if directory.is_dir():
+                yield directory
+
+    def test_there_are_corpora_to_check(self):
+        # Guards every other test in this class: a path change that found nothing would make
+        # them all pass vacuously.
+        self.assertEqual(len(gen.DEFAULT_DIRS), len(list(self.corpora())))
+
+    def test_every_corpus_generates_without_problems(self):
+        for directory in self.corpora():
+            with self.subTest(corpus=directory.name):
+                _, problems = gen.build_rows(directory)
+                self.assertEqual([], problems)
+
+    def test_every_cited_clause_has_a_row(self):
+        for directory in self.corpora():
+            with self.subTest(corpus=directory.name):
+                rows, _ = gen.build_rows(directory)
+                self.assertEqual([], gen.unindexed_clauses(directory, rows))
+
+    def test_every_index_is_up_to_date(self):
+        for directory in self.corpora():
+            with self.subTest(corpus=directory.name):
+                ok, messages = gen.process(directory, check_only=True)
+                self.assertTrue(ok, messages)
+
+    def test_every_row_links_to_a_heading_that_exists(self):
+        for directory in self.corpora():
+            rows, _ = gen.build_rows(directory)
+            self.assertTrue(rows, f"{directory} produced no rows")
+            for row in rows:
+                with self.subTest(corpus=directory.name, row=row.title):
+                    target = directory / row.file_name
+                    self.assertTrue(target.is_file(), f"{row.link} names a missing file")
+                    self.assertIn(row.anchor, anchors_in(target), f"{row.link} is a dead anchor")
+
+    def test_no_pointer_merely_restates_its_own_title(self):
+        """The defect the review named: a row whose pointer repeats its heading.
+
+        Length is deliberately not the test. "No MduX-specific mechanism." is a shorter pointer
+        than the clause title it sits beside and a perfectly good one - it answers the question a
+        reader brought to the index. Nor is "the pointer contains the title" a defect: a pointer
+        for a risk-management clause will naturally say "risk management". What must not happen
+        is the pointer *being* the title, which is what the previous generator produced.
+        """
+        def normalize(text):
+            return re.sub(r"[^a-z0-9 ]", "", text.lower()).strip()
+
+        for directory in self.corpora():
+            rows, _ = gen.build_rows(directory)
+            for row in rows:
+                with self.subTest(corpus=directory.name, row=row.title):
+                    pointer, title = normalize(row.pointer), normalize(row.title)
+                    self.assertTrue(pointer, "pointer is empty")
+                    self.assertNotEqual(pointer, title, "pointer restates its own heading")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `tools/docs-lint/generate_ai_reference.py` and runs it against all five regulatory corpora, producing a one-row-per-clause `AI-Reference.md` in each (clause, title, source file, `Justification` IDs).
- Deliberately mechanical: the script reads what's already in each corpus (headings + `Justification` blocks) rather than deciding what a clause covers. It can't drift from the prose it indexes without the source changing too.
- **A real bug caught before committing, not after:** the first version matched Justifications to clause headings by string comparison and silently dropped IEC 81001-5-1's one Justification (cited at §4, which doesn't match any practice-category heading in that file, deliberately, per that corpus's confidence limits). Fixed by attributing by *position* (which section a `json` block textually falls under) instead — added as a regression test.
- Updates each README to link the real file instead of the issue #32 placeholder; the two lower-confidence corpora note that the generated index inherits their existing caveats rather than implying new confidence.

## Test plan
- [x] 12 new tests for the generator, all passing (16 total in `tools/docs-lint/`)
- [x] Cross-checked against source of truth before committing: 11 unique `JUS-003`–`JUS-013` across all five generated indexes, matching a direct grep of every `justification_id` field exactly
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 0 findings, full repo (53 files)
- [x] Every markdown link resolves

Stacked on #92 (issue #31). Part of #8, issue #32.
