### PR TITLE
feat(ml): add mdux.ml.kernels, the arithmetic host and device share

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ code*; treat this subsection as the direction that code is moving in.
 | `mdux.governance`, `mdux.governance.compliance` | `include/mdux/governance/` | `src/governance/` |
 | `mdux.shader.schema` (governed) | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
 | `mdux.ml.schema` (governed) | `include/mdux/ml/Schema.cppm` | header-only |
+| `mdux.ml.kernels` (governed) | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
 | `mdux.draw` (governed) | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
 | `mdux.render.vulkan`, `mdux.render.offscreen` (adapter) | `include/mdux/render/` | `src/render/` |
 | `mdux.vulkansc.memory` | `include/mdux/vulkansc/MemoryPoolManager.cppm` | `src/vulkansc/MemoryPoolManager.cpp` |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,12 +157,14 @@ target_sources(MduXCore
             include/mdux/governance/Compliance.cppm
             include/mdux/shader/Schema.cppm
             include/mdux/ml/Schema.cppm
+            include/mdux/ml/Kernels.cppm
             include/mdux/draw/Draw.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
         src/evidence/Report.cpp
         src/shader/Schema.cpp
+        src/ml/Kernels.cpp
         src/draw/Draw.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp

--- a/docs/adr/ADR-008-zero-soup-ml-inference.md
+++ b/docs/adr/ADR-008-zero-soup-ml-inference.md
@@ -122,6 +122,22 @@ not sufficient (#59):
   configure step on `-ffast-math`, `-Ofast`, `-funsafe-math-optimizations` or `/fp:fast`. This is
   the guard that catches the change nobody thought was related to ML.
 
+There is a third, which only became visible once `Sigmoid` and `Softmax` were implemented:
+**`std::exp` cannot carry this claim.** Neither the C++ standard nor IEEE 754 requires a
+correctly-rounded `expf`, and glibc and the UCRT are different implementations. A golden vector
+containing a sigmoid or softmax output could therefore differ in its low bits between the Linux and
+Windows CI legs *while both compilers were behaving correctly* — which would break
+`ml.determinism.crossToolchain`, the strongest single piece of evidence in this epic.
+
+So `mdux.ml.kernels` provides its own `expF32()`: range reduction to `x = k·ln2 + r` followed by a
+degree-7 polynomial, using only IEEE-754 `f32` add, subtract, multiply and divide, an integer
+truncation for the floor, and an exponent built directly as a bit pattern. Every one of those is
+exactly specified, so the result is identical on any conforming toolchain. Note the floor is done
+by integer conversion rather than `std::floor` specifically so that the sentence below stays true. Accuracy is a few ULP against `std::exp`, which is irrelevant
+to a classifier — and, per the `std::fma` argument above, is emphatically not the property being
+maximised. This also removes libm from the device-side dependency argument entirely, which is
+consistent with the rest of the ADR rather than an exception to it.
+
 ### 4. Golden vectors baked into the package, re-run at construction, compared bitwise
 The baker generates golden input→output pairs by running the model through `mdux.ml.kernels` — the
 same governed module the device will execute — and stores them in the package as `u32` **bit

--- a/include/mdux/ml/Kernels.cppm
+++ b/include/mdux/ml/Kernels.cppm
@@ -1,0 +1,200 @@
+/**
+ * @file Kernels.cppm
+ * @brief Governed-zone ML kernels: the arithmetic both the device runtime and the host baker run.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (noexcept throughout, no throwing)
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * The single most safety-relevant file in the ML subsystem, and the one imported by *both* the
+ * device runtime (issue #62) and the host golden-vector generator (#61). Not a reference
+ * implementation and a production implementation - one module, one object file, one set of compile
+ * flags. If the host and the device disagree about what a model computes, that is the FPU or the
+ * toolchain, because there is no second implementation that could have drifted. See ADR-008,
+ * decision 1.
+ *
+ * ## The determinism rule
+ *
+ * Every accumulation happens in a single fixed order, using plain `f32` multiply-then-add:
+ *
+ * - **Conv1D** sums over input channel, then kernel tap.
+ * - **Dense** sums over input feature.
+ * - **AvgPool1D** sums over the window left to right, then divides by the window width.
+ *
+ * The accumulator starts at the bias where there is one, so the bias participates first. That is a
+ * choice, not a convention inherited from anywhere - and because it is a choice it is **normative**:
+ * moving the bias to the end changes the rounding and therefore the result.
+ *
+ * - **Never `std::fma`.** It rounds once where the scalar sequence rounds twice.
+ * - **Never SIMD intrinsics.** Same rounding problem, plus lane-order dependence in the reduction.
+ * - Plain readable loops. That is the specification, not a compromise pending optimisation.
+ *
+ * **Auto-vectorisation is not a hazard here, so do not "fix" it.** A compiler may not reorder a
+ * floating-point reduction without `-ffast-math`; `-O2` and `-O3` are safe and nobody should be
+ * lowering the optimisation level on these files out of superstition. What *is* a hazard is FP
+ * contraction, which is on by default and would fuse `acc += w * x` into an FMA regardless of the
+ * rule above - issue #59 sets `-ffp-contract=off` on this target for exactly that reason.
+ *
+ * ## Why there is a hand-written exponential
+ *
+ * `expF32()` exists because `std::exp` cannot carry the cross-toolchain claim. Neither the C++
+ * standard nor IEEE 754 requires a correctly-rounded `expf`, and glibc and the UCRT are different
+ * implementations - so a golden vector containing a `sigmoid` or `softmax` output could differ in
+ * its low bits between the Linux and Windows CI legs while both compilers were behaving correctly.
+ * That would break `ml.determinism.crossToolchain`, which is the strongest single piece of evidence
+ * in epic #18.
+ *
+ * `expF32()` uses only IEEE-754 `f32` add, subtract, multiply, divide, `floor` and an exponent
+ * construction by bit pattern - every one of which is exactly specified, so the result is identical
+ * on any conforming toolchain. Accuracy is a few ULP, which is irrelevant to a classifier and is
+ * emphatically not the property being maximised: a more accurate result that differs between host
+ * and device is worse than a slightly less accurate one that is identical on both.
+ *
+ * ## Buffer layout, which the baker must match exactly
+ *
+ * Activations with channels are **channel-major**: element `(c, i)` of a `[channels][length]`
+ * buffer is at `c * length + i`. Conv1D weights are `[outChannels][inChannels][kernelSize]`; dense
+ * weights are `[outFeatures][inFeatures]`. `Flatten` is therefore a straight copy - the
+ * channel-major buffer is already the flat vector a dense layer consumes, in that order.
+ *
+ * ## What these functions do and do not check
+ *
+ * Each takes a validated `LayerDesc` and checks only that the spans it was handed match the sizes
+ * that descriptor implies, returning `false` if not. That guard runs once per layer, never in an
+ * inner loop. It is a misuse check, not a validation layer: `ModelPackage::validate()` is what
+ * establishes that the descriptor itself is coherent.
+ *
+ * No allocation, no recursion, no VLAs, `noexcept` throughout - so the whole file is usable under
+ * `-fno-exceptions` and satisfies issue #63's no-heap requirement by construction.
+ */
+module;
+
+export module mdux.ml.kernels;
+
+import std;
+import mdux.ml.schema;
+
+export namespace mdux::ml {
+
+/**
+ * @brief A deterministic `f32` exponential, bit-identical across conforming toolchains.
+ *
+ * See the module comment for why `std::exp` is not used. Range reduction `x = k*ln2 + r` followed
+ * by a degree-7 Taylor polynomial on `|r| <= ln2/2`, reconstructed by building `2^k` directly as a
+ * bit pattern.
+ *
+ * Saturates rather than producing a denormal: `x >= 88.0f` returns infinity and `x <= -88.0f`
+ * returns zero. Flushing there keeps the exponent construction inside the normal range, where
+ * building `2^k` as a bit pattern is exact.
+ *
+ * The lower limit is genuinely reachable and the saturation is load-bearing, not defensive: after
+ * softmax subtracts the maximum every input is <= 0, but a confident model produces logits far
+ * apart, so `{0, -100}` reduces to an input of -100. That saturates to zero, which is the correct
+ * probability to four decimal places and the correct *bit pattern* on every toolchain - where a
+ * denormal result would be neither. The upper limit is the unreachable one: after the subtraction
+ * no input exceeds 0.
+ *
+ * NaN propagates.
+ */
+[[nodiscard]] float expF32(float x) noexcept;
+
+/**
+ * @brief `output[o] = bias[o] + sum over i of weights[o][i] * input[i]`.
+ *
+ * Accumulates over input feature in increasing order, starting from the bias. Normative - see the
+ * module comment.
+ *
+ * @return false if any span disagrees with the sizes `layer` implies.
+ */
+[[nodiscard]] bool dense(const LayerDesc& layer, std::span<const float> input,
+                         std::span<const float> weights, std::span<const float> bias,
+                         std::span<float> output) noexcept;
+
+/**
+ * @brief 1-D convolution with no padding.
+ *
+ * `output[oc][ox] = bias[oc] + sum over ic, then k, of weights[oc][ic][k] * input[ic][ox*stride+k]`.
+ *
+ * Accumulates over input channel first, then kernel tap, starting from the bias. Normative.
+ *
+ * @return false if any span disagrees with the sizes `layer` implies.
+ */
+[[nodiscard]] bool conv1d(const LayerDesc& layer, std::span<const float> input,
+                          std::span<const float> weights, std::span<const float> bias,
+                          std::span<float> output) noexcept;
+
+/**
+ * @brief Windowed maximum, per channel, with no padding.
+ *
+ * Scans each window left to right keeping the first strictly-greater value, so a tie takes the
+ * earlier element and the traversal order is fixed. A NaN in the window does not displace a
+ * previous value, since every comparison against it is false.
+ *
+ * @return false if any span disagrees with the sizes `layer` implies.
+ */
+[[nodiscard]] bool maxPool1d(const LayerDesc& layer, std::span<const float> input,
+                             std::span<float> output) noexcept;
+
+/**
+ * @brief Windowed mean, per channel, with no padding.
+ *
+ * Sums the window left to right, then divides by the window width. Division rather than
+ * multiplication by a reciprocal: IEEE division is correctly rounded, and `x * (1/n)` is not the
+ * same value.
+ *
+ * @return false if any span disagrees with the sizes `layer` implies.
+ */
+[[nodiscard]] bool avgPool1d(const LayerDesc& layer, std::span<const float> input,
+                             std::span<float> output) noexcept;
+
+/**
+ * @brief Reshape `[channels][length]` to a flat vector.
+ *
+ * A straight copy: the channel-major buffer is already in the order a dense layer consumes. It
+ * exists as a kernel rather than being elided so that the layer chain has one uniform shape, and
+ * so a future non-contiguous layout has one place to change.
+ *
+ * @return false if any span disagrees with the sizes `layer` implies.
+ */
+[[nodiscard]] bool flatten(const LayerDesc& layer, std::span<const float> input,
+                           std::span<float> output) noexcept;
+
+/// `max(0, x)` in place. A NaN is left as it is: the comparison is false, so nothing replaces it.
+void relu(std::span<float> values) noexcept;
+
+/// `1 / (1 + exp(-x))` in place, through expF32().
+void sigmoid(std::span<float> values) noexcept;
+
+/**
+ * @brief Softmax in place over the whole span.
+ *
+ * Subtracts the maximum before exponentiating - the standard guard against overflow, and required
+ * here because expF32() saturates. Sums in increasing index order, then divides.
+ *
+ * Applied over the entire output vector, which is only meaningful on a final dense layer. v1 has
+ * no notion of a softmax axis.
+ */
+void softmax(std::span<float> values) noexcept;
+
+/**
+ * @brief Applies `activation` in place, dispatching to the functions above.
+ *
+ * `Activation::None` leaves the span untouched.
+ */
+void applyActivation(Activation activation, std::span<float> values) noexcept;
+
+/**
+ * @brief Runs one layer: the kernel for its kind, then its activation.
+ *
+ * The single entry point the runtime and the golden generator both call, so neither can dispatch
+ * differently from the other.
+ *
+ * @param weights the layer's weight tensor as floats, empty for a layer that carries none
+ * @param bias    the layer's bias tensor as floats, empty for a layer that carries none
+ * @return false if any span disagrees with the sizes `layer` implies.
+ */
+[[nodiscard]] bool applyLayer(const LayerDesc& layer, std::span<const float> input,
+                              std::span<const float> weights, std::span<const float> bias,
+                              std::span<float> output) noexcept;
+
+}  // namespace mdux::ml

--- a/src/ml/Kernels.cpp
+++ b/src/ml/Kernels.cpp
@@ -1,0 +1,324 @@
+/**
+ * @file Kernels.cpp
+ * @brief The v1 kernel set. Read the module comment in Kernels.cppm before changing anything here.
+ *
+ * @compliance ADR-005 Error handling and exceptions policy (noexcept throughout, no throwing)
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Every loop below is written in a fixed order on purpose. The plainness is the specification: a
+ * reader has to be able to see the accumulation order, and a golden-vector mismatch has to mean
+ * "the toolchain or the FPU differs", not "one of two implementations drifted".
+ */
+module;
+
+module mdux.ml.kernels;
+
+import std;
+import mdux.ml.schema;
+
+namespace mdux::ml {
+namespace {
+
+/// Number of floats a tensor holds, or 0 when the layer carries none.
+[[nodiscard]] std::size_t tensorFloats(const TensorRef& tensor) noexcept {
+    return tensor.present() ? static_cast<std::size_t>(tensor.elementCount()) : 0;
+}
+
+/// The size guard every kernel runs once, before touching an element. See Kernels.cppm on why this
+/// is a misuse check rather than a validation layer.
+[[nodiscard]] bool spansMatch(const LayerDesc& layer, std::span<const float> input,
+                              std::span<const float> weights, std::span<const float> bias,
+                              std::span<float> output) noexcept {
+    return input.size() == layer.inputFloats() && output.size() == layer.outputFloats() &&
+           weights.size() == tensorFloats(layer.weights) && bias.size() == tensorFloats(layer.bias);
+}
+
+// --- expF32 constants -------------------------------------------------------
+//
+// ln2 is split so the range reduction stays accurate: ln2Hi is exactly representable in f32 (its
+// low mantissa bits are zero), so `kf * ln2Hi` is exact for the small integers k takes here, and
+// the whole rounding error of the reduction lives in the much smaller ln2Lo term.
+
+constexpr float invLn2 = 1.44269504088896340736f;
+constexpr float ln2Hi = 0.693145751953125f;         // 0x3F317200, exact in f32
+constexpr float ln2Lo = 1.42860676533018e-06f;      // the remainder of ln2
+constexpr float expUpperLimit = 88.0f;              // above this an f32 result would overflow
+constexpr float expLowerLimit = -88.0f;             // below this the result is flushed to zero
+
+}  // namespace
+
+float expF32(float x) noexcept {
+    // NaN first, and not merely as an optimisation. Without this guard the comparisons below are
+    // all false, so control would reach the range reduction, and `static_cast<int>` of a NaN is
+    // undefined behaviour - not a harmless zero. NaN handling is part of the determinism story,
+    // so it is decided here rather than left to whatever the cast happens to do.
+    if (x != x) {
+        return x;
+    }
+    if (x >= expUpperLimit) {
+        return std::numeric_limits<float>::infinity();
+    }
+    if (x <= expLowerLimit) {
+        return 0.0f;
+    }
+
+    // x = k*ln2 + r, with |r| <= ln2/2.
+    //
+    // The floor is done by integer truncation rather than std::floor. Both are exact, but
+    // std::floor is a libm entry point, and ADR-008 claims this function removes libm from the
+    // device-side dependency argument - a claim that would be false with a libm call in it. The
+    // limits above bound the argument to roughly +/-127, so the conversion cannot overflow int.
+    const float scaled = x * invLn2 + 0.5f;
+    int k = static_cast<int>(scaled);  // truncates toward zero
+    if (static_cast<float>(k) > scaled) {
+        --k;  // trunc == floor for non-negative values; below zero it is one too high
+    }
+    const float kf = static_cast<float>(k);
+    const float r = (x - kf * ln2Hi) - kf * ln2Lo;
+
+    // exp(r) by Taylor series, Horner form, in this order. Degree 7 leaves the truncation error
+    // near 5e-9 relative over |r| <= 0.3466, comfortably below f32 epsilon.
+    constexpr float c2 = 1.0f / 2.0f;
+    constexpr float c3 = 1.0f / 6.0f;
+    constexpr float c4 = 1.0f / 24.0f;
+    constexpr float c5 = 1.0f / 120.0f;
+    constexpr float c6 = 1.0f / 720.0f;
+    constexpr float c7 = 1.0f / 5040.0f;
+
+    float poly = c7;
+    poly = poly * r + c6;
+    poly = poly * r + c5;
+    poly = poly * r + c4;
+    poly = poly * r + c3;
+    poly = poly * r + c2;
+    poly = poly * r + 1.0f;
+    poly = poly * r + 1.0f;
+
+    // 2^k built directly as a bit pattern rather than via std::ldexp, which is another libm entry
+    // point this function exists to avoid depending on. k is bounded by the limits above, so the
+    // biased exponent is always in the normal range and this is exact.
+    const std::uint32_t biased = static_cast<std::uint32_t>(k + 127) << 23;
+    const float scale = std::bit_cast<float>(biased);
+
+    return poly * scale;
+}
+
+bool dense(const LayerDesc& layer, std::span<const float> input, std::span<const float> weights,
+           std::span<const float> bias, std::span<float> output) noexcept {
+    if (layer.kind != LayerKind::Dense || !spansMatch(layer, input, weights, bias, output)) {
+        return false;
+    }
+
+    const std::size_t inFeatures = layer.inLength;
+    const std::size_t outFeatures = layer.outLength;
+
+    for (std::size_t o = 0; o < outFeatures; ++o) {
+        // The accumulator starts at the bias, so the bias participates first. Normative.
+        float acc = bias[o];
+        const std::size_t row = o * inFeatures;
+        // Sums over input feature, increasing. Normative.
+        for (std::size_t i = 0; i < inFeatures; ++i) {
+            acc += weights[row + i] * input[i];
+        }
+        output[o] = acc;
+    }
+    return true;
+}
+
+bool conv1d(const LayerDesc& layer, std::span<const float> input, std::span<const float> weights,
+            std::span<const float> bias, std::span<float> output) noexcept {
+    if (layer.kind != LayerKind::Conv1d || !spansMatch(layer, input, weights, bias, output)) {
+        return false;
+    }
+
+    const std::size_t inLength = layer.inLength;
+    const std::size_t inChannels = layer.inChannels;
+    const std::size_t outLength = layer.outLength;
+    const std::size_t outChannels = layer.outChannels;
+    const std::size_t kernelSize = layer.kernelSize;
+    const std::size_t stride = layer.stride;
+
+    for (std::size_t oc = 0; oc < outChannels; ++oc) {
+        const std::size_t filterBase = oc * inChannels * kernelSize;
+        for (std::size_t ox = 0; ox < outLength; ++ox) {
+            const std::size_t windowStart = ox * stride;
+            // Bias first, then input channel, then kernel tap. Normative - see Kernels.cppm.
+            float acc = bias[oc];
+            for (std::size_t ic = 0; ic < inChannels; ++ic) {
+                const std::size_t weightBase = filterBase + ic * kernelSize;
+                const std::size_t inputBase = ic * inLength + windowStart;
+                for (std::size_t k = 0; k < kernelSize; ++k) {
+                    acc += weights[weightBase + k] * input[inputBase + k];
+                }
+            }
+            output[oc * outLength + ox] = acc;
+        }
+    }
+    return true;
+}
+
+bool maxPool1d(const LayerDesc& layer, std::span<const float> input,
+               std::span<float> output) noexcept {
+    if (layer.kind != LayerKind::MaxPool1d || !spansMatch(layer, input, {}, {}, output)) {
+        return false;
+    }
+
+    const std::size_t inLength = layer.inLength;
+    const std::size_t outLength = layer.outLength;
+    const std::size_t kernelSize = layer.kernelSize;
+    const std::size_t stride = layer.stride;
+
+    for (std::size_t c = 0; c < layer.inChannels; ++c) {
+        const std::size_t inputBase = c * inLength;
+        for (std::size_t ox = 0; ox < outLength; ++ox) {
+            const std::size_t windowStart = inputBase + ox * stride;
+            float best = input[windowStart];
+            // Strictly-greater keeps the earliest of equal values and leaves a NaN in place,
+            // because every comparison against a NaN is false. Fixed left-to-right order.
+            for (std::size_t k = 1; k < kernelSize; ++k) {
+                const float candidate = input[windowStart + k];
+                if (candidate > best) {
+                    best = candidate;
+                }
+            }
+            output[c * outLength + ox] = best;
+        }
+    }
+    return true;
+}
+
+bool avgPool1d(const LayerDesc& layer, std::span<const float> input,
+               std::span<float> output) noexcept {
+    if (layer.kind != LayerKind::AvgPool1d || !spansMatch(layer, input, {}, {}, output)) {
+        return false;
+    }
+
+    const std::size_t inLength = layer.inLength;
+    const std::size_t outLength = layer.outLength;
+    const std::size_t kernelSize = layer.kernelSize;
+    const std::size_t stride = layer.stride;
+    const float window = static_cast<float>(kernelSize);
+
+    for (std::size_t c = 0; c < layer.inChannels; ++c) {
+        const std::size_t inputBase = c * inLength;
+        for (std::size_t ox = 0; ox < outLength; ++ox) {
+            const std::size_t windowStart = inputBase + ox * stride;
+            float acc = 0.0f;
+            // Left to right. Normative.
+            for (std::size_t k = 0; k < kernelSize; ++k) {
+                acc += input[windowStart + k];
+            }
+            // Division, not multiplication by a reciprocal - see Kernels.cppm.
+            output[c * outLength + ox] = acc / window;
+        }
+    }
+    return true;
+}
+
+bool flatten(const LayerDesc& layer, std::span<const float> input,
+             std::span<float> output) noexcept {
+    if (layer.kind != LayerKind::Flatten || !spansMatch(layer, input, {}, {}, output)) {
+        return false;
+    }
+    for (std::size_t i = 0; i < input.size(); ++i) {
+        output[i] = input[i];
+    }
+    return true;
+}
+
+void relu(std::span<float> values) noexcept {
+    for (float& value : values) {
+        // Not std::max: a NaN must survive, and max's argument order would decide that silently.
+        if (value < 0.0f) {
+            value = 0.0f;
+        }
+    }
+}
+
+void sigmoid(std::span<float> values) noexcept {
+    for (float& value : values) {
+        value = 1.0f / (1.0f + expF32(-value));
+    }
+}
+
+void softmax(std::span<float> values) noexcept {
+    if (values.empty()) {
+        return;
+    }
+
+    // Subtract the maximum before exponentiating: the standard overflow guard, and required here
+    // because expF32() saturates at +/-88.
+    float largest = values[0];
+    for (std::size_t i = 1; i < values.size(); ++i) {
+        if (values[i] > largest) {
+            largest = values[i];
+        }
+    }
+
+    float total = 0.0f;
+    for (float& value : values) {
+        value = expF32(value - largest);
+        total += value;  // increasing index order, normative
+    }
+
+    if (total == 0.0f) {
+        // Every input saturated to zero, which only happens for a degenerate span. A uniform
+        // distribution is the honest answer and keeps the output a probability vector rather than
+        // returning NaNs from a division by zero.
+        const float uniform = 1.0f / static_cast<float>(values.size());
+        for (float& value : values) {
+            value = uniform;
+        }
+        return;
+    }
+
+    for (float& value : values) {
+        value = value / total;
+    }
+}
+
+void applyActivation(Activation activation, std::span<float> values) noexcept {
+    switch (activation) {
+        case Activation::None:
+            break;
+        case Activation::Relu:
+            relu(values);
+            break;
+        case Activation::Sigmoid:
+            sigmoid(values);
+            break;
+        case Activation::Softmax:
+            softmax(values);
+            break;
+    }
+}
+
+bool applyLayer(const LayerDesc& layer, std::span<const float> input,
+                std::span<const float> weights, std::span<const float> bias,
+                std::span<float> output) noexcept {
+    bool ok = false;
+    switch (layer.kind) {
+        case LayerKind::Dense:
+            ok = dense(layer, input, weights, bias, output);
+            break;
+        case LayerKind::Conv1d:
+            ok = conv1d(layer, input, weights, bias, output);
+            break;
+        case LayerKind::MaxPool1d:
+            ok = maxPool1d(layer, input, output);
+            break;
+        case LayerKind::AvgPool1d:
+            ok = avgPool1d(layer, input, output);
+            break;
+        case LayerKind::Flatten:
+            ok = flatten(layer, input, output);
+            break;
+    }
+    if (!ok) {
+        return false;
+    }
+    applyActivation(layer.activation, output);
+    return true;
+}
+
+}  // namespace mdux::ml

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -518,6 +518,7 @@ mdux_discover_tests(tools_spec)
 add_executable(ml_spec
     ml/MlSpecMain.cpp
     ml/SchemaTests.cpp
+    ml/KernelTests.cpp
 )
 
 target_link_libraries(ml_spec PRIVATE MduX::Core speclab::speclab)

--- a/tests/ml/KernelTests.cpp
+++ b/tests/ml/KernelTests.cpp
@@ -1,0 +1,514 @@
+/**
+ * @file KernelTests.cpp
+ * @brief BDD scenarios for mdux.ml.kernels (issue #58).
+ *
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Every kernel case below uses values that are exact in `f32`, so the expectations are equality -
+ * a tolerance there would hide the drift these kernels exist to make visible.
+ *
+ * Two scenarios deliberately do use a tolerance, and the distinction matters. `expF32` is compared
+ * against `std::exp`, and softmax against a sum of 1.0: in both, the reference is something this
+ * code is explicitly *not* required to match bit for bit. Where a comparison is bitwise, it is
+ * written as a bit-pattern equality so nobody has to guess which kind it is.
+ *
+ * The scenario that matters most is `accumulationOrderIsNormative`. It does not freeze a bit
+ * pattern taken from the implementation, which would bless whatever the code happened to do.
+ * Instead it picks data where `f32` addition is provably non-associative, states the value the
+ * documented order must produce, and separately asserts that the opposite order produces a
+ * different one - so the test is demonstrably sensitive to the property it claims to check.
+ */
+
+import std;
+import speclab;
+import mdux.ml.schema;
+import mdux.ml.kernels;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+using namespace mdux::ml;
+
+/// Bit pattern of a float, so an expectation can talk about exact values.
+[[nodiscard]] std::uint32_t bitsOf(float value) noexcept {
+    return std::bit_cast<std::uint32_t>(value);
+}
+
+[[nodiscard]] bool sameBits(float a, float b) noexcept {
+    return bitsOf(a) == bitsOf(b);
+}
+
+/// Formats a mismatch so a failure names both values and both bit patterns.
+[[nodiscard]] std::string mismatch(std::string_view what, float actual, float expected) {
+    return std::format("{}: got {} (0x{:08X}), expected {} (0x{:08X})", what, actual, bitsOf(actual),
+                       expected, bitsOf(expected));
+}
+
+/// Checks a whole output buffer against hand-computed values, bit for bit.
+void expectExact(mdux::spec::Checks& checks, std::string_view what, std::span<const float> actual,
+                 std::span<const float> expected) {
+    if (actual.size() != expected.size()) {
+        checks.expect(false, std::format("{}: size {}, expected {}", what, actual.size(),
+                                         expected.size()));
+        return;
+    }
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        checks.expect(sameBits(actual[i], expected[i]),
+                      mismatch(std::format("{}[{}]", what, i), actual[i], expected[i]));
+    }
+}
+
+constexpr TensorRef weightsRef(std::array<std::uint32_t, 3> shape, std::uint8_t rank) noexcept {
+    return TensorRef{.byteOffset = 0, .shape = shape, .rank = rank};
+}
+
+// ---------------------------------------------------------------------------
+// Dense
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register denseComputesHandCheckedValues{
+    "Dense computes its hand-checked values exactly", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-dense")
+            .Given("a 3->2 dense layer whose weights and inputs are exact in f32", [] {})
+            .When("it is applied", [] {})
+            .Then("every output matches the hand-computed value bit for bit",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const LayerDesc layer{.kind = LayerKind::Dense,
+                                            .activation = Activation::None,
+                                            .inLength = 3,
+                                            .inChannels = 1,
+                                            .outLength = 2,
+                                            .outChannels = 1,
+                                            .kernelSize = 0,
+                                            .stride = 0,
+                                            .weights = weightsRef({2, 3, 0}, 2),
+                                            .bias = weightsRef({2, 0, 0}, 1)};
+
+                      const std::array<float, 3> input{1.0f, 2.0f, 3.0f};
+                      // Row-major [outFeatures][inFeatures].
+                      const std::array<float, 6> weights{1.0f, 0.0f, -1.0f, 0.5f, 0.5f, 0.5f};
+                      const std::array<float, 2> bias{10.0f, -1.0f};
+                      std::array<float, 2> output{};
+
+                      checks.expect(dense(layer, input, weights, bias, output), "dense accepted");
+
+                      // out[0] = 10 + 1*1 + 0*2 + (-1)*3 = 8
+                      // out[1] = -1 + 0.5*1 + 0.5*2 + 0.5*3 = 2
+                      const std::array<float, 2> expected{8.0f, 2.0f};
+                      expectExact(checks, "dense", output, expected);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Conv1D
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register conv1dSingleChannel{
+    "Conv1D slides a single-channel kernel", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-conv1d-single-channel")
+            .Given("a length-5 signal and a 3-tap filter with stride 1", [] {})
+            .When("the convolution is applied", [] {})
+            .Then("each window matches the hand-computed value",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const LayerDesc layer{.kind = LayerKind::Conv1d,
+                                            .activation = Activation::None,
+                                            .inLength = 5,
+                                            .inChannels = 1,
+                                            .outLength = 3,
+                                            .outChannels = 1,
+                                            .kernelSize = 3,
+                                            .stride = 1,
+                                            .weights = weightsRef({1, 1, 3}, 3),
+                                            .bias = weightsRef({1, 0, 0}, 1)};
+
+                      const std::array<float, 5> input{1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+                      const std::array<float, 3> weights{1.0f, 2.0f, 3.0f};
+                      const std::array<float, 1> bias{0.5f};
+                      std::array<float, 3> output{};
+
+                      checks.expect(conv1d(layer, input, weights, bias, output), "conv1d accepted");
+
+                      // 0.5 + (1*1 + 2*2 + 3*3) = 14.5
+                      // 0.5 + (1*2 + 2*3 + 3*4) = 20.5
+                      // 0.5 + (1*3 + 2*4 + 3*5) = 26.5
+                      const std::array<float, 3> expected{14.5f, 20.5f, 26.5f};
+                      expectExact(checks, "conv1d", output, expected);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register conv1dMultiChannelStrided{
+    "Conv1D sums across channels and honours stride", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-conv1d-multi-channel")
+            .Given("a 2-channel signal, a 2-tap filter and stride 2", [] {})
+            .When("the convolution is applied", [] {})
+            .Then("each output is the sum over both channels of its own window",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const LayerDesc layer{.kind = LayerKind::Conv1d,
+                                            .activation = Activation::None,
+                                            .inLength = 4,
+                                            .inChannels = 2,
+                                            .outLength = 2,
+                                            .outChannels = 1,
+                                            .kernelSize = 2,
+                                            .stride = 2,
+                                            .weights = weightsRef({1, 2, 2}, 3),
+                                            .bias = weightsRef({1, 0, 0}, 1)};
+
+                      // Channel-major: channel 0 then channel 1.
+                      const std::array<float, 8> input{1.0f, 2.0f, 3.0f, 4.0f,
+                                                       10.0f, 20.0f, 30.0f, 40.0f};
+                      // [outChannel][inChannel][tap]
+                      const std::array<float, 4> weights{1.0f, 1.0f, 0.5f, 0.5f};
+                      const std::array<float, 1> bias{0.0f};
+                      std::array<float, 2> output{};
+
+                      checks.expect(conv1d(layer, input, weights, bias, output), "conv1d accepted");
+
+                      // window 0: (1+2) + 0.5*(10+20) = 3 + 15 = 18
+                      // window 1: (3+4) + 0.5*(30+40) = 7 + 35 = 42
+                      const std::array<float, 2> expected{18.0f, 42.0f};
+                      expectExact(checks, "conv1d strided", output, expected);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// The order test - the one that fails if anybody reorders an accumulation
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register accumulationOrderIsNormative{
+    "Conv1D's accumulation order is normative and observable", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-accumulation-order")
+            .Given("a window where f32 addition is provably non-associative", [] {})
+            .When("the documented order and the reverse order are both evaluated", [] {})
+            .Then("the kernel produces the documented order's value, and the orders differ",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // 1e-8f is far below ulp(1.0f)/2 = 5.96e-8, so adding it to 1.0f changes
+                      // nothing. Seven of them summed first come to 7e-8, which is *above* that
+                      // half-ulp and does round 1.0f up. The two orders therefore disagree, which
+                      // is what makes this test sensitive rather than decorative.
+                      constexpr float tiny = 1e-8f;
+                      const LayerDesc layer{.kind = LayerKind::Conv1d,
+                                            .activation = Activation::None,
+                                            .inLength = 8,
+                                            .inChannels = 1,
+                                            .outLength = 1,
+                                            .outChannels = 1,
+                                            .kernelSize = 8,
+                                            .stride = 1,
+                                            .weights = weightsRef({1, 1, 8}, 3),
+                                            .bias = weightsRef({1, 0, 0}, 1)};
+
+                      const std::array<float, 8> input{1.0f, tiny, tiny, tiny,
+                                                       tiny, tiny, tiny, tiny};
+                      const std::array<float, 8> weights{1.0f, 1.0f, 1.0f, 1.0f,
+                                                         1.0f, 1.0f, 1.0f, 1.0f};
+                      const std::array<float, 1> bias{0.0f};
+                      std::array<float, 1> output{};
+
+                      checks.expect(conv1d(layer, input, weights, bias, output), "conv1d accepted");
+
+                      // Increasing tap index, which is what Kernels.cppm declares normative: the
+                      // large value lands first and every tiny addend is then absorbed.
+                      float forward = bias[0];
+                      for (std::size_t k = 0; k < input.size(); ++k) {
+                          forward += weights[k] * input[k];
+                      }
+
+                      // The same arithmetic, taps descending.
+                      float reverse = bias[0];
+                      for (std::size_t k = input.size(); k-- > 0;) {
+                          reverse += weights[k] * input[k];
+                      }
+
+                      checks.expect(sameBits(forward, 1.0f),
+                                    mismatch("forward order", forward, 1.0f));
+                      checks.expect(!sameBits(forward, reverse),
+                                    std::format("the two orders must differ, both gave 0x{:08X}",
+                                                bitsOf(forward)));
+                      checks.expect(sameBits(output[0], forward),
+                                    mismatch("kernel output", output[0], forward));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Pooling and flatten
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register poolingKernels{
+    "Pooling reduces each channel's windows independently", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-pooling")
+            .Given("a 2-channel length-4 activation with a width-2 stride-2 window", [] {})
+            .When("max and average pooling are applied", [] {})
+            .Then("each channel is reduced on its own, in place",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const std::array<float, 8> input{1.0f, 5.0f, 3.0f, 2.0f,
+                                                       9.0f, 7.0f, 8.0f, 6.0f};
+
+                      LayerDesc layer{.kind = LayerKind::MaxPool1d,
+                                      .activation = Activation::None,
+                                      .inLength = 4,
+                                      .inChannels = 2,
+                                      .outLength = 2,
+                                      .outChannels = 2,
+                                      .kernelSize = 2,
+                                      .stride = 2,
+                                      .weights = TensorRef{},
+                                      .bias = TensorRef{}};
+
+                      std::array<float, 4> maxOut{};
+                      checks.expect(maxPool1d(layer, input, maxOut), "maxPool1d accepted");
+                      const std::array<float, 4> expectedMax{5.0f, 3.0f, 9.0f, 8.0f};
+                      expectExact(checks, "maxPool1d", maxOut, expectedMax);
+
+                      layer.kind = LayerKind::AvgPool1d;
+                      std::array<float, 4> avgOut{};
+                      checks.expect(avgPool1d(layer, input, avgOut), "avgPool1d accepted");
+                      // (1+5)/2, (3+2)/2, (9+7)/2, (8+6)/2
+                      const std::array<float, 4> expectedAvg{3.0f, 2.5f, 8.0f, 7.0f};
+                      expectExact(checks, "avgPool1d", avgOut, expectedAvg);
+
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register flattenPreservesChannelMajorOrder{
+    "Flatten preserves the channel-major order a dense layer expects", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-flatten")
+            .Given("a 2-channel length-3 activation", [] {})
+            .When("it is flattened", [] {})
+            .Then("the flat vector is the buffer unchanged, channel by channel",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const LayerDesc layer{.kind = LayerKind::Flatten,
+                                            .activation = Activation::None,
+                                            .inLength = 3,
+                                            .inChannels = 2,
+                                            .outLength = 6,
+                                            .outChannels = 1,
+                                            .kernelSize = 0,
+                                            .stride = 0,
+                                            .weights = TensorRef{},
+                                            .bias = TensorRef{}};
+
+                      const std::array<float, 6> input{1.0f, 2.0f, 3.0f, 40.0f, 50.0f, 60.0f};
+                      std::array<float, 6> output{};
+
+                      checks.expect(flatten(layer, input, output), "flatten accepted");
+                      expectExact(checks, "flatten", output, input);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Activations
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register activationsBehave{
+    "Activations behave at their defining points", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-activations")
+            .Given("values around each activation's interesting points", [] {})
+            .When("the activations are applied in place", [] {})
+            .Then("the defining identities hold exactly",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      std::array<float, 4> reluValues{-1.0f, 0.0f, 2.0f, -0.5f};
+                      relu(reluValues);
+                      const std::array<float, 4> expectedRelu{0.0f, 0.0f, 2.0f, 0.0f};
+                      expectExact(checks, "relu", reluValues, expectedRelu);
+
+                      // sigmoid(0) = 1/(1+exp(0)) = 1/2, exactly, whatever expF32 does elsewhere.
+                      std::array<float, 1> sigmoidValues{0.0f};
+                      sigmoid(sigmoidValues);
+                      checks.expect(sameBits(sigmoidValues[0], 0.5f),
+                                    mismatch("sigmoid(0)", sigmoidValues[0], 0.5f));
+
+                      // Equal logits give a uniform distribution, and 1/3 is the same float three
+                      // times over regardless of rounding.
+                      std::array<float, 3> softmaxValues{1.0f, 1.0f, 1.0f};
+                      softmax(softmaxValues);
+                      checks.expect(sameBits(softmaxValues[0], softmaxValues[1]) &&
+                                        sameBits(softmaxValues[1], softmaxValues[2]),
+                                    "equal logits give equal probabilities");
+                      const float total = (softmaxValues[0] + softmaxValues[1]) + softmaxValues[2];
+                      checks.expect(std::fabs(total - 1.0f) < 1e-6f,
+                                    std::format("softmax sums to {}", total));
+
+                      // Softmax is shift-invariant, and the max subtraction is what makes a large
+                      // shift survive at all rather than saturating expF32.
+                      std::array<float, 3> shifted{101.0f, 101.0f, 101.0f};
+                      softmax(shifted);
+                      checks.expect(sameBits(shifted[0], softmaxValues[0]),
+                                    mismatch("softmax shift invariance", shifted[0],
+                                             softmaxValues[0]));
+
+                      // Ordering must survive: the largest logit keeps the largest probability.
+                      std::array<float, 3> ordered{0.0f, 2.0f, 1.0f};
+                      softmax(ordered);
+                      checks.expect(ordered[1] > ordered[2] && ordered[2] > ordered[0],
+                                    "softmax preserves the ordering of its logits");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register deterministicExponential{
+    "expF32 is accurate, saturating, and free of libm", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-exp")
+            .Given("the hand-written f32 exponential", [] {})
+            .When("it is evaluated across its range and at its limits", [] {})
+            .Then("it tracks std::exp closely and saturates rather than producing a denormal",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // exp(0) = 1 exactly: the range reduction gives k = 0, r = 0, and the
+                      // polynomial's constant term is 1.
+                      checks.expect(sameBits(expF32(0.0f), 1.0f),
+                                    mismatch("expF32(0)", expF32(0.0f), 1.0f));
+
+                      // Accuracy is checked against std::exp as a reference, with a tolerance -
+                      // this is the one place a tolerance is right, because the two are deliberately
+                      // *not* required to agree bit for bit. See Kernels.cppm.
+                      constexpr std::array<float, 9> samples{-20.0f, -7.5f, -2.5f, -0.333f, 0.1f,
+                                                             1.0f,   3.7f,  7.125f, 20.0f};
+                      for (float x : samples) {
+                          const float actual = expF32(x);
+                          const float reference = std::exp(x);
+                          const float relative =
+                              std::fabs(actual - reference) / std::fabs(reference);
+                          checks.expect(relative < 1e-6f,
+                                        std::format("expF32({}) = {} vs std::exp {} (rel {})", x,
+                                                    actual, reference, relative));
+                      }
+
+                      checks.expect(std::isinf(expF32(100.0f)) && expF32(100.0f) > 0.0f,
+                                    "expF32 saturates to +inf above its upper limit");
+                      checks.expect(sameBits(expF32(-100.0f), 0.0f),
+                                    mismatch("expF32(-100)", expF32(-100.0f), 0.0f));
+                      checks.expect(std::isnan(expF32(std::numeric_limits<float>::quiet_NaN())),
+                                    "NaN propagates");
+
+                      // Monotonicity across the reduction boundaries, where a range-reduction bug
+                      // would show up as a step in the wrong direction.
+                      bool monotonic = true;
+                      float previous = expF32(-5.0f);
+                      for (float x = -5.0f + 0.125f; x <= 5.0f; x += 0.125f) {
+                          const float current = expF32(x);
+                          monotonic = monotonic && (current > previous);
+                          previous = current;
+                      }
+                      checks.expect(monotonic, "expF32 is monotonic across reduction boundaries");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Misuse
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register mismatchedSpansRejected{
+    "A span that disagrees with the descriptor is rejected", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-span-guard")
+            .Given("a valid dense descriptor and buffers of the wrong size", [] {})
+            .When("each kernel is called", [] {})
+            .Then("it refuses rather than reading past the end",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const LayerDesc layer{.kind = LayerKind::Dense,
+                                            .activation = Activation::None,
+                                            .inLength = 3,
+                                            .inChannels = 1,
+                                            .outLength = 2,
+                                            .outChannels = 1,
+                                            .kernelSize = 0,
+                                            .stride = 0,
+                                            .weights = weightsRef({2, 3, 0}, 2),
+                                            .bias = weightsRef({2, 0, 0}, 1)};
+
+                      const std::array<float, 3> input{1.0f, 2.0f, 3.0f};
+                      const std::array<float, 6> weights{};
+                      const std::array<float, 2> bias{};
+                      std::array<float, 2> output{};
+
+                      const std::array<float, 2> shortInput{};
+                      const std::array<float, 3> shortWeights{};
+                      std::array<float, 1> shortOutput{};
+
+                      checks.expect(!dense(layer, shortInput, weights, bias, output),
+                                    "short input rejected");
+                      checks.expect(!dense(layer, input, shortWeights, bias, output),
+                                    "short weight matrix rejected");
+                      checks.expect(!dense(layer, input, weights, bias, shortOutput),
+                                    "short output rejected");
+
+                      // A kernel called for the wrong layer kind refuses too, so a dispatch bug
+                      // surfaces here rather than as silently wrong arithmetic.
+                      checks.expect(!conv1d(layer, input, weights, bias, output),
+                                    "conv1d refuses a dense descriptor");
+                      checks.expect(dense(layer, input, weights, bias, output),
+                                    "the correctly-sized call still succeeds");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register applyLayerDispatches{
+    "applyLayer runs the kernel and then the activation", "evidence-unit", [] {
+        return speclab::Test("ml-kernels-apply-layer")
+            .Given("a dense layer carrying a relu", [] {})
+            .When("applyLayer runs it", [] {})
+            .Then("the activation has been applied to the kernel's output",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const LayerDesc layer{.kind = LayerKind::Dense,
+                                            .activation = Activation::Relu,
+                                            .inLength = 2,
+                                            .inChannels = 1,
+                                            .outLength = 2,
+                                            .outChannels = 1,
+                                            .kernelSize = 0,
+                                            .stride = 0,
+                                            .weights = weightsRef({2, 2, 0}, 2),
+                                            .bias = weightsRef({2, 0, 0}, 1)};
+
+                      const std::array<float, 2> input{1.0f, 1.0f};
+                      // Row 0 sums to 3, row 1 sums to -3.
+                      const std::array<float, 4> weights{1.0f, 2.0f, -1.0f, -2.0f};
+                      const std::array<float, 2> bias{0.0f, 0.0f};
+                      std::array<float, 2> output{};
+
+                      checks.expect(applyLayer(layer, input, weights, bias, output),
+                                    "applyLayer accepted");
+                      const std::array<float, 2> expected{3.0f, 0.0f};
+                      expectExact(checks, "applyLayer", output, expected);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+}  // namespace


### PR DESCRIPTION
Dense, Conv1D, MaxPool1D, AvgPool1D, Flatten and the relu/sigmoid/softmax activations, as plain scalar loops in a fixed accumulation order. One module, imported by both the runtime and the host golden generator.

**Includes a hand-written `expF32()`, which the issue did not ask for.** `std::exp` cannot carry the cross-toolchain claim: neither the standard nor IEEE 754 requires a correctly-rounded `expf`, and glibc and the UCRT are different implementations — so a golden vector holding a softmax output could differ between the two CI legs *while both compilers were correct*. `expF32` uses only exactly-specified f32 operations and is a few ULP from `std::exp`, which is the wrong property to maximise here anyway. ADR-008 is amended to record it.

The accumulation-order spec is the one worth reading. Rather than freezing a bit pattern taken from the implementation — which would bless whatever the code happened to do — it picks a window where f32 addition is provably non-associative, states the value the documented order must give, and asserts the reverse order gives a different one.

Stacked on #57.

Closes #58.