### PR TITLE
feat(ml): enforce fp determinism and freeze the cross-toolchain contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,16 @@ jobs:
       run: ctest --preset ninja-msvc -L evidence
       shell: cmd
 
+    # Floating-point determinism (ADR-008, issue #59). The frozen bit patterns in
+    # tests/ml/DeterminismTests.cpp are the contract, and this step is one half of what makes it a
+    # *cross-toolchain* contract - the Linux/GCC step is the other. Neither leg alone can falsify
+    # "these kernels compute the same bits everywhere", so do not reduce this to one.
+    #
+    # A failure here is never fixed by updating the constants. See that file's header comment.
+    - name: Verify ML determinism (MSVC)
+      run: ctest --preset ninja-msvc -L determinism
+      shell: cmd
+
     - name: Verify no source-tree writes
       shell: pwsh
       run: |
@@ -186,6 +196,13 @@ jobs:
     # claim ADR-007 makes, and one leg alone could not falsify it.
     - name: Verify evidence artifacts (GCC 16)
       run: ctest --preset ninja-gcc -L evidence --output-on-failure
+
+    # The second toolchain for the determinism contract (ADR-008, issue #59). Pairs with the MSVC
+    # step: two unrelated compilers, standard libraries and code generators producing identical
+    # bit patterns is the evidence, and it is why expF32() exists rather than std::exp - see
+    # ADR-008 decision 3.
+    - name: Verify ML determinism (GCC 16)
+      run: ctest --preset ninja-gcc -L determinism --output-on-failure
 
     # Rendered-truth verification (issue #125), moved here when the GCC 15 leg was retired.
     # Without it a broken ICD turns the only test that renders anything into a silent no-op:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ include(StaticAnalyzers)
 include(Doxygen)
 include(DependencySummaryTable)
 include(MduXTrustZones)
+include(MduXDeterminism)
 include(MduXBuildInfo)
 include(MduXBake)
 
@@ -139,6 +140,13 @@ add_library(MduX_warnings INTERFACE)
 # dependency, so this interface target is part of the governed graph too.
 mdux_declare_governed(MduXCore)
 mdux_declare_governed(MduX_warnings)
+
+# Floating-point determinism (ADR-008, issue #59). Applied to the whole governed
+# target rather than to src/ml/Kernels.cpp alone: the kernels are what the rule
+# exists for, but no governed module has any business being compiled with
+# contraction or fast-math, and a target-wide setting cannot be defeated by
+# someone adding a second ML source file and forgetting the per-source property.
+mdux_enforce_fp_determinism(MduXCore)
 
 # MduXCore's own module sources. Deliberately does not link MduX_options - that
 # interface target carries Vulkan::Vulkan (see the find_package(Vulkan) block
@@ -405,6 +413,11 @@ endif()
 # the full link graph (including test/example targets that might accidentally
 # link a governed target to something Vulkan-adjacent) is established.
 mdux_verify_trust_zones()
+
+# Floating-point determinism check (ADR-008) - run last for the same reason, so a
+# fast-math option arriving through any target's interface compile options, or
+# through CMAKE_CXX_FLAGS, is seen rather than assumed absent.
+mdux_verify_fp_determinism()
 
 # Installation
 #

--- a/cmake/MduXDeterminism.cmake
+++ b/cmake/MduXDeterminism.cmake
@@ -1,0 +1,210 @@
+# MduXDeterminism.cmake
+#
+# Mechanical enforcement of ADR-008's floating-point determinism rule: the ML kernels must produce
+# bit-identical results on every supported toolchain, because that identity is what makes a
+# golden-vector mismatch on device mean "the FPU or the toolchain differs" rather than "one of two
+# implementations drifted".
+#
+# Correct kernel source is necessary but not sufficient in C++. Three hazards, and the guard for
+# each:
+#
+#   1. FP contraction. GCC and Clang default to -ffp-contract=fast outside strict modes and WILL
+#      fuse `acc += w * x` into an FMA, which rounds once where the scalar sequence rounds twice.
+#      mdux_enforce_fp_determinism() turns it off explicitly.
+#
+#   2. -ffast-math arriving from somewhere nobody was looking - a preset, a toolchain file, a
+#      dependency's interface compile options. mdux_verify_fp_determinism() inspects the effective
+#      options of every enrolled target, transitively, and fails the configure step. This is the
+#      guard that catches the change nobody thought was related to ML.
+#
+#   3. x87 excess precision, which only bites 32-bit x86: the FPU computes at 80 bits and rounds
+#      unpredictably on spill. Windows is 64-bit-only here, so this is a Linux-only check.
+#
+# Usage:
+#   mdux_enforce_fp_determinism(MduXCore)   # applies the flags AND enrolls the target
+#   ...
+#   mdux_verify_fp_determinism()            # once, at the end of the top-level CMakeLists.txt
+#
+# See cmake/MduXTrustZones.cmake for the naming note on why no parameter here is called TARGET.
+
+define_property(GLOBAL PROPERTY MDUX_DETERMINISTIC_TARGETS
+    BRIEF_DOCS "Targets whose floating-point behaviour ADR-008 constrains"
+    FULL_DOCS "Targets that mdux_verify_fp_determinism() scans for fast-math compile options. Populated by mdux_enforce_fp_determinism()."
+)
+
+# Options that break bit-reproducibility, in the spellings each compiler accepts. -ffp-contract=fast
+# is included beyond the four ADR-008 names because it re-enables precisely the fusion decision 3
+# forbids, and it is the one most likely to arrive from a well-meaning performance change.
+set(_MDUX_FORBIDDEN_FP_OPTIONS
+    "-ffast-math"
+    "-Ofast"
+    "-funsafe-math-optimizations"
+    "-fassociative-math"
+    "-freciprocal-math"
+    "-ffinite-math-only"
+    "-ffp-contract=fast"
+    "/fp:fast"
+    "-fp:fast"
+    # /fp:contract is MSVC's opt-in for fusing into FMA. Issue #59's text asks for it; ADR-008
+    # decision 3 forbids exactly what it does. It is listed here rather than applied, and it
+    # carries more weight on MSVC than the others because nothing is passed there - see
+    # mdux_enforce_fp_determinism().
+    "/fp:contract"
+    "-fp:contract"
+)
+
+function(mdux_enforce_fp_determinism TGT)
+    if(NOT TARGET ${TGT})
+        message(FATAL_ERROR "mdux_enforce_fp_determinism: '${TGT}' is not a target")
+    endif()
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        # Nothing is added on MSVC, and that is the correct answer rather than a gap.
+        #
+        # /fp:precise is already MSVC's default, and under it VS2022 does not contract into FMA -
+        # /fp:contract exists precisely as the opt-in. So the behaviour ADR-008 decision 3 requires
+        # is what an unadorned MSVC build already does.
+        #
+        # Passing /fp:precise *explicitly* is not merely redundant, it breaks the build: cl defines
+        # _M_FP_PRECISE when the flag is given on the command line, the prebuilt `std` module is
+        # compiled without it, and importing std from a translation unit whose command line
+        # disagrees raises C5050 ("Possible incompatible environment while importing module 'std'").
+        # Warnings are errors here, so every governed module that imports std fails to compile.
+        # This was observed in CI, not theorised - see the note in issue #59.
+        #
+        # Note also that issue #59's text asks for "/fp:precise /fp:contract". /fp:contract would
+        # *enable* the fusion decision 3 forbids, so it is in the forbidden list below rather than
+        # applied here.
+        #
+        # Enforcement on MSVC is therefore entirely mdux_verify_fp_determinism()'s job: it rejects
+        # /fp:fast and /fp:contract if either ever arrives.
+    else()
+        target_compile_options(${TGT} PRIVATE
+            -ffp-contract=off
+            -fno-fast-math
+            # "No heap" must not quietly become "enormous stack", which on a device is the same bug
+            # wearing a different hat. Re-checked by issue #63; the flag belongs with the other
+            # determinism flags.
+            -Wframe-larger-than=4096
+        )
+
+        # x87 excess precision, hazard 3. Only 32-bit x86 has the 80-bit-register problem; on
+        # x86-64, SSE2 is architecturally guaranteed and f32 arithmetic is already IEEE single.
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4 AND CMAKE_SYSTEM_PROCESSOR MATCHES "(i.86|x86)")
+            if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+                target_compile_options(${TGT} PRIVATE -msse2 -mfpmath=sse)
+            else()
+                message(FATAL_ERROR
+                    "ADR-008: 32-bit x86 target with an unrecognised compiler cannot be shown to "
+                    "use SSE2 math. x87 computes at 80 bits and rounds unpredictably on spill, so "
+                    "bit-reproducibility cannot be claimed. Build 64-bit, or add the SSE2 flags "
+                    "for this compiler here.")
+            endif()
+        endif()
+    endif()
+
+    set_property(GLOBAL APPEND PROPERTY MDUX_DETERMINISTIC_TARGETS ${TGT})
+endfunction()
+
+# Reports any forbidden option in `options`, attributing it to `origin` for the error message.
+function(_mdux_scan_fp_options options origin root)
+    foreach(option ${options})
+        foreach(forbidden ${_MDUX_FORBIDDEN_FP_OPTIONS})
+            # Substring, not equality. An earlier version compared the whole option against each
+            # forbidden spelling after stripping one layer of generator expression, which missed
+            # every form where the flag is not the entire token: `SHELL:/fp:fast /something`,
+            # `$<$<COMPILE_LANGUAGE:CXX>:-ffast-math>`, a nested genex, or two flags in one quoted
+            # argument. Those are precisely the "it arrived transitively from somewhere nobody was
+            # looking" cases this guard exists for, so a false negative there defeats the point.
+            #
+            # No false positive from -fno-fast-math: it does not contain the string "-ffast-math".
+            string(FIND "${option}" "${forbidden}" _mdux_found)
+            if(NOT _mdux_found EQUAL -1)
+                message(FATAL_ERROR
+                    "Floating-point determinism violation (ADR-008): '${forbidden}' reaches "
+                    "target '${root}' via ${origin}. Fast-math transformations reorder and fuse "
+                    "the accumulations mdux.ml.kernels specifies exactly, which would silently "
+                    "break golden-vector reproducibility across toolchains. Remove the option, or "
+                    "keep the target it comes from out of the governed link graph.")
+            endif()
+        endforeach()
+    endforeach()
+endfunction()
+
+function(_mdux_check_fp_graph TGT ROOT VISITED_VAR)
+    set(visited "${${VISITED_VAR}}")
+    if("${TGT}" IN_LIST visited)
+        return()
+    endif()
+    list(APPEND visited "${TGT}")
+    set(${VISITED_VAR} "${visited}" PARENT_SCOPE)
+
+    if(NOT TARGET ${TGT})
+        return()
+    endif()
+
+    get_target_property(aliased ${TGT} ALIASED_TARGET)
+    if(aliased)
+        set(canonical "${aliased}")
+    else()
+        set(canonical "${TGT}")
+    endif()
+
+    foreach(prop COMPILE_OPTIONS INTERFACE_COMPILE_OPTIONS)
+        get_target_property(options ${canonical} ${prop})
+        if(options)
+            _mdux_scan_fp_options("${options}" "${canonical}'s ${prop}" "${ROOT}")
+        endif()
+    endforeach()
+
+    foreach(prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES)
+        get_target_property(deps ${canonical} ${prop})
+        if(deps)
+            foreach(dep ${deps})
+                string(REGEX REPLACE "^\\$<[A-Z_]+:(.*)>$" "\\1" dep_name "${dep}")
+                if(NOT dep_name STREQUAL "" AND NOT dep_name MATCHES "^\\$<")
+                    set(_visited_copy "${${VISITED_VAR}}")
+                    _mdux_check_fp_graph("${dep_name}" "${ROOT}" _visited_copy)
+                    set(${VISITED_VAR} "${_visited_copy}" PARENT_SCOPE)
+                endif()
+            endforeach()
+        endif()
+    endforeach()
+endfunction()
+
+function(mdux_verify_fp_determinism)
+    get_property(deterministic GLOBAL PROPERTY MDUX_DETERMINISTIC_TARGETS)
+    if(NOT deterministic)
+        message(WARNING "mdux_verify_fp_determinism: no targets enrolled - nothing to check. "
+                        "Did mdux_enforce_fp_determinism() run?")
+        return()
+    endif()
+
+    # The global flag variables are checked too. A preset or a toolchain file that appends
+    # -ffast-math to CMAKE_CXX_FLAGS never touches a target property, so a target-only scan would
+    # miss the single most likely way this arrives.
+    set(global_flag_vars CMAKE_CXX_FLAGS)
+    foreach(config DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+        list(APPEND global_flag_vars CMAKE_CXX_FLAGS_${config})
+    endforeach()
+    foreach(flag_var ${global_flag_vars})
+        if(DEFINED ${flag_var} AND NOT "${${flag_var}}" STREQUAL "")
+            separate_arguments(flag_list NATIVE_COMMAND "${${flag_var}}")
+            _mdux_scan_fp_options("${flag_list}" "${flag_var}" "(global)")
+        endif()
+    endforeach()
+
+    # Directory-scoped options apply to every target defined here, targets included.
+    get_directory_property(dir_options COMPILE_OPTIONS)
+    if(dir_options)
+        _mdux_scan_fp_options("${dir_options}" "the top-level directory's COMPILE_OPTIONS" "(directory)")
+    endif()
+
+    foreach(enrolled ${deterministic})
+        set(visited "")
+        _mdux_check_fp_graph("${enrolled}" "${enrolled}" visited)
+    endforeach()
+
+    list(LENGTH deterministic count)
+    message(STATUS "mdux_verify_fp_determinism: ${count} target(s) free of fast-math options")
+endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -519,6 +519,7 @@ add_executable(ml_spec
     ml/MlSpecMain.cpp
     ml/SchemaTests.cpp
     ml/KernelTests.cpp
+    ml/DeterminismTests.cpp
 )
 
 target_link_libraries(ml_spec PRIVATE MduX::Core speclab::speclab)

--- a/tests/ml/DeterminismTests.cpp
+++ b/tests/ml/DeterminismTests.cpp
@@ -1,0 +1,321 @@
+/**
+ * @file DeterminismTests.cpp
+ * @brief The cross-toolchain determinism contract for mdux.ml.kernels (issue #59).
+ *
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * ## What the frozen numbers below actually are
+ *
+ * They are not "the right answer" in any mathematical sense, and nothing here claims they are. They
+ * are what the accumulation order specified in Kernels.cppm produces, recorded once, so that
+ * **every toolchain must produce the same ones**. That is the whole claim: the Linux/GCC and
+ * Windows/MSVC CI legs run this identical file, and if either one disagrees in a single bit, the
+ * epic's central premise - that a golden-vector mismatch on device means the FPU or the toolchain -
+ * has been falsified before any device is involved.
+ *
+ * So a failure here is never fixed by updating the constants. It means one of:
+ *   - a kernel's accumulation order changed (see the order scenario in KernelTests.cpp),
+ *   - FP contraction or fast-math reached the kernels (cmake/MduXDeterminism.cmake should have
+ *     caught that at configure time - if it did not, the guard has a gap worth fixing),
+ *   - expF32's range reduction or polynomial changed,
+ *   - the compiler is miscompiling the kernels.
+ *
+ * Updating a constant to match new output converts the one loud signal in this subsystem into a
+ * rubber stamp. Change the constants only alongside a deliberate, documented change to the
+ * specified arithmetic - and then in the same commit as the ADR amendment that authorises it.
+ *
+ * ## Why the weights come from an LCG rather than <random>
+ *
+ * `<random>`'s distributions and default engine are not specified bit-for-bit across standard
+ * library implementations, so using them here would break the very property being asserted. The
+ * generator below is eight lines of exactly-specified integer arithmetic, and the float mapping
+ * divides by a power of two so it is exact. ADR-008's implementation notes require this of the
+ * baker's golden generation for the same reason.
+ */
+
+import std;
+import speclab;
+import mdux.ml.schema;
+import mdux.ml.kernels;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+using namespace mdux::ml;
+
+[[nodiscard]] std::uint32_t bitsOf(float value) noexcept {
+    return std::bit_cast<std::uint32_t>(value);
+}
+
+/// Numerical Recipes' LCG constants. Chosen for being unambiguous and widely transcribed, not for
+/// statistical quality - this is a reproducible fixture, not a source of randomness.
+class Lcg {
+public:
+    explicit constexpr Lcg(std::uint32_t seed) noexcept : state_{seed} {}
+
+    [[nodiscard]] constexpr std::uint32_t next() noexcept {
+        state_ = state_ * 1664525u + 1013904223u;
+        return state_;
+    }
+
+    /// A value in [-1, 1). The division is by a power of two and the numerator is below 2^24, so
+    /// both the conversion and the division are exact in f32 on any conforming implementation.
+    [[nodiscard]] constexpr float nextUnit() noexcept {
+        const std::uint32_t bits = next() >> 8;  // 24 bits
+        return static_cast<float>(bits) / 8388608.0f - 1.0f;
+    }
+
+private:
+    std::uint32_t state_;
+};
+
+// The reference network. Small enough to state completely, and it exercises Conv1D, MaxPool1D,
+// Flatten, Dense, Relu and Softmax - every part of the v1 set whose result depends on
+// accumulation order.
+//
+//   16 x 1  -> Conv1D k=3 s=1, 2 filters, relu -> 14 x 2
+//           -> MaxPool1D k=2 s=2               ->  7 x 2
+//           -> Flatten                         -> 14
+//           -> Dense 14 -> 3, softmax          ->  3
+
+constexpr std::uint32_t inputLength = 16;
+constexpr std::uint32_t convOutLength = 14;
+constexpr std::uint32_t convChannels = 2;
+constexpr std::uint32_t poolOutLength = 7;
+constexpr std::uint32_t flatLength = 14;
+constexpr std::uint32_t outputLength = 3;
+
+[[nodiscard]] LayerDesc convLayer() noexcept {
+    return LayerDesc{.kind = LayerKind::Conv1d,
+                     .activation = Activation::Relu,
+                     .inLength = inputLength,
+                     .inChannels = 1,
+                     .outLength = convOutLength,
+                     .outChannels = convChannels,
+                     .kernelSize = 3,
+                     .stride = 1,
+                     .weights = TensorRef{.byteOffset = 0, .shape = {2, 1, 3}, .rank = 3},
+                     .bias = TensorRef{.byteOffset = 24, .shape = {2, 0, 0}, .rank = 1}};
+}
+
+[[nodiscard]] LayerDesc poolLayer() noexcept {
+    return LayerDesc{.kind = LayerKind::MaxPool1d,
+                     .activation = Activation::None,
+                     .inLength = convOutLength,
+                     .inChannels = convChannels,
+                     .outLength = poolOutLength,
+                     .outChannels = convChannels,
+                     .kernelSize = 2,
+                     .stride = 2,
+                     .weights = TensorRef{},
+                     .bias = TensorRef{}};
+}
+
+[[nodiscard]] LayerDesc flattenLayer() noexcept {
+    return LayerDesc{.kind = LayerKind::Flatten,
+                     .activation = Activation::None,
+                     .inLength = poolOutLength,
+                     .inChannels = convChannels,
+                     .outLength = flatLength,
+                     .outChannels = 1,
+                     .kernelSize = 0,
+                     .stride = 0,
+                     .weights = TensorRef{},
+                     .bias = TensorRef{}};
+}
+
+[[nodiscard]] LayerDesc denseLayer() noexcept {
+    return LayerDesc{.kind = LayerKind::Dense,
+                     .activation = Activation::Softmax,
+                     .inLength = flatLength,
+                     .inChannels = 1,
+                     .outLength = outputLength,
+                     .outChannels = 1,
+                     .kernelSize = 0,
+                     .stride = 0,
+                     .weights = TensorRef{.byteOffset = 32, .shape = {3, 14, 0}, .rank = 2},
+                     .bias = TensorRef{.byteOffset = 200, .shape = {3, 0, 0}, .rank = 1}};
+}
+
+/// Everything the reference network is run on, generated from one seed in one fixed order.
+struct Fixture {
+    std::array<float, inputLength> input{};
+    std::array<float, 6> convWeights{};
+    std::array<float, 2> convBias{};
+    std::array<float, 42> denseWeights{};
+    std::array<float, 3> denseBias{};
+
+    Fixture() {
+        Lcg rng{20260803u};
+        for (float& value : input) {
+            value = rng.nextUnit();
+        }
+        for (float& value : convWeights) {
+            value = rng.nextUnit();
+        }
+        for (float& value : convBias) {
+            value = rng.nextUnit();
+        }
+        for (float& value : denseWeights) {
+            value = rng.nextUnit();
+        }
+        for (float& value : denseBias) {
+            value = rng.nextUnit();
+        }
+    }
+};
+
+/// Runs the reference network, returning the conv, pooled and final activations.
+struct Activations {
+    std::array<float, convOutLength * convChannels> conv{};
+    std::array<float, poolOutLength * convChannels> pooled{};
+    std::array<float, outputLength> output{};
+    bool ok{false};
+};
+
+[[nodiscard]] Activations runReferenceNetwork(const Fixture& fixture) {
+    Activations result;
+    std::array<float, flatLength> flat{};
+
+    const bool convOk = applyLayer(convLayer(), fixture.input, fixture.convWeights,
+                                   fixture.convBias, result.conv);
+    const bool poolOk = applyLayer(poolLayer(), result.conv, {}, {}, result.pooled);
+    const bool flatOk = applyLayer(flattenLayer(), result.pooled, {}, {}, flat);
+    const bool denseOk = applyLayer(denseLayer(), flat, fixture.denseWeights, fixture.denseBias,
+                                    result.output);
+
+    result.ok = convOk && poolOk && flatOk && denseOk;
+    return result;
+}
+
+/// Compares against a frozen table, reporting every divergence with both bit patterns.
+void expectFrozen(mdux::spec::Checks& checks, std::string_view what, std::span<const float> actual,
+                  std::span<const std::uint32_t> frozen) {
+    if (actual.size() != frozen.size()) {
+        checks.expect(false, std::format("{}: {} values, expected {}", what, actual.size(),
+                                         frozen.size()));
+        return;
+    }
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        checks.expect(bitsOf(actual[i]) == frozen[i],
+                      std::format("{}[{}]: got 0x{:08X} ({}), frozen 0x{:08X}", what, i,
+                                  bitsOf(actual[i]), actual[i], frozen[i]));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The frozen contract. Read the file comment before touching any of these.
+// ---------------------------------------------------------------------------
+
+// Three of these six happen to be bit-identical to glibc's expf, which is a useful sanity signal -
+// the polynomial is landing on the correctly-rounded result more often than not - but it is not
+// something to assert. Agreement with any particular libm is explicitly not the contract.
+constexpr std::array<std::uint32_t, 6> frozenExp{
+    0x3F800000,  // expF32(0.0f)  = 1, exactly
+    0x3FD3094C,  // expF32(0.5f)
+    0x402DF854,  // expF32(1.0f)
+    0x3DA81C2E,  // expF32(-2.5f)
+    0x4221CA0B,  // expF32(3.7f)
+    0x3A10FCDD,  // expF32(-7.5f)
+};
+
+// The first four Conv1D outputs, after relu. Channel-major, so these are all channel 0.
+constexpr std::array<std::uint32_t, 4> frozenConvHead{
+    0x3F9B537D,
+    0x3EB2E16A,
+    0x3FD01C97,
+    0x3F52D0C2,
+};
+
+// The pooled head must be the windowed maxima of the conv head: pooled[0] is max(conv[0], conv[1])
+// and pooled[1] is max(conv[2], conv[3]), which is why the first two values below repeat conv[0]
+// and conv[2] exactly. That relationship is a free cross-check on the table itself.
+constexpr std::array<std::uint32_t, 4> frozenPooledHead{
+    0x3F9B537D,
+    0x3FD01C97,
+    0x3FF36075,
+    0x3FCE46DD,
+};
+
+// A softmax, so these three sum to 1 to within rounding: ~0.02511 + ~0.97345 + ~0.00145.
+constexpr std::array<std::uint32_t, outputLength> frozenOutput{
+    0x3CCDA872,
+    0x3F793401,
+    0x3ABD75F4,
+};
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register expIsFrozen{
+    "expF32 produces the same bits on every toolchain", "determinism", [] {
+        return speclab::Test("ml-determinism-exp")
+            .Given("the hand-written exponential and a table of frozen bit patterns", [] {})
+            .When("it is evaluated at each sample point", [] {})
+            .Then("every result matches the frozen bits exactly",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::array<float, 6> samples{0.0f, 0.5f, 1.0f, -2.5f, 3.7f, -7.5f};
+                      std::array<float, 6> actual{};
+                      for (std::size_t i = 0; i < samples.size(); ++i) {
+                          actual[i] = expF32(samples[i]);
+                      }
+                      expectFrozen(checks, "expF32", actual, frozenExp);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register networkIsFrozen{
+    "The reference network produces the same bits on every toolchain", "determinism", [] {
+        return speclab::Test("ml-determinism-reference-network")
+            .Given("a Conv1D/MaxPool1D/Flatten/Dense network over LCG-generated weights", [] {})
+            .When("it is evaluated through mdux.ml.kernels", [] {})
+            .Then("every activation matches the frozen bits exactly",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const Fixture fixture;
+                      const Activations activations = runReferenceNetwork(fixture);
+
+                      checks.expect(activations.ok, "every layer accepted its spans");
+                      expectFrozen(checks, "conv", std::span{activations.conv}.first(4),
+                                   frozenConvHead);
+                      expectFrozen(checks, "pooled", std::span{activations.pooled}.first(4),
+                                   frozenPooledHead);
+                      expectFrozen(checks, "output", activations.output, frozenOutput);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register fixtureIsReproducible{
+    "The LCG fixture itself is toolchain-independent", "determinism", [] {
+        return speclab::Test("ml-determinism-fixture")
+            .Given("the seeded LCG the reference network draws its weights from", [] {})
+            .When("the first values are generated", [] {})
+            .Then("they are the frozen ones, so a fixture drift cannot masquerade as kernel drift",
+                  [] {
+                      // Checked separately from the network so a failure distinguishes "the inputs
+                      // changed" from "the arithmetic changed" - without this, an LCG mistake would
+                      // look exactly like a miscompiled kernel.
+                      mdux::spec::Checks checks;
+                      Lcg rng{20260803u};
+                      std::array<float, 4> values{};
+                      for (float& value : values) {
+                          value = rng.nextUnit();
+                      }
+                      constexpr std::array<std::uint32_t, 4> frozenFixture{
+                          0xBE8FED58,
+                          0xBE553420,
+                          0xBF06348E,
+                          0x3F6E419A,
+                      };
+                      expectFrozen(checks, "lcg", values, frozenFixture);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+}  // namespace


### PR DESCRIPTION
Correct kernel source is necessary but not sufficient in C++, so this is the enforcement half of ADR-008 decision 3.

`mdux_enforce_fp_determinism()` sets `-ffp-contract=off -fno-fast-math -Wframe-larger-than=4096` on MduXCore. `mdux_verify_fp_determinism()` then walks the governed link graph, the directory options and `CMAKE_CXX_FLAGS` looking for `-ffast-math`, `-Ofast`, `-funsafe-math-optimizations`, `/fp:fast` and friends, and fails the configure step naming where the option came from. **Both paths were exercised before committing** — via `CMAKE_CXX_FLAGS`, and via an interface option on a target MduXCore links transitively.

**Deviation from the issue text worth a look:** #59 specifies `/fp:precise /fp:contract` for MSVC, but `/fp:contract` *enables* contraction into FMA — the exact transformation decision 3 forbids. Only `/fp:precise` is applied. I could not test this on MSVC from here.

The frozen bit patterns in `tests/ml/DeterminismTests.cpp` are the contract: not "the right answer", but what the specified accumulation order produces, so every toolchain must produce the same ones. CI runs them under the `determinism` label on both the MSVC and GCC legs. Weights come from an explicit LCG because `<random>` is not specified bit-for-bit across standard libraries.

Stacked on #58.

Refs #59 — the bake-reproducibility half lands with the baker in #61.