### PR TITLE
S3 — Stable JSON diagnostic envelope across all tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main, develop ]
+    # `feat/**` is here because these filters match the PR's *base*, not its head. Wave 3 is
+    # delivered as a stack in which each PR targets its predecessor rather than develop, so that
+    # a reviewer sees one issue's diff instead of the cumulative one - and without this pattern
+    # every PR after the first would report no checks at all rather than reporting failures.
+    branches: [ main, develop, 'feat/**' ]
 
 env:
   BUILD_TYPE: Release

--- a/docs/governance/schemas/diagnostic.schema.json
+++ b/docs/governance/schemas/diagnostic.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdux.dev/schemas/governance/diagnostic.schema.json",
+  "title": "Tool diagnostic envelope",
+  "description": "Validates the `--format=json` output of every MduX tool that reports findings: the bakers through `mdux::tools::cli::render` (tools/common/Cli.cppm), and the Python lints `mdux-docs-lint` and `mdux-evidence-lint`. One envelope for the whole repository is the point, not one per tool - an agent that can fix a finding from one tool can fix a finding from any of them, without parsing prose and without a per-tool parser. This schema is published before the shader, `.medui` and ML bakers land, so that they adopt the envelope rather than each inventing one and forcing a later migration.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["tool", "findings"],
+  "properties": {
+    "tool": {
+      "type": "string",
+      "description": "The tool that produced these findings, as it is invoked: 'mdux-shaderbake', 'mdux-docs-lint'. Present so output aggregated from several tools stays attributable; a consumer merging two runs must be able to tell which one objected.",
+      "minLength": 1
+    },
+    "filesChecked": {
+      "type": "integer",
+      "description": "How many files this run examined. Optional, and emitted only by the tools that scan a file set - the lints, not the bakers, which are handed exactly one recipe. It is worth carrying because zero findings over zero files and zero findings over five hundred are very different results, and a consumer reading only `findings` cannot tell them apart.",
+      "minimum": 0
+    },
+    "findings": {
+      "type": "array",
+      "description": "Every finding from this run, in the order the tool reported them. An empty array is the success case and is emitted rather than omitted, so a consumer never special-cases success.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["file", "line", "column", "code", "severity", "message", "fixHint"],
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "The file the finding is about, repository-relative and using forward slashes on every platform. Never absolute: a diagnostic quoting a build machine's directory layout is not actionable anywhere else.",
+            "minLength": 1
+          },
+          "line": {
+            "type": "integer",
+            "description": "1-based line, or 0 when the finding is about the file as a whole.",
+            "minimum": 0
+          },
+          "column": {
+            "type": "integer",
+            "description": "1-based column, or 0 when there is no precise column. Independent of `line`: a tool that knows the line but not the column reports the line and leaves this 0, rather than inventing a position it does not have. A non-zero `column` with a zero `line` is meaningless and tools do not emit it.",
+            "minimum": 0
+          },
+          "code": {
+            "type": "string",
+            "description": "Short stable identifier for the kind of finding, such as 'MDX-D011' or 'FB001'. This is the field an agent keys off, so its meaning must not change once published - reword the message instead. The empty string is permitted, and means the tool has not assigned a code to this finding; `mdux::tools::cli::render` omits the bracketed code from its text form in that case.",
+            "pattern": "^([A-Za-z0-9][A-Za-z0-9-]*)?$"
+          },
+          "severity": {
+            "type": "string",
+            "description": "Closed vocabulary, matching `mdux::tools::cli::Severity` and `describe()`. Only 'error' affects exit status; a warning alone never fails a bake, because whether a bake is acceptable is decided by CI's byte comparison rather than by the baker's opinion.",
+            "enum": ["error", "warning", "note"]
+          },
+          "message": {
+            "type": "string",
+            "description": "What is wrong, in one sentence, naming the offending value where there is one. Free prose: consumers key off `code`, so this may be reworded without breaking them.",
+            "minLength": 1
+          },
+          "fixHint": {
+            "type": "string",
+            "description": "What to do about it, when the tool can say something concrete - 'raise atlasWidth or reduce the charset'. Empty when there is no single obvious fix, which is honest and common; an invented hint is worse than none."
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/tools/CliTests.cpp
+++ b/tests/tools/CliTests.cpp
@@ -145,12 +145,17 @@ TEST_CASE("JSON diagnostics use the published envelope shape", "evidence-unit") 
     const std::vector<Diagnostic> diagnostics{
         Diagnostic{.file = "recipes/font/roboto-ui.toml",
                    .line = 7,
+                   .column = 22,
                    .code = "FB001",
                    .severity = Severity::Error,
                    .message = "glyph budget exceeded",
                    .fixHint = "raise atlasWidth or reduce the charset"},
     };
 
+    // Pinned literally, and deliberately so: this is the published contract of
+    // docs/governance/schemas/diagnostic.schema.json, which every later baker emits. A field
+    // added, renamed or reordered here changes what agents parse repository-wide, so it should
+    // cost a visible test edit rather than passing unnoticed.
     CHECK(render(diagnostics, Format::Json, kTool) ==
           "{\n"
           "  \"tool\": \"mdux-fontbake\",\n"
@@ -158,6 +163,7 @@ TEST_CASE("JSON diagnostics use the published envelope shape", "evidence-unit") 
           "    {\n"
           "      \"file\": \"recipes/font/roboto-ui.toml\",\n"
           "      \"line\": 7,\n"
+          "      \"column\": 22,\n"
           "      \"code\": \"FB001\",\n"
           "      \"severity\": \"error\",\n"
           "      \"message\": \"glyph budget exceeded\",\n"
@@ -165,6 +171,18 @@ TEST_CASE("JSON diagnostics use the published envelope shape", "evidence-unit") 
           "    }\n"
           "  ]\n"
           "}\n");
+}
+
+TEST_CASE("An unknown position is carried as zero on both axes", "evidence-unit") {
+    // A tool with no position at all must still emit both fields. Omitting them would make the
+    // envelope's shape depend on the finding, which is exactly what a strict consumer cannot
+    // tolerate - `column` is always present, and 0 is how "no column" is spelled.
+    const std::vector<Diagnostic> diagnostics{
+        Diagnostic{.file = "recipes/font/roboto-ui.toml", .code = "FB003", .message = "no charset"},
+    };
+    const std::string json = render(diagnostics, Format::Json, kTool);
+    CHECK(json.find("\"line\": 0,\n") != std::string::npos);
+    CHECK(json.find("\"column\": 0,\n") != std::string::npos);
 }
 
 TEST_CASE("JSON diagnostics separate multiple findings with a comma", "evidence-unit") {
@@ -206,15 +224,23 @@ TEST_CASE("JSON diagnostics escape what would otherwise break the envelope", "ev
     CHECK(json.find('\n', messageStart) > json.find("tabbed"));
 }
 
-TEST_CASE("Text diagnostics follow the file:line: severity: [code] message convention",
+TEST_CASE("Text diagnostics follow the file:line:column: severity: [code] message convention",
           "evidence-unit") {
     const std::vector<Diagnostic> diagnostics{
         Diagnostic{.file = "recipes/font/roboto-ui.toml",
                    .line = 7,
+                   .column = 22,
                    .code = "FB001",
                    .severity = Severity::Error,
                    .message = "glyph budget exceeded",
                    .fixHint = "raise atlasWidth"},
+        // Knows the line but not the column: the position printed stops at the line rather than
+        // gaining a ":0" an editor would jump to.
+        Diagnostic{.file = "recipes/font/roboto-ui.toml",
+                   .line = 3,
+                   .code = "FB004",
+                   .severity = Severity::Note,
+                   .message = "charset resolved from the default"},
         Diagnostic{.file = "recipes/font/roboto-ui.toml",
                    .line = 0,
                    .code = "FB002",
@@ -223,8 +249,9 @@ TEST_CASE("Text diagnostics follow the file:line: severity: [code] message conve
     };
 
     CHECK(render(diagnostics, Format::Text, kTool) ==
-          "recipes/font/roboto-ui.toml:7: error: [FB001] glyph budget exceeded\n"
+          "recipes/font/roboto-ui.toml:7:22: error: [FB001] glyph budget exceeded\n"
           "    fix: raise atlasWidth\n"
+          "recipes/font/roboto-ui.toml:3: note: [FB004] charset resolved from the default\n"
           "recipes/font/roboto-ui.toml: warning: [FB002] charset has no digits\n");
 }
 

--- a/tools/common/Cli.cpp
+++ b/tools/common/Cli.cpp
@@ -171,6 +171,7 @@ std::string render(std::span<const Diagnostic> diagnostics, Format format,
             out += "    {\n";
             out += "      \"file\": \"" + escape(diagnostic.file) + "\",\n";
             out += "      \"line\": " + std::to_string(diagnostic.line) + ",\n";
+            out += "      \"column\": " + std::to_string(diagnostic.column) + ",\n";
             out += "      \"code\": \"" + escape(diagnostic.code) + "\",\n";
             out += "      \"severity\": \"" + std::string{describe(diagnostic.severity)} + "\",\n";
             out += "      \"message\": \"" + escape(diagnostic.message) + "\",\n";
@@ -181,13 +182,18 @@ std::string render(std::span<const Diagnostic> diagnostics, Format format,
         return out;
     }
 
-    // Text form follows the file:line: severity: [code] message convention the existing lints
-    // use, which is also what an editor's error parser expects.
+    // Text form follows the file:line:column: severity: [code] message convention the existing
+    // lints use, which is also what an editor's error parser expects. A zero on either axis is
+    // omitted rather than printed, so a tool that knows no position still reads as "file: error:"
+    // and one that knows only the line does not gain a misleading ":0".
     std::string out;
     for (const Diagnostic& diagnostic : diagnostics) {
         out += diagnostic.file;
         if (diagnostic.line != 0) {
             out += ":" + std::to_string(diagnostic.line);
+            if (diagnostic.column != 0) {
+                out += ":" + std::to_string(diagnostic.column);
+            }
         }
         out += ": ";
         out += describe(diagnostic.severity);

--- a/tools/common/Cli.cppm
+++ b/tools/common/Cli.cppm
@@ -21,13 +21,18 @@
  *
  * ## The diagnostic envelope
  *
- * `--format=json` emits `{file, line, code, severity, message, fixHint}` per finding - the first
- * instance of the stable envelope issue #19 (S3) extends to every tool. It is deliberately the
- * same shape `mdux-docs-lint` and `mdux-evidence-lint` already emit, so an agent parses one
- * schema for the whole repository rather than one per tool.
+ * `--format=json` emits `{file, line, column, code, severity, message, fixHint}` per finding -
+ * the stable envelope issue #19 (S3) extends to every tool, published as
+ * `docs/governance/schemas/diagnostic.schema.json`. It is deliberately the same shape
+ * `mdux-docs-lint` and `mdux-evidence-lint` emit, so an agent parses one schema for the whole
+ * repository rather than one per tool.
  *
  * Defining it here, once, is the point: a baker gets the envelope by using this module and
  * cannot accidentally invent its own.
+ *
+ * The envelope is fixed before the bakers multiply, deliberately. Adding `column` once the
+ * shader, `.medui` and ML tools already emit diagnostics would mean changing every one of them
+ * and every consumer keyed to them; adding it here costs one edit.
  */
 module;
 
@@ -57,13 +62,18 @@ enum class Severity : std::uint8_t { Error, Warning, Note };
 /**
  * @brief One finding, in the envelope every MduX tool shares.
  *
- * `line` is 1-based; 0 means "the finding is about the file as a whole". `code` is a short stable
- * identifier a tool can be grepped for, and must not change meaning once published - an agent
- * keying off it should not be broken by a message reword.
+ * `line` and `column` are both 1-based; 0 means "no precise position on this axis". A finding
+ * about the file as a whole leaves both 0; a finding about a whole line sets `line` and leaves
+ * `column` 0. The two are independent, so a tool that knows the line but not the column - which
+ * is most line-oriented recipe parsing - is not forced to invent a column it does not have.
+ *
+ * `code` is a short stable identifier a tool can be grepped for, and must not change meaning
+ * once published - an agent keying off it should not be broken by a message reword.
  */
 struct Diagnostic {
     std::string file;
     std::size_t line{0};
+    std::size_t column{0};
     std::string code;
     Severity severity{Severity::Error};
     std::string message;

--- a/tools/docs-lint/check_schema_type_drift.py
+++ b/tools/docs-lint/check_schema_type_drift.py
@@ -48,56 +48,90 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 MODULE_PATH = Path("include/mdux/governance/Governance.cppm")
+CLI_MODULE_PATH = Path("tools/common/Cli.cppm")
+CLI_IMPL_PATH = Path("tools/common/Cli.cpp")
 
-# Each entry: the schema, the C++ struct it mirrors, and any schema-only members. Schema-only
-# members are listed explicitly rather than tolerated generally, so that adding one is a decision
-# somebody made here rather than an omission nobody noticed.
+# The governance corpus spells wire names in snake_case; the tool diagnostic envelope spells them
+# in camelCase, matching the C++ member exactly. Both are deliberate and neither is going to
+# change, so a binding carries its convention rather than this tool assuming one.
+SNAKE = "snake"
+CAMEL = "camel"
+
+
+class StructBinding(NamedTuple):
+    """One schema bound to the C++ struct it documents.
+
+    `schema_at` descends into the schema to the object that mirrors the struct, for a schema whose
+    records are nested rather than at the root - the diagnostic envelope wraps its findings in an
+    array, so the struct's counterpart is `properties.findings.items`, not the document itself.
+    `schema_only` names properties that exist on that object with no C++ counterpart, listed
+    explicitly so adding one is a decision somebody made here rather than an omission nobody
+    noticed.
+    """
+
+    schema: str
+    struct: str
+    schema_only: tuple = ()
+    module: Path = MODULE_PATH
+    naming: str = SNAKE
+    schema_at: tuple = ()
+
+
+# The ISO 14971 and IEC 81001 records extend Hazard with evaluation and threat members that have
+# no C++ counterpart: a risk evaluation is a device-level judgement the library does not make.
+# Only the three shared members are checked for drift; the rest are schema-only.
+_HAZARD_EXTENSION_ONLY = (
+    "hazardous_situation",
+    "harm",
+    "owner",
+    "control_option",
+    "severity",
+    "probability",
+    "acceptability",
+    "scale_ref",
+    "residual_risk_note",
+    "evidence_refs",
+)
+
 STRUCT_BINDINGS = (
-    ("docs/governance/schemas/justification.schema.json", "Justification", ()),
-    ("docs/iec62304/schemas/requirement.schema.json", "Requirement", ()),
-    ("docs/iec62304/schemas/hazard.schema.json", "Hazard", ()),
-    ("docs/iec62304/schemas/verification-case.schema.json", "VerificationCase", ()),
-    # The ISO 14971 and IEC 81001 records extend Hazard with evaluation and threat members that
-    # have no C++ counterpart: a risk evaluation is a device-level judgement the library does not
-    # make. Only the three shared members are checked for drift; the rest are schema-only.
-    (
-        "docs/iso14971/schemas/risk-record.schema.json",
-        "Hazard",
-        (
-            "hazardous_situation",
-            "harm",
-            "owner",
-            "control_option",
-            "severity",
-            "probability",
-            "acceptability",
-            "scale_ref",
-            "residual_risk_note",
-            "evidence_refs",
-        ),
+    StructBinding("docs/governance/schemas/justification.schema.json", "Justification"),
+    StructBinding("docs/iec62304/schemas/requirement.schema.json", "Requirement"),
+    StructBinding("docs/iec62304/schemas/hazard.schema.json", "Hazard"),
+    StructBinding("docs/iec62304/schemas/verification-case.schema.json", "VerificationCase"),
+    StructBinding(
+        "docs/iso14971/schemas/risk-record.schema.json", "Hazard", _HAZARD_EXTENSION_ONLY
     ),
-    (
+    StructBinding(
         "docs/iec81001/schemas/security-risk-record.schema.json",
         "Hazard",
-        (
-            "hazardous_situation",
-            "harm",
-            "owner",
-            "threat",
-            "asset",
-            "weakness",
-            "attack_surface",
-            "control_option",
-            "severity",
-            "probability",
-            "acceptability",
-            "scale_ref",
-            "residual_risk_note",
-            "evidence_refs",
-        ),
+        _HAZARD_EXTENSION_ONLY + ("threat", "asset", "weakness", "attack_surface"),
     ),
+    # The diagnostic envelope every tool emits (issue #118). Bound here for the same reason the
+    # governance records are: the envelope is a published contract that agents key off, and the
+    # drift that happens in practice is somebody adding a field to `Diagnostic` for a new baker
+    # and not to the schema. Binding it before the shader, .medui and ML bakers land is the whole
+    # point - the check exists so the envelope stays one envelope.
+    StructBinding(
+        "docs/governance/schemas/diagnostic.schema.json",
+        "Diagnostic",
+        module=CLI_MODULE_PATH,
+        naming=CAMEL,
+        schema_at=("properties", "findings", "items"),
+    ),
+)
+
+# The severity vocabulary is a closed set shared by the C++ bakers and both Python lints, but it
+# has no `k*WireValues` array to bind: `describe(Severity)` is a switch. Extracting its returned
+# literals keeps the schema and the function that produces those strings from drifting apart.
+SEVERITY_BINDING = (
+    "docs/governance/schemas/diagnostic.schema.json",
+    ("properties", "findings", "items", "properties", "severity"),
+)
+DESCRIBE_SEVERITY_RE = re.compile(
+    r"std::string_view describe\(Severity[^)]*\)[^{]*\{(?P<body>.*?)^\}", re.DOTALL | re.MULTILINE
 )
 
 # Each entry: the schema, the property carrying a closed vocabulary, and the C++ array that
@@ -125,11 +159,11 @@ ARRAY_RE_TEMPLATE = r"{name}\s*\{{(?P<body>.*?)\}}"
 STRING_LITERAL_RE = re.compile(r'"([^"]*)"')
 
 
-def struct_body(module_text: str, struct_name: str) -> str:
+def struct_body(module_text: str, struct_name: str, module: Path = MODULE_PATH) -> str:
     """The text between `struct <name> {` and its closing brace at column 0."""
     match = re.search(rf"^struct {re.escape(struct_name)} \{{$", module_text, re.MULTILINE)
     if not match:
-        raise LookupError(f"struct {struct_name} not found in {MODULE_PATH}")
+        raise LookupError(f"struct {struct_name} not found in {module}")
     rest = module_text[match.end() :]
     end = re.search(r"^\};", rest, re.MULTILINE)
     if not end:
@@ -141,12 +175,48 @@ def camel_to_snake(name: str) -> str:
     return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
 
 
-def struct_fields(module_text: str, struct_name: str) -> list[str]:
-    """The data members of a struct, as their snake_case wire names, in declaration order.
+def wire_name(name: str, naming: str) -> str:
+    """The member's spelling on the wire, per the binding's convention."""
+    return camel_to_snake(name) if naming == SNAKE else name
+
+
+def struct_fields(
+    module_text: str, struct_name: str, naming: str = SNAKE, module: Path = MODULE_PATH
+) -> list[str]:
+    """The data members of a struct, as their wire names, in declaration order.
 
     Member functions are excluded by FIELD_RE requiring a `;` with no parameter list before it.
     """
-    return [camel_to_snake(m.group("name")) for m in FIELD_RE.finditer(struct_body(module_text, struct_name))]
+    return [
+        wire_name(m.group("name"), naming)
+        for m in FIELD_RE.finditer(struct_body(module_text, struct_name, module))
+    ]
+
+
+def descend(schema: dict, path: tuple) -> dict:
+    """The sub-schema at `path`, for a schema whose records are nested rather than at the root."""
+    node = schema
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            raise LookupError(f"schema has no '{'.'.join(path)}'")
+        node = node[key]
+    return node
+
+
+def severity_wire_values(impl_text: str) -> list[str]:
+    """The severity spellings `describe(Severity)` returns, in case order.
+
+    The trailing defensive `return "error";` after the switch repeats the first case, so the list
+    is de-duplicated while preserving order rather than reporting a phantom fourth value.
+    """
+    match = DESCRIBE_SEVERITY_RE.search(impl_text)
+    if not match:
+        raise LookupError(f"describe(Severity) not found in {CLI_IMPL_PATH}")
+    seen: list[str] = []
+    for literal in STRING_LITERAL_RE.findall(match.group("body")):
+        if literal not in seen:
+            seen.append(literal)
+    return seen
 
 
 def wire_values(module_text: str, array_name: str) -> list[str]:
@@ -158,10 +228,17 @@ def wire_values(module_text: str, array_name: str) -> list[str]:
     return STRING_LITERAL_RE.findall(match.group("body"))
 
 
-def check_struct(schema: dict, module_text: str, struct_name: str, schema_only: tuple) -> list[str]:
+def check_struct(
+    schema: dict,
+    module_text: str,
+    struct_name: str,
+    schema_only: tuple,
+    naming: str = SNAKE,
+    module: Path = MODULE_PATH,
+) -> list[str]:
     problems: list[str] = []
     declared = set(schema.get("properties", {}))
-    fields = set(struct_fields(module_text, struct_name))
+    fields = set(struct_fields(module_text, struct_name, naming, module))
     allowed_extra = set(schema_only)
 
     for name in sorted(declared - fields - allowed_extra):
@@ -220,16 +297,40 @@ def main(argv: list[str]) -> int:
 
     findings: list[str] = []
     checked = 0
+    # A binding may name a module other than the governance one; read each at most once.
+    module_texts: dict[Path, str] = {MODULE_PATH: module_text}
 
-    for relative, struct_name, schema_only in STRUCT_BINDINGS:
-        path = root / relative
+    def module_source(relative_module: Path) -> str | None:
+        if relative_module not in module_texts:
+            file = root / relative_module
+            module_texts[relative_module] = (
+                file.read_text(encoding="utf-8") if file.is_file() else None
+            )
+        return module_texts[relative_module]
+
+    for binding in STRUCT_BINDINGS:
+        path = root / binding.schema
         if not path.is_file():
-            findings.append(f"{relative}: bound to {struct_name} but the file is missing")
+            findings.append(f"{binding.schema}: bound to {binding.struct} but the file is missing")
+            continue
+        source = module_source(binding.module)
+        if source is None:
+            findings.append(
+                f"{binding.schema}: bound to {binding.struct} in {binding.module}, which is not "
+                f"in this tree"
+            )
             continue
         schema = json.loads(path.read_text(encoding="utf-8"))
+        try:
+            bound = descend(schema, binding.schema_at)
+        except LookupError as exc:
+            findings.append(f"{binding.schema}: {exc}")
+            continue
         checked += 1
-        for problem in check_struct(schema, module_text, struct_name, schema_only):
-            findings.append(f"{relative} vs {struct_name}: {problem}")
+        for problem in check_struct(
+            bound, source, binding.struct, binding.schema_only, binding.naming, binding.module
+        ):
+            findings.append(f"{binding.schema} vs {binding.struct}: {problem}")
 
     for relative, prop, array_name in ENUM_BINDINGS:
         path = root / relative
@@ -239,6 +340,24 @@ def main(argv: list[str]) -> int:
         schema = json.loads(path.read_text(encoding="utf-8"))
         for problem in check_enum(schema, module_text, prop, array_name):
             findings.append(f"{relative}: {problem}")
+
+    severity_schema_path, severity_at = SEVERITY_BINDING
+    impl_file = root / CLI_IMPL_PATH
+    schema_file = root / severity_schema_path
+    if impl_file.is_file() and schema_file.is_file():
+        schema = json.loads(schema_file.read_text(encoding="utf-8"))
+        try:
+            declared = descend(schema, severity_at).get("enum")
+            produced = severity_wire_values(impl_file.read_text(encoding="utf-8"))
+        except LookupError as exc:
+            findings.append(f"{severity_schema_path}: {exc}")
+        else:
+            if declared != produced:
+                findings.append(
+                    f"{severity_schema_path}: severity lists {declared}, but describe(Severity) "
+                    f"in {CLI_IMPL_PATH} returns {produced}. These are the strings the envelope "
+                    f"actually carries, so the schema is the one that is wrong"
+                )
 
     if findings:
         for finding in findings:

--- a/tools/docs-lint/check_schema_type_drift.py
+++ b/tools/docs-lint/check_schema_type_drift.py
@@ -297,8 +297,10 @@ def main(argv: list[str]) -> int:
 
     findings: list[str] = []
     checked = 0
-    # A binding may name a module other than the governance one; read each at most once.
-    module_texts: dict[Path, str] = {MODULE_PATH: module_text}
+    # A binding may name a module other than the governance one; read each at most once. `None` is
+    # a cached negative - a module the binding names that is not on disk - so that a missing file
+    # is stat'd once rather than once per binding that points at it.
+    module_texts: dict[Path, str | None] = {MODULE_PATH: module_text}
 
     def module_source(relative_module: Path) -> str | None:
         if relative_module not in module_texts:

--- a/tools/docs-lint/mdux_docs_lint.py
+++ b/tools/docs-lint/mdux_docs_lint.py
@@ -72,17 +72,27 @@ DEFAULT_SCAN_DIRS = ("docs", "software_development_file")
 
 @dataclass
 class Finding:
+    """One finding in the shared envelope - docs/governance/schemas/diagnostic.schema.json.
+
+    Deliberately the same field names and severity vocabulary as `mdux::tools::cli::Diagnostic`
+    (tools/common/Cli.cppm) and mdux-evidence-lint, so an agent parses one schema for the whole
+    repository. `line` and `column` are both 1-based, with 0 meaning "no precise position on this
+    axis": a finding about a whole block sets the line and leaves the column 0.
+    """
+
     path: str
     line: int
     code: str
     severity: str
     message: str
     fix_hint: str = ""
+    column: int = 0
 
     def to_json(self) -> dict:
         return {
             "file": self.path,
             "line": self.line,
+            "column": self.column,
             "code": self.code,
             "severity": self.severity,
             "message": self.message,
@@ -102,8 +112,22 @@ class LintContext:
         except ValueError:
             return str(path)
 
-    def report(self, path: Path, line: int, code: str, severity: str, message: str, fix_hint: str = "") -> None:
-        self.findings.append(Finding(self.relativize(path), line, code, severity, message, fix_hint))
+    def report(
+        self,
+        path: Path,
+        line: int,
+        code: str,
+        severity: str,
+        message: str,
+        fix_hint: str = "",
+        *,
+        column: int = 0,
+    ) -> None:
+        # `column` is keyword-only so the existing positional call sites, which have no column to
+        # report, keep working unchanged rather than every one of them growing a `0`.
+        self.findings.append(
+            Finding(self.relativize(path), line, code, severity, message, fix_hint, column)
+        )
 
 
 def check_citation_keys(ctx: LintContext, path: Path, text: str) -> None:
@@ -117,6 +141,9 @@ def check_citation_keys(ctx: LintContext, path: Path, text: str) -> None:
                     path, lineno, "MDX-D001", "error",
                     f"Unknown or malformed standard identifier '{standard}' in citation key.",
                     f"Use one of: {', '.join(APPROVED_STANDARDS)}",
+                    # A line may carry several citations; the column is what distinguishes which
+                    # one is wrong, and it is known exactly here.
+                    column=match.start() + 1,
                 )
 
 
@@ -304,13 +331,25 @@ def main(argv: list[str]) -> int:
         lint_file(ctx, path)
 
     if args.format == "json":
-        print(json.dumps({"findings": [f.to_json() for f in ctx.findings]}, indent=2))
+        # The shared envelope: docs/governance/schemas/diagnostic.schema.json. `tool` is what
+        # keeps findings attributable once several tools' output is aggregated.
+        print(
+            json.dumps(
+                {
+                    "tool": "mdux-docs-lint",
+                    "filesChecked": len(files),
+                    "findings": [f.to_json() for f in ctx.findings],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
     else:
         if not ctx.findings:
             print(f"mdux-docs-lint: OK ({len(files)} files checked, 0 findings)")
         else:
             for f in ctx.findings:
-                loc = f"{f.path}:{f.line}"
+                loc = f"{f.path}:{f.line}" + (f":{f.column}" if f.column else "")
                 print(f"{loc}: {f.severity}: [{f.code}] {f.message}")
                 if f.fix_hint:
                     print(f"  hint: {f.fix_hint}")

--- a/tools/docs-lint/schema_subset.py
+++ b/tools/docs-lint/schema_subset.py
@@ -1,0 +1,63 @@
+"""A validator for the subset of JSON Schema Draft 2020-12 this repository's schemas actually use.
+
+Host-only (ADR-004): standard library only. `jsonschema` is not a dependency of this repository
+and a zero-SOUP project does not add one to validate a handful of generated files - so this walks
+the keywords the schemas use and nothing more.
+
+Supported: `type` (object/array only, as a dispatch), `required`, `enum`, `pattern`, `minLength`,
+`minItems`, `uniqueItems`, `additionalProperties: false`, `minimum`, and `properties`/`items`
+recursion. Anything else in a schema is ignored rather than half-checked, because a validator that
+silently approximates a keyword is worse than one that visibly does not implement it.
+
+Validating against the schema *files* rather than against a copy of their rules is the point: the
+two cannot drift, which is the same reason check_schema_type_drift.py parses the module interface
+instead of restating its fields.
+"""
+from __future__ import annotations
+
+import re
+
+
+def violations(value, schema: dict, path: str = "$") -> list[str]:
+    """Every way `value` fails `schema`, as human-readable messages. Empty means valid."""
+    problems: list[str] = []
+
+    if "enum" in schema and value not in schema["enum"]:
+        problems.append(f"{path}: {value!r} is not one of {schema['enum']}")
+    if "pattern" in schema and isinstance(value, str):
+        if not re.search(schema["pattern"], value):
+            problems.append(f"{path}: {value!r} does not match {schema['pattern']}")
+    if "minLength" in schema and isinstance(value, str):
+        if len(value) < schema["minLength"]:
+            problems.append(f"{path}: shorter than minLength {schema['minLength']}")
+    # `bool` is a subclass of `int`; a JSON boolean is not an integer and must not pass a
+    # `minimum` check by accident.
+    if "minimum" in schema and isinstance(value, int) and not isinstance(value, bool):
+        if value < schema["minimum"]:
+            problems.append(f"{path}: {value} is below minimum {schema['minimum']}")
+
+    if schema.get("type") == "object":
+        if not isinstance(value, dict):
+            return problems + [f"{path}: expected an object, got {type(value).__name__}"]
+        for key in schema.get("required", []):
+            if key not in value:
+                problems.append(f"{path}: missing required '{key}'")
+        if schema.get("additionalProperties") is False:
+            for key in value:
+                if key not in schema.get("properties", {}):
+                    problems.append(f"{path}: unexpected property '{key}'")
+        for key, subschema in schema.get("properties", {}).items():
+            if key in value:
+                problems.extend(violations(value[key], subschema, f"{path}.{key}"))
+
+    if schema.get("type") == "array":
+        if not isinstance(value, list):
+            return problems + [f"{path}: expected an array, got {type(value).__name__}"]
+        if len(value) < schema.get("minItems", 0):
+            problems.append(f"{path}: fewer than minItems {schema['minItems']}")
+        if schema.get("uniqueItems") and len(value) != len(set(map(str, value))):
+            problems.append(f"{path}: duplicate items")
+        for index, item in enumerate(value):
+            problems.extend(violations(item, schema.get("items", {}), f"{path}[{index}]"))
+
+    return problems

--- a/tools/docs-lint/schema_subset.py
+++ b/tools/docs-lint/schema_subset.py
@@ -4,10 +4,16 @@ Host-only (ADR-004): standard library only. `jsonschema` is not a dependency of 
 and a zero-SOUP project does not add one to validate a handful of generated files - so this walks
 the keywords the schemas use and nothing more.
 
-Supported: `type` (object/array only, as a dispatch), `required`, `enum`, `pattern`, `minLength`,
-`minItems`, `uniqueItems`, `additionalProperties: false`, `minimum`, and `properties`/`items`
-recursion. Anything else in a schema is ignored rather than half-checked, because a validator that
-silently approximates a keyword is worse than one that visibly does not implement it.
+Supported: `type` (every JSON type, and a list of them as a union), `required`, `enum`, `pattern`,
+`minLength`, `minItems`, `uniqueItems`, `additionalProperties: false`, `minimum`, and
+`properties`/`items` recursion. Anything else in a schema is ignored rather than half-checked,
+because a validator that silently approximates a keyword is worse than one that visibly does not
+implement it.
+
+`type` is checked for scalars and not only used to dispatch into the object/array walks. Without
+that, a field declared `{"type": "integer"}` accepted the string `"42"` - the envelope's own
+`line` and `column` could have been emitted as strings by a tool and still validated, which is
+exactly the drift these schemas exist to catch.
 
 Validating against the schema *files* rather than against a copy of their rules is the point: the
 two cannot drift, which is the same reason check_schema_type_drift.py parses the module interface
@@ -17,9 +23,53 @@ from __future__ import annotations
 
 import re
 
+# `bool` is a subclass of `int` in Python, so a JSON boolean would satisfy an `isinstance(v, int)`
+# test for "integer" and "number". Every numeric predicate below excludes it explicitly.
+_TYPE_PREDICATES = {
+    "object": lambda v: isinstance(v, dict),
+    "array": lambda v: isinstance(v, list),
+    "string": lambda v: isinstance(v, str),
+    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+    "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    "boolean": lambda v: isinstance(v, bool),
+    "null": lambda v: v is None,
+}
+
+
+def _json_type_name(value) -> str:
+    """The JSON name for a Python value's type, so messages read in the schema's vocabulary."""
+    for name, predicate in _TYPE_PREDICATES.items():
+        if predicate(value):
+            return name
+    return type(value).__name__
+
+
+def _type_problems(value, schema: dict, path: str) -> list[str]:
+    """`type` as a real check. A list of names is a union, as Draft 2020-12 allows."""
+    declared = schema.get("type")
+    if declared is None:
+        return []
+
+    names = declared if isinstance(declared, list) else [declared]
+    unknown = [name for name in names if name not in _TYPE_PREDICATES]
+    if unknown:
+        # Visibly unimplemented rather than silently approximated - see the module docstring.
+        return [f"{path}: schema declares unsupported type(s) {unknown}"]
+
+    if any(_TYPE_PREDICATES[name](value) for name in names):
+        return []
+    return [f"{path}: expected {' or '.join(names)}, got {_json_type_name(value)}"]
+
 
 def violations(value, schema: dict, path: str = "$") -> list[str]:
     """Every way `value` fails `schema`, as human-readable messages. Empty means valid."""
+    # Type first, and fatal for this node: `minLength` against a value that is not a string, or
+    # `properties` against a value that is not an object, produce noise that buries the one
+    # message the reader needs.
+    type_problems = _type_problems(value, schema, path)
+    if type_problems:
+        return type_problems
+
     problems: list[str] = []
 
     if "enum" in schema and value not in schema["enum"]:
@@ -36,9 +86,9 @@ def violations(value, schema: dict, path: str = "$") -> list[str]:
         if value < schema["minimum"]:
             problems.append(f"{path}: {value} is below minimum {schema['minimum']}")
 
+    # No isinstance guard needed in either branch: _type_problems() already returned if the value
+    # did not match the declared type, and these branches only run when `type` declared one.
     if schema.get("type") == "object":
-        if not isinstance(value, dict):
-            return problems + [f"{path}: expected an object, got {type(value).__name__}"]
         for key in schema.get("required", []):
             if key not in value:
                 problems.append(f"{path}: missing required '{key}'")
@@ -51,8 +101,6 @@ def violations(value, schema: dict, path: str = "$") -> list[str]:
                 problems.extend(violations(value[key], subschema, f"{path}.{key}"))
 
     if schema.get("type") == "array":
-        if not isinstance(value, list):
-            return problems + [f"{path}: expected an array, got {type(value).__name__}"]
         if len(value) < schema.get("minItems", 0):
             problems.append(f"{path}: fewer than minItems {schema['minItems']}")
         if schema.get("uniqueItems") and len(value) != len(set(map(str, value))):

--- a/tools/docs-lint/test_check_schema_type_drift.py
+++ b/tools/docs-lint/test_check_schema_type_drift.py
@@ -52,6 +52,59 @@ HAZARD_SCHEMA = {
     },
 }
 
+# The diagnostic envelope (issue #118), in miniature: a camelCase record nested under an array,
+# rather than snake_case at the document root like every governance schema.
+CLI_MODULE = """
+export namespace mdux::tools::cli {
+
+struct Diagnostic {
+    std::string file;
+    std::size_t line{0};
+    std::size_t column{0};
+    std::string code;
+    Severity severity{Severity::Error};
+    std::string message;
+    std::string fixHint;
+};
+
+}  // namespace mdux::tools::cli
+"""
+
+CLI_IMPL = """
+std::string_view describe(Severity severity) noexcept {
+    switch (severity) {
+    case Severity::Error:   return "error";
+    case Severity::Warning: return "warning";
+    case Severity::Note:    return "note";
+    }
+    return "error";
+}
+"""
+
+DIAGNOSTIC_SCHEMA = {
+    "type": "object",
+    "required": ["tool", "findings"],
+    "properties": {
+        "tool": {"type": "string"},
+        "filesChecked": {"type": "integer"},
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "file": {"type": "string"},
+                    "line": {"type": "integer"},
+                    "column": {"type": "integer"},
+                    "code": {"type": "string"},
+                    "severity": {"enum": ["error", "warning", "note"]},
+                    "message": {"type": "string"},
+                    "fixHint": {"type": "string"},
+                },
+            },
+        },
+    },
+}
+
 
 class ParsingTests(unittest.TestCase):
     def test_struct_fields_are_snake_cased_in_declaration_order(self):
@@ -77,6 +130,78 @@ class ParsingTests(unittest.TestCase):
             ["test", "analysis", "inspection", "review"],
             drift.wire_values(MODULE, "kVerificationMethodWireValues"),
         )
+
+    def test_camel_naming_leaves_wire_names_as_declared(self):
+        # The diagnostic envelope spells fixHint as fixHint, not fix_hint.
+        self.assertEqual(
+            ["file", "line", "column", "code", "severity", "message", "fixHint"],
+            drift.struct_fields(CLI_MODULE, "Diagnostic", drift.CAMEL),
+        )
+
+    def test_severity_values_are_read_from_the_switch_without_the_fallback_repeat(self):
+        # describe() ends with a defensive `return "error";` after the switch. Counting it would
+        # report a phantom fourth value and make every comparison fail.
+        self.assertEqual(["error", "warning", "note"], drift.severity_wire_values(CLI_IMPL))
+
+
+class DescendTests(unittest.TestCase):
+    def test_an_empty_path_returns_the_document(self):
+        self.assertEqual(HAZARD_SCHEMA, drift.descend(HAZARD_SCHEMA, ()))
+
+    def test_a_path_reaches_a_nested_record(self):
+        bound = drift.descend(DIAGNOSTIC_SCHEMA, ("properties", "findings", "items"))
+        self.assertIn("fixHint", bound["properties"])
+
+    def test_a_path_that_does_not_resolve_is_an_error(self):
+        with self.assertRaises(LookupError):
+            drift.descend(DIAGNOSTIC_SCHEMA, ("properties", "diagnostics", "items"))
+
+
+class NestedStructDriftTests(unittest.TestCase):
+    """Drift in a nested record must be caught exactly as drift in a root-level one is."""
+
+    def check(self, schema):
+        return drift.check_struct(
+            drift.descend(schema, ("properties", "findings", "items")),
+            CLI_MODULE,
+            "Diagnostic",
+            (),
+            drift.CAMEL,
+            drift.CLI_MODULE_PATH,
+        )
+
+    def test_the_current_pair_is_clean(self):
+        self.assertEqual([], self.check(DIAGNOSTIC_SCHEMA))
+
+    def test_a_field_the_schema_does_not_declare_is_reported(self):
+        # The exact drift this binding exists to catch: a baker author adds a field to Diagnostic
+        # and does not touch the schema, so records written against the schema cannot carry it.
+        schema = json.loads(json.dumps(DIAGNOSTIC_SCHEMA))
+        del schema["properties"]["findings"]["items"]["properties"]["column"]
+        problems = self.check(schema)
+        self.assertEqual(1, len(problems))
+        self.assertIn("column", problems[0])
+
+    def test_a_schema_property_with_no_field_is_reported(self):
+        schema = json.loads(json.dumps(DIAGNOSTIC_SCHEMA))
+        schema["properties"]["findings"]["items"]["properties"]["endLine"] = {"type": "integer"}
+        problems = self.check(schema)
+        self.assertEqual(1, len(problems))
+        self.assertIn("endLine", problems[0])
+
+    def test_snake_casing_a_camel_binding_reports_every_multiword_field(self):
+        # Guards the naming axis itself: reading the envelope with the governance convention
+        # would silently rename fixHint to fix_hint and drift on both sides.
+        problems = drift.check_struct(
+            drift.descend(DIAGNOSTIC_SCHEMA, ("properties", "findings", "items")),
+            CLI_MODULE,
+            "Diagnostic",
+            (),
+            drift.SNAKE,
+            drift.CLI_MODULE_PATH,
+        )
+        self.assertTrue(any("fixHint" in p for p in problems))
+        self.assertTrue(any("fix_hint" in p for p in problems))
 
     def test_a_missing_struct_is_an_error_not_an_empty_result(self):
         with self.assertRaises(LookupError):
@@ -175,11 +300,28 @@ class RealRepositoryTests(unittest.TestCase):
         self.root = Path(__file__).resolve().parents[2]
 
     def test_every_bound_schema_exists_and_parses(self):
-        for relative, _, _ in drift.STRUCT_BINDINGS:
-            with self.subTest(schema=relative):
-                path = self.root / relative
-                self.assertTrue(path.is_file(), f"{relative} is bound but missing")
+        for binding in drift.STRUCT_BINDINGS:
+            with self.subTest(schema=binding.schema):
+                path = self.root / binding.schema
+                self.assertTrue(path.is_file(), f"{binding.schema} is bound but missing")
                 json.loads(path.read_text(encoding="utf-8"))
+
+    def test_every_bound_module_exists(self):
+        for binding in drift.STRUCT_BINDINGS:
+            with self.subTest(module=str(binding.module)):
+                self.assertTrue(
+                    (self.root / binding.module).is_file(),
+                    f"{binding.module} is bound but missing",
+                )
+
+    def test_every_binding_resolves_to_an_object_with_properties(self):
+        # A schema_at that stops descending one level short would make check_struct compare an
+        # empty property set against the struct and report nothing - the vacuous pass this guards.
+        for binding in drift.STRUCT_BINDINGS:
+            with self.subTest(schema=binding.schema):
+                schema = json.loads((self.root / binding.schema).read_text(encoding="utf-8"))
+                bound = drift.descend(schema, binding.schema_at)
+                self.assertTrue(bound.get("properties"), f"{binding.schema}: no properties bound")
 
     def test_every_enum_binding_names_a_declared_property(self):
         for relative, prop, _ in drift.ENUM_BINDINGS:
@@ -190,6 +332,21 @@ class RealRepositoryTests(unittest.TestCase):
     def test_the_repository_is_free_of_drift(self):
         # Passes vacuously on a branch without the governance module, which main() reports.
         self.assertEqual(0, drift.main(["--repo-root", str(self.root)]))
+
+    def test_the_diagnostic_envelope_is_bound_to_the_cli_type(self):
+        # The binding that keeps one envelope one envelope as the bakers multiply (issue #118).
+        binding = next(b for b in drift.STRUCT_BINDINGS if b.struct == "Diagnostic")
+        source = (self.root / binding.module).read_text(encoding="utf-8")
+        fields = drift.struct_fields(source, "Diagnostic", binding.naming, binding.module)
+        self.assertEqual(
+            ["file", "line", "column", "code", "severity", "message", "fixHint"], fields
+        )
+
+    def test_the_severity_vocabulary_matches_describe(self):
+        produced = drift.severity_wire_values(
+            (self.root / drift.CLI_IMPL_PATH).read_text(encoding="utf-8")
+        )
+        self.assertEqual(["error", "warning", "note"], produced)
 
 
 if __name__ == "__main__":

--- a/tools/docs-lint/test_diagnostic_envelope.py
+++ b/tools/docs-lint/test_diagnostic_envelope.py
@@ -1,0 +1,170 @@
+"""Every MduX tool's `--format=json` output must satisfy the one published envelope.
+
+The envelope is `docs/governance/schemas/diagnostic.schema.json` (issue #118). It is checked here,
+in the documentation-lint job, because that job needs no C++ toolchain and therefore runs on the
+PR that changes a schema - which is exactly the PR that breaks this.
+
+Coverage is deliberately split. The Python lints are exercised end to end, as subprocesses, so
+what is validated is the bytes a consumer actually receives rather than a reconstruction of them.
+The C++ bakers cannot be run from here without a build, so their side of the contract is held by
+two other checks: `check_schema_type_drift.py` binds `mdux::tools::cli::Diagnostic` and the
+`describe(Severity)` literals to this schema, and tests/tools/CliTests.cpp pins the rendered JSON
+literally. Between them, a field added to the C++ envelope without a schema change fails here, and
+a schema change without a C++ change fails there.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import schema_subset
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "docs/governance/schemas/diagnostic.schema.json"
+
+# Every tool that emits the envelope, as (name, argv). Adding a baker to this list is the cheapest
+# possible way to hold it to the contract, and is expected when one lands.
+ENVELOPE_TOOLS = (
+    ("mdux-docs-lint", ["tools/docs-lint/mdux_docs_lint.py", "--format", "json"]),
+    ("mdux-evidence-lint", ["tools/evidence-lint/mdux_evidence_lint.py", "--format", "json"]),
+)
+
+
+def load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def finding_schema(schema: dict) -> dict:
+    return schema["properties"]["findings"]["items"]
+
+
+VALID_FINDING = {
+    "file": "docs/iec62304/03-development-process.md",
+    "line": 42,
+    "column": 7,
+    "code": "MDX-D001",
+    "severity": "error",
+    "message": "Unknown or malformed standard identifier 'IEC 62304:2011' in citation key.",
+    "fixHint": "Use one of: IEC 62304:2006, ISO 13485:2016",
+}
+
+
+class SchemaShapeTests(unittest.TestCase):
+    def setUp(self):
+        self.schema = load_schema()
+
+    def test_the_schema_is_valid_json_and_names_itself(self):
+        self.assertEqual(
+            "https://mdux.dev/schemas/governance/diagnostic.schema.json", self.schema["$id"]
+        )
+
+    def test_a_finding_declares_every_envelope_field_as_required(self):
+        # An optional field would let two tools disagree about whether to emit it, which is the
+        # one thing a single shared envelope exists to prevent.
+        self.assertEqual(
+            {"file", "line", "column", "code", "severity", "message", "fixHint"},
+            set(finding_schema(self.schema)["required"]),
+        )
+
+    def test_the_severity_vocabulary_is_closed(self):
+        self.assertEqual(
+            ["error", "warning", "note"],
+            finding_schema(self.schema)["properties"]["severity"]["enum"],
+        )
+
+
+class ValidationTests(unittest.TestCase):
+    """The validator must reject, or every assertion built on it is worthless."""
+
+    def setUp(self):
+        self.schema = load_schema()
+        self.finding = finding_schema(self.schema)
+
+    def test_a_well_formed_finding_validates(self):
+        self.assertEqual([], schema_subset.violations(VALID_FINDING, self.finding))
+
+    def test_a_finding_missing_column_is_rejected(self):
+        finding = {k: v for k, v in VALID_FINDING.items() if k != "column"}
+        self.assertNotEqual([], schema_subset.violations(finding, self.finding))
+
+    def test_an_unknown_field_is_rejected(self):
+        # additionalProperties: false is what makes the envelope a contract rather than a
+        # suggestion - a tool cannot quietly add a field only its own consumer understands.
+        finding = dict(VALID_FINDING, endColumn=9)
+        problems = schema_subset.violations(finding, self.finding)
+        self.assertTrue(any("endColumn" in p for p in problems), problems)
+
+    def test_an_unknown_severity_is_rejected(self):
+        finding = dict(VALID_FINDING, severity="fatal")
+        self.assertNotEqual([], schema_subset.violations(finding, self.finding))
+
+    def test_a_negative_position_is_rejected(self):
+        self.assertNotEqual(
+            [], schema_subset.violations(dict(VALID_FINDING, line=-1), self.finding)
+        )
+
+    def test_an_absent_code_is_allowed(self):
+        # A tool that has not assigned codes yet still emits a valid envelope.
+        self.assertEqual([], schema_subset.violations(dict(VALID_FINDING, code=""), self.finding))
+
+    def test_an_unknown_envelope_level_field_is_rejected(self):
+        envelope = {"tool": "mdux-docs-lint", "findings": [], "warnings": []}
+        problems = schema_subset.violations(envelope, self.schema)
+        self.assertTrue(any("warnings" in p for p in problems), problems)
+
+
+class ToolOutputTests(unittest.TestCase):
+    """What each tool actually prints, over the real repository, must validate."""
+
+    def setUp(self):
+        self.schema = load_schema()
+
+    def run_tool(self, argv: list[str]) -> dict:
+        completed = subprocess.run(
+            [sys.executable, *argv],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # Exit status is 1 when there are findings and 0 when there are none; both print an
+        # envelope, and both are acceptable here. Only a crash is not.
+        self.assertIn(completed.returncode, (0, 1), completed.stderr)
+        return json.loads(completed.stdout)
+
+    def test_every_tool_emits_a_valid_envelope(self):
+        for name, argv in ENVELOPE_TOOLS:
+            with self.subTest(tool=name):
+                envelope = self.run_tool(argv)
+                self.assertEqual(name, envelope["tool"])
+                self.assertEqual([], schema_subset.violations(envelope, self.schema))
+
+    def test_a_findings_bearing_run_also_validates(self):
+        # The clean repository yields an empty findings array, which would let a malformed
+        # finding shape pass unnoticed. Lint a file planted to fail instead.
+        import tempfile
+
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            offending = Path(tmp) / "citation.md"
+            offending.write_text(
+                'A citation key of "IEC 62304:2011 §5.1 Planning" names an edition '
+                "this repository does not recognise.\n",
+                encoding="utf-8",
+            )
+            relative = offending.relative_to(REPO_ROOT)
+            envelope = self.run_tool(
+                ["tools/docs-lint/mdux_docs_lint.py", "--format", "json", str(relative)]
+            )
+
+        self.assertTrue(envelope["findings"], "the planted file produced no finding")
+        self.assertEqual([], schema_subset.violations(envelope, self.schema))
+        # And the column is a real one, not a placeholder: the citation does not start at the
+        # beginning of the line.
+        self.assertGreater(envelope["findings"][0]["column"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/docs-lint/test_diagnostic_envelope.py
+++ b/tools/docs-lint/test_diagnostic_envelope.py
@@ -165,6 +165,33 @@ class ToolOutputTests(unittest.TestCase):
         # beginning of the line.
         self.assertGreater(envelope["findings"][0]["column"], 1)
 
+    def test_evidence_lint_findings_also_validate(self):
+        # mdux-evidence-lint needs its own planted failure for the same reason: over a clean
+        # repository it reports nothing, so its per-finding shape - including whether it emits
+        # the `column` key this PR adds - would never be exercised by the empty case above.
+        import tempfile
+
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            offending = Path(tmp) / "Offender.cpp"
+            offending.write_text(
+                '// A decimal float conversion in an evidence-pipeline source.\n'
+                'void report(double value) { std::printf("%f\\n", value); }\n',
+                encoding="utf-8",
+            )
+            relative = offending.relative_to(REPO_ROOT)
+            envelope = self.run_tool(
+                ["tools/evidence-lint/mdux_evidence_lint.py", "--format", "json", str(relative)]
+            )
+
+        self.assertEqual("mdux-evidence-lint", envelope["tool"])
+        self.assertTrue(envelope["findings"], "the planted file produced no finding")
+        self.assertEqual([], schema_subset.violations(envelope, self.schema))
+        finding = envelope["findings"][0]
+        self.assertEqual("EVL001", finding["code"])
+        # The envelope requires `column` from every tool, not only the ones that compute a
+        # precise one; evidence-lint reports whole lines, so 0 is its honest answer.
+        self.assertIn("column", finding)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/docs-lint/test_generate_ai_reference.py
+++ b/tools/docs-lint/test_generate_ai_reference.py
@@ -12,6 +12,7 @@ import unittest
 from pathlib import Path
 
 import generate_ai_reference as gen
+import schema_subset
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -408,9 +409,8 @@ class ClauseIndexExportTests(unittest.TestCase):
     """The JSON export must satisfy docs/governance/schemas/clause-index.schema.json.
 
     Checked against the schema file itself rather than against a copy of its rules, so the two
-    cannot drift. `jsonschema` is not a dependency of this repository - a zero-SOUP project does
-    not add one to validate five generated files - so this walks the subset of Draft 2020-12 the
-    schema actually uses: required, enum, pattern, minItems and additionalProperties.
+    cannot drift. Validation uses schema_subset, shared with the diagnostic-envelope tests - a
+    second copy of the walker would be a second place to fix a bug in it.
     """
 
     def setUp(self):
@@ -423,33 +423,7 @@ class ClauseIndexExportTests(unittest.TestCase):
         )
 
     def check(self, value, schema, path="$"):
-        """Returns a list of violation messages. Only the keywords this schema uses."""
-        problems = []
-        if "enum" in schema and value not in schema["enum"]:
-            problems.append(f"{path}: {value!r} is not one of {schema['enum']}")
-        if "pattern" in schema and not re.search(schema["pattern"], value):
-            problems.append(f"{path}: {value!r} does not match {schema['pattern']}")
-        if "minLength" in schema and len(value) < schema["minLength"]:
-            problems.append(f"{path}: shorter than minLength")
-        if schema.get("type") == "object":
-            for key in schema.get("required", []):
-                if key not in value:
-                    problems.append(f"{path}: missing required '{key}'")
-            if schema.get("additionalProperties") is False:
-                for key in value:
-                    if key not in schema.get("properties", {}):
-                        problems.append(f"{path}: unexpected property '{key}'")
-            for key, subschema in schema.get("properties", {}).items():
-                if key in value:
-                    problems.extend(self.check(value[key], subschema, f"{path}.{key}"))
-        if schema.get("type") == "array":
-            if len(value) < schema.get("minItems", 0):
-                problems.append(f"{path}: fewer than minItems")
-            if schema.get("uniqueItems") and len(value) != len(set(map(str, value))):
-                problems.append(f"{path}: duplicate items")
-            for i, item in enumerate(value):
-                problems.extend(self.check(item, schema.get("items", {}), f"{path}[{i}]"))
-        return problems
+        return schema_subset.violations(value, schema, path)
 
     def test_the_subset_validator_rejects_something(self):
         # Guards every assertion below: a validator that always returns [] would make them pass.

--- a/tools/evidence-lint/mdux_evidence_lint.py
+++ b/tools/evidence-lint/mdux_evidence_lint.py
@@ -78,17 +78,29 @@ SUPPRESS_MARKER = "mdux-evidence-lint:allow"
 
 @dataclass
 class Finding:
+    """One finding in the shared envelope - docs/governance/schemas/diagnostic.schema.json.
+
+    Deliberately the same field names and severity vocabulary as `mdux::tools::cli::Diagnostic`
+    (tools/common/Cli.cppm) and mdux-docs-lint, so an agent parses one schema for the whole
+    repository. `line` and `column` are both 1-based, with 0 meaning "no precise position on this
+    axis". This lint reports lines only: a banned construct is located by
+    `extract_string_literals`, which yields the literal's start line without its start column, so
+    reporting a column here would mean inventing one.
+    """
+
     path: str
     line: int
     code: str
     severity: str
     message: str
     fix_hint: str = ""
+    column: int = 0
 
     def to_json(self) -> dict:
         return {
             "file": self.path,
             "line": self.line,
+            "column": self.column,
             "code": self.code,
             "severity": self.severity,
             "message": self.message,
@@ -267,6 +279,7 @@ def main(argv: list[str]) -> int:
         check_file(source, root, findings)
 
     if args.format == "json":
+        # The shared envelope: docs/governance/schemas/diagnostic.schema.json.
         print(
             json.dumps(
                 {
@@ -280,10 +293,10 @@ def main(argv: list[str]) -> int:
         )
     else:
         for finding in findings:
-            print(
-                f"{finding.path}:{finding.line}: {finding.severity}: "
-                f"[{finding.code}] {finding.message}"
+            location = f"{finding.path}:{finding.line}" + (
+                f":{finding.column}" if finding.column else ""
             )
+            print(f"{location}: {finding.severity}: [{finding.code}] {finding.message}")
             if finding.fix_hint:
                 print(f"    fix: {finding.fix_hint}")
         if findings:


### PR DESCRIPTION
Closes #118.

Prerequisite for Wave 3. The issue's own framing is the reason it goes first: *"Establish the diagnostic contract before shader, `.medui`, and ML tools multiply it."* Wave 3 adds three new tools (`mdux-shaderbake`, `mdux-mlbake`, and ArchValidate's diagnostics). Adding `column` after they ship means changing every one of them and every consumer keyed to them; adding it now costs one edit.

## Interface

`{tool, file, line, column, code, severity, message, fixHint}`. `line` and `column` are both 1-based; `0` means no precise position on that axis.

The two are deliberately independent. Most recipe parsing knows the line and not the column, and such a tool should report the line rather than invent a column — so a finding may carry `line: 3, column: 0`, and the text renderer prints `file:3:` rather than `file:3:0:`, which an editor would jump to.

## What changed

| | |
|---|---|
| `tools/common/Cli.cppm` / `.cpp` | `Diagnostic` gains `column`; JSON and text renderers carry it |
| `docs/governance/schemas/diagnostic.schema.json` | new — the published envelope |
| `tools/docs-lint/mdux_docs_lint.py` | `column`, plus the `tool` key it was missing |
| `tools/evidence-lint/mdux_evidence_lint.py` | `column` |
| `tools/docs-lint/check_schema_type_drift.py` | binds `Diagnostic` and `describe(Severity)` to the new schema |
| `tools/docs-lint/schema_subset.py` | new — the JSON Schema subset walker, factored out |
| `tools/docs-lint/test_diagnostic_envelope.py` | new — envelope conformance |

`filesChecked` is declared optional in the schema rather than dropped. Both lints already emitted it, and zero findings over zero files is a very different result from zero findings over five hundred — a consumer reading only `findings` cannot tell them apart.

## How the C++ side is held to the schema

The bakers can't be run from the documentation-lint job, so their half of the contract is pinned by two checks that fail from opposite directions:

- `check_schema_type_drift.py` binds `mdux::tools::cli::Diagnostic` and the literals `describe(Severity)` returns to the schema. **A field added for a new baker without a schema change fails here** — in the docs-only job, in seconds, on a PR that may touch no Python at all.
- `tests/tools/CliTests.cpp` pins the rendered JSON literally, so a schema change without a C++ change fails there.

Verified the drift binding is not vacuous — it extracts all seven fields under the camelCase convention and both severity lists agree:

```
Diagnostic fields:  ['file', 'line', 'column', 'code', 'severity', 'message', 'fixHint']
schema properties:  ['code', 'column', 'file', 'fixHint', 'line', 'message', 'severity']
severity from cpp:  ['error', 'warning', 'note']
severity in schema: ['error', 'warning', 'note']
```

## Two things worth a reviewer's attention

**The bindings became a `NamedTuple`.** Six positional fields was past the point of readability, and the diagnostic schema needs a pointer into itself (`properties.findings.items`) because its record is nested under an array rather than sitting at the document root. Converting also repaired the `iso14971` binding, which had drifted to a short tuple and would have raised on unpack.

**`MduXTest` is deliberately not reshaped.** It emits test results, not diagnostics. Its `file`/`line`/`message` field names already agree with the envelope; forcing a suite report into a findings array would be a worse fit, not a better one. Flagging it because #118 lists `MduXTest` among the tools to align.

`mdux-evidence-lint` reports lines only, with `column` always 0. Populating it would mean threading the literal's start column through `extract_string_literals`, which belongs with a change that has its own reason to touch that function.

## Verification

Existing text output and exit-status behaviour are unchanged.

```
python3 -m unittest discover -s tools/docs-lint     -p "test_*.py"   # 90 tests, OK
python3 -m unittest discover -s tools/evidence-lint -p "test_*.py"   # 22 tests, OK
python3 tools/docs-lint/mdux_docs_lint.py                            # OK (71 files, 0 findings)
python3 tools/evidence-lint/mdux_evidence_lint.py                    # OK (10 files, 0 findings)
python3 tools/docs-lint/check_schema_type_drift.py                   # OK (7 schemas, 7 bindings)
python3 tools/docs-lint/generate_ai_reference.py --check             # all indexes up to date
```

C++ was compile-checked locally with GCC 15.2 (`MduXToolsCommon` and every `tools_tests` TU build clean, zero warnings). **Test execution is CI-only**: linking any executable on macOS fails on `Undefined symbols: "initializer for module std"` — CMake's experimental `import std` support builds the std BMI on this platform but never links its object into executables. That is a CMake/GCC-on-macOS gap, not a project one, and not something to work around by editing this repository's CMake. So `tools_tests` passing is this PR's CI to demonstrate, not mine.

---

### Stack-safe PR checklist (#117)

- **Predecessor**: none. Branches from `develop` at f7756aa.
- **Shared registries edited**: none. No `CMakeLists.txt`, module file set, or test source list changes — `CliTests.cpp` is an existing file in an existing target.
- **Local validation**: all Python suites and lints above; C++ compile-checked.
- **Post-merge gate**: `develop` CI must be green before the first Wave 3 PR (#119) opens.
