### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(cmake/PreventInSourceBuilds.cmake)
 
-project(MduX VERSION 0.2.0 DESCRIPTION "Modern C++23 Modules UI Library for Medical Devices" HOMEPAGE_URL "https://github.com/ambroise-leclerc/MduX" LANGUAGES CXX)
+project(MduX VERSION 0.3.0 DESCRIPTION "Modern C++23 Modules UI Library for Medical Devices" HOMEPAGE_URL "https://github.com/ambroise-leclerc/MduX" LANGUAGES CXX)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/software_development_file/regulatory/IEC_62304/SAD.md
+++ b/software_development_file/regulatory/IEC_62304/SAD.md
@@ -9,7 +9,7 @@
 - **Product / software item:** MduX — an experimental, proof-of-concept C++23-modules Vulkan/Vulkan
   SC UI/rendering library. Not a finished product (see `AGENTS.md` § 1).
 - **Version:** the project version reported by `mdux::Version::getString()` (`CMakeLists.txt`'s
-  `project(... VERSION ...)`, currently `0.2.0`); see `CMakeLists.txt` for the exact build.
+  `project(... VERSION ...)`, currently `0.3.0`); see `CMakeLists.txt` for the exact build.
 - **Safety classification:** Class A, B, or C, chosen per-application. Unlike its sibling project
   TrustSC (Class B/C only), MduX keeps Class A explicitly in scope (`docs/governance/citation-convention.md`).
   **Note the gap:** `mdux::ComplianceMetadata.deviceClass` (`include/mdux/mdux.cppm`) is a free-form

--- a/tests/TestRegulatoryCompliance.cpp
+++ b/tests/TestRegulatoryCompliance.cpp
@@ -11,7 +11,7 @@ import mdux.test;
 TEST_CASE("IEC 62304 Version Traceability", "regulatory") {
     // Verify version traceability (required by IEC 62304)
     CHECK(mdux::Version::major == 0);
-    CHECK(mdux::Version::minor == 2);
+    CHECK(mdux::Version::minor == 3);
     CHECK(mdux::Version::patch == 0);
     CHECK(!mdux::Version::getString().empty());
 }

--- a/tests/TestVersion.cpp
+++ b/tests/TestVersion.cpp
@@ -10,9 +10,9 @@ import mdux.test;
 
 TEST_CASE("Version Test") {
     CHECK(mdux::Version::major == 0);
-    CHECK(mdux::Version::minor == 2);
+    CHECK(mdux::Version::minor == 3);
     CHECK(mdux::Version::patch == 0);
-    CHECK(mdux::Version::getString() == "0.2.0");
+    CHECK(mdux::Version::getString() == "0.3.0");
 }
 
 TEST_CASE("Version Test Sections") {
@@ -24,13 +24,13 @@ TEST_CASE("Version Test Sections") {
     SECTION("major and minor") {
         sectionsRun += 1;
         CHECK(mdux::Version::major == 0);
-        CHECK(mdux::Version::minor == 2);
+        CHECK(mdux::Version::minor == 3);
     }
 
     SECTION("patch and string") {
         sectionsRun += 1;
         CHECK(mdux::Version::patch == 0);
-        CHECK(mdux::Version::getString() == "0.2.0");
+        CHECK(mdux::Version::getString() == "0.3.0");
     }
 
     CHECK(sectionsRun == 2);


### PR DESCRIPTION
## Summary

- bump the MduX project version to 0.3.0
- update version and regulatory traceability tests
- synchronize the IEC 62304 software architecture description

This release closes Wave 2: the five-standard regulatory corpus and its generated indexes/schemas, the governance and traceability API, SOUP registration, and software-development-file templates.

## Validation

- `python3 -m unittest discover -s tools/docs-lint -p "test_*.py"` (65 tests)
- `python3 tools/docs-lint/mdux_docs_lint.py` (71 files, 0 findings)
- `python3 tools/docs-lint/generate_ai_reference.py --check` (all five indexes current)
- `python3 tools/docs-lint/check_schema_type_drift.py` (clean)
- `git diff --check`

## Scope

MduX remains experimental and proof-of-concept. This release does not claim certification, validation, production readiness, or regulatory compliance.

