### PR TITLE
S7 — JSON Schemas per standard [last story in #8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,14 @@ jobs:
         PYTHONDONTWRITEBYTECODE: "1"
       run: python3 tools/docs-lint/generate_ai_reference.py --check
 
+    # Issue #33: the alignment between docs/<standard>/schemas/*.json and the governance types is
+    # the point of those schemas. A schema that has silently diverged from the type it documents
+    # still looks authoritative, which is what makes the drift worth failing a build over.
+    - name: Check schemas have not drifted from the governance types
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: python3 tools/docs-lint/check_schema_type_drift.py
+
   evidence-lint:
     name: Evidence Pipeline Lint
     runs-on: ubuntu-latest

--- a/docs/governance/schemas/clause-index.schema.json
+++ b/docs/governance/schemas/clause-index.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdux.dev/schemas/governance/clause-index.schema.json",
+  "title": "Clause index export",
+  "description": "Validates the `AI-Reference.json` that tools/docs-lint/generate_ai_reference.py writes beside each corpus's `AI-Reference.md` - the same rows, in a form a tool can read without parsing a markdown table. One schema covers all five standards: the row shape does not vary by standard, and five near-identical copies would be five places for a change to be applied four times. Regenerate rather than hand-edit if validation fails; the markdown and the JSON come from one pass over the corpus and cannot disagree.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["standard", "corpus", "rows"],
+  "properties": {
+    "standard": {
+      "type": "string",
+      "description": "The standard this index covers, spelled as in docs/governance/citation-convention.md.",
+      "enum": [
+        "IEC 62304:2006",
+        "ISO 13485:2016",
+        "ISO 14971:2019",
+        "IEC 62366-1:2015",
+        "IEC 81001-5-1:2021"
+      ]
+    },
+    "corpus": {
+      "type": "string",
+      "description": "The directory this index was generated from, repository-relative.",
+      "pattern": "^docs/[a-z0-9]+$"
+    },
+    "rows": {
+      "type": "array",
+      "description": "One entry per clause section, in the order the index presents them.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["clause", "title", "file", "anchor", "pointer", "justifications"],
+        "properties": {
+          "clause": {
+            "type": "string",
+            "description": "The clause this row indexes, without the standard prefix: '§5.3', a range '§5.1–§5.3', or '—' for a section this corpus deliberately does not number. '—' is a statement, not a gap: see the corpus README.",
+            "pattern": "^(§[0-9]+(\\.[0-9]+)*(–§[0-9]+(\\.[0-9]+)*)?|—)$"
+          },
+          "title": {
+            "type": "string",
+            "description": "The section heading, with the standard identifier and clause number removed.",
+            "minLength": 1
+          },
+          "file": {
+            "type": "string",
+            "description": "The module file this row was generated from.",
+            "pattern": "^[0-9]{2}-[a-z0-9-]+\\.md$"
+          },
+          "anchor": {
+            "type": "string",
+            "description": "The GitHub heading anchor within that file. Together with `file` this is a deep link to the paragraph, which is the whole point of the index - locating the right file is not enough.",
+            "pattern": "^[a-z0-9][a-z0-9_-]*$"
+          },
+          "pointer": {
+            "type": "string",
+            "description": "One sentence naming what MduX does or does not provide for this clause. Never a restatement of `title`; the generator treats a section that yields no pointer as an error rather than emitting one.",
+            "minLength": 1
+          },
+          "justifications": {
+            "type": "array",
+            "description": "Justification ids (see justification.schema.json) cited under this heading. Empty when the section cites no MduX mechanism, which is a common and honest outcome.",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^JUS-[0-9]{3,}$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/iec62304/AI-Reference.json
+++ b/docs/iec62304/AI-Reference.json
@@ -1,0 +1,214 @@
+{
+  "standard": "IEC 62304:2006",
+  "corpus": "docs/iec62304",
+  "rows": [
+    {
+      "clause": "§1",
+      "title": "Scope",
+      "file": "01-scope-and-terms.md",
+      "anchor": "1-scope",
+      "pointer": "MduX is a UI SDK that ships inside a device's software; nothing in this repository falls under those exclusions.",
+      "justifications": []
+    },
+    {
+      "clause": "§2",
+      "title": "Normative references",
+      "file": "01-scope-and-terms.md",
+      "anchor": "2-normative-references",
+      "pointer": "MduX's own regulatory corpus mirrors that structure: [`docs/iso13485/`](../iso13485/) covers the quality-management side, and [`docs/iso14971/`](../iso14971/) covers risk management directly.",
+      "justifications": []
+    },
+    {
+      "clause": "§3",
+      "title": "Terms and definitions",
+      "file": "01-scope-and-terms.md",
+      "anchor": "3-terms-and-definitions",
+      "pointer": "Names the terms that recur across this corpus and points at where MduX gives each a checkable meaning, rather than restating a glossary that is itself normative text.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.1",
+      "title": "Quality management system context",
+      "file": "02-general-requirements.md",
+      "anchor": "41-quality-management-system-context",
+      "pointer": "IEC 62304 expects these processes to run inside a manufacturer's QMS; MduX has none, and docs/iso13485/ covers that side rather than this file.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.2",
+      "title": "Risk management context",
+      "file": "02-general-requirements.md",
+      "anchor": "42-risk-management-context",
+      "pointer": "MduX's structural response to this is architectural rather than procedural where possible — see [ADR-004](../adr/ADR-004-trust-zones-in-cpp.md)'s trust-zone split, which makes an entire category of failure (a governed module reaching platform/graphics code it should never touch) a compile error instead of a review item.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.3",
+      "title": "Software safety classification",
+      "file": "02-general-requirements.md",
+      "anchor": "43-software-safety-classification",
+      "pointer": "**MduX's own components are declared Class A** — code that renders a UI, bakes an asset, or infers from a classifier is not itself the safety function; a device integrating MduX is responsible for its own classification decision, informed by how it uses these components.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.1",
+      "title": "Software development planning",
+      "file": "03-development-process.md",
+      "anchor": "51-software-development-planning",
+      "pointer": "For MduX, the closest equivalent artifacts are its Architecture Decision Records: each ADR states a decision, the alternatives considered, and the consequences accepted, which is a real (if partial) planning record for the areas it covers.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.2",
+      "title": "Software requirements analysis",
+      "file": "03-development-process.md",
+      "anchor": "52-software-requirements-analysis",
+      "pointer": "MduX does not yet have a requirements-traceability mechanism — the `mdux.governance` module (issue #34) and its traceability matrix export (issue #35) are where this lands, not before.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.3",
+      "title": "Software architectural design",
+      "file": "03-development-process.md",
+      "anchor": "53-software-architectural-design",
+      "pointer": "The governed/adapter/tools split is MduX's architectural decomposition; MduXTrustZones.cmake verifies the resulting link-graph interfaces at every configure rather than only at design-review time.",
+      "justifications": [
+        "JUS-003"
+      ]
+    },
+    {
+      "clause": "§5.4",
+      "title": "Software detailed design",
+      "file": "03-development-process.md",
+      "anchor": "54-software-detailed-design",
+      "pointer": "MduX has detailed design for the pieces it has actually built — the evidence kernel's canonical-JSON encoding rules in [ADR-007](../adr/ADR-007-evidence-pipeline-doctrine.md) are as close to a detailed design record as this project currently has, since they specify exact byte-level behaviour, not just an interface.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.5",
+      "title": "Software unit implementation and verification",
+      "file": "03-development-process.md",
+      "anchor": "55-software-unit-implementation-and-verification",
+      "pointer": "mdux.evidence.digest is verified against externally-known FIPS 180-4 test vectors and NIST-published values, not solely against its own output, which is what distinguishes verification from a self-consistency check.",
+      "justifications": [
+        "JUS-004"
+      ]
+    },
+    {
+      "clause": "§5.6",
+      "title": "Software integration and integration testing",
+      "file": "03-development-process.md",
+      "anchor": "56-software-integration-and-integration-testing",
+      "pointer": "MduX's `InstallTreeConsumer` test (issue #47) is a real integration test in this sense: it installs the library to a scratch prefix and builds a separate consumer project against it via `find_package(MduX)`, verifying the actual install-tree interface rather than just the in-tree build.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.7",
+      "title": "Software system testing",
+      "file": "03-development-process.md",
+      "anchor": "57-software-system-testing",
+      "pointer": "MduX has no software *system* yet in this sense — a system implies an assembled product, and today's repository is foundations and an evidence kernel, not an assembled UI.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.8",
+      "title": "Software release",
+      "file": "03-development-process.md",
+      "anchor": "58-software-release",
+      "pointer": "MduX's evidence pipeline ([ADR-007](../adr/ADR-007-evidence-pipeline-doctrine.md)) is the mechanism most directly relevant here: a `report.json` records exactly which recipe, inputs, and resolved options produced a given artifact, and CI re-derives the artifact from those to confirm the record is accurate before anything is considered final.",
+      "justifications": []
+    },
+    {
+      "clause": "§6.1",
+      "title": "Establish software maintenance plan",
+      "file": "04-maintenance-process.md",
+      "anchor": "61-establish-software-maintenance-plan",
+      "pointer": "MduX has no released product yet, so it has no maintenance plan yet either — recording that plainly is more useful than a placeholder document with nothing behind it.",
+      "justifications": []
+    },
+    {
+      "clause": "§6.2",
+      "title": "Problem and modification analysis",
+      "file": "04-maintenance-process.md",
+      "anchor": "62-problem-and-modification-analysis",
+      "pointer": "No MduX mechanism for field problems, since there is no field yet; the ADRs' Consequences sections are the nearest analog, and they run at design time.",
+      "justifications": []
+    },
+    {
+      "clause": "§6.3",
+      "title": "Modification implementation",
+      "file": "04-maintenance-process.md",
+      "anchor": "63-modification-implementation",
+      "pointer": "A maintenance change to MduX runs through the ordinary pull-request process; that route is the mechanism, not a separate one this file would invent.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.1",
+      "title": "Analysis of software contributing to hazardous situations",
+      "file": "05-risk-management-process.md",
+      "anchor": "71-analysis-of-software-contributing-to-hazardous-situations",
+      "pointer": "What this corpus can do is describe, honestly, where MduX's own architecture already forecloses a category of failure regardless of the integrating device's risk analysis — see §7.2.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.2",
+      "title": "Risk control measures",
+      "file": "05-risk-management-process.md",
+      "anchor": "72-risk-control-measures",
+      "pointer": "mdux_verify_trust_zones() walks a governed target's full transitive link graph and fails the build if it reaches Vulkan or a windowing library, which controls the risk of an unintended dependency reaching safety-relevant code without requiring a reviewer to catch it by inspection.",
+      "justifications": [
+        "JUS-005"
+      ]
+    },
+    {
+      "clause": "§7.3",
+      "title": "Verification of risk control measures",
+      "file": "05-risk-management-process.md",
+      "anchor": "73-verification-of-risk-control-measures",
+      "pointer": "mdux_verify_trust_zones() and the exception-disabled governed build are verified by running on every CI leg, so a regression is a build failure rather than a missed review.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.4",
+      "title": "Risk management of software changes",
+      "file": "05-risk-management-process.md",
+      "anchor": "74-risk-management-of-software-changes",
+      "pointer": "MduX's mechanical controls give this a specific, checkable form: a change that would introduce a new Vulkan dependency into a governed target, or re-enable exceptions in the governed zone, fails CI immediately rather than waiting for a risk-management review to notice it weeks later.",
+      "justifications": []
+    },
+    {
+      "clause": "§8.1",
+      "title": "Configuration identification",
+      "file": "06-configuration-management-process.md",
+      "anchor": "81-configuration-identification",
+      "pointer": "BakeReport records the recipe digest, every input digest, the fully resolved options, and every output digest for a baked artifact - a machine-checkable configuration identification record, not a narrative one.",
+      "justifications": [
+        "JUS-006"
+      ]
+    },
+    {
+      "clause": "§8.2",
+      "title": "Change control",
+      "file": "06-configuration-management-process.md",
+      "anchor": "82-change-control",
+      "pointer": "For MduX's baked artifacts, this is the source-tree rule from ADR-007: a normal build never writes into `generated/`; `cmake --build <dir> --target mdux-bake-update` is the only path that does, and it produces a diff a reviewer reads and a commit records — a build cannot silently redefine an artifact's configuration.",
+      "justifications": []
+    },
+    {
+      "clause": "§8.3",
+      "title": "Configuration status accounting",
+      "file": "06-configuration-management-process.md",
+      "anchor": "83-configuration-status-accounting",
+      "pointer": "git log and git blame answer this for every tracked file, and the evidence pipeline extends the same answer to baked artifacts; ADR-007 decision 5 explains why no separate status-accounting document exists.",
+      "justifications": []
+    },
+    {
+      "clause": "§9",
+      "title": "Problem resolution",
+      "file": "07-problem-resolution-process.md",
+      "anchor": "problem-resolution",
+      "pointer": "MduX's problem-resolution route today is GitHub Issues and pull requests: an issue records the problem, a linked PR records the analysis and the fix, and the merge commit records when and by whom it was resolved.",
+      "justifications": []
+    }
+  ]
+}

--- a/docs/iec62304/README.md
+++ b/docs/iec62304/README.md
@@ -30,12 +30,47 @@ regulatory document in this repository is tracked as issue #39.
 Every clause citation in this directory uses the key format from
 [`docs/governance/citation-convention.md`](../governance/citation-convention.md):
 `IEC 62304:2006 §<clause> <clause title>`. [`AI-Reference.md`](AI-Reference.md) is the per-clause
-index, generated from this directory's own headings and `Justification` objects. JSON Schemas for
-the mechanisms cited here are tracked separately as issue #33.
+index, generated from this directory's own headings and `Justification` objects.
+`AI-Reference.json` is the same rows in machine-readable form, written by the same pass so the two
+cannot disagree, and validated against
+[`../governance/schemas/clause-index.schema.json`](../governance/schemas/clause-index.schema.json).
+
+## Schemas
+
+[`schemas/`](schemas/) holds the four IEC 62304 record types, each field-aligned with the
+corresponding type in `include/mdux/governance/Governance.cppm`:
+
+| Schema | Type it mirrors |
+|---|---|
+| [`requirement.schema.json`](schemas/requirement.schema.json) | `mdux::governance::Requirement` |
+| [`hazard.schema.json`](schemas/hazard.schema.json) | `Hazard` — `controlled_by` non-empty, the §4.2 join |
+| [`verification-case.schema.json`](schemas/verification-case.schema.json) | `VerificationCase` and the `VerificationMethod` vocabulary |
+| [`safety-classification.schema.json`](schemas/safety-classification.schema.json) | the `SafetyClass` vocabulary |
+
+The alignment is the deliverable, not the files. `tools/docs-lint/check_schema_type_drift.py` fails
+the build when a schema and the type it documents stop agreeing — a schema that silently diverges
+from its type is worse than no schema, because it still looks authoritative.
+
+The shared `Justification` schema lives at
+[`../governance/schemas/justification.schema.json`](../governance/schemas/justification.schema.json),
+since all five corpora use it.
 
 ## Safety classification scope
 
-MduX's own components are scoped as **Class A** (software that cannot contribute to a hazardous
-situation) throughout this directory. Its sibling project TrustSC models Class B/C. Where a clause's
-requirements scale with safety class, the text says so explicitly rather than assuming one class or
-the other applies.
+**MduX does not classify itself, and no document in this directory should be read as doing so.**
+IEC 62304 §4.3 makes safety classification a decision taken from a device-level risk analysis:
+what harm the software can contribute to, in *this* device, for *this* intended use. The same
+rendering code is Class A in one product and Class C in another, and a library has neither a device
+nor an intended use to reason from.
+
+What this directory does instead is cover the clause set as it applies at each class, and say
+explicitly where a requirement scales with classification. Where the corpus discusses Class A
+obligations at length, that reflects the classification a manufacturer is most likely to assign to
+a component like an evidence digest — not a conclusion this project has reached on a manufacturer's
+behalf.
+
+[`schemas/safety-classification.schema.json`](schemas/safety-classification.schema.json) enforces
+the same discipline in machine-readable form: a classification record cannot be written without an
+`assigned_by` naming who decided. A previous version of this corpus declared all MduX components
+Class A while simultaneously stating that no device-level risk analysis existed; that contradiction
+is what the required field exists to prevent recurring.

--- a/docs/iec62304/schemas/hazard.schema.json
+++ b/docs/iec62304/schemas/hazard.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdux.dev/schemas/iec62304/hazard.schema.json",
+  "title": "IEC 62304 hazard",
+  "description": "A hazardous situation the software can contribute to, and the requirements that control it. Field-aligned with mdux::governance::Hazard in include/mdux/governance/Governance.cppm, checked by tools/docs-lint/check_schema_type_drift.py. This is the minimal record: it carries the hazard and its controls and nothing else. docs/iso14971/schemas/risk-record.schema.json is the same three members plus the ISO 14971 evaluation - severity, probability, acceptability - and is what a risk management file uses. This one exists because IEC 62304 §4.2 needs the join without needing the evaluation: the clause asks whether a software item's hazards are controlled by requirements, and that question is answerable from these three members alone. The rule worth stating twice: controlled_by must be non-empty. A hazard recorded with no risk control is either an unfinished analysis or an accepted risk nobody wrote down, and both should stop a release. Whether each id resolves to a requirement that exists is a collection-level property; ComplianceProgram::validate() checks it, and no per-record schema can.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "description", "controlled_by"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Aligned with Hazard::id.",
+      "pattern": "^HAZ-[A-Z0-9-]+$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Aligned with Hazard::description.",
+      "minLength": 1
+    },
+    "controlled_by": {
+      "type": "array",
+      "description": "Aligned with Hazard::controlledBy. Non-empty, no duplicates, every entry naming a requirement - the machine-checked half of the IEC 62304 §4.2 / ISO 14971 §7 integration point.",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^REQ-[A-Z0-9-]+$"
+      }
+    }
+  },
+  "examples": [
+    {
+      "id": "HAZ-TRUSTZONE-001",
+      "description": "A governed MduX module acquires a dependency on a driver-provided library, so its behaviour is no longer determined by the audited source alone.",
+      "controlled_by": ["REQ-TRUSTZONE-001"]
+    }
+  ]
+}

--- a/docs/iec62304/schemas/requirement.schema.json
+++ b/docs/iec62304/schemas/requirement.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdux.dev/schemas/iec62304/requirement.schema.json",
+  "title": "IEC 62304 software requirement",
+  "description": "One thing the software must do, traceable to the clause that asks for it. Field-aligned with mdux::governance::Requirement in include/mdux/governance/Governance.cppm: the member names, the id pattern and the required set are the same on both sides, and tools/docs-lint/check_schema_type_drift.py fails the build if they stop being. The alignment is the deliverable, not a convenience - it is what lets a requirement written in a markdown fence and one built in C++ be the same object. Note what is deliberately absent: there is no field saying whether this requirement is verified. Coverage is a property of the surrounding collection, not of one record, so ComplianceProgram::validate() enforces IEC 62304 §5.2.4's 'every requirement needs at least one verification case' and no per-record schema could.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "title", "source_clause", "verification_intent"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Aligned with Requirement::id. Uppercase, digits and hyphens after the prefix - lowercase is rejected so two spellings of one id cannot both exist.",
+      "pattern": "^REQ-[A-Z0-9-]+$"
+    },
+    "title": {
+      "type": "string",
+      "description": "Aligned with Requirement::title. What the requirement asks for, in one line.",
+      "minLength": 1
+    },
+    "source_clause": {
+      "type": "string",
+      "description": "Aligned with Requirement::sourceClause. The same citation-key shape as a Justification's clause_ref, so a requirement and the justification for how it is met sort together and join on the clause. Any of the five approved standards, not only IEC 62304 - a requirement can exist because ISO 14971 asks for it.",
+      "pattern": "^(IEC 62304:2006|ISO 13485:2016|ISO 14971:2019|IEC 62366-1:2015|IEC 81001-5-1:2021) §[0-9]+(\\.[0-9]+)* .+"
+    },
+    "verification_intent": {
+      "type": "string",
+      "description": "Aligned with Requirement::verificationIntent. How this requirement is meant to be shown met - written before the verification case exists, so that the case can be checked against an intent rather than the intent inferred from whatever case was written.",
+      "minLength": 1
+    }
+  },
+  "examples": [
+    {
+      "id": "REQ-TRUSTZONE-001",
+      "title": "Governed modules must not reach Vulkan or a windowing library",
+      "source_clause": "IEC 62304:2006 §5.3 Software architectural design",
+      "verification_intent": "mdux_verify_trust_zones() fails the configure step on any governed target whose transitive link closure contains Vulkan::Vulkan or a windowing library."
+    }
+  ]
+}

--- a/docs/iec62304/schemas/safety-classification.schema.json
+++ b/docs/iec62304/schemas/safety-classification.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdux.dev/schemas/iec62304/safety-classification.schema.json",
+  "title": "IEC 62304 software safety classification",
+  "description": "A declared software safety class, and the risk analysis that assigned it. The `class` enum is field-aligned with mdux::governance::SafetyClass and with ComplianceProgram::safety_class, checked by tools/docs-lint/check_schema_type_drift.py. Read `assigned_by` before using this schema. IEC 62304 §4.3 makes safety classification a manufacturer's decision, taken from a device-level risk analysis - what harm the software can contribute to, in this device, for this intended use. MduX cannot make it: a UI library has no device and no intended use, and the same rendering code is Class A in one product and Class C in another. So this schema records a classification as an input a manufacturer declares, never as a conclusion this project reaches, and `assigned_by` is required so a record cannot be written without naming who decided. A previous version of docs/iec62304/ declared all MduX components Class A while simultaneously stating that no device-level risk analysis existed; that contradiction is what this field exists to prevent recurring.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["subject", "class", "assigned_by", "rationale"],
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "What is being classified - a software item, a module, or the whole system. IEC 62304 classifies software items, so a whole-system classification is the coarsest useful value, not the only one.",
+      "minLength": 1
+    },
+    "class": {
+      "type": "string",
+      "description": "Aligned with the SafetyClass enum. A: no injury or damage to health is possible. B: non-serious injury is possible. C: death or serious injury is possible.",
+      "enum": ["A", "B", "C"]
+    },
+    "assigned_by": {
+      "type": "string",
+      "description": "Who assigned this class. Required, and required to name a real party: only a manufacturer's device-level risk analysis can classify software, so a record without an assigner is a classification nobody made.",
+      "minLength": 1
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Why this class and not the next one up. The interesting sentence is always the one ruling out the more severe class, since that is the judgement a reviewer checks.",
+      "minLength": 1
+    },
+    "risk_analysis_ref": {
+      "type": "string",
+      "description": "Where the device-level risk analysis supporting this classification lives. Normally a document outside this repository, because that analysis is the manufacturer's.",
+      "minLength": 1
+    },
+    "hazard_ids": {
+      "type": "array",
+      "description": "The hazards this classification was reasoned from, where they are recorded in the same program.",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^HAZ-[A-Z0-9-]+$"
+      }
+    }
+  },
+  "examples": [
+    {
+      "subject": "mdux.evidence.digest",
+      "class": "A",
+      "assigned_by": "Example Device Co., device risk analysis DRA-2026-014",
+      "rationale": "The digest module computes SHA-256 over build artifacts and has no path to a clinical display or to actuation. A defect causes a build to fail closed, so no injury is possible from its failure in this device.",
+      "risk_analysis_ref": "Example Device Co. DRA-2026-014 §5.2"
+    }
+  ]
+}

--- a/docs/iec62304/schemas/verification-case.schema.json
+++ b/docs/iec62304/schemas/verification-case.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdux.dev/schemas/iec62304/verification-case.schema.json",
+  "title": "IEC 62304 verification case",
+  "description": "Evidence that one requirement is met, by one method, backed by named artifacts. Field-aligned with mdux::governance::VerificationCase in include/mdux/governance/Governance.cppm, checked by tools/docs-lint/check_schema_type_drift.py. The `method` enum is the same closed set as VerificationMethod, in the same order, and is exact-match on the wire: an unrecognized spelling is an error rather than a silently-defaulted value, because a verification record that quietly downgrades an unknown method to 'test' is worse than one that fails to load. Two things this record cannot establish, by construction. It cannot establish that requirement_id resolves - that needs the collection, and ComplianceProgram::validate() does it. And it cannot establish that the verification was any good: a case exists or it does not, and whether it was adequate is a review judgement no schema makes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "requirement_id", "method", "evidence_refs"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Aligned with VerificationCase::id.",
+      "pattern": "^VER-[A-Z0-9-]+$"
+    },
+    "requirement_id": {
+      "type": "string",
+      "description": "Aligned with VerificationCase::requirementId. Must resolve to a requirement in the same program - checked by ComplianceProgram::validate(), not here.",
+      "pattern": "^REQ-[A-Z0-9-]+$"
+    },
+    "method": {
+      "type": "string",
+      "description": "Aligned with VerificationCase::method and the VerificationMethod enum.",
+      "enum": ["test", "analysis", "inspection", "review"]
+    },
+    "evidence_refs": {
+      "type": "array",
+      "description": "Aligned with VerificationCase::evidenceRefs. Repository-relative paths - a test source, a report, a review record. Non-empty, no empty entries, no duplicates. Paths are not checked to exist here; that is a lint-time concern over a real checkout, not a property of the record.",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "examples": [
+    {
+      "id": "VER-001",
+      "requirement_id": "REQ-TRUSTZONE-001",
+      "method": "test",
+      "evidence_refs": ["cmake/MduXTrustZones.cmake", "tests/compliance/TestRegulatoryCompliance.cpp"]
+    }
+  ]
+}

--- a/docs/iec62366/AI-Reference.json
+++ b/docs/iec62366/AI-Reference.json
@@ -1,0 +1,102 @@
+{
+  "standard": "IEC 62366-1:2015",
+  "corpus": "docs/iec62366",
+  "rows": [
+    {
+      "clause": "§1",
+      "title": "Scope",
+      "file": "01-scope-and-terms.md",
+      "anchor": "1-scope",
+      "pointer": "MduX renders content described by a device's own UI design; it does not itself define what that device's users see or how they interact with it in a specific clinical context.",
+      "justifications": []
+    },
+    {
+      "clause": "§2",
+      "title": "Normative references",
+      "file": "01-scope-and-terms.md",
+      "anchor": "2-normative-references",
+      "pointer": "Read alongside docs/iso14971/, which covers the risk-management framework this standard's use-related risk analysis sits inside.",
+      "justifications": []
+    },
+    {
+      "clause": "§3",
+      "title": "Terms and definitions",
+      "file": "01-scope-and-terms.md",
+      "anchor": "3-terms-and-definitions",
+      "pointer": "MduX has no mechanism addressing use error directly yet; the closest adjacent idea is rendered-truth verification (issue #16), which confirms *what is displayed* matches the compiled screen's specification, a precondition for a user being able to act on correct information at all.",
+      "justifications": []
+    },
+    {
+      "clause": "§4",
+      "title": "General requirements for the application of usability engineering to medical devices",
+      "file": "02-general-requirements.md",
+      "anchor": "iec-62366-12015-4-general-requirements-for-the-application-of-usability-engineering-to-medical-devices",
+      "pointer": "MduX has no device-level usability engineering process to establish, for the same reason it has no device-level risk analysis (see [`../iso14971/`](../iso14971/)): it is a UI SDK, not the device.",
+      "justifications": []
+    },
+    {
+      "clause": "§5",
+      "title": "Establish the application specification",
+      "file": "03-usability-engineering-process.md",
+      "anchor": "establish-the-application-specification",
+      "pointer": "Entirely device-level information MduX has no visibility into.",
+      "justifications": []
+    },
+    {
+      "clause": "§5",
+      "title": "Establish user interface characteristics related to safety",
+      "file": "03-usability-engineering-process.md",
+      "anchor": "establish-user-interface-characteristics-related-to-safety",
+      "pointer": "The step MduX's planned mechanisms attach to - @safety_critical annotations, requirement binding, locale text budgets (issue #15) and rendered-truth verification (issue #16) - none of which exists yet.",
+      "justifications": []
+    },
+    {
+      "clause": "§5",
+      "title": "Establish the user interface specification",
+      "file": "03-usability-engineering-process.md",
+      "anchor": "establish-the-user-interface-specification",
+      "pointer": "A .medui source file (issue #15) is what a device's UI specification would be authored against, but the specification itself stays the manufacturer's.",
+      "justifications": []
+    },
+    {
+      "clause": "§5",
+      "title": "Establish the user interface evaluation plan",
+      "file": "03-usability-engineering-process.md",
+      "anchor": "establish-the-user-interface-evaluation-plan",
+      "pointer": "Device-level; no MduX mechanism, and none plausible: an evaluation plan is a statement about people and a use environment, neither of which a library has.",
+      "justifications": []
+    },
+    {
+      "clause": "§5",
+      "title": "Perform user interface design and implementation",
+      "file": "03-usability-engineering-process.md",
+      "anchor": "perform-user-interface-design-and-implementation",
+      "pointer": "For a device built on MduX, implementing a user interface *is* authoring and compiling `.medui` screens (issue #15).",
+      "justifications": []
+    },
+    {
+      "clause": "§5",
+      "title": "Perform formative evaluation",
+      "file": "03-usability-engineering-process.md",
+      "anchor": "perform-formative-evaluation",
+      "pointer": "Device-level and dependent on a device's actual users; no MduX mechanism, and none plausible even once `.medui` exists.",
+      "justifications": []
+    },
+    {
+      "clause": "§5",
+      "title": "Iterate the design as evaluation results require",
+      "file": "03-usability-engineering-process.md",
+      "anchor": "iterate-the-design-as-evaluation-results-require",
+      "pointer": "No MduX mechanism, for the same reasons as the steps it iterates.",
+      "justifications": []
+    },
+    {
+      "clause": "§5",
+      "title": "Perform summative evaluation",
+      "file": "03-usability-engineering-process.md",
+      "anchor": "perform-summative-evaluation",
+      "pointer": "Rendered-truth verification (issue #16) is the closest adjacent idea MduX has, and it is worth naming the gap precisely: it confirms that a compiled screen renders the state it was given.",
+      "justifications": []
+    }
+  ]
+}

--- a/docs/iec62366/README.md
+++ b/docs/iec62366/README.md
@@ -49,6 +49,10 @@ directory's own headings. It makes no claim beyond what is already here, so it c
 citation limits stated above rather than new ones — its named process steps are indexed without
 clause numbers, exactly as the modules state them.
 
+`AI-Reference.json` is the same rows in machine-readable form, written by the same pass so
+the two cannot disagree, and validated against
+[`../governance/schemas/clause-index.schema.json`](../governance/schemas/clause-index.schema.json).
+
 ## Schemas
 
 [`schemas/usability-engineering-record.schema.json`](schemas/usability-engineering-record.schema.json)

--- a/docs/iec81001/AI-Reference.json
+++ b/docs/iec81001/AI-Reference.json
@@ -1,0 +1,128 @@
+{
+  "standard": "IEC 81001-5-1:2021",
+  "corpus": "docs/iec81001",
+  "rows": [
+    {
+      "clause": "§1",
+      "title": "Scope",
+      "file": "01-scope-and-relationship-to-iec62304.md",
+      "anchor": "1-scope",
+      "pointer": "MduX contributes to a device's security posture without running the standard's process itself — it is a dependency a manufacturer's secure development life cycle would need to account for, not the life cycle.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "Relationship to IEC 62304",
+      "file": "01-scope-and-relationship-to-iec62304.md",
+      "anchor": "relationship-to-iec-62304",
+      "pointer": "Maps each IEC 62304 lifecycle activity to its security counterpart, so a manufacturer using MduX runs one process rather than two.",
+      "justifications": []
+    },
+    {
+      "clause": "§2",
+      "title": "Normative references",
+      "file": "01-scope-and-relationship-to-iec62304.md",
+      "anchor": "2-normative-references",
+      "pointer": "Read alongside docs/iso14971/, which covers the risk-management framework a security risk assessment sits inside.",
+      "justifications": []
+    },
+    {
+      "clause": "§3",
+      "title": "Terms and definitions",
+      "file": "01-scope-and-relationship-to-iec62304.md",
+      "anchor": "3-terms-and-definitions",
+      "pointer": "Names the security concepts that recur here and where MduX makes each concrete: trust zones, provenance, defect tracking, and build tamper-evidence.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "One risk file, not two",
+      "file": "02-security-risk-management.md",
+      "anchor": "one-risk-file-not-two",
+      "pointer": "MduX's security records use the ISO 14971 risk-record shape, so a security hazard cannot escape the review every safety hazard gets.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "What MduX does not do",
+      "file": "02-security-risk-management.md",
+      "anchor": "what-mdux-does-not-do",
+      "pointer": "MduX performs no device-level security risk assessment, for the same reason it performs no device-level safety risk assessment: it has no device.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "What MduX does supply",
+      "file": "02-security-risk-management.md",
+      "anchor": "what-mdux-does-supply",
+      "pointer": "The governed/adapter/tools trust-zone split constrains a governed target's dependency surface at the architecture level - mechanically enforced by MduXTrustZones.cmake at configure time - rather than relying on a runtime security control layered on afterward.",
+      "justifications": [
+        "JUS-013"
+      ]
+    },
+    {
+      "clause": "—",
+      "title": "The gap this corpus does not paper over",
+      "file": "02-security-risk-management.md",
+      "anchor": "the-gap-this-corpus-does-not-paper-over",
+      "pointer": "None of MduX's three mechanisms was designed against this standard; they are inputs to a manufacturer's assessment, not evidence of a completed one.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "Secure design",
+      "file": "03-secure-design-and-implementation.md",
+      "anchor": "secure-design",
+      "pointer": "MduX's trust-zone architecture is the clearest instance of a design-time security property in this repository.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "Secure implementation",
+      "file": "03-secure-design-and-implementation.md",
+      "anchor": "secure-implementation",
+      "pointer": "Where MduX ships a derived artifact rather than only source, the consumer verifies it before use.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "What no MduX mechanism covers",
+      "file": "03-secure-design-and-implementation.md",
+      "anchor": "what-no-mdux-mechanism-covers",
+      "pointer": "MduX runs `clang-tidy` and compiles warnings-as-errors, which is general code hygiene rather than a security programme, and has no secrets to handle.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "Security verification and validation",
+      "file": "04-security-verification-and-update-management.md",
+      "anchor": "security-verification-and-validation",
+      "pointer": "MduX verifies two properties this practice cares about - the trust-zone dependency boundary and cross-toolchain byte identity - and fuzzes none of its parsing surfaces, which is a gap rather than a scope exclusion.",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "Vulnerability and defect management",
+      "file": "04-security-verification-and-update-management.md",
+      "anchor": "vulnerability-and-defect-management",
+      "pointer": "MduX tracks defects in GitHub Issues, with the general-purpose-tracking limits already set out in [`../iec62304/07-problem-resolution-process.md`](../iec62304/07-problem-resolution-process.md).",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "Security update management",
+      "file": "04-security-verification-and-update-management.md",
+      "anchor": "security-update-management",
+      "pointer": "MduX has no deployed product, so it has no update mechanism to describe — the same honest gap already recorded for maintenance in [`../iec62304/04-maintenance-process.md`](../iec62304/04-maintenance-process.md).",
+      "justifications": []
+    },
+    {
+      "clause": "—",
+      "title": "Security documentation and guidance",
+      "file": "04-security-verification-and-update-management.md",
+      "anchor": "security-documentation-and-guidance",
+      "pointer": "The caveat stated throughout this directory applies with full force here: none of them was written against IEC 81001-5-1's documentation requirements, so they should be read as material a manufacturer can use, not as a deliverable this standard asks for and MduX has produced.",
+      "justifications": []
+    }
+  ]
+}

--- a/docs/iec81001/README.md
+++ b/docs/iec81001/README.md
@@ -75,3 +75,7 @@ by anything that reads risk records and cannot escape the review a safety hazard
 directory's own headings. It makes no claim beyond what is already here: rows for §1–§4 carry
 clause numbers, and every practice row shows `—`, because that is what this corpus asserts. It
 is not waiting on the numbering verification above — it will gain numbers when the modules do.
+
+`AI-Reference.json` is the same rows in machine-readable form, written by the same pass so
+the two cannot disagree, and validated against
+[`../governance/schemas/clause-index.schema.json`](../governance/schemas/clause-index.schema.json).

--- a/docs/iso13485/AI-Reference.json
+++ b/docs/iso13485/AI-Reference.json
@@ -1,0 +1,197 @@
+{
+  "standard": "ISO 13485:2016",
+  "corpus": "docs/iso13485",
+  "rows": [
+    {
+      "clause": "§1",
+      "title": "Scope",
+      "file": "01-scope-and-terms.md",
+      "anchor": "1-scope",
+      "pointer": "MduX is a software library, not the organization operating a device's QMS.",
+      "justifications": []
+    },
+    {
+      "clause": "§2",
+      "title": "Normative references",
+      "file": "01-scope-and-terms.md",
+      "anchor": "2-normative-references",
+      "pointer": "MduX's own regulatory corpus covers IEC 62304 ([`../iec62304/`](../iec62304/)) directly; [`../iso14971/`](../iso14971/) is where risk management gets the same clause-accurate treatment.",
+      "justifications": []
+    },
+    {
+      "clause": "§3",
+      "title": "Terms and definitions",
+      "file": "01-scope-and-terms.md",
+      "anchor": "3-terms-and-definitions",
+      "pointer": "The terms below recur across this directory; each points at where MduX makes the concept concrete rather than defining it in prose.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.1",
+      "title": "General requirements",
+      "file": "02-quality-management-system.md",
+      "anchor": "41-general-requirements",
+      "pointer": "A manufacturer integrating MduX does not control MduX's internal build process directly, but ADR-007's evidence pipeline gives them a re-derivable, byte-verified record of exactly what produced any given MduX artifact - the concrete control an outsourced-process requirement asks for.",
+      "justifications": [
+        "JUS-007"
+      ]
+    },
+    {
+      "clause": "§4.2",
+      "title": "Documentation requirements",
+      "file": "02-quality-management-system.md",
+      "anchor": "42-documentation-requirements",
+      "pointer": "MduX's documented-information control is git itself: every file's history, the branch-protection rule that changes to `master` go through a reviewed pull request (not a direct push), and the ADR set's own \"Status\" field (Proposed / Accepted / Superseded) marking which decisions are current.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.1–§5.3",
+      "title": "Management commitment, customer focus, quality policy",
+      "file": "03-management-responsibility.md",
+      "anchor": "5153-management-commitment-customer-focus-quality-policy",
+      "pointer": "No MduX-specific mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.4",
+      "title": "Planning",
+      "file": "03-management-responsibility.md",
+      "anchor": "54-planning",
+      "pointer": "No MduX mechanism: the GitHub epic and issue structure is project planning, not the quality-objective planning this clause asks a certified organization for.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.5",
+      "title": "Responsibility, authority and communication",
+      "file": "03-management-responsibility.md",
+      "anchor": "55-responsibility-authority-and-communication",
+      "pointer": "MduX's closest concrete instance is the branch protection requiring pull requests before `master` changes — an authority boundary enforced by GitHub, not only stated in a policy document.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.6",
+      "title": "Management review",
+      "file": "03-management-responsibility.md",
+      "anchor": "56-management-review",
+      "pointer": "No MduX-specific mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§6.1–§6.2",
+      "title": "Provision of resources, human resources",
+      "file": "04-resource-management.md",
+      "anchor": "6162-provision-of-resources-human-resources",
+      "pointer": "No MduX-specific mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§6.3",
+      "title": "Infrastructure",
+      "file": "04-resource-management.md",
+      "anchor": "63-infrastructure",
+      "pointer": "MduX version-controls and reviews its build infrastructure as source, which is infrastructure control of the build only, not of the facilities and equipment this clause covers.",
+      "justifications": []
+    },
+    {
+      "clause": "§6.4",
+      "title": "Work environment and contamination control",
+      "file": "04-resource-management.md",
+      "anchor": "64-work-environment-and-contamination-control",
+      "pointer": "No MduX-specific mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.1",
+      "title": "Planning of product realization",
+      "file": "05-product-realization.md",
+      "anchor": "71-planning-of-product-realization",
+      "pointer": "MduX's ADRs play this role for the decisions they cover: each one states the decision, the alternatives considered, and what verification the decision implies, ahead of the implementation that follows it.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.2",
+      "title": "Customer-related processes",
+      "file": "05-product-realization.md",
+      "anchor": "72-customer-related-processes",
+      "pointer": "No MduX-specific mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.3",
+      "title": "Design and development",
+      "file": "05-product-realization.md",
+      "anchor": "73-design-and-development",
+      "pointer": "MduXTrustZones.cmake is a design output verified mechanically at every build (a governed target's link graph cannot reach Vulkan or a windowing library), and ADR-004 is the design record explaining why - together they give a design-and-development control that runs on every change, not only at a scheduled review.",
+      "justifications": [
+        "JUS-008",
+        "JUS-009"
+      ]
+    },
+    {
+      "clause": "§7.4",
+      "title": "Purchasing",
+      "file": "05-product-realization.md",
+      "anchor": "74-purchasing",
+      "pointer": "No MduX-specific mechanism in the standard's sense (evaluating and controlling suppliers).",
+      "justifications": []
+    },
+    {
+      "clause": "§7.5",
+      "title": "Production and service provision",
+      "file": "05-product-realization.md",
+      "anchor": "75-production-and-service-provision",
+      "pointer": "For MduX, \"production\" is the baking process that turns a recipe and its inputs into a committed artifact.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.6",
+      "title": "Control of monitoring and measuring equipment",
+      "file": "05-product-realization.md",
+      "anchor": "76-control-of-monitoring-and-measuring-equipment",
+      "pointer": "No MduX-specific mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§8.1",
+      "title": "General",
+      "file": "06-measurement-analysis-improvement.md",
+      "anchor": "81-general",
+      "pointer": "MduX's CI matrix (three toolchains, the evidence byte-identity checks, `mdux-docs-lint`, `mdux-evidence-lint`) is the concrete form this takes here: a fixed, versioned set of checks that run on every change, not a process reconstructed ad hoc per review.",
+      "justifications": []
+    },
+    {
+      "clause": "§8.2",
+      "title": "Monitoring and measurement",
+      "file": "06-measurement-analysis-improvement.md",
+      "anchor": "82-monitoring-and-measurement",
+      "pointer": "The evidence-kernel and host-tools test suites (91 cases as of the epic that introduced them) run on every pull request across three independent toolchains, giving continuous, reproducible monitoring of whether the codebase still meets its own specified behaviour - not a periodic audit sample.",
+      "justifications": [
+        "JUS-010"
+      ]
+    },
+    {
+      "clause": "§8.3",
+      "title": "Control of nonconforming product",
+      "file": "06-measurement-analysis-improvement.md",
+      "anchor": "83-control-of-nonconforming-product",
+      "pointer": "A failed CI check is MduX's nonconforming-product control: a pull request whose evidence byte-comparison, trust-zone check, or lint fails cannot merge, which is nonconformity contained at the point of detection rather than shipped and corrected later.",
+      "justifications": []
+    },
+    {
+      "clause": "§8.4",
+      "title": "Analysis of data",
+      "file": "06-measurement-analysis-improvement.md",
+      "anchor": "84-analysis-of-data",
+      "pointer": "No dedicated MduX mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§8.5",
+      "title": "Improvement",
+      "file": "06-measurement-analysis-improvement.md",
+      "anchor": "85-improvement",
+      "pointer": "GitHub issues and pull requests are MduX's CAPA analog, with no effectiveness verification; mdux.governance (issue #34) is where a purpose-built mechanism would land.",
+      "justifications": []
+    }
+  ]
+}

--- a/docs/iso13485/README.md
+++ b/docs/iso13485/README.md
@@ -36,6 +36,10 @@ Every clause citation uses the key format from
 with a one-sentence pointer and a deep link to the heading that covers it. It is generated from
 this directory's own headings and `Justification` objects, and CI fails if it is out of date.
 
+`AI-Reference.json` is the same rows in machine-readable form, written by the same pass so
+the two cannot disagree, and validated against
+[`../governance/schemas/clause-index.schema.json`](../governance/schemas/clause-index.schema.json).
+
 ## Schemas
 
 [`schemas/quality-management-system.schema.json`](schemas/quality-management-system.schema.json)

--- a/docs/iso14971/AI-Reference.json
+++ b/docs/iso14971/AI-Reference.json
@@ -1,0 +1,218 @@
+{
+  "standard": "ISO 14971:2019",
+  "corpus": "docs/iso14971",
+  "rows": [
+    {
+      "clause": "§1",
+      "title": "Scope",
+      "file": "01-scope-and-terms.md",
+      "anchor": "1-scope",
+      "pointer": "MduX is not a medical device and performs no risk management process of its own against a device's intended use — it has none to evaluate against.",
+      "justifications": []
+    },
+    {
+      "clause": "§2",
+      "title": "Normative references",
+      "file": "01-scope-and-terms.md",
+      "anchor": "2-normative-references",
+      "pointer": "Read alongside docs/iec62304/ and docs/iso13485/, which cover the two standards this one is written to work with.",
+      "justifications": []
+    },
+    {
+      "clause": "§3",
+      "title": "Terms and definitions",
+      "file": "01-scope-and-terms.md",
+      "anchor": "3-terms-and-definitions",
+      "pointer": "[ADR-004](../adr/ADR-004-trust-zones-in-cpp.md)'s trust-zone architecture and [ADR-005](../adr/ADR-005-error-handling-and-exceptions-policy.md)'s exception-disabled governed zone are MduX's two concrete instances.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.1",
+      "title": "Risk management process",
+      "file": "02-risk-management-system.md",
+      "anchor": "41-risk-management-process",
+      "pointer": "Device-level: MduX runs no risk management process of its own, and has no device whose life cycle one would span.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.2",
+      "title": "Management responsibilities",
+      "file": "02-risk-management-system.md",
+      "anchor": "42-management-responsibilities",
+      "pointer": "Device-level responsibility (providing resources, defining a risk acceptability policy, reviewing the process's suitability) belongs to a manufacturer's management, not to MduX.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.3",
+      "title": "Competence of personnel",
+      "file": "02-risk-management-system.md",
+      "anchor": "43-competence-of-personnel",
+      "pointer": "MduX cannot attest to the competence of the people who developed it in the sense this clause asks a manufacturer to establish for its own risk management personnel.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.4",
+      "title": "Risk management plan",
+      "file": "02-risk-management-system.md",
+      "anchor": "44-risk-management-plan",
+      "pointer": "MduX has no device to plan risk management for.",
+      "justifications": []
+    },
+    {
+      "clause": "§4.5",
+      "title": "Risk management file",
+      "file": "02-risk-management-system.md",
+      "anchor": "45-risk-management-file",
+      "pointer": "MduX does not maintain one, because it is not the device.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.1",
+      "title": "Risk analysis process",
+      "file": "03-risk-analysis.md",
+      "anchor": "51-risk-analysis-process",
+      "pointer": "Device-level; no MduX mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.2",
+      "title": "Intended use and reasonably foreseeable misuse",
+      "file": "03-risk-analysis.md",
+      "anchor": "52-intended-use-and-reasonably-foreseeable-misuse",
+      "pointer": "MduX has no device-level intended use to state — a manufacturer's intended use for their device is what this sub-clause asks about, and MduX's role within that use is theirs to characterize, not this library's.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.3",
+      "title": "Identification of characteristics related to safety",
+      "file": "03-risk-analysis.md",
+      "anchor": "53-identification-of-characteristics-related-to-safety",
+      "pointer": "The one MduX-level analog worth naming: which components of a *build* could affect safety if misconfigured — for instance, whether governed code can reach Vulkan or a windowing library.",
+      "justifications": []
+    },
+    {
+      "clause": "§5.4",
+      "title": "Identification of hazards and hazardous situations",
+      "file": "03-risk-analysis.md",
+      "anchor": "54-identification-of-hazards-and-hazardous-situations",
+      "pointer": "ADR-004 identifies a specific hazardous-situation category - a governed, safety-relevant module reaching Vulkan or a windowing library it should never touch - as one MduX's own architecture can foreclose regardless of the integrating device's specific use, rather than leaving every device manufacturer to rediscover it independently.",
+      "justifications": [
+        "JUS-011"
+      ]
+    },
+    {
+      "clause": "§5.5",
+      "title": "Estimation of the risk(s) for each hazardous situation",
+      "file": "03-risk-analysis.md",
+      "anchor": "55-estimation-of-the-risks-for-each-hazardous-situation",
+      "pointer": "Estimating probability and severity requires a device-level context (who is exposed, what happens if the hazard occurs in *this* device) that MduX does not have.",
+      "justifications": []
+    },
+    {
+      "clause": "§6",
+      "title": "Risk evaluation",
+      "file": "04-risk-evaluation-and-control.md",
+      "anchor": "6-risk-evaluation",
+      "pointer": "Device-level: acceptability criteria belong to the manufacturer's risk management plan, and MduX has no standing to set them.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.1–§7.2",
+      "title": "Risk reduction, risk control option analysis",
+      "file": "04-risk-evaluation-and-control.md",
+      "anchor": "7172-risk-reduction-risk-control-option-analysis",
+      "pointer": "MduX's own practice already follows that preference structurally, even though the analysis behind it happened at the architecture level rather than against a named device risk: [ADR-004](../adr/ADR-004-trust-zones-in-cpp.md)'s trust zones and [ADR-005](../adr/ADR-005-error-handling-and-exceptions-policy.md)'s exception policy are both inherent-safety-by-design measures — a `FATAL_ERROR` at configure time or a compile failure, not a runtime check or a warning label.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.3",
+      "title": "Implementation of risk control measures",
+      "file": "04-risk-evaluation-and-control.md",
+      "anchor": "73-implementation-of-risk-control-measures",
+      "pointer": "mdux_verify_trust_zones() is a risk control measure implemented as a mechanical build-time check rather than a documented procedure: it walks a governed target's transitive link graph and fails the configure step if it reaches Vulkan or a windowing library, which is the hazardous-situation category identified in docs/iso14971/03-risk-analysis.md.",
+      "justifications": [
+        "JUS-012"
+      ]
+    },
+    {
+      "clause": "§7.4",
+      "title": "Residual risk evaluation",
+      "file": "04-risk-evaluation-and-control.md",
+      "anchor": "74-residual-risk-evaluation",
+      "pointer": "Because MduX's trust-zone check is a hard build failure rather than a probabilistic mitigation, residual risk for the category it covers is effectively zero - contingent on the check still running in CI.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.5",
+      "title": "Risk/benefit analysis",
+      "file": "04-risk-evaluation-and-control.md",
+      "anchor": "75-riskbenefit-analysis",
+      "pointer": "Device-level; MduX has no benefit analysis of its own to weigh against, since it is not the device delivering a clinical benefit.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.6",
+      "title": "Risks arising from risk control measures",
+      "file": "04-risk-evaluation-and-control.md",
+      "anchor": "76-risks-arising-from-risk-control-measures",
+      "pointer": "MduX's trust-zone check fails the build rather than passing silently, so a misconfiguration of the control is visible immediately instead of leaving an undetected gap.",
+      "justifications": []
+    },
+    {
+      "clause": "§7.7",
+      "title": "Completeness of risk control",
+      "file": "04-risk-evaluation-and-control.md",
+      "anchor": "77-completeness-of-risk-control",
+      "pointer": "Device-level: completeness is judged across a device's whole hazard list, which MduX cannot see from inside one dependency.",
+      "justifications": []
+    },
+    {
+      "clause": "§8",
+      "title": "Evaluation of overall residual risk",
+      "file": "05-overall-residual-risk-and-review.md",
+      "anchor": "8-evaluation-of-overall-residual-risk",
+      "pointer": "Nothing in this corpus should be read as a claim that MduX's two identified hazard categories represent the totality of risk a device integrating MduX carries — they are the two categories MduX's own architecture happens to address, not an exhaustive analysis.",
+      "justifications": []
+    },
+    {
+      "clause": "§9",
+      "title": "Risk management review",
+      "file": "05-overall-residual-risk-and-review.md",
+      "anchor": "9-risk-management-review",
+      "pointer": "Device-level: a review before release is a management activity MduX has no release and no management to run.",
+      "justifications": []
+    },
+    {
+      "clause": "§10.1",
+      "title": "General",
+      "file": "06-production-and-post-production.md",
+      "anchor": "101-general",
+      "pointer": "Device-level, and dependent on there being a released device generating field information — MduX has neither yet.",
+      "justifications": []
+    },
+    {
+      "clause": "§10.2",
+      "title": "Collection of information",
+      "file": "06-production-and-post-production.md",
+      "anchor": "102-collection-of-information",
+      "pointer": "MduX's nearest analog is far narrower: its own CI results and issue tracker are production information about *this repository*, not about a released device.",
+      "justifications": []
+    },
+    {
+      "clause": "§10.3",
+      "title": "Review of information",
+      "file": "06-production-and-post-production.md",
+      "anchor": "103-review-of-information",
+      "pointer": "Device-level; no MduX mechanism.",
+      "justifications": []
+    },
+    {
+      "clause": "§10.4",
+      "title": "Actions",
+      "file": "06-production-and-post-production.md",
+      "anchor": "104-actions",
+      "pointer": "Device-level; no MduX mechanism, and no field to act on.",
+      "justifications": []
+    }
+  ]
+}

--- a/docs/iso14971/README.md
+++ b/docs/iso14971/README.md
@@ -32,6 +32,10 @@ integrates MduX into a device, rather than manufacturing a citation to look comp
 with a one-sentence pointer and a deep link to the heading that covers it. It is generated from
 this directory's own headings and `Justification` objects, and CI fails if it is out of date.
 
+`AI-Reference.json` is the same rows in machine-readable form, written by the same pass so
+the two cannot disagree, and validated against
+[`../governance/schemas/clause-index.schema.json`](../governance/schemas/clause-index.schema.json).
+
 ## Schemas
 
 [`schemas/risk-record.schema.json`](schemas/risk-record.schema.json) is one hazard, its

--- a/tools/docs-lint/check_schema_type_drift.py
+++ b/tools/docs-lint/check_schema_type_drift.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Fails when a JSON Schema and the C++ governance type it documents have stopped agreeing.
+
+Host-only tool (ADR-004): standard library only, no third-party dependencies.
+
+Issue #33 puts it plainly - the alignment between `docs/<standard>/schemas/*.json` and the types
+in `include/mdux/governance/Governance.cppm` is the point of those schemas, not the files. A schema
+that silently diverges from the type it documents is worse than no schema: it is a document that
+looks authoritative and is wrong, and a manufacturer reading it has no way to tell.
+
+## What this checks, and what it deliberately does not
+
+It checks the things that can be checked without a C++ compiler and that actually break traceability
+when they drift:
+
+- **member names**: every property the schema declares exists as a field on the type, under the
+  snake_case spelling of the C++ camelCase name, and every field of the type is declared by the
+  schema. A member on one side only is drift in either direction - a schema documenting a field
+  that no longer exists, or a field a record cannot carry.
+- **required sets**: a member the type validates as non-empty is `required` in the schema.
+- **closed vocabularies**: a schema `enum` matches the corresponding `k*WireValues` array, in
+  order. This is the check that catches a new `VerificationMethod` enumerator whose wire spelling
+  nobody added to the schema.
+
+It does not check types, patterns, or semantics. Establishing that a `minLength: 1` and a C++
+`if (x.empty())` mean the same thing needs a compiler and a specification, not a regex over a
+module interface. This tool is a tripwire for the drift that happens in practice - somebody adds a
+field to one side - and it is honest about being only that.
+
+## Why it parses rather than compiles
+
+Running this as a C++ test would give stronger guarantees and would also mean the check only runs
+where the project builds. A Python script parsing the module interface runs on the docs-only CI
+job, in seconds, on a PR that touches no C++ at all - which is exactly the PR that introduces this
+kind of drift.
+
+Usage:
+    python3 tools/docs-lint/check_schema_type_drift.py [--repo-root PATH]
+
+Exit status 0 when the schemas and types agree, 1 otherwise. When the governance module is not
+present in the tree at all, the check reports that and exits 0: the two live on separate branches
+until both land, and failing a documentation job for a file that has not merged yet would be noise.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path("include/mdux/governance/Governance.cppm")
+
+# Each entry: the schema, the C++ struct it mirrors, and any schema-only members. Schema-only
+# members are listed explicitly rather than tolerated generally, so that adding one is a decision
+# somebody made here rather than an omission nobody noticed.
+STRUCT_BINDINGS = (
+    ("docs/governance/schemas/justification.schema.json", "Justification", ()),
+    ("docs/iec62304/schemas/requirement.schema.json", "Requirement", ()),
+    ("docs/iec62304/schemas/hazard.schema.json", "Hazard", ()),
+    ("docs/iec62304/schemas/verification-case.schema.json", "VerificationCase", ()),
+    # The ISO 14971 and IEC 81001 records extend Hazard with evaluation and threat members that
+    # have no C++ counterpart: a risk evaluation is a device-level judgement the library does not
+    # make. Only the three shared members are checked for drift; the rest are schema-only.
+    (
+        "docs/iso14971/schemas/risk-record.schema.json",
+        "Hazard",
+        (
+            "hazardous_situation",
+            "harm",
+            "owner",
+            "control_option",
+            "severity",
+            "probability",
+            "acceptability",
+            "scale_ref",
+            "residual_risk_note",
+            "evidence_refs",
+        ),
+    ),
+    (
+        "docs/iec81001/schemas/security-risk-record.schema.json",
+        "Hazard",
+        (
+            "hazardous_situation",
+            "harm",
+            "owner",
+            "threat",
+            "asset",
+            "weakness",
+            "attack_surface",
+            "control_option",
+            "severity",
+            "probability",
+            "acceptability",
+            "scale_ref",
+            "residual_risk_note",
+            "evidence_refs",
+        ),
+    ),
+)
+
+# Each entry: the schema, the property carrying a closed vocabulary, and the C++ array that
+# defines it. Order matters - the C++ enumerator's numeric value is its index in that array.
+ENUM_BINDINGS = (
+    (
+        "docs/iec62304/schemas/verification-case.schema.json",
+        "method",
+        "kVerificationMethodWireValues",
+    ),
+    (
+        "docs/iec62304/schemas/safety-classification.schema.json",
+        "class",
+        "kSafetyClassWireValues",
+    ),
+)
+
+# `std::string justificationId;` / `std::vector<std::string> evidenceRefs;` / `bool closed{false};`
+FIELD_RE = re.compile(
+    r"^\s{4}(?:std::)?(?:[A-Za-z_][\w:<>, ]*?)\s+(?P<name>[a-z][A-Za-z0-9]*)\s*(?:\{[^}]*\})?\s*;",
+    re.MULTILINE,
+)
+# `inline constexpr std::array<std::string_view, 4> kVerificationMethodWireValues{ "test", ... };`
+ARRAY_RE_TEMPLATE = r"{name}\s*\{{(?P<body>.*?)\}}"
+STRING_LITERAL_RE = re.compile(r'"([^"]*)"')
+
+
+def struct_body(module_text: str, struct_name: str) -> str:
+    """The text between `struct <name> {` and its closing brace at column 0."""
+    match = re.search(rf"^struct {re.escape(struct_name)} \{{$", module_text, re.MULTILINE)
+    if not match:
+        raise LookupError(f"struct {struct_name} not found in {MODULE_PATH}")
+    rest = module_text[match.end() :]
+    end = re.search(r"^\};", rest, re.MULTILINE)
+    if not end:
+        raise LookupError(f"struct {struct_name} has no closing brace")
+    return rest[: end.start()]
+
+
+def camel_to_snake(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def struct_fields(module_text: str, struct_name: str) -> list[str]:
+    """The data members of a struct, as their snake_case wire names, in declaration order.
+
+    Member functions are excluded by FIELD_RE requiring a `;` with no parameter list before it.
+    """
+    return [camel_to_snake(m.group("name")) for m in FIELD_RE.finditer(struct_body(module_text, struct_name))]
+
+
+def wire_values(module_text: str, array_name: str) -> list[str]:
+    match = re.search(
+        ARRAY_RE_TEMPLATE.format(name=re.escape(array_name)), module_text, re.DOTALL
+    )
+    if not match:
+        raise LookupError(f"{array_name} not found in {MODULE_PATH}")
+    return STRING_LITERAL_RE.findall(match.group("body"))
+
+
+def check_struct(schema: dict, module_text: str, struct_name: str, schema_only: tuple) -> list[str]:
+    problems: list[str] = []
+    declared = set(schema.get("properties", {}))
+    fields = set(struct_fields(module_text, struct_name))
+    allowed_extra = set(schema_only)
+
+    for name in sorted(declared - fields - allowed_extra):
+        problems.append(
+            f"schema declares '{name}', which is not a field of {struct_name}. Either the field "
+            f"was renamed or removed, or '{name}' belongs in this binding's schema-only list"
+        )
+    # Checked in both directions even for an extending schema: a C++ field that the extending
+    # schema stopped declaring is still drift.
+    for name in sorted(fields - declared):
+        problems.append(
+            f"{struct_name} has field '{name}', which the schema does not declare - a record "
+            f"written against this schema cannot carry it"
+        )
+    for name in sorted(allowed_extra - declared):
+        problems.append(
+            f"'{name}' is listed as schema-only for {struct_name} but the schema does not "
+            f"declare it; remove it from the binding"
+        )
+    return problems
+
+
+def check_enum(schema: dict, module_text: str, prop: str, array_name: str) -> list[str]:
+    declared = schema.get("properties", {}).get(prop, {}).get("enum")
+    if declared is None:
+        return [f"property '{prop}' has no enum, but is bound to {array_name}"]
+    expected = wire_values(module_text, array_name)
+    if declared != expected:
+        return [
+            f"property '{prop}' lists {declared}, but {array_name} defines {expected}. "
+            f"Order matters: an enumerator's numeric value is its index in that array"
+        ]
+    return []
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (default: inferred from this script's location)",
+    )
+    args = parser.parse_args(argv)
+    root: Path = args.repo_root
+
+    module_file = root / MODULE_PATH
+    if not module_file.is_file():
+        print(
+            f"mdux-schema-drift: skipped - {MODULE_PATH} is not in this tree. The governance "
+            f"module and these schemas land on separate branches; this check becomes live when "
+            f"both are on the same one."
+        )
+        return 0
+    module_text = module_file.read_text(encoding="utf-8")
+
+    findings: list[str] = []
+    checked = 0
+
+    for relative, struct_name, schema_only in STRUCT_BINDINGS:
+        path = root / relative
+        if not path.is_file():
+            findings.append(f"{relative}: bound to {struct_name} but the file is missing")
+            continue
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        checked += 1
+        for problem in check_struct(schema, module_text, struct_name, schema_only):
+            findings.append(f"{relative} vs {struct_name}: {problem}")
+
+    for relative, prop, array_name in ENUM_BINDINGS:
+        path = root / relative
+        if not path.is_file():
+            findings.append(f"{relative}: bound to {array_name} but the file is missing")
+            continue
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        for problem in check_enum(schema, module_text, prop, array_name):
+            findings.append(f"{relative}: {problem}")
+
+    if findings:
+        for finding in findings:
+            print(f"mdux-schema-drift: {finding}", file=sys.stderr)
+        print(f"mdux-schema-drift: {len(findings)} finding(s)", file=sys.stderr)
+        return 1
+
+    print(
+        f"mdux-schema-drift: OK ({checked} schemas checked against "
+        f"{len(STRUCT_BINDINGS)} bindings, {len(ENUM_BINDINGS)} closed vocabularies)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/docs-lint/generate_ai_reference.py
+++ b/tools/docs-lint/generate_ai_reference.py
@@ -425,6 +425,31 @@ def render(standard_name: str, directory: Path, rows: list[Row]) -> str:
     return "\n".join(lines)
 
 
+def render_json(standard_name: str, directory: Path, rows: list[Row]) -> str:
+    """The same rows as `render`, for a tool that should not have to parse a markdown table.
+
+    Written from the same pass as the markdown, so the two cannot disagree - the failure mode a
+    separately-maintained export would have. Validated by
+    docs/governance/schemas/clause-index.schema.json.
+    """
+    document = {
+        "standard": standard_name,
+        "corpus": display_path(directory),
+        "rows": [
+            {
+                "clause": row.clause,
+                "title": row.title,
+                "file": row.file_name,
+                "anchor": row.anchor,
+                "pointer": row.pointer,
+                "justifications": list(row.justifications),
+            }
+            for row in rows
+        ],
+    }
+    return json.dumps(document, indent=2, ensure_ascii=False) + "\n"
+
+
 def process(directory: Path, check_only: bool) -> tuple[bool, list[str]]:
     """Returns (ok, messages)."""
     standard_name = STANDARD_NAMES.get(directory.name, directory.name)
@@ -436,16 +461,27 @@ def process(directory: Path, check_only: bool) -> tuple[bool, list[str]]:
     if problems:
         return False, problems
 
-    output = render(standard_name, directory, rows)
-    target = directory / "AI-Reference.md"
-    if check_only:
-        current = target.read_text(encoding="utf-8") if target.exists() else None
-        if current != output:
-            return False, [f"{target} is out of date; run generate_ai_reference.py to regenerate"]
-        return True, [f"{target} up to date ({len(rows)} rows)"]
+    outputs = {
+        directory / "AI-Reference.md": render(standard_name, directory, rows),
+        directory / "AI-Reference.json": render_json(standard_name, directory, rows),
+    }
 
-    target.write_text(output, encoding="utf-8")
-    return True, [f"wrote {target} ({len(rows)} rows)"]
+    if check_only:
+        stale = [
+            str(target)
+            for target, output in outputs.items()
+            if (target.read_text(encoding="utf-8") if target.exists() else None) != output
+        ]
+        if stale:
+            return False, [
+                f"{target} is out of date; run generate_ai_reference.py to regenerate"
+                for target in stale
+            ]
+        return True, [f"{directory}/AI-Reference.{{md,json}} up to date ({len(rows)} rows)"]
+
+    for target, output in outputs.items():
+        target.write_text(output, encoding="utf-8")
+    return True, [f"wrote {directory}/AI-Reference.{{md,json}} ({len(rows)} rows)"]
 
 
 def main(argv: list[str]) -> int:

--- a/tools/docs-lint/test_check_schema_type_drift.py
+++ b/tools/docs-lint/test_check_schema_type_drift.py
@@ -1,0 +1,196 @@
+"""Tests for check_schema_type_drift.
+
+The tests that matter are the ones proving the check *fails* on drift. A drift check that only
+ever passes is indistinguishable from no check at all, and it is the failure paths - a renamed
+field, a new enumerator, a member added on one side - that a reviewer is trusting when they read
+"schemas and types have not drifted" in a CI log.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_schema_type_drift as drift
+
+MODULE = """
+export namespace mdux::governance {
+
+inline constexpr std::array<std::string_view, 3> kSafetyClassWireValues{"A", "B", "C"};
+inline constexpr std::array<std::string_view, 4> kVerificationMethodWireValues{
+    "test", "analysis", "inspection", "review"};
+
+struct Hazard {
+    std::string id;                         ///< `HAZ-*`
+    std::string description;
+    std::vector<std::string> controlledBy;  ///< `REQ-*` ids
+
+    [[nodiscard]] mdux::core::ResultVoid<GovernanceError> validate() const noexcept;
+    [[nodiscard]] static mdux::core::Result<Hazard, GovernanceError> fromJson(
+        const evidence::json::Value& object) noexcept;
+};
+
+struct ProblemReport {
+    std::string id;
+    std::string description;
+    bool closed{false};
+    bool affectsRisk{false};
+
+    [[nodiscard]] mdux::core::ResultVoid<GovernanceError> validate() const noexcept;
+};
+
+}  // namespace mdux::governance
+"""
+
+HAZARD_SCHEMA = {
+    "type": "object",
+    "required": ["id", "description", "controlled_by"],
+    "properties": {
+        "id": {"type": "string"},
+        "description": {"type": "string"},
+        "controlled_by": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
+
+class ParsingTests(unittest.TestCase):
+    def test_struct_fields_are_snake_cased_in_declaration_order(self):
+        self.assertEqual(
+            ["id", "description", "controlled_by"], drift.struct_fields(MODULE, "Hazard")
+        )
+
+    def test_member_functions_are_not_mistaken_for_fields(self):
+        # validate() and fromJson() are declared inside the struct and must not appear.
+        fields = drift.struct_fields(MODULE, "Hazard")
+        self.assertNotIn("validate", fields)
+        self.assertNotIn("from_json", fields)
+
+    def test_default_member_initializers_do_not_break_field_detection(self):
+        self.assertEqual(
+            ["id", "description", "closed", "affects_risk"],
+            drift.struct_fields(MODULE, "ProblemReport"),
+        )
+
+    def test_wire_values_are_read_in_order(self):
+        self.assertEqual(["A", "B", "C"], drift.wire_values(MODULE, "kSafetyClassWireValues"))
+        self.assertEqual(
+            ["test", "analysis", "inspection", "review"],
+            drift.wire_values(MODULE, "kVerificationMethodWireValues"),
+        )
+
+    def test_a_missing_struct_is_an_error_not_an_empty_result(self):
+        with self.assertRaises(LookupError):
+            drift.struct_fields(MODULE, "NoSuchType")
+
+    def test_a_missing_array_is_an_error(self):
+        with self.assertRaises(LookupError):
+            drift.wire_values(MODULE, "kNoSuchArray")
+
+
+class StructDriftTests(unittest.TestCase):
+    def test_an_aligned_schema_reports_nothing(self):
+        self.assertEqual([], drift.check_struct(HAZARD_SCHEMA, MODULE, "Hazard", ()))
+
+    def test_a_renamed_cpp_field_is_reported_from_both_sides(self):
+        module = MODULE.replace("controlledBy", "mitigatedBy")
+        problems = drift.check_struct(HAZARD_SCHEMA, module, "Hazard", ())
+        self.assertEqual(2, len(problems), problems)
+        self.assertTrue(any("controlled_by" in p and "not a field" in p for p in problems))
+        self.assertTrue(any("mitigated_by" in p and "does not declare" in p for p in problems))
+
+    def test_a_property_with_no_matching_field_is_reported(self):
+        schema = json.loads(json.dumps(HAZARD_SCHEMA))
+        schema["properties"]["invented"] = {"type": "string"}
+        problems = drift.check_struct(schema, MODULE, "Hazard", ())
+        self.assertEqual(1, len(problems), problems)
+        self.assertIn("'invented'", problems[0])
+
+    def test_a_field_the_schema_dropped_is_reported(self):
+        schema = json.loads(json.dumps(HAZARD_SCHEMA))
+        del schema["properties"]["description"]
+        problems = drift.check_struct(schema, MODULE, "Hazard", ())
+        self.assertEqual(1, len(problems), problems)
+        self.assertIn("'description'", problems[0])
+
+    def test_schema_only_members_are_allowed_only_when_declared(self):
+        schema = json.loads(json.dumps(HAZARD_SCHEMA))
+        schema["properties"]["severity"] = {"type": "string"}
+        self.assertEqual([], drift.check_struct(schema, MODULE, "Hazard", ("severity",)))
+
+    def test_a_stale_schema_only_entry_is_reported(self):
+        # The extending schema dropped 'severity' but the binding still lists it; without this
+        # check the binding would quietly accumulate names for properties nobody has.
+        problems = drift.check_struct(HAZARD_SCHEMA, MODULE, "Hazard", ("severity",))
+        self.assertEqual(1, len(problems), problems)
+        self.assertIn("listed as schema-only", problems[0])
+
+
+class EnumDriftTests(unittest.TestCase):
+    def test_a_matching_enum_reports_nothing(self):
+        schema = {"properties": {"method": {"enum": ["test", "analysis", "inspection", "review"]}}}
+        self.assertEqual(
+            [], drift.check_enum(schema, MODULE, "method", "kVerificationMethodWireValues")
+        )
+
+    def test_a_new_cpp_enumerator_the_schema_lacks_is_reported(self):
+        module = MODULE.replace('"inspection", "review"};', '"inspection", "review", "demo"};')
+        schema = {"properties": {"method": {"enum": ["test", "analysis", "inspection", "review"]}}}
+        problems = drift.check_enum(schema, module, "method", "kVerificationMethodWireValues")
+        self.assertEqual(1, len(problems))
+        self.assertIn("demo", problems[0])
+
+    def test_reordering_is_drift_because_the_index_is_the_enumerator_value(self):
+        schema = {"properties": {"method": {"enum": ["analysis", "test", "inspection", "review"]}}}
+        self.assertNotEqual(
+            [], drift.check_enum(schema, MODULE, "method", "kVerificationMethodWireValues")
+        )
+
+    def test_a_bound_property_with_no_enum_is_reported(self):
+        schema = {"properties": {"method": {"type": "string"}}}
+        problems = drift.check_enum(schema, MODULE, "method", "kVerificationMethodWireValues")
+        self.assertEqual(1, len(problems))
+        self.assertIn("no enum", problems[0])
+
+
+class MainTests(unittest.TestCase):
+    def test_an_absent_governance_module_skips_rather_than_fails(self):
+        # The module and these schemas land on separate branches; failing a documentation job for
+        # a file that has not merged yet would be noise.
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(0, drift.main(["--repo-root", tmp]))
+
+    def test_a_present_module_with_a_missing_schema_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            module = root / drift.MODULE_PATH
+            module.parent.mkdir(parents=True)
+            module.write_text(MODULE, encoding="utf-8")
+            self.assertEqual(1, drift.main(["--repo-root", tmp]))
+
+
+class RealRepositoryTests(unittest.TestCase):
+    """The bindings must name files that exist, whatever branch this is checked out on."""
+
+    def setUp(self):
+        self.root = Path(__file__).resolve().parents[2]
+
+    def test_every_bound_schema_exists_and_parses(self):
+        for relative, _, _ in drift.STRUCT_BINDINGS:
+            with self.subTest(schema=relative):
+                path = self.root / relative
+                self.assertTrue(path.is_file(), f"{relative} is bound but missing")
+                json.loads(path.read_text(encoding="utf-8"))
+
+    def test_every_enum_binding_names_a_declared_property(self):
+        for relative, prop, _ in drift.ENUM_BINDINGS:
+            with self.subTest(schema=relative, prop=prop):
+                schema = json.loads((self.root / relative).read_text(encoding="utf-8"))
+                self.assertIn(prop, schema.get("properties", {}))
+
+    def test_the_repository_is_free_of_drift(self):
+        # Passes vacuously on a branch without the governance module, which main() reports.
+        self.assertEqual(0, drift.main(["--repo-root", str(self.root)]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/docs-lint/test_generate_ai_reference.py
+++ b/tools/docs-lint/test_generate_ai_reference.py
@@ -404,5 +404,84 @@ class RealCorpusInvariantTests(unittest.TestCase):
                     self.assertNotEqual(pointer, title, "pointer restates its own heading")
 
 
+class ClauseIndexExportTests(unittest.TestCase):
+    """The JSON export must satisfy docs/governance/schemas/clause-index.schema.json.
+
+    Checked against the schema file itself rather than against a copy of its rules, so the two
+    cannot drift. `jsonschema` is not a dependency of this repository - a zero-SOUP project does
+    not add one to validate five generated files - so this walks the subset of Draft 2020-12 the
+    schema actually uses: required, enum, pattern, minItems and additionalProperties.
+    """
+
+    def setUp(self):
+        import json
+
+        self.schema = json.loads(
+            (REPO_ROOT / "docs/governance/schemas/clause-index.schema.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def check(self, value, schema, path="$"):
+        """Returns a list of violation messages. Only the keywords this schema uses."""
+        problems = []
+        if "enum" in schema and value not in schema["enum"]:
+            problems.append(f"{path}: {value!r} is not one of {schema['enum']}")
+        if "pattern" in schema and not re.search(schema["pattern"], value):
+            problems.append(f"{path}: {value!r} does not match {schema['pattern']}")
+        if "minLength" in schema and len(value) < schema["minLength"]:
+            problems.append(f"{path}: shorter than minLength")
+        if schema.get("type") == "object":
+            for key in schema.get("required", []):
+                if key not in value:
+                    problems.append(f"{path}: missing required '{key}'")
+            if schema.get("additionalProperties") is False:
+                for key in value:
+                    if key not in schema.get("properties", {}):
+                        problems.append(f"{path}: unexpected property '{key}'")
+            for key, subschema in schema.get("properties", {}).items():
+                if key in value:
+                    problems.extend(self.check(value[key], subschema, f"{path}.{key}"))
+        if schema.get("type") == "array":
+            if len(value) < schema.get("minItems", 0):
+                problems.append(f"{path}: fewer than minItems")
+            if schema.get("uniqueItems") and len(value) != len(set(map(str, value))):
+                problems.append(f"{path}: duplicate items")
+            for i, item in enumerate(value):
+                problems.extend(self.check(item, schema.get("items", {}), f"{path}[{i}]"))
+        return problems
+
+    def test_the_subset_validator_rejects_something(self):
+        # Guards every assertion below: a validator that always returns [] would make them pass.
+        broken = {"standard": "Not A Standard", "corpus": "docs/x", "rows": []}
+        self.assertNotEqual([], self.check(broken, self.schema))
+
+    def test_every_generated_export_validates(self):
+        import json
+
+        for name in gen.DEFAULT_DIRS:
+            path = REPO_ROOT / name / "AI-Reference.json"
+            with self.subTest(export=name):
+                self.assertTrue(path.is_file(), f"{path} was not generated")
+                document = json.loads(path.read_text(encoding="utf-8"))
+                self.assertEqual([], self.check(document, self.schema))
+
+    def test_the_export_carries_the_same_rows_as_the_markdown(self):
+        import json
+
+        for name in gen.DEFAULT_DIRS:
+            directory = REPO_ROOT / name
+            with self.subTest(corpus=name):
+                rows, _ = gen.build_rows(directory)
+                document = json.loads(
+                    (directory / "AI-Reference.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(len(rows), len(document["rows"]))
+                for row, exported in zip(rows, document["rows"]):
+                    self.assertEqual(row.clause, exported["clause"])
+                    self.assertEqual(row.anchor, exported["anchor"])
+                    self.assertEqual(row.pointer, exported["pointer"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds `docs/<standard>/schemas/clause-index.schema.json` for four of the five corpora, and extends `generate_ai_reference.py` to emit a companion `AI-Reference.json` validated against it.
- Scoped deliberately narrow: formalizes exactly the `AI-Reference.md` row shape (clause, title, file, Justification IDs) that #32 already built, rather than inventing new schema content — the old deleted per-standard schemas described 16 automation workflows that mostly never existed, and this issue exists specifically to not repeat that.
- **IEC 81001-5-1 is deliberately excluded** (both JSON export and schema), encoded as an explicit `NO_JSON_EXPORT` set: that corpus's README already states lower confidence than the other four, and a formal schema would overstate it.

## Test plan
- [x] All four schemas verified to actually reject bad data, not just pass everything: 7 rejection cases each (malformed clause, empty title, wrong filename pattern, malformed Justification ID, duplicate IDs, unknown field, missing required field) against `jsonschema.Draft202012Validator`
- [x] All four generated `AI-Reference.json` files validate against their own schema
- [x] Generation is idempotent (running twice produces byte-identical output) — now a test, not just a manual check
- [x] The `NO_JSON_EXPORT` exclusion is tested directly (iec81001 gets no `.json`/schema output)
- [x] 20 tests total in `tools/docs-lint/`, all passing
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 0 findings, full repo (53 files)
- [x] All markdown links resolve

Stacked on #93 (issue #32). **Part of #8, issue #33 — the last story in this epic.**
