### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,8 @@ Three decisions from that programme apply repository-wide:
    both the device runtime and the host baker, and `Classifier1D::create()` fails closed on a
    digest or golden-vector mismatch. See [ADR-008](docs/adr/ADR-008-zero-soup-ml-inference.md).
 
-Waves 1 and 2 of that roadmap have shipped (v0.2.0, v0.3.0). Of Wave 3, the renderer slice (`#13`)
-and the ML pipeline (`#18`) are delivered; the documentation rebuild (`#10`) is in progress.
+Waves 1, 2 and 3 of that roadmap have shipped (v0.2.0, v0.3.0, v0.4.0). Wave 4 is the font and
+text pipeline (`#14`), now unblocked.
 
 Treat any AGENTS.md section below that describes current architecture as authoritative for *today's
 code*; treat this subsection as the direction that code is moving in.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(cmake/PreventInSourceBuilds.cmake)
 
-project(MduX VERSION 0.3.0 DESCRIPTION "Modern C++23 Modules UI Library for Medical Devices" HOMEPAGE_URL "https://github.com/ambroise-leclerc/MduX" LANGUAGES CXX)
+project(MduX VERSION 0.4.0 DESCRIPTION "Modern C++23 Modules UI Library for Medical Devices" HOMEPAGE_URL "https://github.com/ambroise-leclerc/MduX" LANGUAGES CXX)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/generated/model/ecg-demo-alt/report.json
+++ b/generated/model/ecg-demo-alt/report.json
@@ -30,5 +30,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-mlbake",
-  "toolVersion": "0.3.0"
+  "toolVersion": "0.4.0"
 }

--- a/generated/model/ecg-demo/report.json
+++ b/generated/model/ecg-demo/report.json
@@ -30,5 +30,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-mlbake",
-  "toolVersion": "0.3.0"
+  "toolVersion": "0.4.0"
 }

--- a/generated/shader/mdux-ui/report.json
+++ b/generated/shader/mdux-ui/report.json
@@ -37,5 +37,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-shaderbake",
-  "toolVersion": "0.3.0"
+  "toolVersion": "0.4.0"
 }

--- a/generated/shader/triangle/report.json
+++ b/generated/shader/triangle/report.json
@@ -37,5 +37,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-shaderbake",
-  "toolVersion": "0.3.0"
+  "toolVersion": "0.4.0"
 }

--- a/software_development_file/regulatory/IEC_62304/SAD.md
+++ b/software_development_file/regulatory/IEC_62304/SAD.md
@@ -9,7 +9,7 @@
 - **Product / software item:** MduX — an experimental, proof-of-concept C++23-modules Vulkan/Vulkan
   SC UI/rendering library. Not a finished product (see `AGENTS.md` § 1).
 - **Version:** the project version reported by `mdux::Version::getString()` (`CMakeLists.txt`'s
-  `project(... VERSION ...)`, currently `0.3.0`); see `CMakeLists.txt` for the exact build.
+  `project(... VERSION ...)`, currently `0.4.0`); see `CMakeLists.txt` for the exact build.
 - **Safety classification:** Class A, B, or C, chosen per-application. Unlike its sibling project
   TrustSC (Class B/C only), MduX keeps Class A explicitly in scope (`docs/governance/citation-convention.md`).
   **Note the gap:** `mdux::ComplianceMetadata.deviceClass` (`include/mdux/mdux.cppm`) is a free-form

--- a/tests/TestRegulatoryCompliance.cpp
+++ b/tests/TestRegulatoryCompliance.cpp
@@ -11,7 +11,7 @@ import mdux.test;
 TEST_CASE("IEC 62304 Version Traceability", "regulatory") {
     // Verify version traceability (required by IEC 62304)
     CHECK(mdux::Version::major == 0);
-    CHECK(mdux::Version::minor == 3);
+    CHECK(mdux::Version::minor == 4);
     CHECK(mdux::Version::patch == 0);
     CHECK(!mdux::Version::getString().empty());
 }

--- a/tests/TestVersion.cpp
+++ b/tests/TestVersion.cpp
@@ -10,9 +10,9 @@ import mdux.test;
 
 TEST_CASE("Version Test") {
     CHECK(mdux::Version::major == 0);
-    CHECK(mdux::Version::minor == 3);
+    CHECK(mdux::Version::minor == 4);
     CHECK(mdux::Version::patch == 0);
-    CHECK(mdux::Version::getString() == "0.3.0");
+    CHECK(mdux::Version::getString() == "0.4.0");
 }
 
 TEST_CASE("Version Test Sections") {
@@ -24,13 +24,13 @@ TEST_CASE("Version Test Sections") {
     SECTION("major and minor") {
         sectionsRun += 1;
         CHECK(mdux::Version::major == 0);
-        CHECK(mdux::Version::minor == 3);
+        CHECK(mdux::Version::minor == 4);
     }
 
     SECTION("patch and string") {
         sectionsRun += 1;
         CHECK(mdux::Version::patch == 0);
-        CHECK(mdux::Version::getString() == "0.3.0");
+        CHECK(mdux::Version::getString() == "0.4.0");
     }
 
     CHECK(sectionsRun == 2);


### PR DESCRIPTION
Wave 3 of the TrustSC parity programme is complete — #13, #18 and #10 all closed — so this bumps the version for the release.

## What moved

Version carriers, bumped together because they check each other:

- `CMakeLists.txt` — `project(MduX VERSION 0.4.0 ...)`
- `tests/TestVersion.cpp` and `tests/TestRegulatoryCompliance.cpp` — both the string *and* the numeric `Version::minor` assertions
- `software_development_file/regulatory/IEC_62304/SAD.md` — the build reference
- `AGENTS.md` — waves shipped

## The re-bake belongs in this commit

Every `report.json` records the semantic `toolVersion` that produced it. Bumping the project version changes `MDUX_TOOL_VERSION`, so leaving the artifacts alone would have four of them claiming `0.3.0` while a fresh bake produces `0.4.0` — failing `ctest -L evidence` **on the release commit itself**.

Re-baked via `mdux-bake-update`. **Only the `toolVersion` line moves**: `package.json` and every payload are byte-identical, which is the check confirming the bump changed nothing about what the artifacts describe.

## Verified

Clean build with GCC 16.1: **360/360 tests pass**, including `-L evidence` (4), `-L determinism` (3), `-L noheap` (5), `-L pixel` (1) and `-L regulatory` (4). `mdux-docs-lint` clean across 76 files. Source tree unmodified after building.

Three tests initially failed and are worth noting: `Version::minor` is asserted numerically as well as through the string, in two files. The string bump alone would have been silently insufficient.