### PR TITLE
feat(ml): add Classifier1D with its fail-closed golden self-test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ code*; treat this subsection as the direction that code is moving in.
 | `mdux.shader.schema` (governed) | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
 | `mdux.ml.schema` (governed) | `include/mdux/ml/Schema.cppm` | header-only |
 | `mdux.ml.kernels` (governed) | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
+| `mdux.ml.runtime` (governed) | `include/mdux/ml/Runtime.cppm` | `src/ml/Runtime.cpp` |
 | `mdux.draw` (governed) | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
 | `mdux.render.vulkan`, `mdux.render.offscreen` (adapter) | `include/mdux/render/` | `src/render/` |
 | `mdux.vulkansc.memory` | `include/mdux/vulkansc/MemoryPoolManager.cppm` | `src/vulkansc/MemoryPoolManager.cpp` |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ target_sources(MduXCore
             include/mdux/shader/Schema.cppm
             include/mdux/ml/Schema.cppm
             include/mdux/ml/Kernels.cppm
+            include/mdux/ml/Runtime.cppm
             include/mdux/draw/Draw.cppm
     PRIVATE
         src/evidence/Digest.cpp
@@ -173,6 +174,7 @@ target_sources(MduXCore
         src/evidence/Report.cpp
         src/shader/Schema.cpp
         src/ml/Kernels.cpp
+        src/ml/Runtime.cpp
         src/draw/Draw.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp

--- a/include/mdux/ml/Runtime.cppm
+++ b/include/mdux/ml/Runtime.cppm
@@ -1,0 +1,171 @@
+/**
+ * @file Runtime.cppm
+ * @brief Governed-zone ML runtime: the device-side classifier, and its fail-closed self-test.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * No file I/O, no dynamic graph construction, no allocation in `predict()`.
+ *
+ * ## Weights are caller-supplied, deliberately
+ *
+ * A real model is megabytes. A multi-megabyte `constexpr` array takes minutes to compile and can
+ * exhaust MSVC, so the weights are never part of the package object: the caller mmaps them, reads
+ * them from ROM or flash, or links a blob in via `mdux_embed_blob()` (issue #64). The runtime does
+ * no I/O at all, which is what makes it usable on a device with no filesystem.
+ *
+ * ## create() fails closed, in this order
+ *
+ * 1. Validate the package against `mdux.ml.schema`, `schemaVersion` included.
+ * 2. Verify `sha256(weights) == pkg.weightsDigest`. This is the mechanism that makes "weights are
+ *    data" safe: without it, "the caller supplies the weights" would mean "anything can be loaded".
+ * 3. Check `scratch.size() >= pkg.maxScratchFloats`.
+ * 4. Require **at least one** golden vector.
+ * 5. **Re-run every golden vector through the real kernels and compare bit patterns.**
+ *
+ * Step 4 exists because step 5 is vacuously satisfied by a package carrying no goldens, and a
+ * vacuous safety control is worse than an absent one - it reports success. `mdux.ml.schema`
+ * deliberately *accepts* an empty golden set, because the baker validates a package's architecture
+ * before it has generated any; the requirement belongs here, at the point where an unverified model
+ * would actually be executed.
+ *
+ * Step 4 is a genuine Class C safety control, not a unit test that happens to run late. It detects
+ * toolchain miscompilation, target floating-point drift, and a corrupted or mismatched package
+ * *before the device ever classifies a real signal*. It costs bounded startup work and nothing per
+ * frame.
+ *
+ * Any failure returns an error and the `Classifier1D` is never constructed, so there is no
+ * partially-trustworthy object a caller can hold. That is the difference between failing closed and
+ * failing degraded.
+ *
+ * ## MlError carries evidence, not just a code
+ *
+ * When a device fails closed in the field, `MlError` *is* the determinism evidence record: which
+ * layer, which golden, which element, and the two bit patterns that disagreed. A bare enum would
+ * throw away exactly the information the incident report needs, and the divergence is not
+ * reproducible on the bench by definition - if it were, CI would have caught it.
+ */
+module;
+
+export module mdux.ml.runtime;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.ml.schema;
+
+export namespace mdux::ml {
+
+/**
+ * @brief Why a classifier refused to be constructed, or a prediction refused to run.
+ *
+ * The index fields are only meaningful for the codes that set them; the rest stay at their
+ * defaults. `describe()` renders the code, and the caller logs the indices alongside.
+ */
+struct MlError {
+    enum class Code : std::uint8_t {
+        SchemaInvalid,      ///< the package itself is malformed - see schemaError
+        DigestMismatch,     ///< sha256(weights) is not pkg.weightsDigest
+        WeightsWrongSize,   ///< the blob's length is not pkg.weightsByteLength
+        WeightsUnaligned,   ///< the blob is not aligned for f32 access
+        SchemaVersion,      ///< the package's schemaVersion is not one this runtime reads
+        UnsupportedLayer,   ///< more layers than the runtime can hold; layerIndex is the first
+        ShapeMismatch,      ///< a kernel refused the spans a validated package implied
+        ScratchTooSmall,
+        NoGoldens,          ///< a package with no self-test at all - see create()
+        GoldenMismatch,     ///< a golden vector did not reproduce - the important one
+        InputLength,        ///< predict() was handed the wrong input size
+        OutputLength,
+    };
+
+    Code code{Code::SchemaInvalid};
+    /// Set when code is SchemaInvalid, so a package rejection keeps its specific diagnostic.
+    SchemaError schemaError{SchemaError::UnsupportedSchemaVersion};
+    std::uint32_t layerIndex{0};
+    std::uint32_t goldenIndex{0};
+    std::uint32_t elementIndex{0};
+    std::uint32_t expectedBits{0};
+    std::uint32_t actualBits{0};
+
+    [[nodiscard]] bool operator==(const MlError&) const noexcept = default;
+};
+
+[[nodiscard]] std::string_view describe(MlError::Code code) noexcept;
+
+/// The package format's cap on layer count, exposed so the baker can reject early rather than
+/// producing a package no runtime can load. Classifier1D sizes its tensor table from this.
+inline constexpr std::size_t maxSupportedLayers = 32;
+
+/**
+ * @brief A 1-D classifier over a validated, self-tested model package.
+ *
+ * Holds only spans and PODs - see the static_assert below. Construct through create(); the
+ * default constructor exists only because a `std::expected` needs one, and a default-constructed
+ * instance has an empty layer span so predict() refuses.
+ */
+class Classifier1D {
+public:
+    Classifier1D() noexcept = default;
+
+    /**
+     * @brief Validates, verifies and self-tests, or fails closed.
+     *
+     * @param weights the whole weight blob: mmap, ROM, flash, or a linked array
+     * @param scratch caller-supplied working memory, at least pkg.maxScratchFloats floats
+     *
+     * `pkg`, `weights` and `scratch` must all outlive the returned object - it stores spans over
+     * them and copies nothing.
+     */
+    [[nodiscard]] static mdux::core::Result<Classifier1D, MlError> create(
+        const ModelPackage& package, std::span<const std::byte> weights,
+        std::span<float> scratch) noexcept;
+
+    /**
+     * @brief Runs the network. No allocation, no I/O; issue #63 verifies that three ways.
+     *
+     * `output` is written only on success.
+     */
+    [[nodiscard]] mdux::core::ResultVoid<MlError> predict(std::span<const float> input,
+                                                          std::span<float> output) const noexcept;
+
+    [[nodiscard]] std::uint32_t inputLength() const noexcept { return inputLength_; }
+    [[nodiscard]] std::uint32_t outputLength() const noexcept { return outputLength_; }
+
+private:
+    /// The layer's weight and bias tensors as float spans over the blob. Resolved once in create()
+    /// rather than per predict(), and the reason the blob must outlive the object.
+    struct LayerTensors {
+        std::span<const float> weights;
+        std::span<const float> bias;
+    };
+
+    /**
+     * @brief Runs every layer, with the input already staged in the first scratch buffer.
+     *
+     * Returns a span over whichever scratch half holds the final activations. Shared by predict()
+     * and by create()'s golden self-test so that the self-test exercises the identical code path -
+     * a self-test that ran a different path would be evidence about that path instead.
+     *
+     * `const` because scratch_ is a span: the buffer is the caller's, and writing through it does
+     * not modify this object.
+     */
+    [[nodiscard]] mdux::core::Result<std::span<const float>, MlError> runFromScratch()
+        const noexcept;
+
+    std::span<const LayerDesc> layers_;
+    std::span<float> scratch_;
+    /// One entry per layer. Storing these in the caller's scratch is not possible (wrong type), so
+    /// it is a fixed-capacity array: v1 packages are small, and a package with more layers is
+    /// rejected rather than allocated for. Sized from the exported limit rather than repeating the
+    /// number, so the capacity and the rejection threshold cannot drift apart.
+    std::array<LayerTensors, maxSupportedLayers> tensors_{};
+    std::uint32_t inputLength_{0};
+    std::uint32_t outputLength_{0};
+};
+
+static_assert(std::is_trivially_destructible_v<Classifier1D>,
+              "Classifier1D must own nothing: it holds spans into caller memory, so a destructor "
+              "would mean something had been copied that should not have been");
+
+}  // namespace mdux::ml

--- a/src/ml/Runtime.cpp
+++ b/src/ml/Runtime.cpp
@@ -1,0 +1,235 @@
+/**
+ * @file Runtime.cpp
+ * @brief Implementation of the fail-closed device-side classifier.
+ *
+ * @compliance ADR-005 Error handling and exceptions policy (noexcept throughout, no throwing)
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Read Runtime.cppm's module comment first; in particular, the ordering of the checks in create()
+ * is part of the design rather than an accident of how it was written.
+ */
+module;
+
+module mdux.ml.runtime;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.ml.schema;
+import mdux.ml.kernels;
+
+namespace mdux::ml {
+
+using mdux::core::err;
+
+std::string_view describe(MlError::Code code) noexcept {
+    switch (code) {
+        case MlError::Code::SchemaInvalid:    return "model package failed schema validation";
+        case MlError::Code::DigestMismatch:   return "weight blob digest does not match the package";
+        case MlError::Code::WeightsWrongSize: return "weight blob length does not match the package";
+        case MlError::Code::WeightsUnaligned: return "weight blob is not aligned for f32 access";
+        case MlError::Code::SchemaVersion:    return "unsupported package schema version";
+        case MlError::Code::UnsupportedLayer: return "package uses more layers than the runtime supports";
+        case MlError::Code::ShapeMismatch:    return "a kernel rejected the shapes the package implied";
+        case MlError::Code::ScratchTooSmall:  return "scratch buffer is smaller than maxScratchFloats";
+        case MlError::Code::NoGoldens:        return "package carries no golden vectors to self-test against";
+        case MlError::Code::GoldenMismatch:   return "a golden vector did not reproduce bit for bit";
+        case MlError::Code::InputLength:      return "input length does not match the package";
+        case MlError::Code::OutputLength:     return "output length does not match the package";
+    }
+    return "unknown ML error";
+}
+
+namespace {
+
+/// Half the scratch: the largest activation the chain holds. predict() ping-pongs between the two
+/// halves, so this is the width of each buffer.
+[[nodiscard]] std::size_t bufferWidth(std::span<const LayerDesc> layers,
+                                      std::uint32_t inputLength) noexcept {
+    return static_cast<std::size_t>(requiredScratchFloats(layers, inputLength) / 2);
+}
+
+}  // namespace
+
+mdux::core::Result<Classifier1D, MlError> Classifier1D::create(const ModelPackage& package,
+                                                               std::span<const std::byte> weights,
+                                                               std::span<float> scratch) noexcept {
+    // 1. The package itself. Everything below assumes a validated descriptor - the kernels are
+    //    written without defensive checks in their inner loops precisely because of this call.
+    if (auto valid = package.validate(); !valid.has_value()) {
+        // A wrong schema version is reported as itself rather than folded into the generic
+        // "package is invalid": it is the one rejection a caller can act on without reading the
+        // schema diagnostic, because it means the artifact and the binary are different vintages.
+        const MlError::Code code = valid.error() == SchemaError::UnsupportedSchemaVersion
+                                       ? MlError::Code::SchemaVersion
+                                       : MlError::Code::SchemaInvalid;
+        return err(MlError{.code = code, .schemaError = valid.error()});
+    }
+    if (package.layers.size() > maxSupportedLayers) {
+        // The first layer that does not fit, so the field is an index as its name says. The
+        // count is recoverable from the package; the index is the actionable half.
+        return err(MlError{.code = MlError::Code::UnsupportedLayer,
+                           .layerIndex = static_cast<std::uint32_t>(maxSupportedLayers)});
+    }
+
+    // 2. The weights are exactly the bytes the package was baked against. Without this check,
+    //    "the caller supplies the weights" would mean "anything at all can be loaded", and the
+    //    golden vectors would be self-consistent against the wrong model.
+    if (weights.size() != package.weightsByteLength) {
+        return err(MlError{.code = MlError::Code::WeightsWrongSize});
+    }
+    if (package.weightsDigest != evidence::sha256(weights)) {
+        return err(MlError{.code = MlError::Code::DigestMismatch});
+    }
+
+    // The format stores f32 object representations, so the blob has to be readable as float. This
+    // is the one place the runtime depends on the caller's allocation being suitably aligned -
+    // mmap, a linked array and a ROM section all are, but a byte span carved out of a larger
+    // buffer at an odd offset would not be. Checked rather than assumed, and fails closed.
+    //
+    // Note the golden self-test below independently covers a *wrong* interpretation of these
+    // bytes: if the weights were being read incorrectly, no golden vector would reproduce.
+    const auto blobAddress = reinterpret_cast<std::uintptr_t>(weights.data());
+    if (!weights.empty() && blobAddress % alignof(float) != 0) {
+        return err(MlError{.code = MlError::Code::WeightsUnaligned});
+    }
+
+    // 3. Scratch.
+    if (scratch.size() < package.maxScratchFloats) {
+        return err(MlError{.code = MlError::Code::ScratchTooSmall,
+                           .elementIndex = static_cast<std::uint32_t>(scratch.size())});
+    }
+
+    Classifier1D classifier;
+    classifier.layers_ = package.layers;
+    classifier.scratch_ = scratch;
+    classifier.inputLength_ = package.inputLength;
+    classifier.outputLength_ = package.outputLength;
+
+    // Resolve every tensor to a float span once, here, rather than per predict() call.
+    const float* base = weights.empty() ? nullptr : reinterpret_cast<const float*>(weights.data());
+    for (std::size_t i = 0; i < package.layers.size(); ++i) {
+        const LayerDesc& layer = package.layers[i];
+        LayerTensors tensors;
+        if (layer.weights.present()) {
+            tensors.weights = std::span<const float>{
+                base + layer.weights.byteOffset / sizeof(float),
+                static_cast<std::size_t>(layer.weights.elementCount())};
+        }
+        if (layer.bias.present()) {
+            tensors.bias =
+                std::span<const float>{base + layer.bias.byteOffset / sizeof(float),
+                                       static_cast<std::size_t>(layer.bias.elementCount())};
+        }
+        classifier.tensors_[i] = tensors;
+    }
+
+    // 4. There has to be something to self-test against. Step 5's loop over an empty golden set
+    //    succeeds trivially, which would make the strongest control in this subsystem report
+    //    success without checking anything - worse than not having it, because the failure is
+    //    silent. mdux.ml.schema accepts an empty set on purpose (the baker validates an
+    //    architecture before generating goldens); the requirement lives here, at the boundary
+    //    where an unverified model would actually run.
+    if (package.goldens.empty()) {
+        return err(MlError{.code = MlError::Code::NoGoldens});
+    }
+
+    // 5. The self-test. A genuine safety control, not a late unit test - see Runtime.cppm.
+    const std::size_t width = bufferWidth(package.layers, package.inputLength);
+    for (std::size_t g = 0; g < package.goldens.size(); ++g) {
+        const GoldenVector& golden = package.goldens[g];
+
+        // Materialise the golden input into the first scratch buffer. Bit patterns, so this is a
+        // reinterpretation of the stored bits, never a decimal parse.
+        std::span<float> input = scratch.first(width);
+        for (std::size_t i = 0; i < golden.inputBits.size(); ++i) {
+            input[i] = std::bit_cast<float>(golden.inputBits[i]);
+        }
+
+        auto produced = classifier.runFromScratch();
+        if (!produced.has_value()) {
+            MlError error = produced.error();
+            error.goldenIndex = static_cast<std::uint32_t>(g);
+            return err(error);
+        }
+
+        const std::span<const float> actual = *produced;
+        for (std::size_t i = 0; i < golden.expectedOutputBits.size(); ++i) {
+            const std::uint32_t actualBits = std::bit_cast<std::uint32_t>(actual[i]);
+            if (actualBits != golden.expectedOutputBits[i]) {
+                // The whole point of MlError carrying evidence: this record is what a field
+                // incident report needs, and the divergence is by definition not reproducible on
+                // the bench - if it were, CI would have caught it.
+                // schemaError and layerIndex are left at their defaults: the header says the
+                // index fields are only meaningful for the codes that set them, and spelling out
+                // placeholders here would imply they carry information.
+                return err(MlError{.code = MlError::Code::GoldenMismatch,
+                                   .goldenIndex = static_cast<std::uint32_t>(g),
+                                   .elementIndex = static_cast<std::uint32_t>(i),
+                                   .expectedBits = golden.expectedOutputBits[i],
+                                   .actualBits = actualBits});
+            }
+        }
+    }
+
+    return classifier;
+}
+
+mdux::core::Result<std::span<const float>, MlError> Classifier1D::runFromScratch() const noexcept {
+    const std::size_t width = bufferWidth(layers_, inputLength_);
+    std::span<float> bufferA = scratch_.first(width);
+    std::span<float> bufferB = scratch_.subspan(width, width);
+
+    // The input is already in bufferA. Each layer reads one buffer and writes the other, so a
+    // kernel never has its input and output aliased.
+    std::span<const float> current = bufferA.first(static_cast<std::size_t>(layers_[0].inputFloats()));
+
+    for (std::size_t i = 0; i < layers_.size(); ++i) {
+        const LayerDesc& layer = layers_[i];
+        std::span<float> destination = ((i % 2) == 0 ? bufferB : bufferA)
+                                           .first(static_cast<std::size_t>(layer.outputFloats()));
+
+        if (!applyLayer(layer, current, tensors_[i].weights, tensors_[i].bias, destination)) {
+            return err(MlError{.code = MlError::Code::ShapeMismatch,
+                               .layerIndex = static_cast<std::uint32_t>(i)});
+        }
+        current = destination;
+    }
+    return current;
+}
+
+mdux::core::ResultVoid<MlError> Classifier1D::predict(std::span<const float> input,
+                                                      std::span<float> output) const noexcept {
+    if (layers_.empty()) {
+        return err(MlError{.code = MlError::Code::SchemaInvalid});
+    }
+    if (input.size() != inputLength_) {
+        return err(MlError{.code = MlError::Code::InputLength,
+                           .elementIndex = static_cast<std::uint32_t>(input.size())});
+    }
+    if (output.size() != outputLength_) {
+        return err(MlError{.code = MlError::Code::OutputLength,
+                           .elementIndex = static_cast<std::uint32_t>(output.size())});
+    }
+
+    const std::size_t width = bufferWidth(layers_, inputLength_);
+    std::span<float> staging = scratch_.first(width);
+    for (std::size_t i = 0; i < input.size(); ++i) {
+        staging[i] = input[i];
+    }
+
+    auto produced = runFromScratch();
+    if (!produced.has_value()) {
+        return err(produced.error());
+    }
+
+    // Written only on success, so a failed prediction cannot leave a caller holding half an
+    // answer it might mistake for a classification.
+    const std::span<const float> result = *produced;
+    for (std::size_t i = 0; i < output.size(); ++i) {
+        output[i] = result[i];
+    }
+    return {};
+}
+
+}  // namespace mdux::ml

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -520,6 +520,7 @@ add_executable(ml_spec
     ml/SchemaTests.cpp
     ml/KernelTests.cpp
     ml/DeterminismTests.cpp
+    ml/RuntimeTests.cpp
 )
 
 target_link_libraries(ml_spec PRIVATE MduX::Core speclab::speclab)

--- a/tests/ml/RuntimeTests.cpp
+++ b/tests/ml/RuntimeTests.cpp
@@ -1,0 +1,585 @@
+/**
+ * @file RuntimeTests.cpp
+ * @brief BDD scenarios for mdux.ml.runtime (issue #62).
+ *
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * The refusals are what matters here. `create()` succeeding is the easy half; the scenarios that
+ * earn the "fails closed" claim are the ones that corrupt exactly one thing - a weight byte, a
+ * golden bit, the scratch size - and assert the classifier is never constructed.
+ *
+ * The fixture generates its golden vectors by running the model through the runtime itself, which
+ * is not a shortcut: it is the arrangement ADR-008 decision 1 describes, where the authoring path
+ * and the device path are the same object code. The baker (issue #61) does the same thing for real
+ * packages.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.evidence.report;
+import mdux.ml.schema;
+import mdux.ml.kernels;
+import mdux.ml.runtime;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+using namespace mdux::ml;
+namespace evidence = mdux::evidence;
+
+// The model under test:
+//   8 x 1 -> Conv1D k=3 s=1, 2 filters, relu -> 6 x 2
+//         -> MaxPool1D k=2 s=2               -> 3 x 2
+//         -> Flatten                         -> 6
+//         -> Dense 6 -> 2, softmax           -> 2
+
+constexpr std::uint32_t modelInputLength = 8;
+constexpr std::uint32_t modelOutputLength = 2;
+constexpr std::uint32_t modelScratchFloats = 24;  // 2 * 12, the conv layer's 6*2 activation
+
+/// Float offsets into the weight blob, so the byte offsets below stay readable.
+constexpr std::uint64_t convWeightsFloat = 0;   // [2,1,3] = 6
+constexpr std::uint64_t convBiasFloat = 6;      // [2]
+constexpr std::uint64_t denseWeightsFloat = 8;  // [2,6]  = 12
+constexpr std::uint64_t denseBiasFloat = 20;    // [2]
+constexpr std::size_t weightFloatCount = 22;
+
+[[nodiscard]] std::vector<LayerDesc> modelLayers() {
+    return {
+        LayerDesc{.kind = LayerKind::Conv1d,
+                  .activation = Activation::Relu,
+                  .inLength = 8,
+                  .inChannels = 1,
+                  .outLength = 6,
+                  .outChannels = 2,
+                  .kernelSize = 3,
+                  .stride = 1,
+                  .weights = TensorRef{.byteOffset = convWeightsFloat * sizeof(float),
+                                       .shape = {2, 1, 3},
+                                       .rank = 3},
+                  .bias = TensorRef{.byteOffset = convBiasFloat * sizeof(float),
+                                    .shape = {2, 0, 0},
+                                    .rank = 1}},
+        LayerDesc{.kind = LayerKind::MaxPool1d,
+                  .activation = Activation::None,
+                  .inLength = 6,
+                  .inChannels = 2,
+                  .outLength = 3,
+                  .outChannels = 2,
+                  .kernelSize = 2,
+                  .stride = 2,
+                  .weights = TensorRef{},
+                  .bias = TensorRef{}},
+        LayerDesc{.kind = LayerKind::Flatten,
+                  .activation = Activation::None,
+                  .inLength = 3,
+                  .inChannels = 2,
+                  .outLength = 6,
+                  .outChannels = 1,
+                  .kernelSize = 0,
+                  .stride = 0,
+                  .weights = TensorRef{},
+                  .bias = TensorRef{}},
+        LayerDesc{.kind = LayerKind::Dense,
+                  .activation = Activation::Softmax,
+                  .inLength = 6,
+                  .inChannels = 1,
+                  .outLength = 2,
+                  .outChannels = 1,
+                  .kernelSize = 0,
+                  .stride = 0,
+                  .weights = TensorRef{.byteOffset = denseWeightsFloat * sizeof(float),
+                                       .shape = {2, 6, 0},
+                                       .rank = 2},
+                  .bias = TensorRef{.byteOffset = denseBiasFloat * sizeof(float),
+                                    .shape = {2, 0, 0},
+                                    .rank = 1}},
+    };
+}
+
+/// The same LCG the determinism suite uses, for the same reason: <random> is not reproducible
+/// across standard library implementations.
+[[nodiscard]] std::vector<float> generateWeights(std::uint32_t seed) {
+    std::vector<float> weights(weightFloatCount, 0.0f);
+    std::uint32_t state = seed;
+    for (float& value : weights) {
+        state = state * 1664525u + 1013904223u;
+        value = static_cast<float>(state >> 8) / 8388608.0f - 1.0f;
+    }
+    return weights;
+}
+
+/**
+ * @brief Owns a whole model - weights, layers, goldens - and hands out a ModelPackage over them.
+ *
+ * Every span in the package points into this object, so it has to outlive any classifier built
+ * from it. That is the same contract a real caller has with its mmap or its linked blob.
+ */
+struct TestModel {
+    std::vector<float> weightStorage;
+    std::vector<LayerDesc> layers = modelLayers();
+    std::vector<std::uint32_t> goldenInputBits;
+    std::vector<std::uint32_t> goldenOutputBits;
+    std::string id{"runtime-fixture"};
+    std::uint32_t maxScratchFloats{modelScratchFloats};
+    evidence::Digest digest{};
+
+    explicit TestModel(std::uint32_t seed = 4242u) : weightStorage(generateWeights(seed)) {
+        digest = evidence::sha256(weights());
+    }
+
+    /// float storage guarantees the blob is aligned for f32, which is what create() requires.
+    [[nodiscard]] std::span<const std::byte> weights() const noexcept {
+        return std::as_bytes(std::span{weightStorage});
+    }
+
+    [[nodiscard]] std::vector<GoldenVector> goldens() const {
+        if (goldenInputBits.empty()) {
+            return {};
+        }
+        return {GoldenVector{.inputBits = goldenInputBits,
+                             .expectedOutputBits = goldenOutputBits}};
+    }
+
+    [[nodiscard]] ModelPackage package(std::span<const GoldenVector> goldenSpan) const noexcept {
+        return ModelPackage{.id = id,
+                            .schemaVersion = evidence::kSchemaVersion,
+                            .weightsDigest = digest,
+                            .weightsByteLength = weightStorage.size() * sizeof(float),
+                            .layers = layers,
+                            .goldens = goldenSpan,
+                            .inputLength = modelInputLength,
+                            .outputLength = modelOutputLength,
+                            .maxScratchFloats = maxScratchFloats};
+    }
+
+    /// Recomputes the digest after a test has altered the weights.
+    void reseal() noexcept { digest = evidence::sha256(weights()); }
+};
+
+/// A fixed, unremarkable input. Exact in f32 so nothing here depends on decimal parsing.
+[[nodiscard]] std::array<float, modelInputLength> sampleInput() noexcept {
+    return {0.5f, -0.25f, 1.0f, 0.75f, -1.0f, 0.125f, 0.0f, -0.5f};
+}
+
+/**
+ * @brief Bakes the goldens into `model`, the way mdux-mlbake will.
+ *
+ * Runs the layer chain directly through `mdux.ml.kernels` rather than through a classifier. It
+ * used to build a classifier with no goldens and predict through that, which is no longer possible
+ * now that create() rejects a package with nothing to self-test against - and that is the right
+ * outcome: generating the goldens is precisely the step that happens *before* a package can be
+ * verified, so it cannot depend on verification.
+ *
+ * This is the same ping-pong the runtime and the baker's GoldenGen both use, over the same
+ * applyLayer(), so the goldens it produces are the ones create() will later reproduce.
+ */
+[[nodiscard]] bool bakeGoldens(TestModel& model) {
+    const auto input = sampleInput();
+    const std::span<const float> weightFloats{model.weightStorage};
+
+    const std::size_t width = modelScratchFloats / 2;
+    std::array<float, modelScratchFloats> scratch{};
+    std::span<float> bufferA{scratch.data(), width};
+    std::span<float> bufferB{scratch.data() + width, width};
+
+    for (std::size_t i = 0; i < input.size(); ++i) {
+        bufferA[i] = input[i];
+    }
+
+    std::span<const float> current =
+        bufferA.first(static_cast<std::size_t>(model.layers[0].inputFloats()));
+    for (std::size_t i = 0; i < model.layers.size(); ++i) {
+        const LayerDesc& layer = model.layers[i];
+        std::span<const float> weights;
+        std::span<const float> bias;
+        if (layer.weights.present()) {
+            weights = weightFloats.subspan(layer.weights.byteOffset / sizeof(float),
+                                           static_cast<std::size_t>(layer.weights.elementCount()));
+        }
+        if (layer.bias.present()) {
+            bias = weightFloats.subspan(layer.bias.byteOffset / sizeof(float),
+                                        static_cast<std::size_t>(layer.bias.elementCount()));
+        }
+        std::span<float> destination = ((i % 2) == 0 ? bufferB : bufferA)
+                                           .first(static_cast<std::size_t>(layer.outputFloats()));
+        if (!applyLayer(layer, current, weights, bias, destination)) {
+            return false;
+        }
+        current = destination;
+    }
+
+    model.goldenInputBits.clear();
+    for (float value : input) {
+        model.goldenInputBits.push_back(std::bit_cast<std::uint32_t>(value));
+    }
+    model.goldenOutputBits.clear();
+    for (std::size_t i = 0; i < modelOutputLength; ++i) {
+        model.goldenOutputBits.push_back(std::bit_cast<std::uint32_t>(current[i]));
+    }
+    return true;
+}
+
+/// The error a create() attempt produces, or nullopt when it succeeds.
+[[nodiscard]] std::optional<MlError> createError(const TestModel& model,
+                                                 std::span<float> scratch) {
+    const std::vector<GoldenVector> goldens = model.goldens();
+    auto classifier = Classifier1D::create(model.package(goldens), model.weights(), scratch);
+    if (classifier.has_value()) {
+        return std::nullopt;
+    }
+    return classifier.error();
+}
+
+[[nodiscard]] std::string describeOutcome(const std::optional<MlError>& error) {
+    if (!error.has_value()) {
+        return "created successfully";
+    }
+    return std::string{describe(error->code)};
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register createSucceedsAndPredicts{
+    "A sound package creates a classifier that reproduces its goldens", "evidence-unit", [] {
+        return speclab::Test("ml-runtime-create-and-predict")
+            .Given("a validated package whose goldens were generated through the same kernels", [] {})
+            .When("a classifier is created and asked to predict", [] {})
+            .Then("creation succeeds and the prediction matches the golden bits exactly",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TestModel model;
+                      checks.expect(bakeGoldens(model), "goldens baked");
+
+                      std::array<float, modelScratchFloats> scratch{};
+                      const std::vector<GoldenVector> goldens = model.goldens();
+                      auto classifier =
+                          Classifier1D::create(model.package(goldens), model.weights(), scratch);
+
+                      checks.expect(classifier.has_value(),
+                                    classifier.has_value()
+                                        ? "created"
+                                        : std::string{describe(classifier.error().code)});
+                      if (!classifier.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      checks.expect(classifier->inputLength() == modelInputLength, "input length");
+                      checks.expect(classifier->outputLength() == modelOutputLength,
+                                    "output length");
+
+                      std::array<float, modelOutputLength> output{};
+                      checks.expect(classifier->predict(sampleInput(), output).has_value(),
+                                    "predict succeeded");
+                      for (std::size_t i = 0; i < output.size(); ++i) {
+                          checks.expect(std::bit_cast<std::uint32_t>(output[i]) ==
+                                            model.goldenOutputBits[i],
+                                        std::format("output[{}] reproduces its golden", i));
+                      }
+
+                      // A softmax, so this is a probability vector rather than arbitrary numbers.
+                      const float total = output[0] + output[1];
+                      checks.expect(std::fabs(total - 1.0f) < 1e-6f,
+                                    std::format("outputs sum to {}", total));
+
+                      // Same input, same bits, every time - no accumulated state anywhere.
+                      std::array<float, modelOutputLength> again{};
+                      checks.expect(classifier->predict(sampleInput(), again).has_value(),
+                                    "second predict succeeded");
+                      checks.expect(std::bit_cast<std::uint32_t>(again[0]) ==
+                                        std::bit_cast<std::uint32_t>(output[0]),
+                                    "predict is repeatable bit for bit");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register digestCheckIsLoadBearing{
+    "Weights that do not match the digest are refused", "evidence-unit", [] {
+        return speclab::Test("ml-runtime-digest-mismatch")
+            .Given("a package whose weight blob has been altered by one value", [] {})
+            .When("a classifier is created", [] {})
+            .Then("it fails closed on digestMismatch rather than classifying with wrong weights",
+                  [] {
+                      // This is the scenario that makes "weights are data" safe. Without it, a
+                      // caller-supplied blob would mean anything at all could be loaded, and the
+                      // goldens would happily verify against the wrong model.
+                      mdux::spec::Checks checks;
+                      TestModel model;
+                      checks.expect(bakeGoldens(model), "goldens baked");
+
+                      // Alter a weight but keep the digest the package was baked with.
+                      model.weightStorage[3] += 1.0f;
+
+                      std::array<float, modelScratchFloats> scratch{};
+                      const auto error = createError(model, scratch);
+                      checks.expect(error.has_value() &&
+                                        error->code == MlError::Code::DigestMismatch,
+                                    std::format("expected digestMismatch, got {}",
+                                                describeOutcome(error)));
+
+                      // And with the digest brought back into agreement, the *goldens* must then
+                      // fail - the weights really did change, so the recorded outputs cannot still
+                      // be reproducible. Two independent controls, both firing.
+                      model.reseal();
+                      const auto goldenError = createError(model, scratch);
+                      checks.expect(goldenError.has_value() &&
+                                        goldenError->code == MlError::Code::GoldenMismatch,
+                                    std::format("expected goldenMismatch, got {}",
+                                                describeOutcome(goldenError)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register goldenMismatchCarriesEvidence{
+    "A golden mismatch reports which element diverged and by what", "evidence-unit", [] {
+        return speclab::Test("ml-runtime-golden-evidence")
+            .Given("a package with one corrupted golden output bit", [] {})
+            .When("a classifier is created", [] {})
+            .Then("the error names the golden, the element and both bit patterns",
+                  [] {
+                      // MlError is the field incident record. A bare enum would discard exactly
+                      // the information the report needs, so the indices are asserted here.
+                      mdux::spec::Checks checks;
+                      TestModel model;
+                      checks.expect(bakeGoldens(model), "goldens baked");
+
+                      const std::uint32_t original = model.goldenOutputBits[1];
+                      const std::uint32_t corrupted = original ^ 0x1u;  // one low mantissa bit
+                      model.goldenOutputBits[1] = corrupted;
+
+                      std::array<float, modelScratchFloats> scratch{};
+                      const auto error = createError(model, scratch);
+
+                      checks.expect(error.has_value() &&
+                                        error->code == MlError::Code::GoldenMismatch,
+                                    std::format("expected goldenMismatch, got {}",
+                                                describeOutcome(error)));
+                      if (!error.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(error->goldenIndex == 0, "golden index");
+                      checks.expect(error->elementIndex == 1, "element index");
+                      checks.expect(error->expectedBits == corrupted, "expected bits recorded");
+                      checks.expect(error->actualBits == original, "actual bits recorded");
+
+                      // A single flipped mantissa bit is caught: the comparison is bitwise, and an
+                      // epsilon would have accepted this difference silently.
+                      checks.expect(error->expectedBits != error->actualBits,
+                                    "the divergence is one bit and is still fatal");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register createRefusesUnsoundInputs{
+    "create() refuses every unsound combination", "evidence-unit", [] {
+        return speclab::Test("ml-runtime-create-refusals")
+            .Given("a sound package, and one thing wrong at a time", [] {})
+            .When("a classifier is created from each", [] {})
+            .Then("each refusal names its own cause",
+                  [] {
+                      mdux::spec::Checks checks;
+                      std::array<float, modelScratchFloats> scratch{};
+
+                      {  // Scratch smaller than the package declares it needs.
+                          TestModel model;
+                          checks.expect(bakeGoldens(model), "goldens baked");
+                          std::array<float, 4> tinyScratch{};
+                          const auto error = createError(model, tinyScratch);
+                          checks.expect(error.has_value() &&
+                                            error->code == MlError::Code::ScratchTooSmall,
+                                        std::format("expected scratchTooSmall, got {}",
+                                                    describeOutcome(error)));
+                      }
+
+                      {  // A blob shorter than the package declares. Handed to create() directly
+                         // rather than by resizing the fixture, because the fixture derives
+                         // weightsByteLength from its storage - growing that would move both sides
+                         // of the comparison and test nothing. The length check runs before the
+                         // digest, so this reports the specific cause rather than a generic
+                         // mismatch.
+                          TestModel model;
+                          checks.expect(bakeGoldens(model), "goldens baked");
+                          const std::vector<GoldenVector> goldens = model.goldens();
+                          const std::span<const std::byte> truncated =
+                              model.weights().first(model.weights().size() - sizeof(float));
+                          auto classifier =
+                              Classifier1D::create(model.package(goldens), truncated, scratch);
+                          checks.expect(!classifier.has_value() &&
+                                            classifier.error().code ==
+                                                MlError::Code::WeightsWrongSize,
+                                        "a short weight blob is refused on length");
+                      }
+
+                      {  // A package that does not validate at all.
+                          TestModel model;
+                          checks.expect(bakeGoldens(model), "goldens baked");
+                          model.maxScratchFloats = 2;  // below the computed worst case
+                          const auto error = createError(model, scratch);
+                          checks.expect(error.has_value() &&
+                                            error->code == MlError::Code::SchemaInvalid,
+                                        std::format("expected schemaInvalid, got {}",
+                                                    describeOutcome(error)));
+                          checks.expect(error.has_value() &&
+                                            error->schemaError == SchemaError::ScratchTooSmall,
+                                        "the schema's own diagnostic is preserved");
+                      }
+
+                      {  // A package with nothing to self-test against. The loop over an empty
+                         // golden set would succeed trivially, so this is the case that stops the
+                         // strongest control in the subsystem from reporting a vacuous success.
+                          TestModel model;
+                          checks.expect(bakeGoldens(model), "goldens baked");
+                          const std::vector<GoldenVector> none;
+                          auto classifier =
+                              Classifier1D::create(model.package(none), model.weights(), scratch);
+                          checks.expect(!classifier.has_value() &&
+                                            classifier.error().code == MlError::Code::NoGoldens,
+                                        "a package with no goldens is refused");
+                      }
+
+                      {  // A blob that is not f32-aligned gets its own code rather than borrowing
+                         // ShapeMismatch, which would say a kernel rejected validated shapes.
+                          TestModel model;
+                          checks.expect(bakeGoldens(model), "goldens baked");
+                          const std::vector<GoldenVector> goldens = model.goldens();
+
+                          // Offset the blob by one byte inside an oversized buffer, so the span is
+                          // the right length but starts off the f32 grid.
+                          std::vector<std::byte> shifted(model.weights().size() + 1);
+                          const std::span<const std::byte> source = model.weights();
+                          for (std::size_t i = 0; i < source.size(); ++i) {
+                              shifted[i + 1] = source[i];
+                          }
+                          const std::span<const std::byte> misaligned{shifted.data() + 1,
+                                                                      source.size()};
+                          if ((reinterpret_cast<std::uintptr_t>(misaligned.data()) %
+                               alignof(float)) != 0) {
+                              auto classifier = Classifier1D::create(model.package(goldens),
+                                                                     misaligned, scratch);
+                              checks.expect(!classifier.has_value() &&
+                                                classifier.error().code ==
+                                                    MlError::Code::WeightsUnaligned,
+                                            "a misaligned weight blob is refused by its own code");
+                          }
+                      }
+
+                      {  // An unsupported schema version, rejected by validate().
+                          TestModel model;
+                          checks.expect(bakeGoldens(model), "goldens baked");
+                          const std::vector<GoldenVector> goldens = model.goldens();
+                          ModelPackage package = model.package(goldens);
+                          package.schemaVersion = evidence::kSchemaVersion + 1;
+                          auto classifier =
+                              Classifier1D::create(package, model.weights(), scratch);
+                          checks.expect(!classifier.has_value() &&
+                                            classifier.error().code ==
+                                                MlError::Code::SchemaVersion,
+                                        "a future schema version is refused by its own code");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register predictValidatesItsSpans{
+    "predict() refuses spans that are not the package's shape", "evidence-unit", [] {
+        return speclab::Test("ml-runtime-predict-spans")
+            .Given("a working classifier", [] {})
+            .When("predict is called with the wrong input or output length", [] {})
+            .Then("it refuses and writes nothing",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TestModel model;
+                      checks.expect(bakeGoldens(model), "goldens baked");
+
+                      std::array<float, modelScratchFloats> scratch{};
+                      const std::vector<GoldenVector> goldens = model.goldens();
+                      auto classifier =
+                          Classifier1D::create(model.package(goldens), model.weights(), scratch);
+                      checks.expect(classifier.has_value(), "created");
+                      if (!classifier.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      std::array<float, modelOutputLength> output{0.25f, 0.25f};
+                      const std::array<float, 3> shortInput{};
+                      auto shortInputResult = classifier->predict(shortInput, output);
+                      checks.expect(!shortInputResult.has_value() &&
+                                        shortInputResult.error().code ==
+                                            MlError::Code::InputLength,
+                                    "short input refused");
+                      checks.expect(output[0] == 0.25f && output[1] == 0.25f,
+                                    "output untouched by a refused prediction");
+
+                      std::array<float, 5> wrongOutput{};
+                      auto wrongOutputResult = classifier->predict(sampleInput(), wrongOutput);
+                      checks.expect(!wrongOutputResult.has_value() &&
+                                        wrongOutputResult.error().code ==
+                                            MlError::Code::OutputLength,
+                                    "wrong output length refused");
+
+                      // A default-constructed classifier holds no layers and must refuse rather
+                      // than dereferencing an empty span.
+                      const Classifier1D empty;
+                      std::array<float, modelOutputLength> ignored{};
+                      checks.expect(!empty.predict(sampleInput(), ignored).has_value(),
+                                    "a default-constructed classifier refuses to predict");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register goldensAreOptionalButChecked{
+    "A package with several goldens checks every one of them", "evidence-unit", [] {
+        return speclab::Test("ml-runtime-multiple-goldens")
+            .Given("a package carrying three goldens, the last of which is wrong", [] {})
+            .When("a classifier is created", [] {})
+            .Then("the self-test reaches the third rather than stopping at the first pass",
+                  [] {
+                      // A self-test that only checked golden 0 would pass this and be worthless.
+                      mdux::spec::Checks checks;
+                      TestModel model;
+                      checks.expect(bakeGoldens(model), "goldens baked");
+
+                      std::vector<GoldenVector> goldens;
+                      goldens.push_back(GoldenVector{.inputBits = model.goldenInputBits,
+                                                     .expectedOutputBits = model.goldenOutputBits});
+                      goldens.push_back(GoldenVector{.inputBits = model.goldenInputBits,
+                                                     .expectedOutputBits = model.goldenOutputBits});
+
+                      std::vector<std::uint32_t> wrongOutput = model.goldenOutputBits;
+                      wrongOutput[0] ^= 0x1u;
+                      goldens.push_back(GoldenVector{.inputBits = model.goldenInputBits,
+                                                     .expectedOutputBits = wrongOutput});
+
+                      std::array<float, modelScratchFloats> scratch{};
+                      auto classifier =
+                          Classifier1D::create(model.package(goldens), model.weights(), scratch);
+
+                      checks.expect(!classifier.has_value(), "the third golden is not skipped");
+                      if (classifier.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(classifier.error().code == MlError::Code::GoldenMismatch,
+                                    "reported as a golden mismatch");
+                      checks.expect(classifier.error().goldenIndex == 2,
+                                    std::format("golden index is 2, got {}",
+                                                classifier.error().goldenIndex));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+}  // namespace


### PR DESCRIPTION
The device-side engine. `create()` validates the package, verifies `sha256(weights)` against the digest it was baked with, checks the scratch budget, and then re-runs every golden vector through the real kernels comparing bit patterns. Any divergence returns an error and the object is never constructed.

Step 4 is the point of the whole subsystem: it detects toolchain miscompilation, target FP drift and a corrupted or mismatched package **before the device classifies anything real**, for bounded startup work and nothing per frame.

`MlError` carries the layer, golden and element indices plus both bit patterns, because when a device fails closed in the field that record is the evidence — and the divergence is by definition not reproducible on the bench, or CI would have caught it.

The self-test and `predict()` share `runFromScratch()`, so the self-test exercises the identical path rather than being evidence about a different one.

One implementation note: the weight blob arrives as bytes and is read as f32, so `create()` checks the blob's alignment and fails closed rather than assuming it.

Stacked on #59.

Closes #62.