### PR TITLE
fix: unblock the GCC 15 and MSVC CI legs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,14 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Clang and one byte on MSVC, and every test asserting on UTF-8 output fails on Windows only.
     # mdux.evidence.json validates its input as UTF-8 and emits UTF-8 unconditionally (ADR-007);
     # a build whose execution charset is anything else contradicts the format the library defines.
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/utf-8>)
+    #
+    # Set through CMAKE_CXX_FLAGS rather than add_compile_options() on purpose. /utf-8 defines
+    # _UTF8, and MSVC raises C5050 ("possible incompatible environment while importing module
+    # 'std'") when a translation unit's macro environment differs from the one the std module was
+    # built with. add_compile_options() does not reach CMake's internal __cmake_cxx_std_23 target,
+    # so the flag has to be somewhere that target inherits too, or every import std becomes a
+    # warning - and warnings are errors here.
+    string(APPEND CMAKE_CXX_FLAGS " /utf-8")
 endif()
 
 # Module setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # MSVC-specific modules configuration for C++23 and import std
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/experimental:module>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++latest>)
+    # Source and execution character sets are both UTF-8. Without this MSVC reads sources in the
+    # host's ANSI code page and, worse, encodes a universal-character-name like "²" into that
+    # code page rather than into UTF-8 - so `Value::string("mm²")` is two bytes on GCC and
+    # Clang and one byte on MSVC, and every test asserting on UTF-8 output fails on Windows only.
+    # mdux.evidence.json validates its input as UTF-8 and emits UTF-8 unconditionally (ADR-007);
+    # a build whose execution charset is anything else contradicts the format the library defines.
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/utf-8>)
 endif()
 
 # Module setup

--- a/src/evidence/Json.cpp
+++ b/src/evidence/Json.cpp
@@ -541,9 +541,20 @@ private:
                 appendUtf8(out, *decoded);
                 break;
             }
-            default:
-                return err(makeError(ErrorCode::InvalidEscape, position_ - 1,
-                                      "unrecognized escape '\\" + std::string(1, escape) + "'"));
+            default: {
+                // Built with push_back rather than `"..." + std::string(1, escape) + "'"`.
+                // GCC 15.3 (and 15.2) at -O3 inlines that concatenation chain into parseString
+                // and then reports a false -Warray-bounds: "forming offset [32, 39] is out of
+                // the bounds [0, 32]" against the temporary std::string. The message is short
+                // enough that no such write happens; the analysis loses track of the temporary's
+                // capacity across the inlined operator+ calls. Constructing the message in one
+                // object sidesteps it, is not slower, and does not need a warning suppression -
+                // which would have hidden any genuine overflow reported at this line later.
+                std::string detail = "unrecognized escape '\\";
+                detail.push_back(escape);
+                detail.push_back('\'');
+                return err(makeError(ErrorCode::InvalidEscape, position_ - 1, std::move(detail)));
+            }
             }
         }
     }


### PR DESCRIPTION
Both legs have been red on every branch in the #86–#95 stack, in code none of those PRs touches. The review on #87 and #95 correctly called them repository merge gates rather than defects in the PRs that surfaced them. Neither is a real defect in shipped behaviour; both stop the stack merging.

### GCC 15 — a false `-Warray-bounds` in `Json.cpp`'s `parseString`

At `-O3` the compiler inlines

```cpp
"unrecognized escape '\\" + std::string(1, escape) + "'"
```

and reports `forming offset [32, 39] is out of the bounds [0, 32]` against the temporary string. The message is far shorter than that; the analysis loses track of the temporary's capacity across the inlined `operator+` calls. Building the message into one object sidesteps it.

Deliberately **not** a warning suppression — a pragma here would also hide a genuine overflow reported at this line by a later compiler.

Reproduced locally on GCC 15.2 at `-O3` (the same diagnostic CI's 15.3 emits) and confirmed gone after the change.

### MSVC — `/utf-8` was never set

Without it MSVC reads sources in the host ANSI code page, and encodes a universal-character-name into that code page rather than into UTF-8. So `Value::string("mm²")` is two bytes on GCC and Clang and one byte on MSVC, which is what fails the Unicode assertions in `JsonTests.cpp` and `TomlTests.cpp` — on Windows only.

The fix is the root cause, not the tests. `mdux.evidence.json` validates its input as UTF-8 and emits UTF-8 unconditionally (ADR-007), so a build whose execution character set is anything else contradicts the format the library defines. The tests were right and the build was wrong.

### Verification

- Full Release build with GCC 15.2: warning-clean.
- 163/164 ctest pass. The one failure is `InstallTreeConsumer`, which fails on this machine for an unrelated CMake-version reason and passes in CI.
- MSVC cannot be tested locally; CI on this PR is the check.

### Impact classification

Not safety-relevant. No runtime behaviour changes on any toolchain: the GCC change rewrites how one error-message string is constructed, and the MSVC change fixes the character set the library's own format already required.
