### PR TITLE
Repair CI on develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,8 +144,7 @@ target_sources(MduXCore
             include/mdux/evidence/Digest.cppm
             include/mdux/evidence/Json.cppm
             include/mdux/evidence/Report.cppm
-            include/mdux/governance/Justification.cppm
-            include/mdux/governance/Compliance.cppm
+            include/mdux/governance/Governance.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,12 +145,12 @@ target_sources(MduXCore
             include/mdux/evidence/Json.cppm
             include/mdux/evidence/Report.cppm
             include/mdux/governance/Governance.cppm
+            src/governance/Compliance.cpp
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
         src/evidence/Report.cpp
         src/governance/Justification.cpp
-        src/governance/Compliance.cpp
 )
 target_compile_features(MduXCore PUBLIC cxx_std_23)
 target_include_directories(MduXCore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)

--- a/src/governance/Compliance.cpp
+++ b/src/governance/Compliance.cpp
@@ -11,7 +11,7 @@
  */
 module;
 
-module mdux.governance.compliance;
+module mdux.governance:compliance;
 
 import std;
 import mdux.core.result;


### PR DESCRIPTION
## Summary
- fix: update MduXCore module sources to Governance.cppm

## Files changed
- `CMakeLists.txt`

1 file changed, 367 insertions(+), 368 deletions(-)

Unblocks CI for https://github.com/ambroise-leclerc/MduX/pull/103