### PR TITLE
test(spec): adopt SpecLab for BDD, behind the existing test-discovery contract

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -445,10 +445,14 @@ mdux_discover_tests(vulkansc_object_tests)
 # It is also the reason this project's GCC floor is 16. GCC 15 cannot build SpecLab at all -
 # reading a named module that transitively re-exports parts of `std` fails with "failed to load
 # pendings for 'std::_Sp_counted_ptr_inplace'", a defect in GCC's own std BMI.
+# Pinned to a commit, not to a branch. SpecLab has no tagged release yet, and a moving ref would
+# mean the test framework under a medical device library could change between two builds of the
+# same MduX commit - which is the same reproducibility argument ADR-007 makes about baked
+# artifacts. Bump this deliberately, in a reviewable diff.
 CPMAddPackage(
     NAME SpecLab
     GITHUB_REPOSITORY ambroise-leclerc/SpecLab
-    GIT_TAG main
+    GIT_TAG 84631c9f01f5309baf1d12618b2ef66c3512b511
     OPTIONS
         "SPECLAB_BUILD_TESTS OFF"
         "SPECLAB_BUILD_EXAMPLES OFF"
@@ -461,7 +465,7 @@ add_executable(bridge_spec
     spec/BridgeSpec.cpp
 )
 
-target_link_libraries(bridge_spec PRIVATE MduX::Core speclab)
+target_link_libraries(bridge_spec PRIVATE MduX::Core speclab::speclab)
 target_include_directories(bridge_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 set_target_properties(bridge_spec

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -433,3 +433,50 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 mdux_discover_tests(vulkansc_object_tests)
+
+# ---------------------------------------------------------------------------
+# SpecLab BDD specs
+# ---------------------------------------------------------------------------
+#
+# SpecLab (https://github.com/ambroise-leclerc/SpecLab) provides Given/When/Then without macros,
+# via `import speclab;`. It is a test-only dependency: no library target links it, and
+# mdux_verify_trust_zones() would fail the configure step if a governed target ever did.
+#
+# It is also the reason this project's GCC floor is 16. GCC 15 cannot build SpecLab at all -
+# reading a named module that transitively re-exports parts of `std` fails with "failed to load
+# pendings for 'std::_Sp_counted_ptr_inplace'", a defect in GCC's own std BMI.
+CPMAddPackage(
+    NAME SpecLab
+    GITHUB_REPOSITORY ambroise-leclerc/SpecLab
+    GIT_TAG main
+    OPTIONS
+        "SPECLAB_BUILD_TESTS OFF"
+        "SPECLAB_BUILD_EXAMPLES OFF"
+        "ENABLE_CACHE OFF"
+)
+
+# The bridge's own coverage. Deliberately a separate binary from the converted suites: if the
+# integration breaks, this fails with a name that says so rather than looking like a draw-list bug.
+add_executable(bridge_spec
+    spec/BridgeSpec.cpp
+)
+
+target_link_libraries(bridge_spec PRIVATE MduX::Core speclab)
+target_include_directories(bridge_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(bridge_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(bridge_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(bridge_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(bridge_spec)

--- a/tests/framework/SpecLabBridge.hpp
+++ b/tests/framework/SpecLabBridge.hpp
@@ -111,9 +111,13 @@ private:
 
 /// Implements `--list-tests` and `--run=<name>`; with neither, runs everything.
 ///
-/// Returns 0 when every selected scenario passed and 1 otherwise. A `--run` naming a scenario
-/// that does not exist is an error rather than a silent pass: a stale generated CTest file would
-/// otherwise report success for a test that no longer exists.
+/// Returns 0 when every selected scenario passed and 1 otherwise - including when `--run` names a
+/// scenario that does not exist, which is an error rather than a silent pass: a stale generated
+/// CTest file would otherwise report success for a test that no longer exists.
+///
+/// 1 rather than a distinct code, to match `mdux::test::runMain` (tests/framework/MduXTest.cppm),
+/// which also answers 1 for a missing named case. Both binaries are driven by the same CTest
+/// machinery, and the message on stderr is what distinguishes the two situations for a reader.
 inline int main(int argc, char** argv, std::string_view suiteName) {
     const std::span<char*> args{argv, static_cast<std::size_t>(argc)};
 
@@ -133,7 +137,7 @@ inline int main(int argc, char** argv, std::string_view suiteName) {
                 registry(), [wanted](const Scenario& s) { return s.name == wanted; });
             if (found == registry().end()) {
                 std::println(std::cerr, "{}: no scenario named '{}'", suiteName, wanted);
-                return 2;
+                return 1;
             }
             const speclab::core::TestResult result = found->run();
             if (!result.passed()) {

--- a/tests/framework/SpecLabBridge.hpp
+++ b/tests/framework/SpecLabBridge.hpp
@@ -57,6 +57,58 @@ struct Register {
     }
 };
 
+/// Collects several failed expectations and reports them together.
+///
+/// SpecLab's assertions all throw, so the first failure inside a `Then` ends the scenario. That is
+/// right for a scenario making one behavioural claim, and wrong for the ones being converted from
+/// MduXTest, where `CHECK` is deliberately soft: a test asserting six things reports all six that
+/// are wrong, and the reader fixes them in one pass rather than rerunning six times.
+///
+/// `Checks` restores that inside a single `Then`. Record as many expectations as the claim needs,
+/// then call `raise()`; nothing is thrown unless at least one failed, and what is thrown names
+/// every one of them.
+///
+///     Checks checks;
+///     checks.expect(vertex.x == 4, "x");
+///     checks.expect(vertex.y == 8, "y");
+///     checks.raise();
+class Checks {
+public:
+    /// Records `condition`. `what` should name the thing being checked, not restate the operator.
+    void expect(bool condition, std::string_view what,
+                std::source_location where = std::source_location::current()) {
+        if (!condition) {
+            failures_.push_back(
+                std::format("{} ({}:{})", what, fileName(where.file_name()), where.line()));
+        }
+    }
+
+    /// Throws a single AssertionFailure listing every failed expectation, or returns if none did.
+    void raise(std::source_location where = std::source_location::current()) const {
+        if (failures_.empty()) {
+            return;
+        }
+        std::string message =
+            std::format("{} expectation(s) failed:", failures_.size());
+        for (const std::string& failure : failures_) {
+            message += "\n    - " + failure;
+        }
+        throw speclab::core::AssertionFailure(message, where);
+    }
+
+    [[nodiscard]] bool anyFailed() const noexcept { return !failures_.empty(); }
+
+private:
+    /// Just the filename: a source_location carries an absolute build path, which is noise in a
+    /// message and differs between machines for the same failure.
+    [[nodiscard]] static std::string_view fileName(std::string_view path) noexcept {
+        const std::size_t slash = path.find_last_of("/\\");
+        return slash == std::string_view::npos ? path : path.substr(slash + 1);
+    }
+
+    std::vector<std::string> failures_;
+};
+
 /// Implements `--list-tests` and `--run=<name>`; with neither, runs everything.
 ///
 /// Returns 0 when every selected scenario passed and 1 otherwise. A `--run` naming a scenario

--- a/tests/framework/SpecLabBridge.hpp
+++ b/tests/framework/SpecLabBridge.hpp
@@ -1,0 +1,110 @@
+/**
+ * @brief Runs SpecLab scenarios under the test-discovery contract the rest of this suite uses.
+ *
+ * ## Why a bridge exists at all
+ *
+ * `cmake/MduXTestDiscoveryImpl.cmake` gives every test binary the same two-part contract:
+ * `--list-tests` prints one `name<TAB>labels` line per test, and `--run=<name>` executes exactly
+ * one and reports pass or fail through its exit status. That is what produces a separate CTest
+ * entry per test, and it is what `ctest -L evidence` and `ctest -L pixel` select on.
+ *
+ * SpecLab has its own runner and its own reporters, and knows nothing about that contract. Left
+ * to itself, a SpecLab binary would be a single CTest entry - so a failure would name the binary
+ * rather than the scenario, and the labels the CI steps depend on would have nowhere to live.
+ * This header is the adapter, and it is deliberately thin: SpecLab still executes the scenario
+ * and still decides whether it passed.
+ *
+ * ## Registration is an object, not a macro
+ *
+ * A namespace-scope `Register` runs its constructor before `main`, which is the whole mechanism.
+ * That is the same reason MduXTest's `TEST_CASE` exists, minus the macro - which is the point of
+ * adopting SpecLab in the first place.
+ *
+ * ## State between Given, When and Then
+ *
+ * SpecLab's steps are `void()` callables, so anything a `Then` needs from a `When` has to outlive
+ * both. The idiom used throughout these specs is a `std::shared_ptr` to a local state struct,
+ * created inside the factory and captured by each step. `Execute()` is called inside that same
+ * factory, so the state is alive for exactly as long as the steps can run and is destroyed
+ * immediately afterwards - no globals, and no ordering between scenarios.
+ *
+ * Include after `import std;` and after `import speclab;`.
+ */
+#pragma once
+
+namespace mdux::spec {
+
+/// One registered scenario: what CTest will call it, how it is labelled, and how to run it.
+struct Scenario {
+    std::string name;
+    std::string labels;  ///< comma-separated, as the discovery script expects
+    std::function<speclab::TestResult()> run;
+};
+
+/// The registry. A function-local static so registration order across translation units cannot
+/// depend on the initialisation order of a namespace-scope container.
+inline std::vector<Scenario>& registry() {
+    static std::vector<Scenario> scenarios;
+    return scenarios;
+}
+
+/// Registers one scenario at namespace scope. Construct one per scenario; the object itself is
+/// never used again.
+struct Register {
+    Register(std::string name, std::string labels, std::function<speclab::TestResult()> run) {
+        registry().push_back(
+            Scenario{.name = std::move(name), .labels = std::move(labels), .run = std::move(run)});
+    }
+};
+
+/// Implements `--list-tests` and `--run=<name>`; with neither, runs everything.
+///
+/// Returns 0 when every selected scenario passed and 1 otherwise. A `--run` naming a scenario
+/// that does not exist is an error rather than a silent pass: a stale generated CTest file would
+/// otherwise report success for a test that no longer exists.
+inline int main(int argc, char** argv, std::string_view suiteName) {
+    const std::span<char*> args{argv, static_cast<std::size_t>(argc)};
+
+    for (std::size_t i = 1; i < args.size(); ++i) {
+        const std::string_view argument{args[i]};
+
+        if (argument == "--list-tests") {
+            for (const Scenario& scenario : registry()) {
+                std::println(std::cout, "{}\t{}", scenario.name, scenario.labels);
+            }
+            return 0;
+        }
+
+        if (argument.starts_with("--run=")) {
+            const std::string_view wanted = argument.substr(std::string_view{"--run="}.size());
+            const auto found = std::ranges::find_if(
+                registry(), [wanted](const Scenario& s) { return s.name == wanted; });
+            if (found == registry().end()) {
+                std::println(std::cerr, "{}: no scenario named '{}'", suiteName, wanted);
+                return 2;
+            }
+            const speclab::TestResult result = found->run();
+            if (!result.passed()) {
+                std::println(std::cerr, "FAILED: {}\n  {}", found->name, result.message);
+                return 1;
+            }
+            return 0;
+        }
+    }
+
+    // No selection: run the lot, which is what a developer invoking the binary directly wants.
+    std::size_t failed = 0;
+    for (const Scenario& scenario : registry()) {
+        const speclab::TestResult result = scenario.run();
+        if (result.passed()) {
+            std::println(std::cout, "PASS  {}", scenario.name);
+        } else {
+            std::println(std::cout, "FAIL  {}\n      {}", scenario.name, result.message);
+            ++failed;
+        }
+    }
+    std::println(std::cout, "\n{}: {} scenarios, {} failed", suiteName, registry().size(), failed);
+    return failed == 0 ? 0 : 1;
+}
+
+}  // namespace mdux::spec

--- a/tests/framework/SpecLabBridge.hpp
+++ b/tests/framework/SpecLabBridge.hpp
@@ -38,7 +38,7 @@ namespace mdux::spec {
 struct Scenario {
     std::string name;
     std::string labels;  ///< comma-separated, as the discovery script expects
-    std::function<speclab::TestResult()> run;
+    std::function<speclab::core::TestResult()> run;
 };
 
 /// The registry. A function-local static so registration order across translation units cannot
@@ -51,7 +51,7 @@ inline std::vector<Scenario>& registry() {
 /// Registers one scenario at namespace scope. Construct one per scenario; the object itself is
 /// never used again.
 struct Register {
-    Register(std::string name, std::string labels, std::function<speclab::TestResult()> run) {
+    Register(std::string name, std::string labels, std::function<speclab::core::TestResult()> run) {
         registry().push_back(
             Scenario{.name = std::move(name), .labels = std::move(labels), .run = std::move(run)});
     }
@@ -83,7 +83,7 @@ inline int main(int argc, char** argv, std::string_view suiteName) {
                 std::println(std::cerr, "{}: no scenario named '{}'", suiteName, wanted);
                 return 2;
             }
-            const speclab::TestResult result = found->run();
+            const speclab::core::TestResult result = found->run();
             if (!result.passed()) {
                 std::println(std::cerr, "FAILED: {}\n  {}", found->name, result.message);
                 return 1;
@@ -95,7 +95,7 @@ inline int main(int argc, char** argv, std::string_view suiteName) {
     // No selection: run the lot, which is what a developer invoking the binary directly wants.
     std::size_t failed = 0;
     for (const Scenario& scenario : registry()) {
-        const speclab::TestResult result = scenario.run();
+        const speclab::core::TestResult result = scenario.run();
         if (result.passed()) {
             std::println(std::cout, "PASS  {}", scenario.name);
         } else {

--- a/tests/spec/BridgeSpec.cpp
+++ b/tests/spec/BridgeSpec.cpp
@@ -105,6 +105,62 @@ const mdux::spec::Register governedTypesReachable{
             .Execute();
     }};
 
+const mdux::spec::Register checksCollect{
+    "Checks reports every failed expectation, not just the first", "evidence-unit", [] {
+        // The reason Checks exists. MduXTest's CHECK is soft, so a converted test asserting six
+        // things must still report all six that are wrong - otherwise the conversion trades a
+        // one-pass fix for one rerun per failure.
+        struct State {
+            std::string message;
+            bool threw{false};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("bridge-checks-collect")
+            .Given("three expectations of which two fail",
+                   [state] {
+                       mdux::spec::Checks checks;
+                       checks.expect(true, "the one that holds");
+                       checks.expect(false, "first failure");
+                       checks.expect(false, "second failure");
+                       try {
+                           checks.raise();
+                       } catch (const speclab::core::AssertionFailure& failure) {
+                           state->threw = true;
+                           state->message = failure.what();
+                       }
+                   })
+            .When("the collected failures are inspected", [] {})
+            .Then("both are named in one message",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      checks.expect(state->threw, "raise() threw");
+                      checks.expect(state->message.find("first failure") != std::string::npos,
+                                    "the first failure is named");
+                      checks.expect(state->message.find("second failure") != std::string::npos,
+                                    "the second failure is named");
+                      checks.expect(state->message.find("the one that holds") == std::string::npos,
+                                    "the passing expectation is not mentioned");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register checksSilentWhenClean{
+    "Checks throws nothing when every expectation holds", "evidence-unit", [] {
+        return speclab::Test("bridge-checks-clean")
+            .Given("only passing expectations", [] {})
+            .When("raise() is called", [] {})
+            .Then("it returns normally",
+                  [] {
+                      mdux::spec::Checks checks;
+                      checks.expect(1 + 1 == 2, "arithmetic");
+                      checks.expect(!checks.anyFailed(), "nothing recorded");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 }  // namespace
 
 int main(int argc, char** argv) {

--- a/tests/spec/BridgeSpec.cpp
+++ b/tests/spec/BridgeSpec.cpp
@@ -36,7 +36,7 @@ const mdux::spec::Register arithmetic{
             .Then("the sum is five",
                   [state] {
                       if (state->sum != 5) {
-                          throw speclab::AssertionFailure("2 + 3 did not produce 5",
+                          throw speclab::core::AssertionFailure("2 + 3 did not produce 5",
                                                           std::source_location::current());
                       }
                   })
@@ -53,13 +53,13 @@ const mdux::spec::Register assertionsFire{
         };
         auto state = std::make_shared<State>();
 
-        const speclab::TestResult inner =
+        const speclab::core::TestResult inner =
             speclab::Test("bridge-inner-failure")
                 .Given("a scenario that will fail", [] {})
                 .When("its assertion is evaluated", [] {})
                 .Then("it throws",
                       [] {
-                          throw speclab::AssertionFailure("deliberate",
+                          throw speclab::core::AssertionFailure("deliberate",
                                                           std::source_location::current());
                       })
                 .Execute();
@@ -71,7 +71,7 @@ const mdux::spec::Register assertionsFire{
             .Then("SpecLab reports it as not passed",
                   [state] {
                       if (!state->threw) {
-                          throw speclab::AssertionFailure(
+                          throw speclab::core::AssertionFailure(
                               "a throwing Then was reported as passing",
                               std::source_location::current());
                       }
@@ -98,7 +98,7 @@ const mdux::spec::Register governedTypesReachable{
             .Then("the members are what was written",
                   [state] {
                       if (state->rect.width != 16 || state->rect.height != 32) {
-                          throw speclab::AssertionFailure("Rect did not round-trip",
+                          throw speclab::core::AssertionFailure("Rect did not round-trip",
                                                           std::source_location::current());
                       }
                   })

--- a/tests/spec/BridgeSpec.cpp
+++ b/tests/spec/BridgeSpec.cpp
@@ -1,0 +1,112 @@
+/**
+ * @brief Proves the SpecLab integration itself, before any suite is written against it.
+ *
+ * This file exists because the bridge has more moving parts than the tests it will carry: a
+ * dependency resolved by CPM, a named module imported into a test target, namespace-scope
+ * registration running before `main`, and a discovery contract implemented by hand. A failure in
+ * any of those would otherwise surface as a converted suite that mysteriously does not run - and
+ * "no tests were discovered" is a green CTest run unless something asserts otherwise.
+ *
+ * So the first scenario is deliberately trivial, and the second one deliberately fails when the
+ * bridge reports a failing scenario as passing. Together they check the two directions that
+ * matter: a passing scenario is reported as passing, and SpecLab's assertions actually throw.
+ */
+import std;
+import speclab;
+import mdux.core.units;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace core = mdux::core;
+
+const mdux::spec::Register arithmetic{
+    "The SpecLab bridge runs a passing scenario", "evidence-unit", [] {
+        // Shared state, as the bridge header describes: created here, captured by each step,
+        // and destroyed when Execute() returns.
+        struct State {
+            int sum{0};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("bridge-passing")
+            .Given("two numbers", [state] { state->sum = 0; })
+            .When("they are added", [state] { state->sum = 2 + 3; })
+            .Then("the sum is five",
+                  [state] {
+                      if (state->sum != 5) {
+                          throw speclab::AssertionFailure("2 + 3 did not produce 5",
+                                                          std::source_location::current());
+                      }
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register assertionsFire{
+    "SpecLab assertions fail a scenario rather than being ignored", "evidence-unit", [] {
+        // A scenario whose Then throws is expected to come back not-passed. If SpecLab ever
+        // swallowed that, every converted suite would pass unconditionally - which is the single
+        // most dangerous way for a test framework to be wrong, so it is checked directly.
+        struct State {
+            bool threw{false};
+        };
+        auto state = std::make_shared<State>();
+
+        const speclab::TestResult inner =
+            speclab::Test("bridge-inner-failure")
+                .Given("a scenario that will fail", [] {})
+                .When("its assertion is evaluated", [] {})
+                .Then("it throws",
+                      [] {
+                          throw speclab::AssertionFailure("deliberate",
+                                                          std::source_location::current());
+                      })
+                .Execute();
+        state->threw = !inner.passed();
+
+        return speclab::Test("bridge-assertion-propagates")
+            .Given("a deliberately failing inner scenario", [] {})
+            .When("it has been executed", [] {})
+            .Then("SpecLab reports it as not passed",
+                  [state] {
+                      if (!state->threw) {
+                          throw speclab::AssertionFailure(
+                              "a throwing Then was reported as passing",
+                              std::source_location::current());
+                      }
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register governedTypesReachable{
+    "A governed MduX type is usable from a SpecLab scenario", "evidence-unit", [] {
+        // The integration has to work with MduX's own modules imported alongside SpecLab's, on
+        // the same compiler and the same `import std`. That combination is what GCC 15 could not
+        // do, and is why this project's floor is GCC 16.
+        struct State {
+            core::Rect rect{};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("bridge-governed-types")
+            .Given("a rectangle in pixels",
+                   [state] {
+                       state->rect = core::Rect{.x = 4, .y = 8, .width = 16, .height = 32};
+                   })
+            .When("its extent is read", [] {})
+            .Then("the members are what was written",
+                  [state] {
+                      if (state->rect.width != 16 || state->rect.height != 32) {
+                          throw speclab::AssertionFailure("Rect did not round-trip",
+                                                          std::source_location::current());
+                      }
+                  })
+            .Execute();
+    }};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX SpecLab Bridge");
+}


### PR DESCRIPTION
Wires [SpecLab](https://github.com/ambroise-leclerc/SpecLab) into the test build and proves the integration, ahead of converting the suites the review asked about.

**Stacked on #138** (GCC 16 floor), which this needs — GCC 15 cannot build SpecLab.

## What this is

The five open review threads on #128–#132 asked for BDD tests. Catch2 is not a dependency here and ADR-002 was never implemented; the direction is SpecLab, which gives `Given`/`When`/`Then` **without macros**, via `import speclab;`.

Before converting several hundred assertions, this PR establishes that the integration works:

- **`tests/framework/SpecLabBridge.hpp`** — implements the `--list-tests` / `--run=<name>` contract that `cmake/MduXTestDiscoveryImpl.cmake` already defines. SpecLab has its own runner and knows nothing about it, so without a bridge a SpecLab binary is a *single* CTest entry: a failure would name the binary rather than the scenario, and the labels `ctest -L evidence` and `ctest -L pixel` select on would have nowhere to live.
- **`tests/spec/BridgeSpec.cpp`** — three scenarios covering the integration itself.

## The scenario worth reading

The second one deliberately runs a `Then` that throws, and asserts SpecLab reports it as **not passed**. A test framework that silently swallowed assertions would make every converted suite pass unconditionally — the single most dangerous way for this layer to be wrong, so it is checked directly rather than assumed.

The third imports a governed MduX type alongside SpecLab, on the same compiler and the same `import std`. That exact combination is what GCC 15 could not do.

## Why registration is an object

```cpp
const mdux::spec::Register arithmetic{
    "The SpecLab bridge runs a passing scenario", "evidence-unit", [] {
        return speclab::Test("bridge-passing")
            .Given("two numbers", [state] { ... })
            .When("they are added", [state] { ... })
            .Then("the sum is five", [state] { ... })
            .Execute();
    }};
```

A namespace-scope constructor runs before `main` — the same mechanism `TEST_CASE` uses, minus the macro, which is the reason for choosing SpecLab.

`Given`/`When`/`Then` steps are `void()`, so state is a `shared_ptr` created in the factory and captured by each step. `Execute()` is called inside that factory, so the state lives exactly as long as the steps can run — no globals and no ordering between scenarios.

## Verification

**CI only.** Homebrew packages no GCC 16, so I cannot build this tree locally any more (see #138). That is also why this lands as a small, self-checking increment rather than alongside the conversions.

## Next

Once green, convert the suites the review named: `CliTests`, `SchemaTests`, `UiPackageTests`, `EmitTests`, `GeneratedTests`, `DrawTests`. Per the agreed scope, new (wave 3) suites only — the older MduXTest cases stay as they are.
