### PR TITLE
feat(ml): verify no-heap-in-predict three independent ways

### DIFF
--- a/cmake/MduXNoHeapScan.cmake
+++ b/cmake/MduXNoHeapScan.cmake
@@ -1,0 +1,116 @@
+# MduXNoHeapScan.cmake
+#
+# Layer 2 of issue #63: scan the compiled ML objects for any undefined reference to the allocation
+# and deallocation family, or to the exception-throwing runtime.
+#
+# The delete operators are in the forbidden set alongside the new ones deliberately. A reference to
+# `operator delete` means the object owns heap memory just as surely as a reference to `operator
+# new` does - often more visibly, because a destructor emitted for a std container is what pulls it
+# in. So a failure naming a delete symbol means the same thing as one naming new: something in the
+# governed ML zone acquired owning memory. Run as a ctest via `cmake -P`, not at configure time, because
+# the object files do not exist until after a build.
+#
+# Where layer 1 (tests/ml/NoHeapTests.cpp) proves predict() does not allocate *when run*, this
+# proves the kernels and the runtime cannot allocate *at all* - no path through them, taken or not,
+# reaches operator new or malloc. It is also far cheaper, and it fails in the PR that introduced
+# the reference rather than whenever someone next executes that path.
+#
+# __cxa_throw is in the forbidden set for a second reason: it double-checks ADR-005's no-throwing
+# rule for the governed zone. A std::vector::at() or a std::stoi() that crept in would show up here
+# as a throw reference even if it never allocated.
+#
+# Expected variables (passed with -D):
+#   MDUX_NOHEAP_OBJECT_LIST - path to a newline-separated file of object paths, written by
+#                             file(GENERATE) so that a generator expression resolves per config
+#   MDUX_NOHEAP_TOOL        - "nm" or "dumpbin"
+#   MDUX_NOHEAP_COMMAND     - path to that tool
+
+if(NOT DEFINED MDUX_NOHEAP_OBJECT_LIST OR NOT EXISTS "${MDUX_NOHEAP_OBJECT_LIST}")
+    message(FATAL_ERROR
+        "MduXNoHeapScan: object list '${MDUX_NOHEAP_OBJECT_LIST}' not found. The scan cannot pass "
+        "vacuously.")
+endif()
+
+file(STRINGS "${MDUX_NOHEAP_OBJECT_LIST}" MDUX_NOHEAP_OBJECTS)
+if(MDUX_NOHEAP_OBJECTS STREQUAL "")
+    message(FATAL_ERROR
+        "MduXNoHeapScan: the object list is empty. That would make this test pass by checking "
+        "nothing - the ML sources are expected to be part of MduXCore.")
+endif()
+
+# Mangled and demangled spellings both, so this works whether or not the tool demangles.
+set(forbidden_symbols
+    "operator new"
+    "operator delete"
+    "_Znwm"      # operator new(unsigned long)
+    "_Znam"      # operator new[](unsigned long)
+    "_ZdlPv"     # operator delete(void*)
+    "_ZdaPv"     # operator delete[](void*)
+    "malloc"
+    "calloc"
+    "realloc"
+    "__cxa_throw"
+    "??2@"       # MSVC operator new
+    "??_U@"      # MSVC operator new[]
+)
+
+set(violations "")
+set(scanned_count 0)
+
+foreach(object ${MDUX_NOHEAP_OBJECTS})
+    if(NOT EXISTS "${object}")
+        message(FATAL_ERROR
+            "MduXNoHeapScan: object '${object}' does not exist. The scan would otherwise pass by "
+            "checking nothing - build the ML targets before running this test.")
+    endif()
+    math(EXPR scanned_count "${scanned_count} + 1")
+
+    if(MDUX_NOHEAP_TOOL STREQUAL "dumpbin")
+        execute_process(COMMAND "${MDUX_NOHEAP_COMMAND}" /SYMBOLS "${object}"
+                        OUTPUT_VARIABLE symbol_output
+                        ERROR_VARIABLE symbol_error
+                        RESULT_VARIABLE symbol_result)
+    else()
+        # -u lists only undefined symbols, which is exactly the question being asked: does this
+        # object *call out* to an allocator. Defined local symbols are irrelevant.
+        execute_process(COMMAND "${MDUX_NOHEAP_COMMAND}" -u -C "${object}"
+                        OUTPUT_VARIABLE symbol_output
+                        ERROR_VARIABLE symbol_error
+                        RESULT_VARIABLE symbol_result)
+    endif()
+
+    if(NOT symbol_result EQUAL 0)
+        message(FATAL_ERROR
+            "MduXNoHeapScan: ${MDUX_NOHEAP_TOOL} failed on '${object}': ${symbol_error}")
+    endif()
+
+    get_filename_component(object_name "${object}" NAME)
+    string(REPLACE "\n" ";" symbol_lines "${symbol_output}")
+    foreach(line ${symbol_lines})
+        if(MDUX_NOHEAP_TOOL STREQUAL "dumpbin")
+            # Only undefined symbols matter; dumpbin marks them UNDEF.
+            if(NOT line MATCHES "UNDEF")
+                continue()
+            endif()
+        endif()
+        foreach(symbol ${forbidden_symbols})
+            string(FIND "${line}" "${symbol}" found)
+            if(NOT found EQUAL -1)
+                list(APPEND violations "${object_name}: ${line}")
+            endif()
+        endforeach()
+    endforeach()
+endforeach()
+
+if(violations)
+    list(REMOVE_DUPLICATES violations)
+    string(REPLACE ";" "\n  " violation_text "${violations}")
+    message(FATAL_ERROR
+        "No-heap violation (ADR-008, issue #63): the ML objects reference an allocator or the "
+        "throwing runtime.\n  ${violation_text}\n"
+        "mdux.ml.kernels and mdux.ml.runtime must reach neither. If this is a std facility that "
+        "allocates only on a path you believe is unreachable, that is not sufficient - the device "
+        "build must not contain the reference at all.")
+endif()
+
+message(STATUS "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")

--- a/src/ml/.clang-tidy
+++ b/src/ml/.clang-tidy
@@ -1,0 +1,26 @@
+# Layer 3 of issue #63, scoped to the ML implementation sources.
+#
+# Inherits the repository root .clang-tidy and adds the allocation checks as errors rather than
+# warnings. The root configuration governs style for the whole tree; this file only tightens what
+# ADR-008 requires of the governed ML zone, so a check disabled at the root stays disabled here
+# unless it is named below.
+#
+# Layers 1 and 2 (the interposition test and the object-file symbol scan) catch an allocation that
+# is *reachable* and one that is *linked*. This layer catches the source construct, with a message
+# pointing at the line, which is the fastest of the three to act on.
+#
+# -Wframe-larger-than=4096 belongs with these and lives in cmake/MduXDeterminism.cmake, applied to
+# MduXCore alongside the floating-point flags: "no heap" must not quietly become "enormous stack",
+# which on a device is the same bug wearing a different hat.
+
+InheritParentConfig: true
+
+Checks: >
+  cppcoreguidelines-no-malloc,
+  cppcoreguidelines-owning-memory,
+  cppcoreguidelines-pro-type-vararg,
+  cppcoreguidelines-prefer-member-initializer
+
+WarningsAsErrors: >
+  cppcoreguidelines-no-malloc,
+  cppcoreguidelines-owning-memory

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -542,3 +542,73 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 mdux_discover_tests(ml_spec)
+
+# No-heap verification, layer 1 (issue #63): global operator new interposition.
+#
+# Its own binary because it replaces the global allocator - see tests/ml/NoHeapSpecMain.cpp.
+add_executable(ml_noheap_spec
+    ml/NoHeapSpecMain.cpp
+    ml/NoHeapTests.cpp
+)
+
+target_link_libraries(ml_noheap_spec PRIVATE MduX::Core speclab::speclab)
+target_include_directories(ml_noheap_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(ml_noheap_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(ml_noheap_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(ml_noheap_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(ml_noheap_spec)
+
+# No-heap verification, layer 2 (issue #63): object-file symbol scan.
+#
+# Catches an allocator reference at build time, in the PR that introduced it, rather than whenever
+# someone next executes the path that would have allocated. The object list is written by
+# file(GENERATE) rather than passed as a -D argument, because a generator expression producing a
+# ;-separated list would be split into separate arguments by add_test().
+set(mdux_ml_object_list "${CMAKE_CURRENT_BINARY_DIR}/ml_objects_$<CONFIG>.txt")
+file(GENERATE
+    OUTPUT "${mdux_ml_object_list}"
+    CONTENT "$<JOIN:$<FILTER:$<TARGET_OBJECTS:MduXCore>,INCLUDE,/ml/>,\n>"
+)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    find_program(MDUX_SYMBOL_TOOL NAMES dumpbin)
+    set(mdux_symbol_tool_kind "dumpbin")
+else()
+    # CMAKE_NM is set by the toolchain; fall back to a plain nm on PATH.
+    if(CMAKE_NM)
+        set(MDUX_SYMBOL_TOOL "${CMAKE_NM}")
+    else()
+        find_program(MDUX_SYMBOL_TOOL NAMES nm)
+    endif()
+    set(mdux_symbol_tool_kind "nm")
+endif()
+
+if(MDUX_SYMBOL_TOOL)
+    add_test(NAME ml.noheap.symbolScan
+        COMMAND ${CMAKE_COMMAND}
+            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_ml_object_list}
+            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+    )
+    set_tests_properties(ml.noheap.symbolScan PROPERTIES LABELS "noheap")
+else()
+    # Deliberately not silent. A missing tool means this layer is not running, and the other two
+    # layers do not cover what it covers.
+    message(WARNING
+        "No symbol tool (nm/dumpbin) found - ml.noheap.symbolScan will not run, so issue #63's "
+        "layer 2 is unverified in this build.")
+endif()

--- a/tests/ml/NoHeapSpecMain.cpp
+++ b/tests/ml/NoHeapSpecMain.cpp
@@ -1,0 +1,19 @@
+/**
+ * @brief Entry point for the no-heap SpecLab executable (issue #63).
+ *
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Separate from ml_spec because this binary replaces the global `operator new` family. Keeping
+ * that replacement out of the main suite means the other scenarios run against the ordinary
+ * allocator, and a failure here names the no-heap property rather than appearing as one line among
+ * two dozen unrelated ones.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX ML No-Heap Spec");
+}

--- a/tests/ml/NoHeapTests.cpp
+++ b/tests/ml/NoHeapTests.cpp
@@ -1,0 +1,519 @@
+/**
+ * @file NoHeapTests.cpp
+ * @brief Layer 1 of issue #63: predict() makes no `operator new` call, proved by interposition.
+ *
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * "No allocation in predict()" is easy to claim and easy to break silently - a `std::vector` in a
+ * helper, a `std::function`, a `std::string` in an error path. Review discipline does not catch
+ * that reliably, so this binary replaces the global `operator new` family with counting versions
+ * and measures.
+ *
+ * It catches any allocation that goes through the global `operator new` family - including one
+ * hidden inside a `std` call nobody expected to allocate, which is the case review never finds.
+ * It does **not** see a direct `std::malloc`, a pool allocator, or anything else that bypasses
+ * `operator new`; layer 2's symbol scan is what covers those, which is why the three layers are
+ * not redundant. It is also the one that could
+ * silently become worthless: if the interposition stopped taking effect - a linker change, an
+ * inlined allocation, a static runtime - the counter would simply never move and every scenario
+ * would pass. So the first scenario below deliberately allocates and asserts the counter *does*
+ * move. Without it, this file would be a test that cannot fail.
+ *
+ * Its own binary rather than a case inside ml_spec, so that a failure names the property that
+ * broke instead of appearing as one line among two dozen unrelated scenarios.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.evidence.report;
+import mdux.ml.schema;
+import mdux.ml.kernels;
+import mdux.ml.runtime;
+
+#include "../framework/SpecLabBridge.hpp"
+
+// ---------------------------------------------------------------------------
+// The interposition
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Bumped by every allocating operator below. Not atomic-by-necessity - the scenarios are
+/// single-threaded - but atomic anyway, so that a future threaded case cannot make this quietly
+/// unreliable.
+std::atomic<std::size_t> allocationCount{0};
+
+[[nodiscard]] std::size_t allocations() noexcept {
+    return allocationCount.load(std::memory_order_relaxed);
+}
+
+/**
+ * @brief Over-aligned allocation built on plain malloc, with no platform branch.
+ *
+ * Neither standard route works here. `std::aligned_alloc` does not exist on MSVC at all, and
+ * `_aligned_malloc` is declared in `<malloc.h>` - a header this translation unit cannot include,
+ * because it reaches the standard library through `import std;` and mixing the two is what the
+ * C5050 diagnostics elsewhere in this epic were about.
+ *
+ * So the alignment is done by hand: over-allocate, step the pointer up to the boundary, and stash
+ * the original just below it for the matching free. Portable, needs nothing but `std::malloc`, and
+ * keeps the counter covering over-aligned allocations - which matters, because leaving the aligned
+ * operators unreplaced would leave a path through which predict() could allocate uncounted.
+ */
+[[nodiscard]] void* allocateAligned(std::size_t size, std::size_t alignment) {
+    // The stash slot has to be addressable, so never align more loosely than a pointer.
+    const std::size_t effective = alignment < alignof(void*) ? alignof(void*) : alignment;
+    const std::size_t slack = effective - 1 + sizeof(void*);
+
+    void* raw = std::malloc(size + slack);
+    if (raw == nullptr) {
+        return nullptr;
+    }
+
+    auto address = reinterpret_cast<std::uintptr_t>(raw) + sizeof(void*);
+    address = (address + effective - 1) & ~static_cast<std::uintptr_t>(effective - 1);
+    auto* aligned = reinterpret_cast<void*>(address);
+
+    // `aligned` is a multiple of effective >= alignof(void*), so the slot below it is aligned too.
+    *(reinterpret_cast<void**>(aligned) - 1) = raw;
+    return aligned;
+}
+
+void freeAligned(void* pointer) noexcept {
+    if (pointer == nullptr) {
+        return;
+    }
+    std::free(*(reinterpret_cast<void**>(pointer) - 1));
+}
+
+}  // namespace
+
+// Every allocating form is replaced, not just the common one. A partial replacement would leave a
+// path through which predict() could allocate uncounted, which is the failure this file exists to
+// make impossible.
+
+void* operator new(std::size_t size) {
+    allocationCount.fetch_add(1, std::memory_order_relaxed);
+    void* pointer = std::malloc(size == 0 ? 1 : size);
+    if (pointer == nullptr) {
+        throw std::bad_alloc{};
+    }
+    return pointer;
+}
+
+void* operator new[](std::size_t size) {
+    return ::operator new(size);
+}
+
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+    allocationCount.fetch_add(1, std::memory_order_relaxed);
+    return std::malloc(size == 0 ? 1 : size);
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+    return ::operator new(size, tag);
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment) {
+    allocationCount.fetch_add(1, std::memory_order_relaxed);
+    void* pointer = allocateAligned(size == 0 ? 1 : size, static_cast<std::size_t>(alignment));
+    if (pointer == nullptr) {
+        throw std::bad_alloc{};
+    }
+    return pointer;
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment) {
+    return ::operator new(size, alignment);
+}
+
+// GCC's -Wmismatched-new-delete sees std::free() applied to a pointer that came from
+// `operator new` and reports a mismatch. It is right about the shape and wrong about the facts:
+// the operator new above *is* std::malloc, so free is the correct counterpart. The warning cannot
+// see that pairing because these are separate replaceable functions. Scoped to exactly the delete
+// family below, so the diagnostic keeps working everywhere else in this file.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#endif
+
+void operator delete(void* pointer) noexcept {
+    std::free(pointer);
+}
+
+void operator delete[](void* pointer) noexcept {
+    std::free(pointer);
+}
+
+void operator delete(void* pointer, std::size_t) noexcept {
+    std::free(pointer);
+}
+
+void operator delete[](void* pointer, std::size_t) noexcept {
+    std::free(pointer);
+}
+
+void operator delete(void* pointer, const std::nothrow_t&) noexcept {
+    std::free(pointer);
+}
+
+void operator delete[](void* pointer, const std::nothrow_t&) noexcept {
+    std::free(pointer);
+}
+
+void operator delete(void* pointer, std::align_val_t) noexcept {
+    freeAligned(pointer);
+}
+
+void operator delete[](void* pointer, std::align_val_t) noexcept {
+    freeAligned(pointer);
+}
+
+void operator delete(void* pointer, std::size_t, std::align_val_t) noexcept {
+    freeAligned(pointer);
+}
+
+void operator delete[](void* pointer, std::size_t, std::align_val_t) noexcept {
+    freeAligned(pointer);
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+// ---------------------------------------------------------------------------
+// The model under test - the same shape the runtime suite uses
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace mdux::ml;
+namespace evidence = mdux::evidence;
+
+constexpr std::uint32_t modelInputLength = 8;
+constexpr std::uint32_t modelOutputLength = 2;
+constexpr std::uint32_t modelScratchFloats = 24;
+constexpr std::size_t weightFloatCount = 22;
+
+[[nodiscard]] std::vector<LayerDesc> modelLayers() {
+    return {
+        LayerDesc{.kind = LayerKind::Conv1d,
+                  .activation = Activation::Relu,
+                  .inLength = 8,
+                  .inChannels = 1,
+                  .outLength = 6,
+                  .outChannels = 2,
+                  .kernelSize = 3,
+                  .stride = 1,
+                  .weights = TensorRef{.byteOffset = 0, .shape = {2, 1, 3}, .rank = 3},
+                  .bias = TensorRef{.byteOffset = 24, .shape = {2, 0, 0}, .rank = 1}},
+        LayerDesc{.kind = LayerKind::MaxPool1d,
+                  .activation = Activation::None,
+                  .inLength = 6,
+                  .inChannels = 2,
+                  .outLength = 3,
+                  .outChannels = 2,
+                  .kernelSize = 2,
+                  .stride = 2,
+                  .weights = TensorRef{},
+                  .bias = TensorRef{}},
+        LayerDesc{.kind = LayerKind::Flatten,
+                  .activation = Activation::None,
+                  .inLength = 3,
+                  .inChannels = 2,
+                  .outLength = 6,
+                  .outChannels = 1,
+                  .kernelSize = 0,
+                  .stride = 0,
+                  .weights = TensorRef{},
+                  .bias = TensorRef{}},
+        LayerDesc{.kind = LayerKind::Dense,
+                  .activation = Activation::Softmax,
+                  .inLength = 6,
+                  .inChannels = 1,
+                  .outLength = 2,
+                  .outChannels = 1,
+                  .kernelSize = 0,
+                  .stride = 0,
+                  .weights = TensorRef{.byteOffset = 32, .shape = {2, 6, 0}, .rank = 2},
+                  .bias = TensorRef{.byteOffset = 80, .shape = {2, 0, 0}, .rank = 1}},
+    };
+}
+
+/// Declared ahead of Harness, which bakes its goldens over this input at construction.
+[[nodiscard]] std::array<float, modelInputLength> sampleInput() noexcept;
+
+/// Everything a classifier needs, kept alive for the duration of a scenario.
+struct Harness {
+    std::vector<float> weightStorage;
+    std::vector<LayerDesc> layers = modelLayers();
+    std::vector<float> scratch = std::vector<float>(modelScratchFloats, 0.0f);
+    std::string id{"noheap-fixture"};
+    evidence::Digest digest{};
+
+    Harness() : weightStorage(weightFloatCount, 0.0f) {
+        std::uint32_t state = 99001u;
+        for (float& value : weightStorage) {
+            state = state * 1664525u + 1013904223u;
+            value = static_cast<float>(state >> 8) / 8388608.0f - 1.0f;
+        }
+        digest = evidence::sha256(std::as_bytes(std::span{weightStorage}));
+        bakeGoldens();
+    }
+
+    /**
+     * @brief Fills the golden storage by running the chain straight through the kernels.
+     *
+     * create() refuses a package with nothing to self-test against, so the goldens cannot be
+     * produced by predicting through a classifier - generating them is the step that happens
+     * before a package can be verified. Same applyLayer() the runtime uses, so what is recorded
+     * here is what create() will later reproduce.
+     */
+    void bakeGoldens() {
+        const auto input = sampleInput();
+        const std::span<const float> weightFloats{weightStorage};
+        const std::size_t width = modelScratchFloats / 2;
+        std::array<float, modelScratchFloats> work{};
+        std::span<float> bufferA{work.data(), width};
+        std::span<float> bufferB{work.data() + width, width};
+
+        for (std::size_t i = 0; i < input.size(); ++i) {
+            bufferA[i] = input[i];
+        }
+        std::span<const float> current =
+            bufferA.first(static_cast<std::size_t>(layers[0].inputFloats()));
+        for (std::size_t i = 0; i < layers.size(); ++i) {
+            const LayerDesc& layer = layers[i];
+            std::span<const float> weights;
+            std::span<const float> bias;
+            if (layer.weights.present()) {
+                weights = weightFloats.subspan(
+                    layer.weights.byteOffset / sizeof(float),
+                    static_cast<std::size_t>(layer.weights.elementCount()));
+            }
+            if (layer.bias.present()) {
+                bias = weightFloats.subspan(layer.bias.byteOffset / sizeof(float),
+                                            static_cast<std::size_t>(layer.bias.elementCount()));
+            }
+            std::span<float> destination =
+                ((i % 2) == 0 ? bufferB : bufferA)
+                    .first(static_cast<std::size_t>(layer.outputFloats()));
+            if (!applyLayer(layer, current, weights, bias, destination)) {
+                return;
+            }
+            current = destination;
+        }
+
+        for (float value : input) {
+            goldenInputBits.push_back(std::bit_cast<std::uint32_t>(value));
+        }
+        for (std::size_t i = 0; i < modelOutputLength; ++i) {
+            goldenOutputBits.push_back(std::bit_cast<std::uint32_t>(current[i]));
+        }
+        goldenViews.push_back(GoldenVector{.inputBits = goldenInputBits,
+                                           .expectedOutputBits = goldenOutputBits});
+    }
+
+    /// Golden storage, filled by bakeGoldens() before any classifier is built.
+    std::vector<std::uint32_t> goldenInputBits;
+    std::vector<std::uint32_t> goldenOutputBits;
+    std::vector<GoldenVector> goldenViews;
+
+    [[nodiscard]] ModelPackage package() const noexcept {
+        return ModelPackage{.id = id,
+                            .schemaVersion = evidence::kSchemaVersion,
+                            .weightsDigest = digest,
+                            .weightsByteLength = weightStorage.size() * sizeof(float),
+                            .layers = layers,
+                            .goldens = goldenViews,
+                            .inputLength = modelInputLength,
+                            .outputLength = modelOutputLength,
+                            .maxScratchFloats = modelScratchFloats};
+    }
+};
+
+[[nodiscard]] std::array<float, modelInputLength> sampleInput() noexcept {
+    return {0.5f, -0.25f, 1.0f, 0.75f, -1.0f, 0.125f, 0.0f, -0.5f};
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register counterIsLive{
+    "The allocation counter actually observes allocations", "noheap", [] {
+        return speclab::Test("ml-noheap-counter-is-live")
+            .Given("the replaced global operator new", [] {})
+            .When("an allocation is deliberately performed", [] {})
+            .Then("the counter moves, so a zero delta elsewhere means something",
+                  [] {
+                      // Without this scenario the whole file could pass while the interposition
+                      // was not in effect at all - the counter would simply never move. This is
+                      // the control that makes every other assertion here meaningful.
+                      mdux::spec::Checks checks;
+
+                      const std::size_t before = allocations();
+                      // volatile so the allocation cannot be optimised away entirely.
+                      auto* volatile probe = new int(7);
+                      const std::size_t afterNew = allocations();
+                      delete probe;
+
+                      checks.expect(afterNew > before,
+                                    std::format("operator new is interposed: {} -> {}", before,
+                                                afterNew));
+
+                      const std::size_t beforeVector = allocations();
+                      std::vector<double> values(64, 1.0);
+                      // Defeat any chance of the vector being elided.
+                      values[0] += static_cast<double>(values.size());
+                      const std::size_t afterVector = allocations();
+                      checks.expect(afterVector > beforeVector,
+                                    "container allocation is counted too");
+
+                      // The over-aligned path is hand-written pointer arithmetic, so it is
+                      // exercised here rather than left to chance. Without this the aligned
+                      // operators could be quietly broken and every scenario would still pass,
+                      // because nothing else in this binary allocates an over-aligned type.
+                      struct alignas(64) Overaligned {
+                          double values[8];
+                      };
+                      const std::size_t beforeAligned = allocations();
+                      auto* volatile wide = new Overaligned{};
+                      const auto address = reinterpret_cast<std::uintptr_t>(wide);
+                      const std::size_t afterAligned = allocations();
+
+                      checks.expect(afterAligned > beforeAligned,
+                                    "over-aligned operator new is counted");
+                      checks.expect(address % 64 == 0,
+                                    std::format("over-aligned allocation is 64-aligned (got {})",
+                                                address % 64));
+                      // Freeing through the replaced aligned delete has to recover the original
+                      // malloc pointer; if the stash were wrong this would corrupt the heap.
+                      delete wide;
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register predictAllocatesNothing{
+    "predict() allocates nothing across a thousand calls", "noheap", [] {
+        return speclab::Test("ml-noheap-predict")
+            .Given("a constructed classifier and a warmed-up first call", [] {})
+            .When("predict() runs a thousand times", [] {})
+            .Then("the allocation counter has not moved at all",
+                  [] {
+                      mdux::spec::Checks checks;
+                      Harness harness;
+
+                      auto classifier = Classifier1D::create(
+                          harness.package(), std::as_bytes(std::span{harness.weightStorage}),
+                          harness.scratch);
+                      checks.expect(classifier.has_value(), "classifier created");
+                      if (!classifier.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      const auto input = sampleInput();
+                      std::array<float, modelOutputLength> output{};
+
+                      // One call outside the measurement, so anything one-time - a lazily
+                      // initialised locale, a first-touch page - cannot be mistaken for a
+                      // per-prediction allocation.
+                      checks.expect(classifier->predict(input, output).has_value(),
+                                    "warm-up prediction succeeded");
+
+                      const std::size_t before = allocations();
+                      bool everyCallSucceeded = true;
+                      for (int i = 0; i < 1000; ++i) {
+                          everyCallSucceeded =
+                              everyCallSucceeded && classifier->predict(input, output).has_value();
+                      }
+                      const std::size_t after = allocations();
+
+                      checks.expect(everyCallSucceeded, "all 1000 predictions succeeded");
+                      checks.expect(after == before,
+                                    std::format("{} allocation(s) during 1000 predictions",
+                                                after - before));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register failingPredictAllocatesNothing{
+    "A refused prediction allocates nothing either", "noheap", [] {
+        return speclab::Test("ml-noheap-predict-error-path")
+            .Given("a classifier and inputs of the wrong shape", [] {})
+            .When("predict() refuses them repeatedly", [] {})
+            .Then("the error path is as allocation-free as the success path",
+                  [] {
+                      // The error path is where a std::string or a formatted diagnostic would
+                      // most plausibly creep in, so it is measured separately rather than assumed
+                      // to be covered by the success case.
+                      mdux::spec::Checks checks;
+                      Harness harness;
+
+                      auto classifier = Classifier1D::create(
+                          harness.package(), std::as_bytes(std::span{harness.weightStorage}),
+                          harness.scratch);
+                      checks.expect(classifier.has_value(), "classifier created");
+                      if (!classifier.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      const std::array<float, 3> wrongInput{};
+                      std::array<float, modelOutputLength> output{};
+                      (void)classifier->predict(wrongInput, output);  // warm-up
+
+                      const std::size_t before = allocations();
+                      bool everyCallRefused = true;
+                      for (int i = 0; i < 1000; ++i) {
+                          everyCallRefused = everyCallRefused &&
+                                             !classifier->predict(wrongInput, output).has_value();
+                      }
+                      const std::size_t after = allocations();
+
+                      checks.expect(everyCallRefused, "all 1000 predictions were refused");
+                      checks.expect(after == before,
+                                    std::format("{} allocation(s) on the error path",
+                                                after - before));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register selfTestAllocatesNothing{
+    "create()'s golden self-test allocates nothing", "noheap", [] {
+        return speclab::Test("ml-noheap-create")
+            .Given("a package carrying golden vectors", [] {})
+            .When("create() runs its digest check and self-test", [] {})
+            .Then("no allocation occurs, so create() is usable before any heap exists",
+                  [] {
+                      // create() runs once at startup, so an allocation there would be far less
+                      // serious than one in predict(). It is still asserted: on a device that
+                      // brings the classifier up before its allocator, "bounded startup work"
+                      // needs to mean no heap at all.
+                      mdux::spec::Checks checks;
+                      Harness harness;
+
+                      // The harness baked its goldens at construction, so the package handed
+                      // to create() below already carries a real self-test to run.
+                      const ModelPackage package = harness.package();
+                      const auto weights = std::as_bytes(std::span{harness.weightStorage});
+
+                      const std::size_t before = allocations();
+                      auto verified = Classifier1D::create(package, weights, harness.scratch);
+                      const std::size_t after = allocations();
+
+                      checks.expect(verified.has_value(), "self-tested classifier created");
+                      checks.expect(after == before,
+                                    std::format("{} allocation(s) during create()", after - before));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+}  // namespace


### PR DESCRIPTION
"No allocation in `predict()`" is easy to claim and easy to break silently, so none of the three layers is review discipline.

**Layer 1** replaces the whole global `operator new` family with counting versions and asserts a zero delta across 1000 predictions. It is also the layer most able to become worthless — a broken interposition would simply never move the counter and every case would pass — so the first scenario deliberately allocates and asserts the counter *does* move. The error path and `create()`'s self-test are measured separately, since a formatted diagnostic would creep into the error path first.

**Layer 2** scans the compiled ML objects with `nm`/`dumpbin` for undefined references to `operator new`, `malloc` and friends, plus `__cxa_throw`, which double-checks ADR-005's no-throwing rule. It fails in the PR that introduced the reference rather than whenever someone next runs that path. The scan refuses to run on an empty object list, and was checked against a known-allocating object to confirm it is not vacuous.

**Layer 3** is `src/ml/.clang-tidy` making `cppcoreguidelines-no-malloc` and `-owning-memory` errors.

Stacked on #62.

Closes #63.