### PR TITLE
feat(ml): add the safetensors reader and architecture validator

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -543,6 +543,36 @@ endif()
 
 mdux_discover_tests(ml_spec)
 
+# ML host-tools suite (issue #60)
+#
+# Links MduX::MlBakeLib, the host-tools-zone target. Deliberately separate from ml_spec, which
+# links MduX::Core only - keeping the two apart is what preserves ml_spec's standing evidence that
+# the governed ML modules reach nothing but std.
+add_executable(ml_tools_spec
+    ml/MlToolsSpecMain.cpp
+    ml/SafetensorsTests.cpp
+)
+
+target_link_libraries(ml_tools_spec PRIVATE MduX::MlBakeLib speclab::speclab)
+target_include_directories(ml_tools_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(ml_tools_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(ml_tools_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(ml_tools_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(ml_tools_spec)
+
 # No-heap verification, layer 1 (issue #63): global operator new interposition.
 #
 # Its own binary because it replaces the global allocator - see tests/ml/NoHeapSpecMain.cpp.

--- a/tests/ml/MlToolsSpecMain.cpp
+++ b/tests/ml/MlToolsSpecMain.cpp
@@ -1,0 +1,20 @@
+/**
+ * @brief Entry point for the ML host-tools SpecLab executable (issue #60).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Separate from ml_spec, which links MduX::Core only. These scenarios exercise the safetensors
+ * reader and the architecture validator, which live in the host-tools zone and may throw - so a
+ * suite covering them has to link MduX::MlBakeLib, and keeping that out of ml_spec preserves
+ * ml_spec's standing evidence that the governed ML modules need nothing but std.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX ML Tools Spec");
+}

--- a/tests/ml/SafetensorsTests.cpp
+++ b/tests/ml/SafetensorsTests.cpp
@@ -1,0 +1,389 @@
+/**
+ * @file SafetensorsTests.cpp
+ * @brief BDD scenarios for the host-side weight importer (issue #60).
+ *
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * The corpus is built in memory rather than committed as binary fixtures. A malformed safetensors
+ * file is a handful of bytes described by one line of code here; as a committed blob it would be an
+ * opaque artifact whose intended defect a reviewer has to take on trust, and which the
+ * source-tree-cleanliness gate would have to be taught about.
+ *
+ * Every case asserts a specific diagnostic code, not merely that parsing failed. A parser that
+ * rejects everything with one generic error passes "it was rejected" and is useless to the author
+ * who has to fix the file.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.ml.schema;
+import mdux.tools.cli;
+import mdux.tools.ml.safetensors;
+import mdux.tools.ml.archvalidate;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+using namespace mdux::tools::ml;
+namespace cli = mdux::tools::cli;
+namespace ml = mdux::ml;
+
+/// Assembles a safetensors file: the 8-byte little-endian header length, the header, then data.
+[[nodiscard]] std::vector<std::byte> buildFile(std::string_view header,
+                                               std::span<const std::byte> data) {
+    std::vector<std::byte> bytes;
+    const std::uint64_t headerLength = header.size();
+    for (std::size_t i = 0; i < 8; ++i) {
+        bytes.push_back(static_cast<std::byte>((headerLength >> (8 * i)) & 0xFFu));
+    }
+    for (char character : header) {
+        bytes.push_back(static_cast<std::byte>(character));
+    }
+    bytes.insert(bytes.end(), data.begin(), data.end());
+    return bytes;
+}
+
+[[nodiscard]] std::vector<std::byte> floatBytes(std::span<const float> values) {
+    std::vector<std::byte> bytes;
+    for (float value : values) {
+        const auto bits = std::bit_cast<std::array<std::byte, 4>>(value);
+        bytes.insert(bytes.end(), bits.begin(), bits.end());
+    }
+    return bytes;
+}
+
+/// A well-formed two-tensor file: a [2,3] weight matrix and a [2] bias.
+[[nodiscard]] std::vector<std::byte> validFile() {
+    const std::array<float, 8> values{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 0.5f, -0.5f};
+    const std::string header =
+        R"({"bias":{"dtype":"F32","shape":[2],"data_offsets":[24,32]},)"
+        R"("weight":{"dtype":"F32","shape":[2,3],"data_offsets":[0,24]}})";
+    return buildFile(header, floatBytes(values));
+}
+
+/// The diagnostic code a file parses to, or "ok" when it parses.
+[[nodiscard]] std::string codeOf(std::span<const std::byte> bytes) {
+    auto parsed = parseSafetensors(bytes, "fixture.safetensors");
+    if (parsed.has_value()) {
+        return "ok";
+    }
+    return parsed.error().code;
+}
+
+/// One corpus entry: a deliberately broken file and the code it must produce.
+struct Case {
+    std::string_view what;
+    std::string_view expectedCode;
+    std::function<std::vector<std::byte>()> build;
+};
+
+const std::vector<Case>& corpus() {
+    static const std::vector<Case> cases{
+        {"a well-formed file", "ok", [] { return validFile(); }},
+
+        {"a file too short to hold a header length",
+         "mdux.ml.safetensors.malformedTruncatedHeaderLength",
+         [] { return std::vector<std::byte>(4, std::byte{0}); }},
+
+        {"a header length longer than the file",
+         "mdux.ml.safetensors.malformedHeaderOutOfBounds",
+         [] {
+             std::vector<std::byte> bytes = validFile();
+             bytes[0] = std::byte{0xFF};  // header now claims far more than remains
+             bytes[1] = std::byte{0xFF};
+             return bytes;
+         }},
+
+        {"a header that is not JSON", "mdux.ml.safetensors.malformedHeaderJson",
+         [] { return buildFile("{not json at all", {}); }},
+
+        {"a header that is a JSON array", "mdux.ml.safetensors.malformedHeaderNotObject",
+         [] { return buildFile("[]", {}); }},
+
+        {"a tensor described by a string", "mdux.ml.safetensors.malformedTensorNotObject",
+         [] { return buildFile(R"({"weight":"nonsense"})", {}); }},
+
+        {"a tensor missing its shape", "mdux.ml.safetensors.malformedTensorFields",
+         [] {
+             return buildFile(R"({"weight":{"dtype":"F32","data_offsets":[0,4]}})",
+                              floatBytes(std::array<float, 1>{1.0f}));
+         }},
+
+        {"an unrecognised dtype spelling", "mdux.ml.safetensors.malformedUnknownDtype",
+         [] {
+             return buildFile(R"({"weight":{"dtype":"F42","shape":[1],"data_offsets":[0,4]}})",
+                              floatBytes(std::array<float, 1>{1.0f}));
+         }},
+
+        // Recognised, well-formed, and out of v1 scope - a different code on purpose, because the
+        // author's file is fine and their model is not supported.
+        {"an f16 tensor", "mdux.ml.safetensors.unsupportedDtype",
+         [] {
+             const std::vector<std::byte> data(4, std::byte{0});
+             return buildFile(R"({"weight":{"dtype":"F16","shape":[2],"data_offsets":[0,4]}})",
+                              data);
+         }},
+
+        {"a rank-4 tensor", "mdux.ml.safetensors.unsupportedRank",
+         [] {
+             const std::vector<std::byte> data(16, std::byte{0});
+             return buildFile(
+                 R"({"weight":{"dtype":"F32","shape":[1,1,2,2],"data_offsets":[0,16]}})", data);
+         }},
+
+        {"data_offsets that are not a pair", "mdux.ml.safetensors.malformedOffsets",
+         [] {
+             return buildFile(R"({"weight":{"dtype":"F32","shape":[1],"data_offsets":[0]}})",
+                              floatBytes(std::array<float, 1>{1.0f}));
+         }},
+
+        {"a tensor that ends before it begins", "mdux.ml.safetensors.malformedOffsets",
+         [] {
+             return buildFile(R"({"weight":{"dtype":"F32","shape":[1],"data_offsets":[8,4]}})",
+                              floatBytes(std::array<float, 4>{}));
+         }},
+
+        {"a range past the end of the data section",
+         "mdux.ml.safetensors.malformedRangeOutOfBounds",
+         [] {
+             return buildFile(R"({"weight":{"dtype":"F32","shape":[8],"data_offsets":[0,32]}})",
+                              floatBytes(std::array<float, 2>{1.0f, 2.0f}));
+         }},
+
+        {"a shape that disagrees with its byte range",
+         "mdux.ml.safetensors.malformedShapeByteLength",
+         [] {
+             // [4] f32 needs 16 bytes; the range reserves 8.
+             return buildFile(R"({"weight":{"dtype":"F32","shape":[4],"data_offsets":[0,8]}})",
+                              floatBytes(std::array<float, 2>{1.0f, 2.0f}));
+         }},
+
+        {"a shape whose element count overflows 64 bits",
+         "mdux.ml.safetensors.malformedShapeByteLength",
+         [] {
+             // Three near-2^32 extents multiply past 2^64. The wrapped product can land exactly on
+             // a small declared byte range, so without the overflow guard this validates and the
+             // baker then packs a tensor described by nonsense.
+             const std::vector<std::byte> data(8, std::byte{0});
+             return buildFile(
+                 R"({"weight":{"dtype":"F32","shape":[4294967295,4294967295,4294967295],)"
+                 R"("data_offsets":[0,8]}})",
+                 data);
+         }},
+
+        {"two tensors sharing bytes", "mdux.ml.safetensors.malformedOverlappingTensors",
+         [] {
+             const std::string header =
+                 R"({"a":{"dtype":"F32","shape":[2],"data_offsets":[0,8]},)"
+                 R"("b":{"dtype":"F32","shape":[2],"data_offsets":[4,12]}})";
+             return buildFile(header, floatBytes(std::array<float, 4>{1.0f, 2.0f, 3.0f, 4.0f}));
+         }},
+    };
+    return cases;
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register corpusProducesSpecificCodes{
+    "Every malformed fixture produces its own diagnostic code", "evidence-unit", [] {
+        return speclab::Test("ml-safetensors-corpus")
+            .Given("a corpus of valid and deliberately malformed safetensors files", [] {})
+            .When("each is parsed", [] {})
+            .Then("each yields exactly the code an author would need to fix it",
+                  [] {
+                      mdux::spec::Checks checks;
+                      for (const Case& entry : corpus()) {
+                          const std::string actual = codeOf(entry.build());
+                          checks.expect(actual == entry.expectedCode,
+                                        std::format("{}: got '{}', expected '{}'", entry.what,
+                                                    actual, entry.expectedCode));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register validFileIsReadCorrectly{
+    "A well-formed file yields its tensors in a fixed order", "evidence-unit", [] {
+        return speclab::Test("ml-safetensors-valid")
+            .Given("a two-tensor file whose header lists them in a particular order", [] {})
+            .When("it is parsed", [] {})
+            .Then("both tensors are present, sorted by name, with absolute byte offsets",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::vector<std::byte> bytes = validFile();
+                      auto parsed = parseSafetensors(bytes, "fixture.safetensors");
+
+                      checks.expect(parsed.has_value(), "parsed");
+                      if (!parsed.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      checks.expect(parsed->tensors.size() == 2, "two tensors");
+                      // Sorted by name, so the order is the baker's, not the exporter's - which is
+                      // what keeps a bake byte-identical between two machines.
+                      checks.expect(parsed->tensors[0].name == "bias", "bias sorts first");
+                      checks.expect(parsed->tensors[1].name == "weight", "weight sorts second");
+
+                      const TensorEntry* weight = parsed->find("weight");
+                      checks.expect(weight != nullptr, "weight found by name");
+                      if (weight == nullptr) {
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(weight->shape == std::vector<std::uint64_t>{2, 3}, "shape");
+                      checks.expect(weight->elementCount() == 6, "element count");
+                      checks.expect(weight->byteLength == 24, "byte length");
+
+                      // Absolute, so a caller never has to remember to add the data-section start.
+                      // The header length is read back out of the file the way the parser does it,
+                      // rather than hardcoded - a literal here would silently stop testing anything
+                      // the moment the fixture's header string changed length.
+                      std::uint64_t headerLength = 0;
+                      for (std::size_t i = 0; i < 8; ++i) {
+                          headerLength |=
+                              static_cast<std::uint64_t>(std::to_integer<std::uint8_t>(bytes[i]))
+                              << (8 * i);
+                      }
+                      const std::uint64_t dataStart = 8 + headerLength;
+                      checks.expect(weight->byteOffset >= dataStart,
+                                    std::format("offset {} is absolute (data starts at {})",
+                                                weight->byteOffset, dataStart));
+
+                      // And the bytes really are the values that went in.
+                      const auto first = std::bit_cast<float>(std::array<std::byte, 4>{
+                          bytes[weight->byteOffset], bytes[weight->byteOffset + 1],
+                          bytes[weight->byteOffset + 2], bytes[weight->byteOffset + 3]});
+                      checks.expect(first == 1.0f, std::format("first weight is {}", first));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register architectureMustMatchWeights{
+    "The declared architecture is checked against the imported tensors", "evidence-unit", [] {
+        return speclab::Test("ml-archvalidate")
+            .Given("a recipe architecture and the weights file it names", [] {})
+            .When("the architecture is resolved", [] {})
+            .Then("agreement resolves and every disagreement is reported",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::vector<std::byte> bytes = validFile();
+                      auto parsed = parseSafetensors(bytes, "fixture.safetensors");
+                      checks.expect(parsed.has_value(), "weights parsed");
+                      if (!parsed.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      // A single dense layer: 3 inputs -> 2 outputs, matching the [2,3] weight.
+                      const auto denseSpec = [](std::uint32_t inLength, std::uint32_t outLength) {
+                          ArchitectureSpec spec;
+                          spec.id = "fixture";
+                          spec.inputLength = inLength;
+                          spec.outputLength = outLength;
+                          spec.layers.push_back(LayerSpec{.kind = ml::LayerKind::Dense,
+                                                          .activation = ml::Activation::Softmax,
+                                                          .inLength = inLength,
+                                                          .inChannels = 1,
+                                                          .outLength = outLength,
+                                                          .outChannels = 1,
+                                                          .kernelSize = 0,
+                                                          .stride = 0,
+                                                          .weightsTensor = "weight",
+                                                          .biasTensor = "bias"});
+                          return spec;
+                      };
+
+                      {  // The agreeing case.
+                          auto resolved = resolveArchitecture(denseSpec(3, 2), *parsed, bytes,
+                                                              "fixture.toml");
+                          checks.expect(resolved.has_value(),
+                                        resolved.has_value()
+                                            ? "resolved"
+                                            : std::format("unexpected: {}",
+                                                          resolved.error().front().message));
+                          if (resolved.has_value()) {
+                              checks.expect(resolved->weights.size() == 32,
+                                            "blob holds both tensors packed in layer order");
+                              // Derived rather than restated in the recipe: 2 * max(3, 2).
+                              checks.expect(resolved->maxScratchFloats == 6,
+                                            std::format("scratch derived as {}",
+                                                        resolved->maxScratchFloats));
+                          }
+                      }
+
+                      {  // Dimensions that disagree with the tensor the recipe named. This is the
+                         // check that catches weights imported against the wrong architecture, and
+                         // it comes from the governed schema rather than a host-side copy.
+                          auto resolved = resolveArchitecture(denseSpec(4, 2), *parsed, bytes,
+                                                              "fixture.toml");
+                          checks.expect(!resolved.has_value(), "a mismatched width is rejected");
+                          if (!resolved.has_value()) {
+                              checks.expect(resolved.error().front().code ==
+                                                "mdux.ml.arch.shapeMismatch",
+                                            std::format("code is {}",
+                                                        resolved.error().front().code));
+                          }
+                      }
+
+                      {  // A tensor name that is not in the file.
+                          ArchitectureSpec spec = denseSpec(3, 2);
+                          spec.layers[0].weightsTensor = "not_present";
+                          auto resolved =
+                              resolveArchitecture(spec, *parsed, bytes, "fixture.toml");
+                          checks.expect(!resolved.has_value(), "a missing tensor is rejected");
+                          if (!resolved.has_value()) {
+                              checks.expect(resolved.error().front().code ==
+                                                "mdux.ml.arch.missingTensor",
+                                            "code is missingTensor");
+                          }
+                      }
+
+                      {  // A pooling layer that names weights it cannot use.
+                          ArchitectureSpec spec;
+                          spec.id = "fixture";
+                          spec.inputLength = 4;
+                          spec.outputLength = 2;
+                          spec.layers.push_back(LayerSpec{.kind = ml::LayerKind::MaxPool1d,
+                                                          .activation = ml::Activation::None,
+                                                          .inLength = 4,
+                                                          .inChannels = 1,
+                                                          .outLength = 2,
+                                                          .outChannels = 1,
+                                                          .kernelSize = 2,
+                                                          .stride = 2,
+                                                          .weightsTensor = "weight",
+                                                          .biasTensor = ""});
+                          auto resolved =
+                              resolveArchitecture(spec, *parsed, bytes, "fixture.toml");
+                          checks.expect(!resolved.has_value(),
+                                        "pooling with weights is rejected");
+                          if (!resolved.has_value()) {
+                              checks.expect(resolved.error().front().code ==
+                                                "mdux.ml.arch.unexpectedTensor",
+                                            "code is unexpectedTensor");
+                          }
+                      }
+
+                      {  // An empty architecture.
+                          ArchitectureSpec spec;
+                          spec.id = "fixture";
+                          auto resolved =
+                              resolveArchitecture(spec, *parsed, bytes, "fixture.toml");
+                          checks.expect(!resolved.has_value() &&
+                                            resolved.error().front().code ==
+                                                "mdux.ml.arch.noLayers",
+                                        "an empty architecture is rejected");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+}  // namespace

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -101,6 +101,46 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(MduXShaderBakeLib PRIVATE /experimental:module /std:c++latest)
 endif()
 
+# Zero-SOUP ML weight import and baking (epic #18, ADR-008)
+#
+# Host-tools zone, exactly like the shader baker: it parses untrusted weight files and may throw,
+# so it is deliberately not declared governed. It links MduX::ToolsCommon (and through it
+# MduX::Core), which is how the baker reaches mdux.ml.kernels - the same governed module the device
+# runtime executes. That identity is the whole basis of the golden-vector argument in ADR-008.
+add_library(MduXMlBakeLib)
+add_library(MduX::MlBakeLib ALIAS MduXMlBakeLib)
+
+target_sources(MduXMlBakeLib
+    PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES
+            ml/Safetensors.cppm
+            ml/ArchValidate.cppm
+    PRIVATE
+        ml/Safetensors.cpp
+        ml/ArchValidate.cpp
+)
+
+target_compile_features(MduXMlBakeLib PUBLIC cxx_std_23)
+target_link_libraries(MduXMlBakeLib PUBLIC MduX::ToolsCommon)
+target_link_libraries(MduXMlBakeLib PRIVATE MduX_warnings)
+
+set_target_properties(MduXMlBakeLib
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(MduXMlBakeLib PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(MduXMlBakeLib PRIVATE /experimental:module /std:c++latest)
+endif()
+
 add_executable(mdux-shaderbake shader/ShaderBakeMain.cpp)
 target_link_libraries(mdux-shaderbake PRIVATE MduX::ShaderBakeLib MduX_warnings)
 

--- a/tools/ml/ArchValidate.cpp
+++ b/tools/ml/ArchValidate.cpp
@@ -1,0 +1,220 @@
+/**
+ * @file ArchValidate.cpp
+ * @brief Implementation of the recipe-versus-weights architecture check.
+ *
+ * @compliance ADR-008 Zero-SOUP ML inference
+ */
+module;
+
+module mdux.tools.ml.archvalidate;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.report;
+import mdux.ml.schema;
+import mdux.tools.cli;
+import mdux.tools.ml.safetensors;
+
+namespace mdux::tools::ml {
+
+using mdux::core::err;
+namespace ml = mdux::ml;
+
+namespace {
+
+[[nodiscard]] cli::Diagnostic problem(std::string_view recipeName, std::string code,
+                                      std::string message, std::string fixHint = {}) {
+    return cli::Diagnostic{.file = std::string{recipeName},
+                           .line = 0,
+                           .column = 0,
+                           .code = std::move(code),
+                           .severity = cli::Severity::Error,
+                           .message = std::move(message),
+                           .fixHint = std::move(fixHint)};
+}
+
+/// Maps a schema rejection to a diagnostic code. The most actionable causes get their own code so
+/// a recipe author (or an agent reading --format=json) can key off it; the rest share one.
+[[nodiscard]] std::string codeFor(ml::SchemaError error) noexcept {
+    switch (error) {
+        case ml::SchemaError::WeightShapeMismatch:
+        case ml::SchemaError::BiasShapeMismatch:
+            return "mdux.ml.arch.shapeMismatch";
+        case ml::SchemaError::MissingBias:
+        case ml::SchemaError::MissingWeights:
+            return "mdux.ml.arch.missingTensor";
+        case ml::SchemaError::UnexpectedWeights:
+            return "mdux.ml.arch.unexpectedTensor";
+        case ml::SchemaError::ScratchTooSmall:
+            return "mdux.ml.arch.scratchTooSmall";
+        case ml::SchemaError::LayerChainMismatch:
+        case ml::SchemaError::InputLengthMismatch:
+        case ml::SchemaError::OutputLengthMismatch:
+            return "mdux.ml.arch.chainMismatch";
+        case ml::SchemaError::OutputLengthNotDerivable:
+        case ml::SchemaError::KernelLargerThanInput:
+            return "mdux.ml.arch.windowMismatch";
+        default:
+            return "mdux.ml.arch.invalid";
+    }
+}
+
+/// Copies a tensor's f32 bytes out of the file and appends them to the packed blob, returning the
+/// TensorRef that addresses them. The shape recorded is the *file's*, which is what makes the
+/// schema's shape check meaningful - see ArchValidate.cppm.
+[[nodiscard]] std::optional<ml::TensorRef> appendTensor(const TensorEntry& tensor,
+                                                        std::span<const std::byte> fileBytes,
+                                                        std::vector<std::byte>& blob) {
+    ml::TensorRef reference;
+    reference.byteOffset = blob.size();
+    reference.rank = static_cast<std::uint8_t>(tensor.shape.size());
+    for (std::size_t i = 0; i < tensor.shape.size() && i < ml::maxTensorRank; ++i) {
+        // TensorRef stores extents as uint32 while safetensors declares them as uint64. A silent
+        // narrowing here would be the worst kind: the appended bytes stay the full length, but the
+        // TensorRef describing them wraps to something small, so the package validates against a
+        // blob it mis-describes. Reported rather than truncated.
+        if (tensor.shape[i] > std::numeric_limits<std::uint32_t>::max()) {
+            return std::nullopt;
+        }
+        reference.shape[i] = static_cast<std::uint32_t>(tensor.shape[i]);
+    }
+
+    const std::span<const std::byte> source =
+        fileBytes.subspan(static_cast<std::size_t>(tensor.byteOffset),
+                          static_cast<std::size_t>(tensor.byteLength));
+    blob.insert(blob.end(), source.begin(), source.end());
+    return reference;
+}
+
+/// Appends `tensor` into `blob`, reporting a diagnostic instead of narrowing an extent silently.
+[[nodiscard]] bool appendInto(const TensorEntry& tensor, std::span<const std::byte> fileBytes,
+                              std::vector<std::byte>& blob, ml::TensorRef& out,
+                              std::string_view recipeName, std::size_t layerIndex,
+                              std::string_view role, std::vector<cli::Diagnostic>& diagnostics) {
+    auto appended = appendTensor(tensor, fileBytes, blob);
+    if (!appended.has_value()) {
+        diagnostics.push_back(problem(
+            recipeName, "mdux.ml.arch.shapeMismatch",
+            std::format("layer {}'s {} tensor '{}' has an extent too large to describe", layerIndex,
+                        role, tensor.name)));
+        return false;
+    }
+    out = *appended;
+    return true;
+}
+
+}  // namespace
+
+mdux::core::Result<ResolvedArchitecture, std::vector<cli::Diagnostic>> resolveArchitecture(
+    const ArchitectureSpec& spec, const SafetensorsFile& file, std::span<const std::byte> fileBytes,
+    std::string_view recipeName) {
+    std::vector<cli::Diagnostic> diagnostics;
+
+    if (spec.layers.empty()) {
+        diagnostics.push_back(problem(recipeName, "mdux.ml.arch.noLayers",
+                                      "the architecture declares no layers"));
+        return err(std::move(diagnostics));
+    }
+
+    ResolvedArchitecture resolved;
+    resolved.inputLength = spec.inputLength;
+    resolved.outputLength = spec.outputLength;
+    resolved.layers.reserve(spec.layers.size());
+
+    for (std::size_t i = 0; i < spec.layers.size(); ++i) {
+        const LayerSpec& layerSpec = spec.layers[i];
+        ml::LayerDesc layer{.kind = layerSpec.kind,
+                            .activation = layerSpec.activation,
+                            .inLength = layerSpec.inLength,
+                            .inChannels = layerSpec.inChannels,
+                            .outLength = layerSpec.outLength,
+                            .outChannels = layerSpec.outChannels,
+                            .kernelSize = layerSpec.kernelSize,
+                            .stride = layerSpec.stride,
+                            .weights = ml::TensorRef{},
+                            .bias = ml::TensorRef{}};
+
+        // A layer kind that carries no weights must not name any: silently ignoring the name would
+        // hide a recipe that thinks its pooling layer is learned.
+        const bool wantsWeights = ml::carriesWeights(layerSpec.kind);
+        if (!wantsWeights && (!layerSpec.weightsTensor.empty() || !layerSpec.biasTensor.empty())) {
+            diagnostics.push_back(problem(
+                recipeName, "mdux.ml.arch.unexpectedTensor",
+                std::format("layer {} is {} and carries no weights, but names a tensor", i,
+                            ml::layerKindWireValues[static_cast<std::size_t>(layerSpec.kind)])));
+        }
+
+        if (wantsWeights) {
+            if (layerSpec.weightsTensor.empty()) {
+                diagnostics.push_back(problem(
+                    recipeName, "mdux.ml.arch.missingTensor",
+                    std::format("layer {} names no weight tensor", i)));
+            } else if (const TensorEntry* tensor = file.find(layerSpec.weightsTensor)) {
+                (void)appendInto(*tensor, fileBytes, resolved.weights, layer.weights, recipeName, i,
+                                 "weight", diagnostics);
+            } else {
+                diagnostics.push_back(problem(
+                    recipeName, "mdux.ml.arch.missingTensor",
+                    std::format("layer {} names weight tensor '{}', which the weights file does "
+                                "not contain",
+                                i, layerSpec.weightsTensor),
+                    "check the tensor name against the exporter's naming"));
+            }
+
+            if (layerSpec.biasTensor.empty()) {
+                diagnostics.push_back(problem(
+                    recipeName, "mdux.ml.arch.missingTensor",
+                    std::format("layer {} names no bias tensor; every v1 dense and conv1d layer "
+                                "carries one",
+                                i)));
+            } else if (const TensorEntry* tensor = file.find(layerSpec.biasTensor)) {
+                (void)appendInto(*tensor, fileBytes, resolved.weights, layer.bias, recipeName, i,
+                                 "bias", diagnostics);
+            } else {
+                diagnostics.push_back(problem(
+                    recipeName, "mdux.ml.arch.missingTensor",
+                    std::format("layer {} names bias tensor '{}', which the weights file does not "
+                                "contain",
+                                i, layerSpec.biasTensor)));
+            }
+        }
+
+        resolved.layers.push_back(layer);
+    }
+
+    // A missing tensor makes every downstream shape finding noise, so stop before delegating.
+    if (!diagnostics.empty()) {
+        return err(std::move(diagnostics));
+    }
+
+    resolved.maxScratchFloats =
+        spec.maxScratchFloats != 0
+            ? spec.maxScratchFloats
+            : static_cast<std::uint32_t>(
+                  ml::requiredScratchFloats(resolved.layers, spec.inputLength));
+
+    // The canonical rules, run once, from the governed module. See ArchValidate.cppm.
+    const ml::ModelPackage package{.id = spec.id,
+                                   .schemaVersion = mdux::evidence::kSchemaVersion,
+                                   .weightsDigest = {},
+                                   .weightsByteLength = resolved.weights.size(),
+                                   .layers = resolved.layers,
+                                   .goldens = {},
+                                   .inputLength = spec.inputLength,
+                                   .outputLength = spec.outputLength,
+                                   .maxScratchFloats = resolved.maxScratchFloats};
+
+    if (auto valid = package.validate(); !valid.has_value()) {
+        const ml::SchemaError error = valid.error();
+        diagnostics.push_back(problem(
+            recipeName, codeFor(error),
+            std::format("the declared architecture does not match the imported weights: {}",
+                        ml::describe(error)),
+            "compare the recipe's layer dimensions against the tensor shapes in the weights file"));
+        return err(std::move(diagnostics));
+    }
+
+    return resolved;
+}
+
+}  // namespace mdux::tools::ml

--- a/tools/ml/ArchValidate.cppm
+++ b/tools/ml/ArchValidate.cppm
@@ -1,0 +1,94 @@
+/**
+ * @file ArchValidate.cppm
+ * @brief Host-tools-zone architecture check: does the recipe describe the weights it imported?
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Checks a recipe's declared architecture against the tensors actually present in a safetensors
+ * file, *before* anything is baked. Every rejection is an explicit error rather than a silent
+ * coercion - a dense layer quietly reshaped to fit its weights is a model that classifies
+ * something other than what the author reviewed.
+ *
+ * ## One set of shape rules, not two
+ *
+ * This module deliberately does not restate the shape rules. It resolves each layer's named
+ * tensors, records their shapes **as the file declares them**, packs the weight blob, and then
+ * hands the result to `mdux::ml::ModelPackage::validate()` - the same governed function the device
+ * runtime calls. Every "weight tensor disagrees with the layer's dimensions" finding therefore
+ * comes from the canonical rule rather than from a host-side copy of it that could drift.
+ *
+ * The reason that works is that the `TensorRef` shapes come from the *file* while the layer
+ * dimensions come from the *recipe*. If the host filled in both sides from the recipe, the check
+ * would be vacuous - which is the mistake this comment exists to prevent.
+ *
+ * What is left here is only what the schema cannot see: tensor names, their presence in the file,
+ * and the packing of the blob.
+ *
+ * ## The blob layout is MduX's, not the file's
+ *
+ * Tensors are packed in layer order, weights then bias, contiguously. The safetensors file's own
+ * ordering is irrelevant and is not preserved: the package addresses its blob by byte offset, and
+ * a layout derived from the layer chain is reproducible from the recipe alone.
+ */
+module;
+
+export module mdux.tools.ml.archvalidate;
+
+import std;
+import mdux.core.result;
+import mdux.ml.schema;
+import mdux.tools.cli;
+import mdux.tools.ml.safetensors;
+
+export namespace mdux::tools::ml {
+
+/// One layer as a recipe declares it: the dimensions the author asserts, plus the names of the
+/// tensors in the weights file that should fill them.
+struct LayerSpec {
+    mdux::ml::LayerKind kind{mdux::ml::LayerKind::Dense};
+    mdux::ml::Activation activation{mdux::ml::Activation::None};
+    std::uint32_t inLength{0};
+    std::uint32_t inChannels{0};
+    std::uint32_t outLength{0};
+    std::uint32_t outChannels{0};
+    std::uint32_t kernelSize{0};
+    std::uint32_t stride{0};
+    std::string weightsTensor;  ///< empty for a layer that carries no weights
+    std::string biasTensor;
+};
+
+/// A whole architecture as a recipe declares it.
+struct ArchitectureSpec {
+    std::string id;
+    std::uint32_t inputLength{0};
+    std::uint32_t outputLength{0};
+    std::vector<LayerSpec> layers;
+    /// 0 means "derive it", which is the normal case - the baker should not be asked to restate a
+    /// number the layer chain already determines.
+    std::uint32_t maxScratchFloats{0};
+};
+
+/// What a successful resolution produces: everything a ModelPackage needs except its goldens.
+struct ResolvedArchitecture {
+    std::vector<mdux::ml::LayerDesc> layers;
+    std::vector<std::byte> weights;  ///< packed in layer order, f32 throughout
+    std::uint32_t inputLength{0};
+    std::uint32_t outputLength{0};
+    std::uint32_t maxScratchFloats{0};
+};
+
+/**
+ * @brief Resolves and validates, returning every problem rather than only the first.
+ *
+ * An author fixing a recipe wants the whole list; stopping at the first missing tensor turns one
+ * edit-and-rerun cycle into five. (The safetensors parser stops at its first problem for the
+ * opposite reason - findings past a malformed header are not trustworthy.)
+ *
+ * @param fileBytes the whole safetensors file, which the tensor byte ranges index into
+ */
+[[nodiscard]] mdux::core::Result<ResolvedArchitecture, std::vector<cli::Diagnostic>>
+resolveArchitecture(const ArchitectureSpec& spec, const SafetensorsFile& file,
+                    std::span<const std::byte> fileBytes, std::string_view recipeName);
+
+}  // namespace mdux::tools::ml

--- a/tools/ml/Safetensors.cpp
+++ b/tools/ml/Safetensors.cpp
@@ -1,0 +1,323 @@
+/**
+ * @file Safetensors.cpp
+ * @brief Implementation of the hand-written safetensors reader.
+ *
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * Every bound is checked before it is used. The arithmetic on offsets is done in `std::uint64_t`
+ * with explicit overflow guards rather than by adding and hoping - a header can declare any
+ * numbers at all, and `begin + length` wrapping is the classic way a range check passes and the
+ * read still runs off the end.
+ */
+module;
+
+module mdux.tools.ml.safetensors;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.json;
+import mdux.tools.cli;
+
+namespace mdux::tools::ml {
+
+using mdux::core::err;
+namespace json = mdux::evidence::json;
+
+namespace {
+
+/// v1 caps rank at 3, matching mdux.ml.schema's maxTensorRank.
+constexpr std::size_t maxSupportedRank = 3;
+
+[[nodiscard]] cli::Diagnostic problem(std::string_view fileName, std::string code,
+                                      std::string message, std::string fixHint = {}) {
+    return cli::Diagnostic{.file = std::string{fileName},
+                           .line = 0,
+                           .column = 0,
+                           .code = std::move(code),
+                           .severity = cli::Severity::Error,
+                           .message = std::move(message),
+                           .fixHint = std::move(fixHint)};
+}
+
+}  // namespace
+
+std::uint64_t dtypeByteWidth(Dtype dtype) noexcept {
+    switch (dtype) {
+        case Dtype::Bool:
+        case Dtype::U8:
+        case Dtype::I8:   return 1;
+        case Dtype::U16:
+        case Dtype::I16:
+        case Dtype::F16:
+        case Dtype::BF16: return 2;
+        case Dtype::U32:
+        case Dtype::I32:
+        case Dtype::F32:  return 4;
+        case Dtype::U64:
+        case Dtype::I64:
+        case Dtype::F64:  return 8;
+    }
+    return 0;
+}
+
+std::optional<Dtype> dtypeFromWire(std::string_view wire) noexcept {
+    for (std::size_t i = 0; i < dtypeWireValues.size(); ++i) {
+        if (dtypeWireValues[i] == wire) {
+            return static_cast<Dtype>(i);
+        }
+    }
+    return std::nullopt;
+}
+
+std::uint64_t TensorEntry::elementCount() const noexcept {
+    std::uint64_t count = 1;
+    for (std::uint64_t dimension : shape) {
+        count *= dimension;
+    }
+    return count;
+}
+
+const TensorEntry* SafetensorsFile::find(std::string_view name) const noexcept {
+    for (const TensorEntry& tensor : tensors) {
+        if (tensor.name == name) {
+            return &tensor;
+        }
+    }
+    return nullptr;
+}
+
+mdux::core::Result<SafetensorsFile, cli::Diagnostic> parseSafetensors(
+    std::span<const std::byte> bytes, std::string_view fileName) {
+    // 1. The 8-byte little-endian header length.
+    constexpr std::size_t headerLengthSize = 8;
+    if (bytes.size() < headerLengthSize) {
+        return err(problem(fileName, "mdux.ml.safetensors.malformedTruncatedHeaderLength",
+                           std::format("file is {} bytes; a safetensors file starts with an "
+                                       "8-byte header length",
+                                       bytes.size()),
+                           "check the file downloaded completely"));
+    }
+
+    std::uint64_t headerLength = 0;
+    for (std::size_t i = 0; i < headerLengthSize; ++i) {
+        headerLength |= static_cast<std::uint64_t>(std::to_integer<std::uint8_t>(bytes[i]))
+                        << (8 * i);
+    }
+
+    // Guarded against overflow rather than written as `8 + headerLength > size`, which wraps for a
+    // header length near 2^64 and would let a hostile file past this check.
+    if (headerLength > bytes.size() - headerLengthSize) {
+        return err(problem(fileName, "mdux.ml.safetensors.malformedHeaderOutOfBounds",
+                           std::format("header claims {} bytes but only {} remain after the "
+                                       "length prefix",
+                                       headerLength, bytes.size() - headerLengthSize),
+                           "the file is truncated or is not safetensors"));
+    }
+
+    const std::size_t dataStart = headerLengthSize + static_cast<std::size_t>(headerLength);
+    const std::string_view headerText{
+        reinterpret_cast<const char*>(bytes.data() + headerLengthSize),
+        static_cast<std::size_t>(headerLength)};
+
+    auto parsed = json::parse(headerText);
+    if (!parsed.has_value()) {
+        return err(problem(fileName, "mdux.ml.safetensors.malformedHeaderJson",
+                           std::format("header is not valid JSON: {}",
+                                       json::describe(parsed.error().code)),
+                           "re-export the weights"));
+    }
+    const json::Value& header = *parsed;
+    if (header.kind() != json::Value::Kind::Object) {
+        return err(problem(fileName, "mdux.ml.safetensors.malformedHeaderNotObject",
+                           "header JSON is not an object"));
+    }
+
+    SafetensorsFile file;
+    const std::uint64_t dataBytes = bytes.size() - dataStart;
+
+    for (const json::Member& member : header.members()) {
+        // __metadata__ is the one reserved key, and it is a flat string map rather than a tensor.
+        if (member.key == "__metadata__") {
+            if (member.value.kind() == json::Value::Kind::Object) {
+                for (const json::Member& entry : member.value.members()) {
+                    auto text = entry.value.asString();
+                    if (text.has_value()) {
+                        file.metadata.emplace_back(entry.key, std::string{*text});
+                    }
+                }
+            }
+            continue;
+        }
+
+        const json::Value& descriptor = member.value;
+        if (descriptor.kind() != json::Value::Kind::Object) {
+            return err(problem(fileName, "mdux.ml.safetensors.malformedTensorNotObject",
+                               std::format("tensor '{}' is not described by an object",
+                                           member.key)));
+        }
+
+        const json::Value* dtypeValue = descriptor.find("dtype");
+        const json::Value* shapeValue = descriptor.find("shape");
+        const json::Value* offsetsValue = descriptor.find("data_offsets");
+        if (dtypeValue == nullptr || shapeValue == nullptr || offsetsValue == nullptr) {
+            return err(problem(fileName, "mdux.ml.safetensors.malformedTensorFields",
+                               std::format("tensor '{}' is missing dtype, shape or data_offsets",
+                                           member.key)));
+        }
+
+        auto dtypeText = dtypeValue->asString();
+        if (!dtypeText.has_value()) {
+            return err(problem(fileName, "mdux.ml.safetensors.malformedTensorFields",
+                               std::format("tensor '{}' has a non-string dtype", member.key)));
+        }
+        const std::optional<Dtype> dtype = dtypeFromWire(*dtypeText);
+        if (!dtype.has_value()) {
+            return err(problem(fileName, "mdux.ml.safetensors.malformedUnknownDtype",
+                               std::format("tensor '{}' declares unknown dtype '{}'", member.key,
+                                           *dtypeText)));
+        }
+        // v1 scope, not a format problem - see the module comment on code prefixes.
+        if (*dtype != Dtype::F32) {
+            return err(problem(
+                fileName, "mdux.ml.safetensors.unsupportedDtype",
+                std::format("tensor '{}' is {}; MduX v1 inference is f32 only", member.key,
+                            *dtypeText),
+                "convert the checkpoint to f32, or raise an ADR extending ADR-008's v1 scope"));
+        }
+
+        if (shapeValue->kind() != json::Value::Kind::Array) {
+            return err(problem(fileName, "mdux.ml.safetensors.malformedTensorFields",
+                               std::format("tensor '{}' has a non-array shape", member.key)));
+        }
+        const std::span<const json::Value> dimensions = shapeValue->elements();
+        if (dimensions.size() > maxSupportedRank) {
+            return err(problem(
+                fileName, "mdux.ml.safetensors.unsupportedRank",
+                std::format("tensor '{}' has rank {}; MduX v1 supports up to {}", member.key,
+                            dimensions.size(), maxSupportedRank),
+                "the v1 kernel set is 1-D; a higher-rank model needs a follow-up ADR"));
+        }
+
+        TensorEntry entry;
+        entry.name = member.key;
+        entry.dtype = *dtype;
+        for (const json::Value& dimension : dimensions) {
+            auto extent = dimension.asUInt();
+            if (!extent.has_value()) {
+                return err(problem(fileName, "mdux.ml.safetensors.malformedShape",
+                                   std::format("tensor '{}' has a non-integer dimension",
+                                               member.key)));
+            }
+            entry.shape.push_back(*extent);
+        }
+
+        if (offsetsValue->kind() != json::Value::Kind::Array ||
+            offsetsValue->elements().size() != 2) {
+            return err(problem(fileName, "mdux.ml.safetensors.malformedOffsets",
+                               std::format("tensor '{}' data_offsets is not a pair", member.key)));
+        }
+        auto begin = offsetsValue->elements()[0].asUInt();
+        auto end = offsetsValue->elements()[1].asUInt();
+        if (!begin.has_value() || !end.has_value()) {
+            return err(problem(fileName, "mdux.ml.safetensors.malformedOffsets",
+                               std::format("tensor '{}' data_offsets are not integers",
+                                           member.key)));
+        }
+        if (*end < *begin) {
+            return err(problem(fileName, "mdux.ml.safetensors.malformedOffsets",
+                               std::format("tensor '{}' ends ({}) before it begins ({})",
+                                           member.key, *end, *begin)));
+        }
+        // Both compared against the data-section length rather than summed, so nothing here can
+        // wrap.
+        if (*begin > dataBytes || *end > dataBytes) {
+            return err(problem(
+                fileName, "mdux.ml.safetensors.malformedRangeOutOfBounds",
+                std::format("tensor '{}' occupies [{}, {}) but the data section is {} bytes",
+                            member.key, *begin, *end, dataBytes),
+                "the file is truncated"));
+        }
+
+        entry.byteLength = *end - *begin;
+        entry.byteOffset = static_cast<std::uint64_t>(dataStart) + *begin;
+
+        // Overflow-checked, for the same reason the offset arithmetic above is: a header can
+        // declare any extents it likes, and three of them multiply well past 2^64. A wrapped
+        // product can land exactly on the declared byte length, which would let a tensor whose
+        // shape describes gigabytes validate against a range of a few bytes.
+        constexpr std::uint64_t saturated = std::numeric_limits<std::uint64_t>::max();
+        std::uint64_t elements = 1;
+        bool overflowed = false;
+        for (std::uint64_t extent : entry.shape) {
+            if (extent != 0 && elements > saturated / extent) {
+                overflowed = true;
+                break;
+            }
+            elements *= extent;
+        }
+        const std::uint64_t width = dtypeByteWidth(entry.dtype);
+        if (!overflowed && width != 0 && elements > saturated / width) {
+            overflowed = true;
+        }
+        if (overflowed) {
+            return err(problem(
+                fileName, "mdux.ml.safetensors.malformedShapeByteLength",
+                std::format("tensor '{}' declares a shape whose size overflows", member.key),
+                "the shape cannot describe a real tensor; re-export the weights"));
+        }
+
+        const std::uint64_t expected = elements * width;
+        if (expected != entry.byteLength) {
+            return err(problem(
+                fileName, "mdux.ml.safetensors.malformedShapeByteLength",
+                std::format("tensor '{}' declares a shape needing {} bytes but reserves {}",
+                            member.key, expected, entry.byteLength),
+                "the shape and the byte range disagree; re-export the weights"));
+        }
+
+        file.tensors.push_back(std::move(entry));
+    }
+
+    // Fixed order, so the baker's output does not depend on the exporter's key ordering. See the
+    // SafetensorsFile comment.
+    std::ranges::sort(file.tensors,
+                      [](const TensorEntry& a, const TensorEntry& b) { return a.name < b.name; });
+    std::ranges::sort(file.metadata, [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    // Overlap is checked after sorting by name, so it walks a copy ordered by offset instead.
+    // Two tensors sharing bytes means the file is malformed - unlike weight tying in a *package*,
+    // which is legitimate and is why mdux.ml.schema deliberately does not check this.
+    std::vector<const TensorEntry*> byOffset;
+    byOffset.reserve(file.tensors.size());
+    for (const TensorEntry& tensor : file.tensors) {
+        byOffset.push_back(&tensor);
+    }
+    std::ranges::sort(byOffset, [](const TensorEntry* a, const TensorEntry* b) {
+        return a->byteOffset < b->byteOffset;
+    });
+    for (std::size_t i = 1; i < byOffset.size(); ++i) {
+        const TensorEntry& previous = *byOffset[i - 1];
+        const TensorEntry& current = *byOffset[i];
+        if (previous.byteOffset + previous.byteLength > current.byteOffset) {
+            return err(problem(
+                fileName, "mdux.ml.safetensors.malformedOverlappingTensors",
+                std::format("tensors '{}' and '{}' share bytes", previous.name, current.name),
+                "each tensor must occupy its own range"));
+        }
+    }
+
+    return file;
+}
+
+mdux::core::Result<SafetensorsFile, cli::Diagnostic> readSafetensors(
+    const std::filesystem::path& path) {
+    std::ifstream stream{path, std::ios::binary};
+    if (!stream) {
+        throw std::runtime_error{std::format("cannot open '{}'", path.string())};
+    }
+    std::vector<char> contents{std::istreambuf_iterator<char>{stream},
+                               std::istreambuf_iterator<char>{}};
+    return parseSafetensors(std::as_bytes(std::span{contents}), path.filename().string());
+}
+
+}  // namespace mdux::tools::ml

--- a/tools/ml/Safetensors.cppm
+++ b/tools/ml/Safetensors.cppm
@@ -1,0 +1,111 @@
+/**
+ * @file Safetensors.cppm
+ * @brief Host-tools-zone safetensors reader: weights in, no runtime-adjacent SOUP.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone: may throw, never linked into a device)
+ * @compliance ADR-008 Zero-SOUP ML inference
+ *
+ * The format is small enough to parse by hand, and that is exactly why it was chosen: a `u64`
+ * little-endian header length, a JSON header describing each tensor's name, dtype, shape and byte
+ * range, then the raw tensor bytes. The JSON is read with `mdux.evidence.json` - the same reader
+ * every other MduX artifact goes through - so importing weights adds no dependency at all. See
+ * ADR-008, decision 6.
+ *
+ * **This code is never linked into a device target, and no build step ever feeds it a weights
+ * file.** A malformed or hostile `.safetensors` therefore cannot affect a build or reach a device;
+ * it can only make a developer's `mdux-mlbake` invocation fail with a diagnostic. That containment
+ * is what lets the parser be as small as it is.
+ *
+ * Its own unit tests *do* run in CI, on fixtures this repository authored - `ml_tools_spec` is part
+ * of the ordinary CTest suite. That is testing the parser, not parsing untrusted input during a
+ * build, and the distinction is the whole point: nothing in the pipeline hands this code a file it
+ * did not already trust.
+ *
+ * It still validates aggressively, because the failure it is guarding against is not an attack but
+ * the ordinary one: a weights file that does not describe what the author thinks it describes.
+ *
+ * ## "malformed" versus "unsupported"
+ *
+ * Two different rejections, deliberately distinguishable by diagnostic code:
+ *
+ * - `mdux.ml.safetensors.malformed*` - the file is not a well-formed safetensors container. The
+ *   file is wrong.
+ * - `mdux.ml.safetensors.unsupported*` - the container is fine and MduX v1 does not accept it: a
+ *   dtype other than `f32`, or a rank above 3. The file is fine and out of scope (ADR-008,
+ *   decision 5), and the fix is a follow-up ADR rather than a different export.
+ *
+ * An author who gets `unsupportedDtype` on an `f16` checkpoint needs to know it is their model
+ * that is out of scope, not their file that is broken.
+ */
+module;
+
+export module mdux.tools.ml.safetensors;
+
+import std;
+import mdux.core.result;
+import mdux.tools.cli;
+
+export namespace mdux::tools::ml {
+
+/// Every dtype the container format defines, so an unrecognised spelling is distinguishable from a
+/// recognised one MduX does not accept. Only F32 is in v1 scope.
+enum class Dtype : std::uint8_t { Bool, U8, I8, U16, I16, F16, BF16, U32, I32, F32, U64, I64, F64 };
+
+/// Wire spellings, in enumerator order. These are the format's, not MduX's, so they are upper case.
+inline constexpr std::array<std::string_view, 13> dtypeWireValues{
+    "BOOL", "U8", "I8", "U16", "I16", "F16", "BF16", "U32", "I32", "F32", "U64", "I64", "F64"};
+
+/// Bytes per element. Bool is one byte in this format.
+[[nodiscard]] std::uint64_t dtypeByteWidth(Dtype dtype) noexcept;
+
+[[nodiscard]] std::optional<Dtype> dtypeFromWire(std::string_view wire) noexcept;
+
+/// One tensor as the file declares it. `byteOffset` is absolute within the file, not relative to
+/// the data section - resolved during parsing so no caller has to remember the adjustment.
+struct TensorEntry {
+    std::string name;
+    Dtype dtype{Dtype::F32};
+    std::vector<std::uint64_t> shape;
+    std::uint64_t byteOffset{0};
+    std::uint64_t byteLength{0};
+
+    [[nodiscard]] std::uint64_t elementCount() const noexcept;
+};
+
+/**
+ * @brief A parsed file: its tensors, and whatever `__metadata__` carried.
+ *
+ * Tensors are sorted by name rather than left in header order. A JSON object has no guaranteed
+ * ordering, and the baker's output has to be byte-identical between two machines - so the order is
+ * fixed here, once, instead of depending on however the exporter happened to emit it.
+ */
+struct SafetensorsFile {
+    std::vector<TensorEntry> tensors;
+    std::vector<std::pair<std::string, std::string>> metadata;
+
+    [[nodiscard]] const TensorEntry* find(std::string_view name) const noexcept;
+};
+
+/**
+ * @brief Parses a whole safetensors file.
+ *
+ * @param bytes    the entire file
+ * @param fileName used only to populate the diagnostic's `file` field
+ *
+ * Returns the first problem found as a `Diagnostic` carrying a stable code - see the module
+ * comment for what the code prefixes mean. Parsing stops at the first problem because a file that
+ * is malformed at byte 8 cannot yield trustworthy findings about byte 8000.
+ */
+[[nodiscard]] mdux::core::Result<SafetensorsFile, cli::Diagnostic> parseSafetensors(
+    std::span<const std::byte> bytes, std::string_view fileName);
+
+/**
+ * @brief Reads `path` and parses it.
+ *
+ * Host-tools zone, so this throws `std::runtime_error` if the file cannot be read - a missing file
+ * is a usage mistake, not a finding about a model.
+ */
+[[nodiscard]] mdux::core::Result<SafetensorsFile, cli::Diagnostic> readSafetensors(
+    const std::filesystem::path& path);
+
+}  // namespace mdux::tools::ml


### PR DESCRIPTION
Host-tools zone: never linked into a device target, never run in CI, never fed by a build step, so a malformed or hostile weights file can only make a developer's mlbake invocation fail. The format is a `u64` header length, a JSON header and raw bytes — small enough to read with the evidence JSON parser, which is why it was chosen over anything needing a dependency.

**Two rejection families, distinguishable by code.** `malformed*` means the file is not a well-formed container; `unsupported*` means the container is fine and MduX v1 does not accept it — an f16 checkpoint or a rank-4 tensor. An author who sees `unsupportedDtype` needs to know their model is out of scope, not that their file is broken.

**ArchValidate deliberately restates none of the shape rules.** It resolves each layer's named tensors, records their shapes as the *file* declares them, packs the blob, and hands the result to `ModelPackage::validate()` — the same governed function the runtime calls. The shapes coming from the file while the dimensions come from the recipe is what makes that check mean something; filling both sides from the recipe would make it vacuous.

The corpus is built in memory rather than committed as binary fixtures, and every case asserts its specific diagnostic code.

Stacked on #63.

Closes #60.