### PR TITLE
build!: raise the GCC floor to 16 and retire the GCC 15 CI leg

### DIFF
--- a/.agents/skills/mdux-build-and-test/SKILL.md
+++ b/.agents/skills/mdux-build-and-test/SKILL.md
@@ -16,7 +16,7 @@ Before configuring, check:
 
 1. **Platform**: Windows 10+ or Linux only. There is no macOS build path — a fatal CMake check in
    the root `CMakeLists.txt` rejects other platforms.
-2. **Compiler version**: MSVC 17.14+, GCC 15+, or Clang 20+. The root `CMakeLists.txt` fails fast
+2. **Compiler version**: MSVC 17.14+, GCC 16+, or Clang 20+. The root `CMakeLists.txt` fails fast
    with `message(FATAL_ERROR ...)` if the detected compiler is below these floors — read that
    error message; it names the exact required version.
 3. **CMake**: 4.0+ (`cmake_minimum_required(VERSION 4.0.0)`).
@@ -66,13 +66,15 @@ know will fail or guessing at results.
 
 ## Compiler-specific module limitations
 
-- **GCC 15+**: `VulkanSCTriangleExample` is currently skipped entirely on **any GCC version 15.0 or
-  later** in `examples/CMakeLists.txt` (the guard is `CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL
-  15.0`, not a check for exactly GCC 15) due to a documented internal-compiler-error (segfault in
-  `std::array` under C++23 modules). This means GCC 16 and newer are skipped too, not just GCC 15 —
-  do not assume a newer GCC re-enables the target. Do not try to force-enable it as a workaround for
-  a task — treat the skip as the working configuration and report the underlying GCC limitation if
-  it blocks your task.
+- **GCC**: the project floor is **GCC 16**, enforced by a `FATAL_ERROR` in the root
+  `CMakeLists.txt`. GCC 15 built the library but could not build a SpecLab-based test suite
+  (`failed to load pendings for 'std::_Sp_counted_ptr_inplace'`, a defect in GCC's own `std` BMI),
+  and it is also the compiler whose `<array>` ICE kept `VulkanSCTriangleExample` excluded. Both
+  problems are gone with the floor: the example is now built unconditionally, and there is no
+  version guard on it any more.
+- **GCC, still current**: `vulkansc_memory_tests` is compiled `-O0` on GCC. That one is *not*
+  historical - the ICE in the GIMPLE ealias pass reproduces on GCC 16 as well, and every level
+  above `-O0` triggers it. See `tests/CMakeLists.txt` and issue #48.
 - **Clang 20**: the Clang CI job in `.github/workflows/ci.yml` is present but commented out. Clang
   builds are not currently verified by CI even though the version floor is enforced in
   `CMakeLists.txt` — treat any Clang build result as unverified against the project's own CI and

--- a/.agents/skills/mdux-cpp23-vulkan-development/SKILL.md
+++ b/.agents/skills/mdux-cpp23-vulkan-development/SKILL.md
@@ -43,8 +43,8 @@ ground truth for current conventions, not this document.
 - These conventions exist to work around current C++23 modules toolchain limitations (see
   `docs/adr/ADR-003-compiler-modernization.md`, status "Accepted") — don't restructure them
   without checking whether the change still compiles on all three supported compilers (see
-  `mdux-build-and-test` for the per-compiler caveats, notably the GCC 15 ICE and unverified Clang
-  CI).
+  `mdux-build-and-test` for the per-compiler caveats, notably the `-O0` requirement for
+  `vulkansc_memory_tests` on GCC and the unverified Clang CI).
 
 ## Vulkan / Vulkan SC resource-ownership model
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
   compliance-docs:
     name: Compliance & Documentation
     runs-on: ubuntu-latest
-    container: gcc:15
+    container: gcc:16
     
     steps:
     - name: Checkout repository
@@ -358,7 +358,7 @@ jobs:
   security-analysis:
     name: Security Analysis
     runs-on: ubuntu-latest
-    container: gcc:15
+    container: gcc:16
     
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           exit 1
         }
 
-  # Linux Build with GCC 15 container
+  # Linux Build with GCC 16 container
   linux-build-gcc16:
     name: Linux (GCC 16, Vulkan)
     runs-on: ubuntu-latest
@@ -166,23 +166,26 @@ jobs:
         cmake --version
         ninja --version
 
+    # Through the preset, not a hand-written configure line. CMakePresets.json describes
+    # ninja-gcc as mirroring what this job runs, and the only way that statement stays true is
+    # for the job to actually use it - otherwise the preset is unexercised by CI and free to rot.
     - name: Configure CMake
-      run: cmake -B build -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DMDUX_BUILD_EXAMPLES=ON -DMDUX_BUILD_TESTS=ON -DMDUX_BUILD_DOCS=OFF
+      run: cmake --preset ninja-gcc
 
     - name: Build
-      run: cmake --build build --config ${{ env.BUILD_TYPE }}
+      run: cmake --build --preset ninja-gcc
 
     - name: Run Tests
       run: |
         export DISPLAY=:99
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} --output-on-failure
+        ctest --preset ninja-gcc --output-on-failure
 
     # The second toolchain for the byte-identity check (ADR-007). With the GCC 15 leg retired
     # this pairs with MSVC: an artifact that is byte-identical on two unrelated toolchains is the
     # claim ADR-007 makes, and one leg alone could not falsify it.
     - name: Verify evidence artifacts (GCC 16)
-      run: ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} -L evidence --output-on-failure
+      run: ctest --preset ninja-gcc -L evidence --output-on-failure
 
     # Rendered-truth verification (issue #125), moved here when the GCC 15 leg was retired.
     # Without it a broken ICD turns the only test that renders anything into a silent no-op:
@@ -198,7 +201,7 @@ jobs:
         ls -1 /usr/share/vulkan/icd.d/ || true
         # -V rather than --output-on-failure: a passing run must still print, because two of the
         # things this step verifies are only visible in the output of tests that succeeded.
-        ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} -L pixel -V --no-tests=error 2>&1 | tee pixel.log
+        ctest --preset ninja-gcc -L pixel -V --no-tests=error 2>&1 | tee pixel.log
         if grep -q "Skipped" pixel.log; then
           echo "::error::Pixel tests were skipped - no Vulkan device. They must run on this leg."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,135 +112,6 @@ jobs:
         }
 
   # Linux Build with GCC 15 container
-  linux-build:
-    name: Linux (GCC 15, Vulkan)
-    runs-on: ubuntu-latest
-    container: gcc:15
-    
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Install dependencies
-      run: |
-        apt-get update
-        apt-get install -y \
-          cmake \
-          ninja-build \
-          pkg-config \
-          libvulkan-dev \
-          vulkan-tools \
-          vulkan-utility-libraries-dev \
-          spirv-tools \
-          mesa-vulkan-drivers \
-          vulkan-validationlayers \
-          libglfw3-dev \
-          libwayland-dev \
-          wayland-protocols \
-          wayland-utils \
-          libwayland-egl1 \
-          libxrandr-dev \
-          libxinerama-dev \
-          libxcursor-dev \
-          libxi-dev \
-          xvfb \
-          wget \
-          gnupg
-          
-    - name: Install latest CMake
-      run: |
-        # Install CMake 4.x for C++23 import std support via direct download
-        # Avoid libssl1.1 dependency issues in Debian containers
-        CMAKE_VERSION="4.1.1"
-        CMAKE_ARCHIVE="${RUNNER_TEMP}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz"
-        wget -O "$CMAKE_ARCHIVE" https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz
-        tar -xzf "$CMAKE_ARCHIVE" -C /opt/
-        ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/cmake /usr/bin/cmake
-        ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/ctest /usr/bin/ctest
-        cmake --version
-        
-    - name: Verify compiler and tools
-      run: |
-        gcc --version
-        g++ --version
-        cmake --version
-        ninja --version
-        
-    - name: Configure CMake
-      run: cmake --preset ninja-gcc
-      
-    - name: Build
-      run: cmake --build --preset ninja-gcc
-      
-    - name: Run Tests
-      run: |
-        export DISPLAY=:99
-        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        ctest --preset ninja-gcc
-
-    # The other half of the two-toolchain byte-identity claim (ADR-007, decision 6).
-    #
-    # Running the evidence tests on Windows/MSVC *and* Linux/GCC in the same pull request proves
-    # the bakers produce byte-identical output across two independent toolchains, two standard
-    # libraries and two floating-point code generators. TrustSC's equivalent check runs against a
-    # single rustc; this is strictly stronger, and it is free because both legs already exist.
-    #
-    # Do not "optimise" CI by dropping either leg. Doing so silently discards the guarantee -
-    # every test would still pass, and nothing would be verifying determinism any more.
-    - name: Verify evidence artifacts (GCC 15)
-      run: ctest --preset ninja-gcc -L evidence
-
-    # Rendered-truth verification (issue #125). Until mesa-vulkan-drivers was installed above,
-    # this leg had no Vulkan ICD at all and vkCreateInstance found zero physical devices.
-    #
-    # The loader is left to choose its own driver rather than being pinned with VK_DRIVER_FILES.
-    # Pinning was tried first and was worse: the hardcoded ICD path does not exist on this image,
-    # so the pin turned a working device into no device at all. On a runner with no GPU, radv and
-    # anv report no devices and the loader falls through to lavapipe by itself.
-    #
-    # That is safe for a test asserting pixel values because the assertions are driver-independent
-    # by construction - solid axis-aligned rectangles sampled in their interior and well outside,
-    # never at an edge where conformant drivers may legitimately differ.
-    #
-    # The grep is the point of the step. offscreen_tests exits 77 when no device is present and
-    # CTest reports Skipped, which does not fail a run - so without this check a broken ICD would
-    # turn the only test that renders anything into a silent no-op while the job stayed green.
-    # It has already earned its place: it is what caught the bad pin.
-    - name: Verify rendered output
-      run: |
-        echo "Available Vulkan ICDs:"
-        ls -1 /usr/share/vulkan/icd.d/ || true
-        # -V rather than --output-on-failure: a passing run must still print, because two of the
-        # things this step verifies are only visible in the output of tests that succeeded.
-        ctest --preset ninja-gcc -L pixel -V --no-tests=error 2>&1 | tee pixel.log
-        if grep -q "Skipped" pixel.log; then
-          echo "::error::Pixel tests were skipped - no Vulkan device. They must run on this leg."
-          exit 1
-        fi
-        # The validation layers decide whether this suite's layout and synchronisation assertions
-        # check anything. Installing the package does not prove the layer loads, so the run says
-        # which it was and this fails if it was not loaded - otherwise those assertions could go
-        # quietly vacuous and the log would look identical.
-        if ! grep -q "validation layers enabled" pixel.log; then
-          echo "::error::Validation layers did not load on this leg - the layout and sync assertions are vacuous."
-          grep -i "validation layers" pixel.log || true
-          exit 1
-        fi
-
-    - name: Verify no source-tree writes
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        status="$(git status --porcelain)"
-        if [ -n "$status" ]; then
-          echo "Build wrote into the source tree (generated/ artifacts must be staged via mdux-bake-update, never produced by a normal build):"
-          echo "$status"
-          exit 1
-        fi
-
-  # Linux Build with GCC 16 container - never let CI depend on a single compiler
-  # (see issue #48: GCC 15 and 16 both hit the same modules-related ICE, so this
-  # leg is not "the fix", but it is what catches a regression that only shows up
-  # on one GCC version and not the other).
   linux-build-gcc16:
     name: Linux (GCC 16, Vulkan)
     runs-on: ubuntu-latest
@@ -307,11 +178,40 @@ jobs:
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} --output-on-failure
 
-    # A third toolchain for the byte-identity check (ADR-007). GCC 16's code generation differs
-    # from GCC 15's, so this catches a determinism regression that only one version exhibits -
-    # the same reasoning that motivated adding this leg at all (issue #48).
+    # The second toolchain for the byte-identity check (ADR-007). With the GCC 15 leg retired
+    # this pairs with MSVC: an artifact that is byte-identical on two unrelated toolchains is the
+    # claim ADR-007 makes, and one leg alone could not falsify it.
     - name: Verify evidence artifacts (GCC 16)
       run: ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} -L evidence --output-on-failure
+
+    # Rendered-truth verification (issue #125), moved here when the GCC 15 leg was retired.
+    # Without it a broken ICD turns the only test that renders anything into a silent no-op:
+    # offscreen_tests exits 77 with no device and CTest reports Skipped, which does not fail a run.
+    #
+    # The loader is left to choose its own driver rather than being pinned with VK_DRIVER_FILES.
+    # Pinning was tried and was worse: the hardcoded ICD path does not exist on this image, so it
+    # turned a working device into no device. radv and anv report nothing on a runner with no GPU
+    # and the loader falls through to lavapipe by itself.
+    - name: Verify rendered output
+      run: |
+        echo "Available Vulkan ICDs:"
+        ls -1 /usr/share/vulkan/icd.d/ || true
+        # -V rather than --output-on-failure: a passing run must still print, because two of the
+        # things this step verifies are only visible in the output of tests that succeeded.
+        ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} -L pixel -V --no-tests=error 2>&1 | tee pixel.log
+        if grep -q "Skipped" pixel.log; then
+          echo "::error::Pixel tests were skipped - no Vulkan device. They must run on this leg."
+          exit 1
+        fi
+        # The validation layers decide whether this suite's layout and synchronisation assertions
+        # check anything. Installing the package does not prove the layer loads, so the run says
+        # which it was and this fails if it was not loaded - otherwise those assertions could go
+        # quietly vacuous and the log would look identical.
+        if ! grep -q "validation layers enabled" pixel.log; then
+          echo "::error::Validation layers did not load on this leg - the layout and sync assertions are vacuous."
+          grep -i "validation layers" pixel.log || true
+          exit 1
+        fi
 
     - name: Verify no source-tree writes
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ scope, not a mechanically enforced restriction.
 
 **Toolchain minimums** (enforced by fatal CMake checks in the root `CMakeLists.txt`):
 - MSVC 17.14+ (Visual Studio 2022 version 17.10+)
-- GCC 15+
+- GCC 16+
 - Clang 20+ — note the Clang CI job in `.github/workflows/ci.yml` is currently commented out
   (disabled), so Clang support is unverified in CI even though the version floor is enforced.
 - CMake 4.0+
@@ -186,9 +186,8 @@ cmake --build build
 
 **Targets** (verified in `CMakeLists.txt`, `examples/CMakeLists.txt`, `tests/CMakeLists.txt`):
 - Library: `MduX` (alias `MduX::MduX`)
-- Examples: `MedicalUiExample`; `VulkanSCTriangleExample` (skipped on GCC 15 due to a documented
-  compiler internal-compiler-error with C++23 modules — see the comment in
-  `examples/CMakeLists.txt`)
+- Examples: `MedicalUiExample`; `VulkanSCTriangleExample` (built on every supported compiler; the
+  GCC 15 ICE guard was removed when the floor rose to GCC 16)
 - Tests: `unit_tests`, `compliance_tests`, `vulkansc_memory_tests`, `vulkansc_object_tests`,
   registered with CTest as `MduXUnitTests`, `MduXComplianceTests`, `VulkanSCMemoryPoolTests`,
   `VulkanSCDeviceObjectTests`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,24 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         message(FATAL_ERROR "MSVC 17.14 (Visual Studio 2022 version 17.10) or later is required for C++23 modules support. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "15.0")
-        message(FATAL_ERROR "GCC 15 or later is required for C++23 modules support. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
+    # GCC 16, not 15. GCC 15 builds the library, but cannot build a test suite written against
+    # SpecLab: reading a named module that transitively re-exports parts of `std` fails with
+    # "failed to load pendings for 'std::_Sp_counted_ptr_inplace'", a defect in GCC's own std BMI
+    # rather than in any code here or in SpecLab. It is also the compiler whose ICE keeps
+    # VulkanSCTriangleExample excluded, and whose -Warray-bounds false positive on std::string
+    # concatenation has failed CI on code the other two toolchains accept.
+    #
+    # Raising the floor rather than excluding the BDD suites on one leg: a test that does not run
+    # on a supported compiler is a coverage hole that reads as coverage.
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0")
+        message(FATAL_ERROR "GCC 16 or later is required. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "20.0")
         message(FATAL_ERROR "Clang 20 or later is required for C++23 modules support. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
     endif()
 else()
-    message(WARNING "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}. MduX requires MSVC 17.14+, GCC 15+, or Clang 20+ for C++23 modules support.")
+    message(WARNING "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}. MduX requires MSVC 17.14+, GCC 16+, or Clang 20+ for C++23 modules support.")
 endif()
 
 # Platform validation

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,7 +47,7 @@
         {
             "name": "ninja-gcc",
             "displayName": "Ninja with GCC",
-            "description": "Ninja generator with GCC 15+ for C++23 modules and import std support. Mirrors the configure line .github/workflows/ci.yml's linux-build job actually runs.",
+            "description": "Ninja generator with GCC 16+ for C++23 modules and import std support. Mirrors the configure line .github/workflows/ci.yml's linux-build job actually runs.",
             "generator": "Ninja",
             "binaryDir": "build-gcc",
             "condition": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,7 +47,7 @@
         {
             "name": "ninja-gcc",
             "displayName": "Ninja with GCC",
-            "description": "Ninja generator with GCC 16+ for C++23 modules and import std support. Mirrors the configure line .github/workflows/ci.yml's linux-build job actually runs.",
+            "description": "Ninja generator with GCC 16+ for C++23 modules and import std support. This is the preset .github/workflows/ci.yml's linux-build-gcc16 job runs, rather than a separate configure line that resembles it.",
             "generator": "Ninja",
             "binaryDir": "build-gcc",
             "condition": {

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > This project is an **experimental early evaluation** of C++23 modules feasibility for cross-platform development with rich dependencies (Vulkan graphics, medical device compliance frameworks). It represents an attempt to leverage **C++23 and emerging C++26 safety evolutions** for medical device software development.
 > 
 > **Current Status:**
-> - C++23 modules support requires cutting-edge toolchains (GCC 15+, MSVC 17.14+, Clang 20+)
+> - C++23 modules support requires cutting-edge toolchains (GCC 16+, MSVC 17.14+, Clang 20+)
 > - CMake 4.x+ experimental support for `import std;` 
 > - Cross-platform compatibility still evolving
 > - Medical device compliance framework is conceptual/educational
@@ -241,7 +241,7 @@ governance records under `docs/` and `software_development_file/`.
 **Technical Prerequisites:**
 - **C++23 compatible compiler** with modules support:
   - **MSVC 17.14+** (Visual Studio 2022 version 17.10+)
-  - **GCC 15+** 
+  - **GCC 16+** 
   - **Clang 20+**
 - **Vulkan SDK 1.3+** installed and findable by CMake
 - **CMake 4.0+** with C++23 modules support  
@@ -278,7 +278,7 @@ vulkaninfo --summary
 ### Platform Support
 - **Windows 10/11** - Full Vulkan support
 - **Linux** - X11/Wayland with Vulkan support
-- **MacOS** - MoltenVK + GCC15 will be evaluated for future support
+- **MacOS** - MoltenVK works, but no GCC 16 is packaged for it yet, so macOS is unsupported
 
 ### Quick Start for Medical Device Development
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ vulkaninfo --summary
 ### Platform Support
 - **Windows 10/11** - Full Vulkan support
 - **Linux** - X11/Wayland with Vulkan support
-- **MacOS** - MoltenVK works, but no GCC 16 is packaged for it yet, so macOS is unsupported
+- **MacOS** - not supported. Nothing in the build refuses it, and MoltenVK provides a working
+  Vulkan device, but no CI leg covers it and no claim is made that it builds
 
 ### Quick Start for Medical Device Development
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,76 +17,65 @@ target_link_libraries(MedicalUiExample PRIVATE MduX::MduX)
 
 # Vulkan SC Triangle Demo - visual rendering with static memory.
 #
-# The exclusion below is issue #48 item 2. It used to read VERSION_GREATER_EQUAL 15.0 while its
-# message named only GCC 15, so it silently disabled the example on GCC 16 as well - meaning the
-# example was built on MSVC alone and neither Linux leg compiled it at all.
+# No longer guarded. The exclusion here was issue #48 item 2: a GCC 15 internal compiler error
+# ("internal compiler error: Segmentation fault" inside <array>) compiling this translation unit
+# under C++23 modules. With the project's GCC floor raised to 16 the guard became unreachable -
+# every GCC that can configure this project is one the ICE was never observed on - and an
+# unreachable guard that still names a version is worse than none, because it reads as a live
+# constraint. #48 item 2 is closed by the floor rather than by a workaround.
+# GLFW is the triangle demo's, and only the triangle demo's - the examples-only windowing
+# boundary. MduX itself never links it, which mdux_verify_trust_zones() enforces from the
+# other side for the governed target.
 #
-# Now scoped to the version range where the ICE is actually reproduced. Confirmed still present
-# on GCC 15.2.0 while writing this: "internal compiler error: Segmentation fault" inside
-# <array>:102 compiling this translation unit. GCC 16 is presumed fixed and is now enabled - if
-# that is wrong, the GCC 16 leg says so rather than the example being quietly absent everywhere.
-# The lower bound is explicit rather than implied by the project's GCC >= 15 floor. If that floor
-# ever drops, an open-ended "less than 16" would silently start excluding compilers this ICE was
-# never observed on, and the guard would no longer describe what it is for.
-if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16.0))
-    # GLFW is the triangle demo's, and only the triangle demo's - the examples-only windowing
-    # boundary. MduX itself never links it, which mdux_verify_trust_zones() enforces from the
-    # other side for the governed target.
-    #
-    # Discovered inside the guard rather than above it: when this example is excluded nothing
-    # links GLFW, and resolving it anyway means a find_package on every configure and, where the
-    # system has no GLFW, a source download for a target that will not be built.
-    find_package(glfw3 QUIET)
-    if(NOT glfw3_FOUND)
-        CPMAddPackage(NAME glfw GITHUB_REPOSITORY glfw/glfw GIT_TAG 3.4
-                      OPTIONS "GLFW_BUILD_DOCS OFF" "GLFW_BUILD_TESTS OFF" "GLFW_BUILD_EXAMPLES OFF" "GLFW_INSTALL OFF")
-        message(STATUS "Using CPM GLFW for VulkanSCTriangleExample")
-    else()
-        message(STATUS "Using system GLFW for VulkanSCTriangleExample")
-    endif()
-
-    add_executable(VulkanSCTriangleExample
-        VulkanSCTriangleExample.cpp
-    )
-
-    # The generated module lives in the build tree, so it needs a file set naming that directory.
-    target_sources(VulkanSCTriangleExample
-        PRIVATE
-            FILE_SET generated_modules
-                TYPE CXX_MODULES
-                BASE_DIRS ${MDUX_GENERATED_SHADER_DIR}
-                FILES ${MDUX_TRIANGLE_SHADER_MODULE}
-    )
-    add_dependencies(VulkanSCTriangleExample emit-shader-triangle)
-
-    target_link_libraries(VulkanSCTriangleExample PRIVATE MduX::MduX)
-
-    # GLFW for windowing. The conditional this replaces linked `glfw` in both branches, so it
-    # never chose anything - which is why the target name is resolved above instead.
-    target_link_libraries(VulkanSCTriangleExample PRIVATE glfw)
-
-    # Set C++23 standard
-    set_target_properties(VulkanSCTriangleExample PROPERTIES
-        CXX_STANDARD 23
-        CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-    )
-
-    if(TARGET __CMAKE::CXX23)
-        set_target_properties(VulkanSCTriangleExample PROPERTIES CXX_MODULE_STD ON)
-    endif()
-
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        target_compile_options(VulkanSCTriangleExample PRIVATE /experimental:module /std:c++latest)
-    endif()
-
-    if(UNIX)
-        target_link_libraries(VulkanSCTriangleExample PRIVATE Threads::Threads)
-    endif()
+# Unconditional again now the compiler guard is gone: this example is always built, so GLFW is
+# always needed. It was moved inside the guard while the example could be excluded, to avoid a
+# find_package and possibly a source download for a target that would not be built.
+find_package(glfw3 QUIET)
+if(NOT glfw3_FOUND)
+    CPMAddPackage(NAME glfw GITHUB_REPOSITORY glfw/glfw GIT_TAG 3.4
+                  OPTIONS "GLFW_BUILD_DOCS OFF" "GLFW_BUILD_TESTS OFF" "GLFW_BUILD_EXAMPLES OFF" "GLFW_INSTALL OFF")
+    message(STATUS "Using CPM GLFW for VulkanSCTriangleExample")
 else()
-    message(STATUS "Skipping VulkanSCTriangleExample on GCC 15 due to compiler ICE bugs with C++23 modules")
+    message(STATUS "Using system GLFW for VulkanSCTriangleExample")
+endif()
+
+add_executable(VulkanSCTriangleExample
+    VulkanSCTriangleExample.cpp
+)
+
+# The generated module lives in the build tree, so it needs a file set naming that directory.
+target_sources(VulkanSCTriangleExample
+    PRIVATE
+        FILE_SET generated_modules
+            TYPE CXX_MODULES
+            BASE_DIRS ${MDUX_GENERATED_SHADER_DIR}
+            FILES ${MDUX_TRIANGLE_SHADER_MODULE}
+)
+add_dependencies(VulkanSCTriangleExample emit-shader-triangle)
+
+target_link_libraries(VulkanSCTriangleExample PRIVATE MduX::MduX)
+
+# GLFW for windowing. The conditional this replaces linked `glfw` in both branches, so it
+# never chose anything - which is why the target name is resolved above instead.
+target_link_libraries(VulkanSCTriangleExample PRIVATE glfw)
+
+# Set C++23 standard
+set_target_properties(VulkanSCTriangleExample PROPERTIES
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(VulkanSCTriangleExample PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(VulkanSCTriangleExample PRIVATE /experimental:module /std:c++latest)
+endif()
+
+if(UNIX)
+    target_link_libraries(VulkanSCTriangleExample PRIVATE Threads::Threads)
 endif()
 
 # Platform-specific libraries for file watching


### PR DESCRIPTION
Raises the GCC floor to **16** and retires the Linux GCC 15 CI leg.

## Why

The BDD conversion the review asked for depends on [SpecLab](https://github.com/ambroise-leclerc/SpecLab), and **GCC 15 cannot build SpecLab**:

```
speclab.core.testsuite: error: failed to read compiled module cluster 327: Bad file data
TestRunner.cppm:32: fatal error: failed to load pendings for 'std::_Sp_counted_ptr_inplace'
```

This is not SpecLab's to fix. SpecLab names no `std::future` anywhere in its sources — the entity that fails to deserialize is `std::_Sp_counted_ptr_inplace<std::__future_base::_State_baseV2>`, instantiated inside GCC's own `std` BMI and re-read through a module import chain. I reproduced it locally on GCC 15.2.0 **with and without ccache** (the "Bad file data" wording invites a ccache theory; it is not that). SpecLab's maintainer reached the same conclusion and dropped their GCC 15 leg.

`import speclab;` re-exports the failing module, so a test cannot route around it, and the module is a source of the `speclab` library target — the dependency itself will not compile.

## The alternative, and why not

Build the BDD suites on GCC 16 and MSVC only, skipping them on GCC 15. Rejected: **a test that does not run on a supported compiler is a coverage hole that reads as coverage.** Two green legs where one silently tests less is worse than one fewer leg.

## What falls out of the floor rather than needing a fix

- **`VulkanSCTriangleExample`'s version guard is gone.** It existed for a GCC 15 `<array>` ICE; every GCC that can now configure this project is one the ICE was never observed on. That closes **#48 item 2** by removing the constraint rather than working around it. GLFW discovery returns to unconditional, since the example is always built now.
- **The "Verify rendered output" step moved to the GCC 16 job**, adapted to its build directory. That step is the `Skipped` grep *and* the `validation layers enabled` grep, so deleting the job without moving it would have quietly removed the only check that the pixel tests ran at all.

## What is unchanged

`vulkansc_memory_tests` keeps its `-O0` override. That ICE (GIMPLE ealias pass) reproduces on **GCC 16 too** and is unrelated to this change.

## Verification

CI only. Homebrew packages no GCC 16, so the local build I have been using through wave 3 — the one that caught the move-assignment defect in #133 — cannot run this tree any more. Worth knowing when weighing later PRs.

## Cost to state plainly

This drops a supported platform for a medical device library. If you would rather keep GCC 15 and accept BDD suites that skip on that leg, say so and I will invert it.

Follow-up: the SpecLab adoption and suite conversion land in a second PR on top of this one.
