### PR TITLE
feat(ml): add mdux.ml.schema, the canonical model package format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ code*; treat this subsection as the direction that code is moving in.
 | `mdux.evidence.digest`, `.json`, `.report` | `include/mdux/evidence/` | `src/evidence/` |
 | `mdux.governance`, `mdux.governance.compliance` | `include/mdux/governance/` | `src/governance/` |
 | `mdux.shader.schema` (governed) | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
+| `mdux.ml.schema` (governed) | `include/mdux/ml/Schema.cppm` | header-only |
 | `mdux.draw` (governed) | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
 | `mdux.render.vulkan`, `mdux.render.offscreen` (adapter) | `include/mdux/render/` | `src/render/` |
 | `mdux.vulkansc.memory` | `include/mdux/vulkansc/MemoryPoolManager.cppm` | `src/vulkansc/MemoryPoolManager.cpp` |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ target_sources(MduXCore
             include/mdux/governance/Governance.cppm
             include/mdux/governance/Compliance.cppm
             include/mdux/shader/Schema.cppm
+            include/mdux/ml/Schema.cppm
             include/mdux/draw/Draw.cppm
     PRIVATE
         src/evidence/Digest.cpp

--- a/include/mdux/ml/Schema.cppm
+++ b/include/mdux/ml/Schema.cppm
@@ -1,0 +1,478 @@
+/**
+ * @file Schema.cppm
+ * @brief Governed-zone ML model types: the canonical shape of every model package.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Part of MduXCore. This module is canonical: the kernels (issue #58), the runtime (#62), the
+ * golden-vector generator and `mdux-mlbake` (#61) all import it rather than restating its records.
+ * Two files describing the same artifact will disagree eventually, and the disagreement surfaces as
+ * a byte-comparison failure nobody can localise.
+ *
+ * Header-only by design - there is no `src/ml/Schema.cpp`. Everything here is `constexpr`, so a
+ * generated `ModelPackage` can be validated at compile time and placed in read-only memory.
+ *
+ * ## Two design points worth defending in review
+ *
+ * **`TensorRef` holds a byte offset, not a pointer.** That is what lets `ModelPackage` be a
+ * `constexpr` object while the weights live in a separately-supplied blob - an mmap, ROM, flash, or
+ * a linked byte array. A pointer would make the package non-`constexpr` and force multi-megabyte
+ * weights into generated source, which MSVC does not survive in reasonable time.
+ *
+ * **`GoldenVector` stores `u32` bit patterns, not floats.** Comparison is bitwise. Never decimal,
+ * never an epsilon. An epsilon comparison would silently accept exactly the floating-point drift
+ * this mechanism exists to detect, and a decimal round-trip is a lossy re-encoding of the thing
+ * being checked. See ADR-008, decision 4.
+ *
+ * ## `f32` only
+ *
+ * v1 scope per ADR-008, decision 5. There is no dtype field to get wrong: every tensor is `f32`,
+ * so `byteLength()` is `elementCount() * 4` and nothing here can express anything else. `int8`
+ * quantisation needs its own ADR and its own determinism argument, not an enumerator.
+ *
+ * ## What this module deliberately does not check
+ *
+ * `validate()` does not reject weight tensors whose byte ranges overlap. Weight tying is a real
+ * technique, and a package that shares one tensor between two layers is well-formed. The importer
+ * (#60) rejects overlap in *safetensors input*, where it means a malformed file; that is the layer
+ * where the check is meaningful.
+ *
+ * It also **accepts a package carrying no golden vectors**, which is worth defending because
+ * ADR-008 decision 4 makes the goldens a mandatory fail-closed control. The control belongs at the
+ * device boundary, not here: `Classifier1D::create()` (#62) rejects an empty golden set, because
+ * that is the point where an unverified model would actually be executed. `validate()` is a
+ * *structural* check, and it is deliberately usable on a half-assembled package - the baker calls
+ * it to check an architecture against imported weights before it has generated any goldens, and
+ * the golden generator needs a validated layer chain to run at all. Rejecting empty goldens here
+ * would make that bootstrap impossible and would move the safety argument to the wrong layer.
+ */
+module;
+
+export module mdux.ml.schema;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.evidence.report;
+
+export namespace mdux::ml {
+
+// The whole format is f32, and byteLength() computes from sizeof(float) rather than a constant, so
+// the on-wire assumption is stated here rather than left implicit. A platform with a 64-bit float
+// would silently double every computed byte range.
+static_assert(sizeof(float) == 4, "mdux.ml's package format is f32; sizeof(float) must be 4");
+
+/// The `<kind>` component of `generated/<kind>/<id>/`, and the value of a package's `kind` member.
+inline constexpr std::string_view packageKind = "model";
+
+/// The operations v1 can express. ADR-008, decision 5 caps this set deliberately: recurrent layers
+/// and attention need a follow-up ADR, not a quiet enumerator.
+enum class LayerKind : std::uint8_t { Dense, Conv1d, MaxPool1d, AvgPool1d, Flatten };
+
+/// Wire spellings for LayerKind. Order is load-bearing: an enumerator's numeric value is its index.
+inline constexpr std::array<std::string_view, 5> layerKindWireValues{"dense", "conv1d", "maxPool1d",
+                                                                    "avgPool1d", "flatten"};
+
+enum class Activation : std::uint8_t { None, Relu, Sigmoid, Softmax };
+
+/// Wire spellings for Activation. Order is load-bearing, as for layerKindWireValues.
+inline constexpr std::array<std::string_view, 4> activationWireValues{"none", "relu", "sigmoid",
+                                                                     "softmax"};
+
+/// The largest rank v1 accepts. A Conv1D weight tensor is `[outChannels, inChannels, kernelSize]`;
+/// nothing in the v1 kernel set needs a fourth dimension.
+inline constexpr std::uint8_t maxTensorRank = 3;
+
+enum class SchemaError : std::uint8_t {
+    UnsupportedSchemaVersion,
+    EmptyId,
+    NoLayers,
+    ZeroInputLength,
+    ZeroOutputLength,
+    UnknownLayerKind,        ///< a wire value outside layerKindWireValues
+    UnknownActivation,
+    RankTooLarge,            ///< rank > maxTensorRank
+    ZeroDimension,           ///< a shape entry within the rank is zero
+    InputLengthMismatch,     ///< the first layer does not consume exactly inputLength floats
+    OutputLengthMismatch,    ///< the last layer does not produce exactly outputLength floats
+    LayerChainMismatch,      ///< layer i's output footprint is not layer i+1's input footprint
+    ZeroLayerDimension,      ///< an in/out length or channel count is zero
+    ZeroKernelSize,
+    ZeroStride,
+    KernelLargerThanInput,
+    OutputLengthNotDerivable,  ///< declared outLength disagrees with the windowing arithmetic
+    ChannelCountChanged,       ///< a pooling layer may not change the channel count
+    MissingWeights,            ///< a layer that must carry weights declares rank 0
+    UnexpectedWeights,         ///< a layer that carries none declares a tensor
+    MissingBias,
+    WeightShapeMismatch,       ///< a weight tensor's shape disagrees with the layer's dimensions
+    BiasShapeMismatch,
+    UnalignedTensor,           ///< a byte offset that is not a multiple of 4 cannot hold f32
+    TensorOutOfBounds,         ///< the range extends past the end of the weight blob
+    ScratchTooSmall,           ///< maxScratchFloats does not cover the worst-case footprint
+    GoldenInputLengthMismatch,
+    GoldenOutputLengthMismatch,
+};
+
+[[nodiscard]] constexpr std::string_view describe(SchemaError error) noexcept {
+    switch (error) {
+        case SchemaError::UnsupportedSchemaVersion: return "unsupported schema version";
+        case SchemaError::EmptyId:                  return "package id is empty";
+        case SchemaError::NoLayers:                 return "package declares no layers";
+        case SchemaError::ZeroInputLength:          return "inputLength is zero";
+        case SchemaError::ZeroOutputLength:         return "outputLength is zero";
+        case SchemaError::UnknownLayerKind:         return "unknown layer kind";
+        case SchemaError::UnknownActivation:        return "unknown activation";
+        case SchemaError::RankTooLarge:             return "tensor rank exceeds 3";
+        case SchemaError::ZeroDimension:            return "tensor shape has a zero dimension";
+        case SchemaError::InputLengthMismatch:      return "first layer does not consume inputLength floats";
+        case SchemaError::OutputLengthMismatch:     return "last layer does not produce outputLength floats";
+        case SchemaError::LayerChainMismatch:       return "layer output footprint is not the next layer's input";
+        case SchemaError::ZeroLayerDimension:       return "layer dimension or channel count is zero";
+        case SchemaError::ZeroKernelSize:           return "kernel size is zero";
+        case SchemaError::ZeroStride:               return "stride is zero";
+        case SchemaError::KernelLargerThanInput:    return "kernel is wider than the input";
+        case SchemaError::OutputLengthNotDerivable: return "declared outLength disagrees with the windowing arithmetic";
+        case SchemaError::ChannelCountChanged:      return "a pooling layer may not change the channel count";
+        case SchemaError::MissingWeights:           return "layer requires a weight tensor";
+        case SchemaError::UnexpectedWeights:        return "layer carries weights it cannot use";
+        case SchemaError::MissingBias:              return "layer requires a bias tensor";
+        case SchemaError::WeightShapeMismatch:      return "weight shape disagrees with layer dimensions";
+        case SchemaError::BiasShapeMismatch:        return "bias shape disagrees with layer dimensions";
+        case SchemaError::UnalignedTensor:          return "tensor byte offset is not a multiple of 4";
+        case SchemaError::TensorOutOfBounds:        return "tensor range extends past the weight blob";
+        case SchemaError::ScratchTooSmall:          return "maxScratchFloats is below the worst-case footprint";
+        case SchemaError::GoldenInputLengthMismatch:  return "golden input length is not inputLength";
+        case SchemaError::GoldenOutputLengthMismatch: return "golden output length is not outputLength";
+    }
+    return "unknown schema error";
+}
+
+/**
+ * @brief Where a tensor lives in the weight blob, and what shape it has.
+ *
+ * A byte offset rather than a pointer - see the module comment for why that is load-bearing.
+ * `rank == 0` means "no tensor": a pooling layer's weights, or a layer declared without a bias.
+ */
+struct TensorRef {
+    std::uint64_t byteOffset{0};
+    std::array<std::uint32_t, maxTensorRank> shape{};
+    std::uint8_t rank{0};
+
+    [[nodiscard]] constexpr bool present() const noexcept { return rank != 0; }
+
+    /**
+     * @brief Product of the first `rank` dimensions, saturating rather than wrapping.
+     *
+     * Three `uint32` extents multiply to as much as 2^96, so the product genuinely can exceed
+     * `uint64`. Saturating at the maximum instead of wrapping is what lets validate()'s bounds
+     * check stay a simple comparison: an absurd shape produces an absurd length, which is then
+     * rejected. Wrapping would produce a *small* length and quietly validate.
+     *
+     * Returns 1 for an absent tensor, which keeps the arithmetic total - callers gate on present()
+     * rather than relying on that value.
+     */
+    [[nodiscard]] constexpr std::uint64_t elementCount() const noexcept {
+        constexpr std::uint64_t saturated = std::numeric_limits<std::uint64_t>::max();
+        std::uint64_t count = 1;
+        for (std::uint8_t i = 0; i < rank && i < maxTensorRank; ++i) {
+            if (shape[i] != 0 && count > saturated / shape[i]) {
+                return saturated;
+            }
+            count *= shape[i];
+        }
+        return count;
+    }
+
+    /// Every tensor is f32 - there is no dtype to consult. Saturates for the same reason
+    /// elementCount() does.
+    [[nodiscard]] constexpr std::uint64_t byteLength() const noexcept {
+        constexpr std::uint64_t saturated = std::numeric_limits<std::uint64_t>::max();
+        if (!present()) {
+            return 0;
+        }
+        const std::uint64_t count = elementCount();
+        return count > saturated / sizeof(float) ? saturated : count * sizeof(float);
+    }
+
+    [[nodiscard]] constexpr std::uint64_t byteEnd() const noexcept {
+        return byteOffset + byteLength();
+    }
+
+    [[nodiscard]] constexpr bool operator==(const TensorRef&) const noexcept = default;
+};
+
+/**
+ * @brief One layer of the network, fully described.
+ *
+ * The four dimension fields describe the layer's activation footprint, not its weights:
+ * `inLength * inChannels` floats in, `outLength * outChannels` floats out. `validate()` checks
+ * that the weight tensor's shape agrees with them, which is the check that catches a weight file
+ * imported against the wrong architecture.
+ */
+struct LayerDesc {
+    LayerKind kind{LayerKind::Dense};
+    Activation activation{Activation::None};
+    std::uint32_t inLength{0};
+    std::uint32_t inChannels{0};
+    std::uint32_t outLength{0};
+    std::uint32_t outChannels{0};
+    std::uint32_t kernelSize{0};  ///< convolution and pooling only; 0 elsewhere
+    std::uint32_t stride{0};      ///< convolution and pooling only; 0 elsewhere
+    TensorRef weights{};
+    TensorRef bias{};
+
+    [[nodiscard]] constexpr std::uint64_t inputFloats() const noexcept {
+        return static_cast<std::uint64_t>(inLength) * inChannels;
+    }
+
+    [[nodiscard]] constexpr std::uint64_t outputFloats() const noexcept {
+        return static_cast<std::uint64_t>(outLength) * outChannels;
+    }
+
+    [[nodiscard]] constexpr bool operator==(const LayerDesc&) const noexcept = default;
+};
+
+/// Whether a layer kind carries a weight tensor at all. Pooling and flatten do not.
+[[nodiscard]] constexpr bool carriesWeights(LayerKind kind) noexcept {
+    return kind == LayerKind::Dense || kind == LayerKind::Conv1d;
+}
+
+/// Whether a layer kind uses a windowing kernel, and therefore kernelSize/stride.
+[[nodiscard]] constexpr bool isWindowed(LayerKind kind) noexcept {
+    return kind == LayerKind::Conv1d || kind == LayerKind::MaxPool1d || kind == LayerKind::AvgPool1d;
+}
+
+/**
+ * @brief The output length a windowed layer produces, with no padding.
+ *
+ * v1 has no padding mode: a window that does not fit is simply not evaluated. Returns 0 when the
+ * kernel is wider than the input, which validate() reports as KernelLargerThanInput rather than
+ * letting it underflow.
+ */
+[[nodiscard]] constexpr std::uint32_t windowedOutputLength(std::uint32_t inLength,
+                                                           std::uint32_t kernelSize,
+                                                           std::uint32_t stride) noexcept {
+    if (kernelSize == 0 || stride == 0 || kernelSize > inLength) {
+        return 0;
+    }
+    return (inLength - kernelSize) / stride + 1;
+}
+
+/**
+ * @brief One golden input→output pair, as `u32` bit patterns.
+ *
+ * Bit patterns, not floats, and compared bitwise - see the module comment and ADR-008, decision 4.
+ * `std::bit_cast<float>` recovers the value where a diagnostic needs to print one.
+ */
+struct GoldenVector {
+    std::span<const std::uint32_t> inputBits;
+    std::span<const std::uint32_t> expectedOutputBits;
+};
+
+/**
+ * @brief A whole model as generated code exposes it and the runtime consumes it.
+ *
+ * Non-owning and `constexpr`-constructible throughout: the spans point at generated static data,
+ * and the weights live in a blob the caller supplies separately, identified by `weightsDigest`.
+ */
+struct ModelPackage {
+    std::string_view id;
+    std::uint64_t schemaVersion{evidence::kSchemaVersion};
+    evidence::Digest weightsDigest{};
+    std::uint64_t weightsByteLength{0};
+    std::span<const LayerDesc> layers;
+    std::span<const GoldenVector> goldens;
+    std::uint32_t inputLength{0};   ///< total input floats, channels included
+    std::uint32_t outputLength{0};  ///< total output floats
+    std::uint32_t maxScratchFloats{0};
+
+    /// Checks every invariant a consumer is entitled to assume, so the kernels can be written
+    /// without defensive checks in their inner loops. See requiredScratchFloats() for the scratch
+    /// rule in particular.
+    [[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> validate() const noexcept;
+};
+
+/**
+ * @brief The scratch floats `predict()` needs for this layer chain.
+ *
+ * `predict()` ping-pongs between two buffers, so the requirement is twice the largest activation
+ * the chain ever holds - input, every intermediate, and output. Computing it here rather than in
+ * the baker is what keeps the baker's `maxScratchFloats` and the runtime's check in agreement:
+ * there is one formula, and both sides call it.
+ *
+ * Returns 0 for an empty layer span, which validate() has already rejected as NoLayers.
+ */
+[[nodiscard]] constexpr std::uint64_t requiredScratchFloats(std::span<const LayerDesc> layers,
+                                                            std::uint32_t inputLength) noexcept {
+    std::uint64_t largest = inputLength;
+    for (const LayerDesc& layer : layers) {
+        largest = std::max(largest, layer.outputFloats());
+    }
+    return largest * 2;
+}
+
+constexpr mdux::core::ResultVoid<SchemaError> ModelPackage::validate() const noexcept {
+    using core::err;
+
+    if (schemaVersion != evidence::kSchemaVersion) {
+        return err(SchemaError::UnsupportedSchemaVersion);
+    }
+    if (id.empty()) {
+        return err(SchemaError::EmptyId);
+    }
+    if (layers.empty()) {
+        return err(SchemaError::NoLayers);
+    }
+    if (inputLength == 0) {
+        return err(SchemaError::ZeroInputLength);
+    }
+    if (outputLength == 0) {
+        return err(SchemaError::ZeroOutputLength);
+    }
+
+    for (const LayerDesc& layer : layers) {
+        if (static_cast<std::uint8_t>(layer.kind) >= layerKindWireValues.size()) {
+            return err(SchemaError::UnknownLayerKind);
+        }
+        if (static_cast<std::uint8_t>(layer.activation) >= activationWireValues.size()) {
+            return err(SchemaError::UnknownActivation);
+        }
+        if (layer.inLength == 0 || layer.inChannels == 0 || layer.outLength == 0 ||
+            layer.outChannels == 0) {
+            return err(SchemaError::ZeroLayerDimension);
+        }
+
+        for (const TensorRef* tensor : {&layer.weights, &layer.bias}) {
+            if (tensor->rank > maxTensorRank) {
+                return err(SchemaError::RankTooLarge);
+            }
+            for (std::uint8_t i = 0; i < tensor->rank; ++i) {
+                if (tensor->shape[i] == 0) {
+                    return err(SchemaError::ZeroDimension);
+                }
+            }
+            if (tensor->present()) {
+                if (tensor->byteOffset % sizeof(float) != 0) {
+                    return err(SchemaError::UnalignedTensor);
+                }
+                // Written as two subtractions rather than `byteEnd() > weightsByteLength`, which
+                // is what it replaced. A generated or hand-edited package can name any offset and
+                // any shape, and `byteOffset + byteLength()` wraps for large values - so the
+                // obvious form lets an out-of-bounds tensor validate and then read off the end of
+                // the weight blob. Neither expression below can overflow.
+                if (tensor->byteOffset > weightsByteLength ||
+                    tensor->byteLength() > weightsByteLength - tensor->byteOffset) {
+                    return err(SchemaError::TensorOutOfBounds);
+                }
+            }
+        }
+
+        if (isWindowed(layer.kind)) {
+            if (layer.kernelSize == 0) {
+                return err(SchemaError::ZeroKernelSize);
+            }
+            if (layer.stride == 0) {
+                return err(SchemaError::ZeroStride);
+            }
+            if (layer.kernelSize > layer.inLength) {
+                return err(SchemaError::KernelLargerThanInput);
+            }
+            if (layer.outLength !=
+                windowedOutputLength(layer.inLength, layer.kernelSize, layer.stride)) {
+                return err(SchemaError::OutputLengthNotDerivable);
+            }
+        }
+
+        switch (layer.kind) {
+            case LayerKind::Dense:
+                // A dense layer consumes a flat vector: inChannels/outChannels are 1, and the
+                // weight matrix is [outLength, inLength].
+                if (!layer.weights.present()) {
+                    return err(SchemaError::MissingWeights);
+                }
+                if (layer.weights.rank != 2 || layer.weights.shape[0] != layer.outLength ||
+                    layer.weights.shape[1] != layer.inLength || layer.inChannels != 1 ||
+                    layer.outChannels != 1) {
+                    return err(SchemaError::WeightShapeMismatch);
+                }
+                if (!layer.bias.present()) {
+                    return err(SchemaError::MissingBias);
+                }
+                if (layer.bias.rank != 1 || layer.bias.shape[0] != layer.outLength) {
+                    return err(SchemaError::BiasShapeMismatch);
+                }
+                break;
+
+            case LayerKind::Conv1d:
+                if (!layer.weights.present()) {
+                    return err(SchemaError::MissingWeights);
+                }
+                if (layer.weights.rank != 3 || layer.weights.shape[0] != layer.outChannels ||
+                    layer.weights.shape[1] != layer.inChannels ||
+                    layer.weights.shape[2] != layer.kernelSize) {
+                    return err(SchemaError::WeightShapeMismatch);
+                }
+                if (!layer.bias.present()) {
+                    return err(SchemaError::MissingBias);
+                }
+                if (layer.bias.rank != 1 || layer.bias.shape[0] != layer.outChannels) {
+                    return err(SchemaError::BiasShapeMismatch);
+                }
+                break;
+
+            case LayerKind::MaxPool1d:
+            case LayerKind::AvgPool1d:
+                if (layer.weights.present() || layer.bias.present()) {
+                    return err(SchemaError::UnexpectedWeights);
+                }
+                if (layer.outChannels != layer.inChannels) {
+                    return err(SchemaError::ChannelCountChanged);
+                }
+                break;
+
+            case LayerKind::Flatten:
+                if (layer.weights.present() || layer.bias.present()) {
+                    return err(SchemaError::UnexpectedWeights);
+                }
+                // Flatten reshapes without moving data, so its footprint must be preserved
+                // exactly; the runtime implements it as a no-op on the activation buffer.
+                if (layer.inputFloats() != layer.outputFloats() || layer.outChannels != 1) {
+                    return err(SchemaError::WeightShapeMismatch);
+                }
+                break;
+        }
+    }
+
+    if (layers.front().inputFloats() != inputLength) {
+        return err(SchemaError::InputLengthMismatch);
+    }
+    if (layers.back().outputFloats() != outputLength) {
+        return err(SchemaError::OutputLengthMismatch);
+    }
+    for (std::size_t i = 1; i < layers.size(); ++i) {
+        if (layers[i - 1].outputFloats() != layers[i].inputFloats()) {
+            return err(SchemaError::LayerChainMismatch);
+        }
+    }
+
+    if (maxScratchFloats < requiredScratchFloats(layers, inputLength)) {
+        return err(SchemaError::ScratchTooSmall);
+    }
+
+    for (const GoldenVector& golden : goldens) {
+        if (golden.inputBits.size() != inputLength) {
+            return err(SchemaError::GoldenInputLengthMismatch);
+        }
+        if (golden.expectedOutputBits.size() != outputLength) {
+            return err(SchemaError::GoldenOutputLengthMismatch);
+        }
+    }
+
+    return {};
+}
+
+}  // namespace mdux::ml

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -509,3 +509,33 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 mdux_discover_tests(tools_spec)
+
+# Zero-SOUP ML inference (epic #18, ADR-008)
+#
+# Links MduX::Core only. The schema, kernels and runtime are governed modules by design - a
+# scenario that needed MduX::MduX to build one would mean the trust-zone boundary had moved, and
+# the whole zero-SOUP argument rests on the ML subsystem reaching nothing but std.
+add_executable(ml_spec
+    ml/MlSpecMain.cpp
+    ml/SchemaTests.cpp
+)
+
+target_link_libraries(ml_spec PRIVATE MduX::Core speclab::speclab)
+target_include_directories(ml_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(ml_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(ml_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(ml_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(ml_spec)

--- a/tests/ml/MlSpecMain.cpp
+++ b/tests/ml/MlSpecMain.cpp
@@ -1,0 +1,20 @@
+/**
+ * @brief Entry point for the mdux.ml SpecLab BDD executable.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Runs SpecLab scenarios under the rest of the suite's discovery contract: `--list-tests` prints
+ * one `name<TAB>labels` line per scenario, and `--run=<name>` executes exactly one. Links
+ * MduX::Core only - the ML schema, kernels and runtime are governed modules, so a scenario that
+ * needed MduX::MduX to build one would mean the trust-zone boundary had moved.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX ML Spec");
+}

--- a/tests/ml/SchemaTests.cpp
+++ b/tests/ml/SchemaTests.cpp
@@ -1,0 +1,398 @@
+/**
+ * @file SchemaTests.cpp
+ * @brief BDD scenarios for mdux.ml.schema (issue #57).
+ *
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * The rejections are the point. A schema whose validate() only ever succeeds is a comment claiming
+ * there are invariants, so every SchemaError below has a case that produces exactly it - and the
+ * `static_assert` at namespace scope is the evidence for the header-only `constexpr` claim in the
+ * module comment: if validation could not run at compile time, this file would not compile.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.evidence.report;
+import mdux.ml.schema;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+using namespace mdux::ml;
+namespace evidence = mdux::evidence;
+
+// ---------------------------------------------------------------------------
+// The reference architecture used throughout: the demonstrator's shape in miniature.
+//
+//   32 samples x 1 channel
+//     -> Conv1D  k=5 s=1, 4 filters, relu   -> 28 x 4
+//     -> MaxPool k=2 s=2                    -> 14 x 4
+//     -> Flatten                            -> 56
+//     -> Dense 56->3, softmax               -> 3
+//
+// It exercises every v1 layer kind, which is what makes it a useful base for mutation: each
+// rejection below changes exactly one field of an otherwise-valid package.
+// ---------------------------------------------------------------------------
+
+constexpr std::uint64_t convWeightsOffset = 0;    // [4,1,5] = 20 floats
+constexpr std::uint64_t convBiasOffset = 80;      // [4]     =  4 floats
+constexpr std::uint64_t denseWeightsOffset = 96;  // [3,56]  = 168 floats
+constexpr std::uint64_t denseBiasOffset = 768;    // [3]     =  3 floats
+constexpr std::uint64_t weightsBytes = 780;
+
+constexpr LayerDesc conv1d() noexcept {
+    return LayerDesc{.kind = LayerKind::Conv1d,
+                     .activation = Activation::Relu,
+                     .inLength = 32,
+                     .inChannels = 1,
+                     .outLength = 28,
+                     .outChannels = 4,
+                     .kernelSize = 5,
+                     .stride = 1,
+                     .weights = TensorRef{.byteOffset = convWeightsOffset,
+                                          .shape = {4, 1, 5},
+                                          .rank = 3},
+                     .bias = TensorRef{.byteOffset = convBiasOffset, .shape = {4, 0, 0}, .rank = 1}};
+}
+
+constexpr LayerDesc maxPool1d() noexcept {
+    return LayerDesc{.kind = LayerKind::MaxPool1d,
+                     .activation = Activation::None,
+                     .inLength = 28,
+                     .inChannels = 4,
+                     .outLength = 14,
+                     .outChannels = 4,
+                     .kernelSize = 2,
+                     .stride = 2,
+                     .weights = TensorRef{},
+                     .bias = TensorRef{}};
+}
+
+constexpr LayerDesc flatten() noexcept {
+    return LayerDesc{.kind = LayerKind::Flatten,
+                     .activation = Activation::None,
+                     .inLength = 14,
+                     .inChannels = 4,
+                     .outLength = 56,
+                     .outChannels = 1,
+                     .kernelSize = 0,
+                     .stride = 0,
+                     .weights = TensorRef{},
+                     .bias = TensorRef{}};
+}
+
+constexpr LayerDesc dense() noexcept {
+    return LayerDesc{.kind = LayerKind::Dense,
+                     .activation = Activation::Softmax,
+                     .inLength = 56,
+                     .inChannels = 1,
+                     .outLength = 3,
+                     .outChannels = 1,
+                     .kernelSize = 0,
+                     .stride = 0,
+                     .weights = TensorRef{.byteOffset = denseWeightsOffset,
+                                          .shape = {3, 56, 0},
+                                          .rank = 2},
+                     .bias =
+                         TensorRef{.byteOffset = denseBiasOffset, .shape = {3, 0, 0}, .rank = 1}};
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time evidence for the constexpr claim
+// ---------------------------------------------------------------------------
+
+constexpr std::array<LayerDesc, 4> constLayers{conv1d(), maxPool1d(), flatten(), dense()};
+constexpr std::array<std::uint32_t, 32> constGoldenInput{};
+constexpr std::array<std::uint32_t, 3> constGoldenOutput{};
+constexpr std::array<GoldenVector, 1> constGoldens{
+    GoldenVector{.inputBits = constGoldenInput, .expectedOutputBits = constGoldenOutput}};
+
+constexpr ModelPackage constPackage{.id = "ecg-demo",
+                                    .schemaVersion = evidence::kSchemaVersion,
+                                    .weightsDigest = evidence::Digest{},
+                                    .weightsByteLength = weightsBytes,
+                                    .layers = constLayers,
+                                    .goldens = constGoldens,
+                                    .inputLength = 32,
+                                    .outputLength = 3,
+                                    .maxScratchFloats = 224};
+
+// The module promises a generated package can be validated at compile time and placed in read-only
+// memory. This is that promise, mechanically checked.
+static_assert(constPackage.validate().has_value(),
+              "the reference package must validate at compile time");
+static_assert(requiredScratchFloats(constLayers, 32) == 224,
+              "the scratch formula is 2x the largest activation (28*4 floats here)");
+
+// ---------------------------------------------------------------------------
+// A mutable equivalent, so each rejection can change exactly one field
+// ---------------------------------------------------------------------------
+
+/// Owns everything `ModelPackage`'s spans point at, so a mutated fixture stays self-consistent.
+struct Model {
+    std::string id{"ecg-demo"};
+    std::uint64_t schemaVersion{evidence::kSchemaVersion};
+    std::uint64_t weightsByteLength{weightsBytes};
+    std::vector<LayerDesc> layers{conv1d(), maxPool1d(), flatten(), dense()};
+    std::vector<std::uint32_t> goldenInput = std::vector<std::uint32_t>(32, 0u);
+    std::vector<std::uint32_t> goldenOutput = std::vector<std::uint32_t>(3, 0u);
+    std::uint32_t inputLength{32};
+    std::uint32_t outputLength{3};
+    std::uint32_t maxScratchFloats{224};
+
+    /// Rebuilt on demand so a test may resize the golden storage without dangling a span.
+    [[nodiscard]] std::vector<GoldenVector> goldens() const {
+        return {GoldenVector{.inputBits = goldenInput, .expectedOutputBits = goldenOutput}};
+    }
+};
+
+/// The error a model validates to, or nullopt when it is valid. Keeps each case to one line.
+std::optional<SchemaError> errorOf(const Model& model) {
+    const std::vector<GoldenVector> goldens = model.goldens();
+    const ModelPackage package{.id = model.id,
+                               .schemaVersion = model.schemaVersion,
+                               .weightsDigest = evidence::Digest{},
+                               .weightsByteLength = model.weightsByteLength,
+                               .layers = model.layers,
+                               .goldens = goldens,
+                               .inputLength = model.inputLength,
+                               .outputLength = model.outputLength,
+                               .maxScratchFloats = model.maxScratchFloats};
+    auto result = package.validate();
+    if (result.has_value()) {
+        return std::nullopt;
+    }
+    return result.error();
+}
+
+/// One rejection case: what to break, and what validate() must say about it.
+struct Rejection {
+    std::string_view what;
+    SchemaError expected;
+    std::function<void(Model&)> breakIt;
+};
+
+const std::vector<Rejection>& rejections() {
+    static const std::vector<Rejection> cases{
+        {"schema version from the future", SchemaError::UnsupportedSchemaVersion,
+         [](Model& m) { m.schemaVersion = evidence::kSchemaVersion + 1; }},
+        {"empty id", SchemaError::EmptyId, [](Model& m) { m.id.clear(); }},
+        {"no layers", SchemaError::NoLayers, [](Model& m) { m.layers.clear(); }},
+        {"zero input length", SchemaError::ZeroInputLength, [](Model& m) { m.inputLength = 0; }},
+        {"zero output length", SchemaError::ZeroOutputLength, [](Model& m) { m.outputLength = 0; }},
+        {"layer kind outside the enum", SchemaError::UnknownLayerKind,
+         [](Model& m) { m.layers[0].kind = static_cast<LayerKind>(9); }},
+        {"activation outside the enum", SchemaError::UnknownActivation,
+         [](Model& m) { m.layers[0].activation = static_cast<Activation>(9); }},
+        {"rank 4 tensor", SchemaError::RankTooLarge,
+         [](Model& m) { m.layers[0].weights.rank = 4; }},
+        {"zero dimension within the rank", SchemaError::ZeroDimension,
+         [](Model& m) { m.layers[0].weights.shape[0] = 0; }},
+        {"zero channel count", SchemaError::ZeroLayerDimension,
+         [](Model& m) { m.layers[0].inChannels = 0; }},
+        {"tensor offset off the f32 grid", SchemaError::UnalignedTensor,
+         [](Model& m) { m.layers[0].weights.byteOffset = 2; }},
+        {"tensor past the end of the blob", SchemaError::TensorOutOfBounds,
+         [](Model& m) { m.layers[0].weights.byteOffset = weightsBytes; }},
+        {"a byte offset chosen so that offset + length wraps", SchemaError::TensorOutOfBounds,
+         [](Model& m) {
+             // The naive check `byteOffset + byteLength() > weightsByteLength` wraps here and
+             // reports a tiny end offset, so the tensor validates and the runtime then reads far
+             // off the end of the blob. Kept as a case because the bug is invisible by inspection.
+             m.layers[0].weights.byteOffset = std::numeric_limits<std::uint64_t>::max() - 63;
+         }},
+        {"a shape whose element count overflows", SchemaError::TensorOutOfBounds,
+         [](Model& m) {
+             // 3 * 2^32-ish extents multiply past 2^64. Saturating rather than wrapping is what
+             // turns this into a rejection instead of a small, plausible-looking byte length.
+             m.layers[0].weights.shape = {0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu};
+             m.layers[0].weights.byteOffset = 0;
+         }},
+        {"zero kernel size", SchemaError::ZeroKernelSize,
+         [](Model& m) { m.layers[0].kernelSize = 0; }},
+        {"zero stride", SchemaError::ZeroStride, [](Model& m) { m.layers[0].stride = 0; }},
+        {"kernel wider than the input", SchemaError::KernelLargerThanInput,
+         [](Model& m) { m.layers[0].kernelSize = 64; }},
+        {"outLength disagreeing with the windowing", SchemaError::OutputLengthNotDerivable,
+         [](Model& m) { m.layers[0].outLength = 27; }},
+        {"pooling that changes the channel count", SchemaError::ChannelCountChanged,
+         [](Model& m) { m.layers[1].outChannels = 2; }},
+        {"dense without weights", SchemaError::MissingWeights,
+         [](Model& m) { m.layers[3].weights.rank = 0; }},
+        {"pooling carrying weights", SchemaError::UnexpectedWeights,
+         [](Model& m) { m.layers[1].weights = conv1d().weights; }},
+        {"dense without bias", SchemaError::MissingBias,
+         [](Model& m) { m.layers[3].bias.rank = 0; }},
+        {"weight matrix of the wrong width", SchemaError::WeightShapeMismatch,
+         [](Model& m) { m.layers[3].weights.shape[1] = 55; }},
+        {"bias of the wrong length", SchemaError::BiasShapeMismatch,
+         [](Model& m) { m.layers[3].bias.shape[0] = 2; }},
+        {"first layer not consuming inputLength", SchemaError::InputLengthMismatch,
+         [](Model& m) { m.inputLength = 64; }},
+        {"last layer not producing outputLength", SchemaError::OutputLengthMismatch,
+         [](Model& m) { m.outputLength = 5; }},
+        {"a break in the layer chain", SchemaError::LayerChainMismatch,
+         [](Model& m) {
+             // Kept internally consistent, so the dense layer itself still validates and only the
+             // seam between it and flatten is wrong.
+             m.layers[3].inLength = 55;
+             m.layers[3].weights.shape[1] = 55;
+         }},
+        {"scratch below the worst case", SchemaError::ScratchTooSmall,
+         [](Model& m) { m.maxScratchFloats = 10; }},
+        {"golden input of the wrong length", SchemaError::GoldenInputLengthMismatch,
+         [](Model& m) { m.goldenInput.resize(31); }},
+        {"golden output of the wrong length", SchemaError::GoldenOutputLengthMismatch,
+         [](Model& m) { m.goldenOutput.resize(4); }},
+    };
+    return cases;
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register referenceValidates{
+    "The reference architecture validates", "evidence-unit", [] {
+        return speclab::Test("ml-schema-reference-validates")
+            .Given("a Conv1D/MaxPool1D/Flatten/Dense package covering every v1 layer kind", [] {})
+            .When("it is validated", [] {})
+            .Then("no invariant is reported broken",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto error = errorOf(Model{});
+                      checks.expect(!error.has_value(),
+                                    error.has_value()
+                                        ? std::format("unexpected rejection: {}", describe(*error))
+                                        : "valid");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register wireSpellingsStable{
+    "LayerKind and Activation wire spellings are stable", "evidence-unit", [] {
+        return speclab::Test("ml-schema-wire-spellings-stable")
+            .Given("the published model package format", [] {})
+            .When("each enumerator is looked up by its numeric value", [] {})
+            .Then("the wire spellings are the published ones",
+                  [] {
+                      // These strings are the published package format; renaming one silently
+                      // invalidates every committed artifact that carries it.
+                      mdux::spec::Checks checks;
+                      checks.expect(layerKindWireValues[0] == "dense", "dense");
+                      checks.expect(layerKindWireValues[1] == "conv1d", "conv1d");
+                      checks.expect(layerKindWireValues[2] == "maxPool1d", "maxPool1d");
+                      checks.expect(layerKindWireValues[3] == "avgPool1d", "avgPool1d");
+                      checks.expect(layerKindWireValues[4] == "flatten", "flatten");
+                      checks.expect(activationWireValues[0] == "none", "none");
+                      checks.expect(activationWireValues[1] == "relu", "relu");
+                      checks.expect(activationWireValues[2] == "sigmoid", "sigmoid");
+                      checks.expect(activationWireValues[3] == "softmax", "softmax");
+                      checks.expect(packageKind == "model", "packageKind");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyInvariantRejects{
+    "Every schema invariant rejects the case that breaks it", "evidence-unit", [] {
+        // Validation is a pure function of the package, so there is nothing for a When to stage:
+        // the whole table runs in the Then, and Checks reports every mismatch rather than the
+        // first. A shared State here would also trip a GCC 16 -Warray-bounds false positive on
+        // make_shared of a struct holding a growing container.
+        return speclab::Test("ml-schema-invariants-reject")
+            .Given("the reference package and one mutation per invariant", [] {})
+            .When("each mutated package is validated", [] {})
+            .Then("each is rejected with its own diagnostic",
+                  [] {
+                      mdux::spec::Checks checks;
+                      for (const Rejection& rejection : rejections()) {
+                          Model model;
+                          rejection.breakIt(model);
+                          const auto actual = errorOf(model);
+                          if (!actual.has_value()) {
+                              checks.expect(false,
+                                            std::format("{}: accepted, expected {}", rejection.what,
+                                                        describe(rejection.expected)));
+                          } else {
+                              checks.expect(*actual == rejection.expected,
+                                            std::format("{}: got {}, expected {}", rejection.what,
+                                                        describe(*actual),
+                                                        describe(rejection.expected)));
+                          }
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register tensorArithmetic{
+    "TensorRef addresses the weight blob in f32 units", "evidence-unit", [] {
+        return speclab::Test("ml-schema-tensor-arithmetic")
+            .Given("present and absent tensor references", [] {})
+            .When("their element counts and byte ranges are computed", [] {})
+            .Then("an absent tensor occupies nothing and a present one is four bytes per element",
+                  [] {
+                      mdux::spec::Checks checks;
+                      constexpr TensorRef absent{};
+                      constexpr TensorRef conv{
+                          .byteOffset = 128, .shape = {4, 1, 5}, .rank = 3};
+
+                      checks.expect(!absent.present(), "rank 0 means absent");
+                      checks.expect(absent.byteLength() == 0, "an absent tensor occupies nothing");
+
+                      checks.expect(conv.present(), "rank 3 is present");
+                      checks.expect(conv.elementCount() == 20, "4 * 1 * 5 elements");
+                      checks.expect(conv.byteLength() == 80, "20 f32 is 80 bytes");
+                      checks.expect(conv.byteEnd() == 208, "128 + 80");
+
+                      // Dimensions past the rank are ignored, not multiplied in - a rank-1 bias
+                      // whose trailing shape entries are stale must still count its own length.
+                      constexpr TensorRef bias{.byteOffset = 0, .shape = {3, 7, 9}, .rank = 1};
+                      checks.expect(bias.elementCount() == 3, "only the first rank dims count");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register windowingArithmetic{
+    "Windowed output length and scratch follow one formula", "evidence-unit", [] {
+        return speclab::Test("ml-schema-windowing-arithmetic")
+            .Given("the v1 no-padding windowing rule", [] {})
+            .When("output lengths and scratch requirements are computed", [] {})
+            .Then("both agree with the values the baker and runtime must independently derive",
+                  [] {
+                      mdux::spec::Checks checks;
+                      checks.expect(windowedOutputLength(32, 5, 1) == 28, "k=5 s=1 over 32");
+                      checks.expect(windowedOutputLength(28, 2, 2) == 14, "k=2 s=2 over 28");
+                      checks.expect(windowedOutputLength(10, 3, 3) == 3,
+                                    "a trailing partial window is not evaluated");
+                      checks.expect(windowedOutputLength(4, 4, 1) == 1, "kernel exactly the input");
+
+                      // Rejected shapes return 0 rather than underflowing, which is what lets
+                      // validate() report KernelLargerThanInput instead of a vast outLength.
+                      checks.expect(windowedOutputLength(4, 5, 1) == 0, "kernel wider than input");
+                      checks.expect(windowedOutputLength(32, 0, 1) == 0, "zero kernel");
+                      checks.expect(windowedOutputLength(32, 5, 0) == 0, "zero stride");
+
+                      // Twice the largest activation the chain holds: conv1d's 28*4 = 112 here.
+                      const std::array<LayerDesc, 4> layers{conv1d(), maxPool1d(), flatten(),
+                                                            dense()};
+                      checks.expect(requiredScratchFloats(layers, 32) == 224,
+                                    "2 * 112 floats of scratch");
+
+                      // The input can be the largest activation in a shrinking network.
+                      const std::array<LayerDesc, 1> onlyDense{dense()};
+                      checks.expect(requiredScratchFloats(onlyDense, 56) == 112,
+                                    "2 * 56 when the input dominates");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+}  // namespace


### PR DESCRIPTION
The record every other part of epic #18 imports rather than restating.

Two choices worth the review time:

- **`TensorRef` holds a byte offset, not a pointer**, which is what lets a `ModelPackage` be `constexpr` while its weights live in a separately-supplied blob. A pointer would force multi-megabyte weights into generated source.
- **`GoldenVector` stores `u32` bit patterns, not floats**, because comparison has to be bitwise — an epsilon would accept exactly the FP drift the goldens exist to detect.

Header-only, so a generated package validates at compile time. The spec asserts that with a `static_assert` on the reference architecture, and gives every `SchemaError` a mutation that produces exactly it — 28 invariants, each breaking one field of an otherwise-valid package.

Stacked on #56.

Closes #57.