### PR TITLE
S2 — Hand-parsed TrueType (glyf only) (#158)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,7 @@ performs no checking and confers no compliance.
 | `MduXToolsCommon` | `tools/common/` | TOML subset reader, CLI parser, shared diagnostic envelope |
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
-| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake` |
+| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser, #158) |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -209,7 +209,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | S1 (`mdux.text.schema` + `mdux-textbake` skeleton) landed; S2–S6 open |
+| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | S1 (`mdux.text.schema` + `mdux-textbake` skeleton) landed. S2 (`mdux.tools.truetype` glyf parser, #158) landed; S3–S6 open |
 | `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | the replacement for the retired HTML/CSS path |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -586,6 +586,7 @@ mdux_discover_tests(text_spec)
 add_executable(text_tools_spec
     text/TextToolsSpecMain.cpp
     text/TextBakeTests.cpp
+    text/TruetypeTests.cpp
 )
 
 target_link_libraries(text_tools_spec PRIVATE MduX::TextBakeLib speclab::speclab)

--- a/tests/text/TruetypeTests.cpp
+++ b/tests/text/TruetypeTests.cpp
@@ -1,0 +1,1063 @@
+/**
+ * @file TruetypeTests.cpp
+ * @brief BDD scenarios for the host-only TrueType (glyf) parser (issue #158).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * The corpus is built in memory rather than committed as `.ttf` files. A malformed font is a
+ * handful of bytes described by one line of code here; as a committed blob it would be an
+ * opaque artifact whose intended defect a reviewer has to take on trust (the same argument
+ * `SpirvTests.cpp` makes for `SpirvFixtures.hpp` and `SafetensorsTests.cpp` makes for its
+ * fixtures).
+ *
+ * Every rejection scenario asserts the specific `ParseError` code, not merely that parsing
+ * failed. A parser that rejects everything with one generic error passes "it was rejected"
+ * and is useless to the author who has to fix the font - and useless to S4 (#160), which has
+ * to convert each code into a distinct `TXT` diagnostic. The first scenario belows holds the
+ * success case; the two table-driven scenarios hold all rejection paths for `parse()` and
+ * `parseGlyph()`, so a new rejection added later lands next to its enumerator by index rather
+ * than spread across the file.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.tools.truetype;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace tt = mdux::tools::truetype;
+using tt::ParseError;
+
+constexpr std::uint32_t kSfntTrue  = 0x00010000u;
+constexpr std::uint32_t kHeadMagic = 0x5F0F3CF5u;
+
+// ---------------------------------------------------------------------------
+// An assembler for in-memory TrueType files, plus helpers for the glyf records each scenario
+// uses. A real `.ttf` would be the same bytes in a different file; building them in code keeps
+// the tests free of binary fixtures whose defect a reviewer would have to inspect with a hex
+// dump. The assembler emits directory records in a fixed order (head, maxp, loca, glyf,
+// extras) so the per-table offsets are deterministic and a `poke()` on a known location is
+// safe across the whole corpus.
+// ---------------------------------------------------------------------------
+
+class Builder {
+public:
+    Builder& sfnt(std::uint32_t v) {
+        sfnt_ = v;
+        return *this;
+    }
+    Builder& unitsPerEm(std::uint16_t v) {
+        upe_ = v;
+        return *this;
+    }
+    Builder& indexToLocFormat(std::int16_t v) {
+        idxFmt_ = v;
+        return *this;
+    }
+    Builder& numGlyphs(std::uint16_t n) {
+        ng_ = n;
+        return *this;
+    }
+    Builder& headMagic(std::uint32_t v) {
+        headMagic_ = v;
+        return *this;
+    }
+
+    /// Replaces the glyf record at index `i`. `numGlyphs` is bumped to `i+1` if lower.
+    Builder& rawGlyph(std::size_t i, std::vector<std::byte> bytes) {
+        if (i + 1 > rawGlyphs_.size()) {
+            rawGlyphs_.resize(i + 1);
+        }
+        rawGlyphs_[i] = std::move(bytes);
+        if (ng_ < i + 1) {
+            ng_ = static_cast<std::uint16_t>(i + 1);
+        }
+        return *this;
+    }
+
+    Builder& extraTable(std::string tag, std::vector<std::byte> bytes) {
+        extras_.emplace_back(std::move(tag), std::move(bytes));
+        return *this;
+    }
+
+    Builder& dropHead() {
+        dropHead_ = true;
+        return *this;
+    }
+    Builder& dropMaxp() {
+        dropMaxp_ = true;
+        return *this;
+    }
+    Builder& dropLoca() {
+        dropLoca_ = true;
+        return *this;
+    }
+    Builder& dropGlyf() {
+        dropGlyf_ = true;
+        return *this;
+    }
+
+    /// An override for the byte length the `loca` directory record declares - the directory
+    /// length is what `readLoca()` reads when sizing the table, so a smaller value here is the
+    /// `LocaSizeMismatch` fixture. Zero means "use the derived length".
+    Builder& locaDeclaredLength(std::uint32_t v) {
+        locaLen_ = v;
+        return *this;
+    }
+
+    /// An override for the byte length the `head` directory record declares - a smaller value
+    /// fires `TruncatedHead`, since the `head` subspan shrinks below 54 bytes.
+    Builder& headDeclaredLength(std::uint32_t v) {
+        headLen_ = v;
+        return *this;
+    }
+
+    /// An override for the byte length the `maxp` directory record declares.
+    Builder& maxpDeclaredLength(std::uint32_t v) {
+        maxpLen_ = v;
+        return *this;
+    }
+
+    /// An override for the head table's directory `offset` field; setting it past `bytes().size()`
+    /// is the `TableOutOfBounds` fixture.
+    Builder& headDeclaredOffset(std::uint32_t v) {
+        headOff_ = v;
+        return *this;
+    }
+
+    /// Sets `numTables` declared in the offset table to a different value than the directory's
+    /// physical length - the parser reads only as many records as `numTables` claims, so a
+    /// larger value is the `TruncatedTableDirectory` fixture.
+    Builder& declaredNumTables(std::uint16_t n) {
+        declaredNumTables_ = n;
+        return *this;
+    }
+
+    /// An override that replaces the loca slot at index `i`'s stored short entry with `v`. The
+    /// builder re-derives loca contents; this is the simple per-entry perturbation the
+    /// `LocaOutOfBounds` fixture uses.
+    Builder& locaShortEntry(std::size_t i, std::uint16_t v) {
+        locaOverrides_[i] = v;
+        return *this;
+    }
+
+    /// Serialized bytes plus deterministic per-table offsets, so a test can `poke()` into the
+    /// directory record of each required table without searching for it.
+    struct Serialized {
+        std::vector<std::byte>                           bytes;
+        std::size_t                                      headRecordStart{0};
+        std::size_t                                      maxpRecordStart{0};
+        std::size_t                                      locaRecordStart{0};
+        std::size_t                                      glyfRecordStart{0};
+        std::size_t                                      headDataStart{0};
+        std::size_t                                      maxpDataStart{0};
+        std::size_t                                      locaDataStart{0};
+        std::size_t                                      glyfDataStart{0};
+        std::vector<std::pair<std::size_t, std::size_t>> glyfRecords;
+    };
+
+    [[nodiscard]] Serialized serialize() const {
+        // 1. Build the per-table byte contents.
+        std::vector<std::byte> head;
+        if (!dropHead_) {
+            head.assign(headMinSize, std::byte{0});
+            putU32(head, headMagicOffset, headMagic_);
+            putU16(head, headUnitsPerEmOffset, upe_);
+            putI16(head, headIndexToLocFormatOffset, idxFmt_);
+        }
+        std::vector<std::byte> maxp;
+        if (!dropMaxp_) {
+            maxp.assign(maxpMinSize, std::byte{0});
+            putU32(maxp, 0, 0x00010000u);  // version 1.0
+            putU16(maxp, 4, ng_);
+        }
+        std::vector<std::byte> loca;
+        if (!dropLoca_) {
+            const std::size_t entryCount = static_cast<std::size_t>(ng_) + 1u;
+            std::uint32_t     cursor     = 0;
+            for (std::size_t i = 0; i < entryCount; ++i) {
+                std::uint16_t stored = 0;
+                if (i < rawGlyphs_.size()) {
+                    if (const auto it = locaOverrides_.find(i); it != locaOverrides_.end()) {
+                        stored = static_cast<std::uint16_t>(it->second);
+                    } else {
+                        stored = static_cast<std::uint16_t>(cursor / 2u);
+                    }
+                } else if (const auto it = locaOverrides_.find(i); it != locaOverrides_.end()) {
+                    stored = static_cast<std::uint16_t>(it->second);
+                } else {
+                    stored = static_cast<std::uint16_t>(cursor / 2u);
+                }
+                appendU16(loca, stored);
+                if (i < rawGlyphs_.size()) {
+                    cursor += static_cast<std::uint32_t>(roundUp2(rawGlyphs_[i].size()));
+                }
+            }
+        }
+        std::vector<std::byte> glyf;
+        if (!dropGlyf_) {
+            for (const auto& g : rawGlyphs_) {
+                glyf.insert(glyf.end(), g.begin(), g.end());
+                if (g.size() % 2 != 0) {
+                    glyf.push_back(std::byte{0});  // pad each glyf record to 2-byte alignment
+                }
+            }
+        }
+
+        // 2. Plan a flat list of (tag, bytes) in fixed order, with extras appended.
+        struct Entry {
+            std::string                   tag;
+            const std::vector<std::byte>* bytes;
+        };
+        std::vector<Entry> entries;
+        if (!dropHead_)
+            entries.push_back({"head", &head});
+        if (!dropMaxp_)
+            entries.push_back({"maxp", &maxp});
+        if (!dropLoca_)
+            entries.push_back({"loca", &loca});
+        if (!dropGlyf_)
+            entries.push_back({"glyf", &glyf});
+        for (const auto& extra : extras_) {
+            entries.push_back({extra.first, &extra.second});
+        }
+
+        const std::uint16_t numTables    = declaredNumTables_.value_or(static_cast<std::uint16_t>(entries.size()));
+        const std::size_t   directoryEnd = offsetTableSize + static_cast<std::size_t>(numTables) * tableRecordSize;
+
+        Serialized out;
+        out.bytes.resize(directoryEnd);
+
+        // Offset table.
+        putU32(out.bytes, 0, sfnt_);
+        putU16(out.bytes, 4, numTables);
+        putU16(out.bytes, 6, 0);
+        putU16(out.bytes, 8, 0);
+        putU16(out.bytes, 10, 0);
+
+        std::size_t cursor = directoryEnd;
+        for (std::size_t i = 0; i < entries.size(); ++i) {
+            while (cursor % 4u != 0u) {
+                out.bytes.push_back(std::byte{0});
+                ++cursor;
+            }
+            const std::size_t rec = offsetTableSize + i * tableRecordSize;
+            out.bytes[rec + 0]    = static_cast<std::byte>(entries[i].tag[0]);
+            out.bytes[rec + 1]    = static_cast<std::byte>(entries[i].tag[1]);
+            out.bytes[rec + 2]    = static_cast<std::byte>(entries[i].tag[2]);
+            out.bytes[rec + 3]    = static_cast<std::byte>(entries[i].tag[3]);
+            for (std::size_t b = 0; b < 4u; ++b)
+                out.bytes[rec + 4 + b] = std::byte{0};  // checksum
+
+            std::uint32_t dataOffset = static_cast<std::uint32_t>(cursor);
+            std::uint32_t dataLength = static_cast<std::uint32_t>(entries[i].bytes->size());
+            if (entries[i].tag == "head") {
+                if (headOff_.has_value())
+                    dataOffset = *headOff_;
+                if (headLen_.has_value())
+                    dataLength = *headLen_;
+                out.headRecordStart = rec;
+                out.headDataStart   = cursor;
+            } else if (entries[i].tag == "maxp") {
+                if (maxpLen_.has_value())
+                    dataLength = *maxpLen_;
+                out.maxpRecordStart = rec;
+                out.maxpDataStart   = cursor;
+            } else if (entries[i].tag == "loca") {
+                if (locaLen_.has_value())
+                    dataLength = *locaLen_;
+                out.locaRecordStart = rec;
+                out.locaDataStart   = cursor;
+            } else if (entries[i].tag == "glyf") {
+                out.glyfRecordStart = rec;
+                out.glyfDataStart   = cursor;
+            }
+            putU32(out.bytes, rec + 8, dataOffset);
+            putU32(out.bytes, rec + 12, dataLength);
+
+            // Append the table's bytes. Padding below accounts for alignment to 4 between
+            // tables; the embedded bytes are left untouched.
+            out.bytes.insert(out.bytes.end(), entries[i].bytes->begin(), entries[i].bytes->end());
+            cursor += entries[i].bytes->size();
+        }
+
+        // Trim or pad to the directory's claimed size if `declaredNumTables` lied. The parser walks
+        // `numTables` records starting at offset 12, so a smaller file is itself the malformed
+        // state the TruncatedTableDirectory fixture wants: leave the bytes ending at `cursor`,
+        // which is shorter than `directoryEnd` claims when `numTables` was larger than the
+        // physical record count.
+        if (cursor < directoryEnd) {
+            // The records past entries.size() are uninitialised in our vector; resize down to
+            // what we actually wrote so the parser sees a real "not enough bytes" gap there.
+            out.bytes.resize(cursor);
+        }
+
+        // 3. Compute glyf record offsets for individual poke operations by re-scanning the
+        // directory; rawGlyphs_ order is preserved in glyf layout.
+        std::uint32_t offset = 0;
+        for (const auto& g : rawGlyphs_) {
+            out.glyfRecords.emplace_back(out.glyfDataStart + offset, g.size());
+            offset += static_cast<std::uint32_t>(roundUp2(g.size()));
+        }
+
+        return out;
+    }
+
+private:
+    static constexpr std::size_t headMinSize                = 54;
+    static constexpr std::size_t headMagicOffset            = 12;
+    static constexpr std::size_t headUnitsPerEmOffset       = 18;
+    static constexpr std::size_t headIndexToLocFormatOffset = 50;
+    static constexpr std::size_t maxpMinSize                = 6;
+    static constexpr std::size_t offsetTableSize            = 12;
+    static constexpr std::size_t tableRecordSize            = 16;
+
+    static std::size_t roundUp2(std::size_t n) noexcept {
+        return n + (n % 2 != 0 ? 1u : 0u);
+    }
+
+    static void putU16(std::vector<std::byte>& v, std::size_t off, std::uint16_t val) {
+        v[off + 0] = static_cast<std::byte>((val >> 8) & 0xffu);
+        v[off + 1] = static_cast<std::byte>(val & 0xffu);
+    }
+    static void putI16(std::vector<std::byte>& v, std::size_t off, std::int16_t val) {
+        putU16(v, off, static_cast<std::uint16_t>(val));
+    }
+    static void putU32(std::vector<std::byte>& v, std::size_t off, std::uint32_t val) {
+        v[off + 0] = static_cast<std::byte>((val >> 24) & 0xffu);
+        v[off + 1] = static_cast<std::byte>((val >> 16) & 0xffu);
+        v[off + 2] = static_cast<std::byte>((val >> 8) & 0xffu);
+        v[off + 3] = static_cast<std::byte>(val & 0xffu);
+    }
+    static void appendU16(std::vector<std::byte>& v, std::uint16_t val) {
+        v.push_back(static_cast<std::byte>((val >> 8) & 0xffu));
+        v.push_back(static_cast<std::byte>(val & 0xffu));
+    }
+
+    std::uint32_t                                               sfnt_      = kSfntTrue;
+    std::uint16_t                                               upe_       = 2048;
+    std::int16_t                                                idxFmt_    = 0;
+    std::uint16_t                                               ng_        = 1;
+    std::uint32_t                                               headMagic_ = kHeadMagic;
+    bool                                                        dropHead_  = false;
+    bool                                                        dropMaxp_  = false;
+    bool                                                        dropLoca_  = false;
+    bool                                                        dropGlyf_  = false;
+    std::optional<std::uint16_t>                                declaredNumTables_;
+    std::optional<std::uint32_t>                                headOff_;
+    std::optional<std::uint32_t>                                headLen_;
+    std::optional<std::uint32_t>                                maxpLen_;
+    std::optional<std::uint32_t>                                locaLen_;
+    std::map<std::size_t, std::uint16_t>                        locaOverrides_;
+    std::vector<std::vector<std::byte>>                         rawGlyphs_;
+    std::vector<std::pair<std::string, std::vector<std::byte>>> extras_;
+};
+
+/// A 12-byte empty glyf record: numberOfContours = 0, bbox 0..0, instructionLength = 0.
+[[nodiscard]] std::vector<std::byte> emptyGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(0);  // numberOfContours = 0
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);  // bbox
+    u16(0);  // instructionLength = 0
+    return b;
+}
+
+/// A simple square glyf record: 1 contour, 4 on-curve points at (0,0), (100,0), (100,100),
+/// (0,100). Coords encode as signed 16-bit deltas; flags carry on-curve only (0x01) - the
+/// success-path `parseGlyph()` exercises the no-short / no-same/positive branch in both axes.
+[[nodiscard]] std::vector<std::byte> squareGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);  // numberOfContours = 1
+    i16(0);
+    i16(0);
+    i16(100);
+    i16(100);                      // bbox
+    u16(3);                        // endPtsOfContours[0] = 3 (4 points, indices 0..3)
+    u16(0);                        // instructionLength = 0
+    b.push_back(std::byte{0x01});  // on-curve, signed-16 X delta, signed-16 Y delta
+    b.push_back(std::byte{0x01});
+    b.push_back(std::byte{0x01});
+    b.push_back(std::byte{0x01});
+    i16(0);
+    i16(100);
+    i16(0);
+    i16(-100);  // X deltas
+    i16(0);
+    i16(0);
+    i16(100);
+    i16(0);  // Y deltas
+    return b;
+}
+
+/// A 10-byte composite glyf record: numberOfContours = -1, bbox 0..0. The parser rejects at
+/// the contour count check before touching the component stream - testing the rejection is the
+/// point of the fixture, not exercising composite walking.
+[[nodiscard]] std::vector<std::byte> compositeGlyph() {
+    std::vector<std::byte> b;
+    const auto             u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    u16(0xFFFFu);  // numberOfContours = -1 (int16)
+    u16(0);
+    u16(0);
+    u16(0);
+    u16(0);  // bbox
+    return b;
+}
+
+/// A glyph whose coordinate stream is shorter than the flags declared. Built as a 1-contour
+/// glyph with 4 on-curve points but with the X coordinate array truncated to one entry - the
+/// parser hits `TruncatedGlyphCoords` mid-X.
+[[nodiscard]] std::vector<std::byte> coordsTruncatedGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);  // bbox
+    u16(3);  // endPtsOfContours[0] = 3 (4 points)
+    u16(0);  // instructionLength = 0
+    for (int i = 0; i < 4; ++i)
+        b.push_back(std::byte{0x01});
+    i16(0);  // only one signed-16 X delta for the first point; the rest would extend past EOD
+    return b;
+}
+
+/// A glyph whose flag array is shorter than its `endPtsOfContours[N] + 1` claim. One contour of
+/// 4 points declared, only 1 flag byte supplied.
+[[nodiscard]] std::vector<std::byte> flagsTruncatedGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);
+    u16(3);                        // 4 points
+    u16(0);
+    b.push_back(std::byte{0x01});  // 1 flag only
+    return b;
+}
+
+/// A glyph with two contours whose end points are non-monotonic (3 then 1).
+[[nodiscard]] std::vector<std::byte> nonMonotonicGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(2);  // numberOfContours = 2
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);
+    u16(3);  // endPts[0] = 3
+    u16(1);  // endPts[1] = 1 -- not > 3
+    u16(0);  // instructionLength = 0
+    return b;
+}
+
+/// A glyph declaring one contour but offering no endPtsOfContours field after the header.
+[[nodiscard]] std::vector<std::byte> endPtsTruncatedGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    i16(1);
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);
+    return b;  // 10 bytes: no endPts, no instructionLength
+}
+
+/// A single-point glyph whose flag has bits 6-7 set: parser rejects with UnsupportedGlyphFlag.
+[[nodiscard]] std::vector<std::byte> reservedFlagGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);
+    u16(0);                        // endPtsOfContours[0] = 0 - one point
+    u16(0);                        // instructionLength = 0
+    b.push_back(std::byte{0xC1});  // on-curve + reserved bit 7 set
+    return b;
+}
+
+/// A glyph whose `instructionLength` is non-zero; the parser rejects before reading flags.
+[[nodiscard]] std::vector<std::byte> hintedGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);
+    u16(3);  // 4 points
+    u16(1);  // instructionLength = 1
+    // The instruction byte itself is irrelevant; HintingRejected fires before it would be read.
+    b.push_back(std::byte{0x42});
+    return b;
+}
+
+/// A glyph record shorter than the 10-byte header - the parser fails with TruncatedGlyph.
+[[nodiscard]] std::vector<std::byte> shortGlyph() {
+    return std::vector<std::byte>(5, std::byte{0});
+}
+
+/// A 16-byte dummy extra table - its bytes are irrelevant; the parser only inspects the tag.
+[[nodiscard]] std::vector<std::byte> dummyExtra() {
+    return std::vector<std::byte>(16, std::byte{0});
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// parse(): success cases
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register validFontParses{"A minimal well-formed TrueType font parses and reports its metrics", "evidence-unit", [] {
+                                               struct State {
+                                                   Builder::Serialized     serialized;
+                                                   std::optional<tt::Font> font;
+                                               };
+                                               auto state = std::make_shared<State>();
+
+                                               return speclab::Test("text-truetype-parse-valid")
+                                                   .Given("a builder with empty + square + composite glyphs",
+                                                          [state] {
+                                                              auto serialized = Builder()
+                                                                                    .unitsPerEm(2048)
+                                                                                    .indexToLocFormat(0)
+                                                                                    .rawGlyph(0, emptyGlyph())
+                                                                                    .rawGlyph(1, squareGlyph())
+                                                                                    .rawGlyph(2, compositeGlyph())
+                                                                                    .serialize();
+                                                              state->serialized = std::move(serialized);
+                                                          })
+                                                   .When("parse() is called",
+                                                         [state] {
+                                                             auto font = tt::parse(state->serialized.bytes);
+                                                             if (!font.has_value()) {
+                                                                 throw speclab::core::AssertionFailure(
+                                                                     std::format("valid font was rejected: {}", tt::describe(font.error())),
+                                                                     std::source_location::current());
+                                                             }
+                                                             state->font = std::move(*font);
+                                                         })
+                                                   .Then("the font carries the directory's upe, numGlyphs, indexToLocFormat and 4 loca "
+                                                         "entries",
+                                                         [state] {
+                                                             mdux::spec::Checks checks;
+                                                             const auto&        font = *state->font;
+                                                             checks.expect(font.sfntVersion == kSfntTrue, "sfnt version");
+                                                             checks.expect(font.unitsPerEm == 2048, "unitsPerEm");
+                                                             checks.expect(font.numGlyphs == 3, "numGlyphs");
+                                                             checks.expect(font.indexToLocFormat == 0, "indexToLocFormat");
+                                                             checks.expect(font.loca.size() == 4, "loca has numGlyphs+1 entries");
+                                                             checks.expect(!font.glyf.empty(), "glyf span is non-empty");
+                                                             checks.expect(!font.head.empty(), "head span is non-empty");
+                                                             checks.raise();
+                                                         })
+                                                   .Execute();
+                                           }};
+
+const mdux::spec::Register trueAndTyp1Acceptances{"parse() accepts 'true' and 'typ1' TrueType container variants", "evidence-unit", [] {
+                                                      // The directory records walk can pass on either 'true' or 'typ1' if they actually
+                                                      // describe a TrueType outline table set; the check at the version word is the first
+                                                      // gate, not the only one, and these two are alternative container spellings rather than
+                                                      // tow CFF-flavoured ones. (OTTO is the CFF OpenType container and would reject here too,
+                                                      // but parse() rejects CFF fonts later again on the 'CFF ' table tag, regardless.)
+                                                      struct State {
+                                                          Builder::Serialized     s1;
+                                                          Builder::Serialized     s2;
+                                                          std::optional<tt::Font> f1;
+                                                          std::optional<tt::Font> f2;
+                                                      };
+                                                      auto state = std::make_shared<State>();
+
+                                                      return speclab::Test("text-truetype-container-variants")
+                                                          .Given("a 'true' container and a 'typ1' container",
+                                                                 [state] {
+                                                                     state->s1 = Builder().sfnt(0x74727565u).serialize();
+                                                                     state->s2 = Builder().sfnt(0x74797031u).serialize();
+                                                                 })
+                                                          .When("each is parsed",
+                                                                [state] {
+                                                                    auto v1 = tt::parse(state->s1.bytes);
+                                                                    auto v2 = tt::parse(state->s2.bytes);
+                                                                    if (!v1.has_value() || !v2.has_value()) {
+                                                                        throw speclab::core::AssertionFailure(
+                                                                            std::format("'true'={}, 'typ1'={}", v1.has_value(), v2.has_value()),
+                                                                            std::source_location::current());
+                                                                    }
+                                                                    state->f1 = std::move(*v1);
+                                                                    state->f2 = std::move(*v2);
+                                                                })
+                                                          .Then("both are accepted",
+                                                                [state] {
+                                                                    mdux::spec::Checks checks;
+                                                                    checks.expect(state->f1.has_value(), "'true' accepted");
+                                                                    checks.expect(state->f2.has_value(), "'typ1' accepted");
+                                                                    checks.raise();
+                                                                })
+                                                          .Execute();
+                                                  }};
+
+// ---------------------------------------------------------------------------
+// parse(): rejection corpus - one scenario per ParseError the directory walk emits.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register parseRejections{
+    "parse() emits the right stable code per failure mode",
+    "evidence-unit",
+    [] {
+        struct Case {
+            std::string_view                        what;
+            ParseError                              expected;
+            std::function<std::vector<std::byte>()> build;
+        };
+
+        const std::vector<Case> cases{
+            {                                    "an empty buffer",
+             ParseError::Empty,
+             [] {
+             return std::vector<std::byte>{};
+             }},
+            {             "a buffer shorter than the offset table",
+             ParseError::TruncatedOffsetTable,
+             [] {
+             return std::vector<std::byte>(6, std::byte{0});
+             }},
+            {                        "a non-TrueType sfnt version",
+             ParseError::NotATrueTypeOutlineFont,
+             [] {
+             return Builder().sfnt(0x44444444u).serialize().bytes;
+             }},
+            {"numTables claiming more records than the file holds",
+             ParseError::TruncatedTableDirectory,
+             [] {
+             // The Builder allocates the declared directory's rows of zero bytes; in a real
+             // file that the truncation check would have caught the same way, those rows
+             // simply aren't there at all. Trimming to 30 bytes here leaves the header but
+             // not the directory it claims, which is the only shape that fires
+             // TruncatedTableDirectory before the duplicate-tag walk has anything to read.
+             auto s = Builder().declaredNumTables(99).serialize().bytes;
+             s.resize(30);
+             return s;
+             }},
+            {                       "a duplicate 'head' table tag",
+             ParseError::DuplicateTable,
+             [] {
+             auto s = Builder().extraTable("head", dummyExtra()).serialize();
+             return s.bytes;
+             }},
+            {                             "a missing 'head' table",
+             ParseError::MissingRequiredTable,
+             [] {
+             return Builder().dropHead().serialize().bytes;
+             }},
+            {"a 'head' table whose offset+length exceeds the file",
+             ParseError::TableOutOfBounds,
+             [] {
+             return Builder().headDeclaredOffset(0xFFFFFFFFu).serialize().bytes;
+             }},
+            {                             "a 'CFF ' table present",
+             ParseError::CffOutlinesRejected,
+             [] {
+             return Builder().extraTable("CFF ", dummyExtra()).serialize().bytes;
+             }},
+            {                             "a 'CFF2' table present",
+             ParseError::CffOutlinesRejected,
+             [] {
+             return Builder().extraTable("CFF2", dummyExtra()).serialize().bytes;
+             }},
+            {                             "a 'GPOS' table present",
+             ParseError::GposRejected,
+             [] {
+             return Builder().extraTable("GPOS", dummyExtra()).serialize().bytes;
+             }},
+            {                             "a 'GSUB' table present",
+             ParseError::GsubRejected,
+             [] {
+             return Builder().extraTable("GSUB", dummyExtra()).serialize().bytes;
+             }},
+            {                             "a 'morx' table present",
+             ParseError::AppleLayoutRejected,
+             [] {
+             return Builder().extraTable("morx", dummyExtra()).serialize().bytes;
+             }},
+            {                             "a 'mort' table present",
+             ParseError::AppleLayoutRejected,
+             [] {
+             return Builder().extraTable("mort", dummyExtra()).serialize().bytes;
+             }},
+            {               "a 'head' table shorter than 54 bytes",
+             ParseError::TruncatedHead,
+             [] {
+             return Builder().headDeclaredLength(40).serialize().bytes;
+             }},
+            {             "a 'head' table whose magic check fails",
+             ParseError::HeadBadMagicNumber,
+             [] {
+             return Builder().headMagic(0xDEADBEEFu).serialize().bytes;
+             }},
+            {                 "a unitsPerEm value of 8 (below 16)",
+             ParseError::UnsupportedUnitsPerEm,
+             [] {
+             return Builder().unitsPerEm(8).serialize().bytes;
+             }},
+            {            "a unitsPerEm value of 8192 (above 4096)",
+             ParseError::UnsupportedUnitsPerEm,
+             [] {
+             return Builder().unitsPerEm(8192).serialize().bytes;
+             }},
+            {                "a 'maxp' table shorter than 6 bytes",
+             ParseError::TruncatedMaxp,
+             [] {
+             return Builder().maxpDeclaredLength(4).serialize().bytes;
+             }},
+            {                     "an indexToLocFormat value of 2",
+             ParseError::UnsupportedLocaFormat,
+             [] {
+             return Builder().indexToLocFormat(2).serialize().bytes;
+             }},
+            {         "a 'loca' byte length below (numGlyphs+1)*2",
+             ParseError::LocaSizeMismatch,
+             [] {
+             return Builder().locaDeclaredLength(2).serialize().bytes;
+             }},
+            {         "a loca entry pointing past the end of glyf",
+             ParseError::LocaOutOfBounds,
+             [] {
+             // Pipe the trailing entry past the glyf length; the glyph it is supposed to
+             // bound is empty, so any non-zero value past the small glyf length is plenty.
+             return Builder().rawGlyph(0, emptyGlyph()).locaShortEntry(1, 0xFFFFu).serialize().bytes;
+             }},
+        };
+
+        return speclab::Test("text-truetype-parse-rejections")
+            .Given("a corpus of deliberately malformed fonts", [] {})
+            .When("each is parsed", [] {})
+            .Then("each yields exactly the ParseError identified in the corpus",
+                  [&cases] {
+                      mdux::spec::Checks checks;
+                      for (const Case& entry : cases) {
+                          auto                   result = tt::parse(entry.build());
+                          const std::string_view got    = result.has_value() ? std::string_view{"ok"} : tt::describe(result.error());
+                          checks.expect(!result.has_value(), std::format("{}: parse succeeded unexpectedly", entry.what));
+                          if (!result.has_value()) {
+                              checks.expect(result.error() == entry.expected,
+                                            std::format("{}: got '{}', expected '{}'", entry.what, got, tt::describe(entry.expected)));
+                          }
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// parseGlyph(): success and rejection corpus
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register squareGlyphParses{
+    "A simple square glyph parses into 4 on-curve points and one contour",
+    "evidence-unit",
+    [] {
+        struct State {
+            Builder::Serialized            serialized;
+            std::optional<tt::Font>        font;
+            std::optional<tt::SimpleGlyph> glyph;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-square-glyph-parses")
+            .Given("a font with an empty and a square glyph",
+                   [state] {
+                       state->serialized = Builder().rawGlyph(0, emptyGlyph()).rawGlyph(1, squareGlyph()).serialize();
+                       auto font         = tt::parse(state->serialized.bytes);
+                       if (!font.has_value()) {
+                           throw speclab::core::AssertionFailure(std::format("font failed to parse: {}", tt::describe(font.error())),
+                                                                 std::source_location::current());
+                       }
+                       state->font = std::move(*font);
+                   })
+            .When("parseGlyph() is called for the square glyph",
+                  [state] {
+                      auto glyph = tt::parseGlyph(*state->font, 1);
+                      if (!glyph.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("square glyph failed to parse: {}", tt::describe(glyph.error())),
+                                                                std::source_location::current());
+                      }
+                      state->glyph = std::move(*glyph);
+                  })
+            .Then("it has 4 on-curve points at the square's corners",
+                  [state] {
+                      const auto&        g = *state->glyph;
+                      mdux::spec::Checks checks;
+                      checks.expect(g.glyphIndex == 1, "glyphIndex");
+                      checks.expect(g.xMin == 0 && g.yMin == 0, "min bbox");
+                      checks.expect(g.xMax == 100 && g.yMax == 100, "max bbox");
+                      checks.expect(g.endPtsOfContours.size() == 1, "one contour");
+                      if (!g.endPtsOfContours.empty()) {
+                          checks.expect(g.endPtsOfContours[0] == 3, "end point is the 4th point index");
+                      }
+                      checks.expect(g.points.size() == 4, "4 points");
+                      if (g.points.size() == 4) {
+                          checks.expect(g.points[0].x == 0 && g.points[0].y == 0 && g.points[0].onCurve, "point 0 at (0,0)");
+                          checks.expect(g.points[1].x == 100 && g.points[1].y == 0 && g.points[1].onCurve, "point 1 at (100,0)");
+                          checks.expect(g.points[2].x == 100 && g.points[2].y == 100 && g.points[2].onCurve, "point 2 at (100,100)");
+                          checks.expect(g.points[3].x == 0 && g.points[3].y == 100 && g.points[3].onCurve, "point 3 at (0,100)");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register emptyGlyphParses{"An empty glyph (numberOfContours == 0) parses with no points", "evidence-unit", [] {
+                                                struct State {
+                                                    Builder::Serialized            serialized;
+                                                    std::optional<tt::Font>        font;
+                                                    std::optional<tt::SimpleGlyph> glyph;
+                                                };
+                                                auto state = std::make_shared<State>();
+
+                                                return speclab::Test("text-truetype-empty-glyph-parses")
+                                                    .Given("a font with one empty glyph",
+                                                           [state] {
+                                                               state->serialized = Builder().rawGlyph(0, emptyGlyph()).serialize();
+                                                               auto font         = tt::parse(state->serialized.bytes);
+                                                               if (!font.has_value()) {
+                                                                   throw speclab::core::AssertionFailure(
+                                                                       std::format("font failed to parse: {}", tt::describe(font.error())),
+                                                                       std::source_location::current());
+                                                               }
+                                                               state->font = std::move(*font);
+                                                           })
+                                                    .When("parseGlyph() is called for the empty glyph",
+                                                          [state] {
+                                                              auto glyph = tt::parseGlyph(*state->font, 0);
+                                                              if (!glyph.has_value()) {
+                                                                  throw speclab::core::AssertionFailure(
+                                                                      std::format("empty glyph failed to parse: {}", tt::describe(glyph.error())),
+                                                                      std::source_location::current());
+                                                              }
+                                                              state->glyph = std::move(*glyph);
+                                                          })
+                                                    .Then("it has no contours and no points",
+                                                          [state] {
+                                                              const auto&        g = *state->glyph;
+                                                              mdux::spec::Checks checks;
+                                                              checks.expect(g.endPtsOfContours.empty(), "no end points");
+                                                              checks.expect(g.points.empty(), "no contour points");
+                                                              checks.raise();
+                                                          })
+                                                    .Execute();
+                                            }};
+
+const mdux::spec::Register parseGlyphRejections{
+    "parseGlyph() emits the right stable code per failure mode",
+    "evidence-unit",
+    [] {
+        using FontResult  = mdux::core::Result<tt::Font, tt::ParseError>;
+        using GlyphResult = mdux::core::Result<tt::SimpleGlyph, tt::ParseError>;
+
+        struct State {
+            std::optional<tt::Font> font;
+        };
+
+        struct Case {
+            std::string_view                            what;
+            ParseError                                  expected;
+            std::function<FontResult(State&)>           buildFont;
+            std::function<GlyphResult(const tt::Font&)> parse;
+        };
+
+        const std::vector<Case> cases{
+            {                     "a glyph index past numGlyphs",
+             ParseError::GlyphIndexOutOfRange,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, emptyGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 100);
+ }},
+
+            {    "a glyf record shorter than the 10-byte header",
+             ParseError::TruncatedGlyph,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, shortGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {       "a composite glyph (numberOfContours == -1)",
+             ParseError::CompositeGlyphRejected,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, compositeGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {                     "hinting instructions present",
+             ParseError::HintingRejected,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, hintedGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {  "endPtsOfContours extending past the glyf record",
+             ParseError::TruncatedContourEndpoints,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, endPtsTruncatedGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {                   "non-monotonic endPtsOfContours",
+             ParseError::NonMonotonicContours,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, nonMonotonicGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {             "flags extending past the glyf record",
+             ParseError::TruncatedGlyphFlags,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, flagsTruncatedGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {"x or y coordinates extending past the glyf record",
+             ParseError::TruncatedGlyphCoords,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, coordsTruncatedGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {                "a flag with reserved bits 6-7 set",
+             ParseError::UnsupportedGlyphFlag,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, reservedFlagGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+        };
+
+        return speclab::Test("text-truetype-glyph-rejections")
+            .Given("a corpus of malformed glyphs each in its own font", [] {})
+            .When("each is parsed", [] {})
+            .Then("each yields the ParseError identified in the corpus",
+                  [&cases] {
+                      mdux::spec::Checks checks;
+                      State              state;
+                      for (const Case& entry : cases) {
+                          state.font.reset();
+                          auto fontResult = entry.buildFont(state);
+                          if (!fontResult.has_value()) {
+                              throw speclab::core::AssertionFailure(
+                                  std::format("{}: the fixture's font did not parse: {}", entry.what, tt::describe(fontResult.error())),
+                                  std::source_location::current());
+                          }
+                          auto glyph = entry.parse(*state.font);
+                          checks.expect(!glyph.has_value(), std::format("{}: parseGlyph succeeded unexpectedly", entry.what));
+                          if (!glyph.has_value()) {
+                              checks.expect(glyph.error() == entry.expected,
+                                            std::format("{}: got '{}', expected '{}'", entry.what, tt::describe(glyph.error()), tt::describe(entry.expected)));
+                          }
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/text/TruetypeTests.cpp
+++ b/tests/text/TruetypeTests.cpp
@@ -15,10 +15,16 @@
  * Every rejection scenario asserts the specific `ParseError` code, not merely that parsing
  * failed. A parser that rejects everything with one generic error passes "it was rejected"
  * and is useless to the author who has to fix the font - and useless to S4 (#160), which has
- * to convert each code into a distinct `TXT` diagnostic. The first scenario belows holds the
- * success case; the two table-driven scenarios hold all rejection paths for `parse()` and
+ * to convert each code into a distinct `TXT` diagnostic. The scenarios below open with the
+ * success cases; the two table-driven scenarios hold all rejection paths for `parse()` and
  * `parseGlyph()`, so a new rejection added later lands next to its enumerator by index rather
  * than spread across the file.
+ *
+ * Two of those success cases exist because a purely synthetic corpus missed them once. The
+ * parser is meant to read fonts designers ship, and those carry `GPOS`/`GSUB` tables, hinting
+ * bytecode and zero-length `glyf` records (the encoding for the space character) - shapes no
+ * "build the minimal legal font" fixture produces by accident. `layoutTablesAreSkipped`,
+ * `hintedGlyphParses` and `zeroLengthGlyphParses` pin them explicitly.
  */
 
 import std;
@@ -516,7 +522,34 @@ private:
     return b;  // 10 bytes: no endPts, no instructionLength
 }
 
-/// A single-point glyph whose flag has bits 6-7 set: parser rejects with UnsupportedGlyphFlag.
+/// A single-point glyph whose flag has bit 6 (OVERLAP_SIMPLE) set. Bit 6 is a defined flag in
+/// the current OpenType spec with no shaping semantics, and modern tooling sets it, so this must
+/// parse - only bit 7 is reserved.
+[[nodiscard]] std::vector<std::byte> overlapSimpleGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);
+    i16(0);
+    i16(0);
+    i16(7);
+    i16(9);
+    u16(0);                        // endPtsOfContours[0] = 0 - one point
+    u16(0);                        // instructionLength = 0
+    b.push_back(std::byte{0x41});  // on-curve + OVERLAP_SIMPLE (bit 6)
+    i16(7);                        // signed-16 X
+    i16(9);                        // signed-16 Y
+    return b;
+}
+
+/// A single-point glyph whose flag has bit 7 (genuinely reserved) set: the parser rejects with
+/// UnsupportedGlyphFlag.
 [[nodiscard]] std::vector<std::byte> reservedFlagGlyph() {
     std::vector<std::byte> b;
     auto                   i16 = [&](std::int16_t v) {
@@ -534,12 +567,52 @@ private:
     i16(0);
     u16(0);                        // endPtsOfContours[0] = 0 - one point
     u16(0);                        // instructionLength = 0
-    b.push_back(std::byte{0xC1});  // on-curve + reserved bit 7 set
+    b.push_back(std::byte{0x81});  // on-curve + reserved bit 7 set
     return b;
 }
 
-/// A glyph whose `instructionLength` is non-zero; the parser rejects before reading flags.
-[[nodiscard]] std::vector<std::byte> hintedGlyph() {
+/// The square glyph with `instructionLength` bytes of hinting bytecode between the instruction
+/// length field and the flag array. The parser steps over the bytecode, so this must parse to
+/// exactly the same outline `squareGlyph()` does - the instruction bytes are deliberately values
+/// that would be legal flags, so a parser that failed to skip them would mis-decode rather than
+/// merely run short.
+[[nodiscard]] std::vector<std::byte> hintedSquareGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);  // numberOfContours = 1
+    i16(0);
+    i16(0);
+    i16(100);
+    i16(100);  // bbox
+    u16(3);    // endPtsOfContours[0] = 3
+    u16(4);    // instructionLength = 4
+    for (int i = 0; i < 4; ++i)
+        b.push_back(std::byte{0x01});  // bytecode that would read as an on-curve flag
+    b.push_back(std::byte{0x01});      // the real flags start here
+    b.push_back(std::byte{0x01});
+    b.push_back(std::byte{0x01});
+    b.push_back(std::byte{0x01});
+    i16(0);
+    i16(100);
+    i16(0);
+    i16(-100);  // X deltas
+    i16(0);
+    i16(0);
+    i16(100);
+    i16(0);  // Y deltas
+    return b;
+}
+
+/// A glyph whose `instructionLength` claims more bytecode than the record holds; the skip is
+/// bounds-checked, so this fails with TruncatedGlyphInstructions.
+[[nodiscard]] std::vector<std::byte> instructionsTruncatedGlyph() {
     std::vector<std::byte> b;
     auto                   i16 = [&](std::int16_t v) {
         b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
@@ -554,14 +627,72 @@ private:
     i16(0);
     i16(0);
     i16(0);
-    u16(3);  // 4 points
-    u16(1);  // instructionLength = 1
-    // The instruction byte itself is irrelevant; HintingRejected fires before it would be read.
+    u16(3);      // 4 points
+    u16(1000);   // instructionLength = 1000, far past the end of this record
     b.push_back(std::byte{0x42});
     return b;
 }
 
-/// A glyph record shorter than the 10-byte header - the parser fails with TruncatedGlyph.
+/// A glyph declaring one contour of 2 points whose first flag carries REPEAT_FLAG with a count
+/// of 200 - far more points than endPtsOfContours claims. The flag stream and the contour list
+/// disagree, so the parser fails with GlyphFlagRepeatOverrun rather than truncating silently.
+[[nodiscard]] std::vector<std::byte> repeatOverrunGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);
+    u16(1);                        // endPtsOfContours[0] = 1 -- two points
+    u16(0);                        // instructionLength = 0
+    b.push_back(std::byte{0x09});  // on-curve + REPEAT_FLAG
+    b.push_back(std::byte{200});   // ...repeated 200 more times
+    for (int i = 0; i < 8; ++i)    // coordinate bytes, never reached
+        b.push_back(std::byte{0});
+    return b;
+}
+
+/// Two points whose signed-16 X deltas accumulate past INT16_MAX. Well-formed fonts cannot reach
+/// this (coordinates are int16 bounded by the head bbox), so it is malformed input by
+/// construction - and the parser refuses with CoordinateOverflow rather than clamping to a
+/// plausible-looking wrong outline.
+[[nodiscard]] std::vector<std::byte> coordinateOverflowGlyph() {
+    std::vector<std::byte> b;
+    auto                   i16 = [&](std::int16_t v) {
+        b.push_back(static_cast<std::byte>((static_cast<std::uint16_t>(v) >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(static_cast<std::uint16_t>(v) & 0xffu));
+    };
+    auto u16 = [&](std::uint16_t v) {
+        b.push_back(static_cast<std::byte>((v >> 8) & 0xffu));
+        b.push_back(static_cast<std::byte>(v & 0xffu));
+    };
+    i16(1);
+    i16(0);
+    i16(0);
+    i16(0);
+    i16(0);
+    u16(1);  // endPtsOfContours[0] = 1 -- two points
+    u16(0);  // instructionLength = 0
+    b.push_back(std::byte{0x01});
+    b.push_back(std::byte{0x01});
+    i16(30000);  // X deltas: 30000 then +30000 leaves int16
+    i16(30000);
+    i16(0);  // Y deltas
+    i16(0);
+    return b;
+}
+
+/// A glyph record shorter than the 10-byte header - the parser fails with TruncatedGlyph. Five
+/// bytes rather than zero: a *zero*-length record is the spec's encoding of a blank glyph and
+/// parses (see `zeroLengthGlyphParses`), so the truncation fixture has to be non-empty.
 [[nodiscard]] std::vector<std::byte> shortGlyph() {
     return std::vector<std::byte>(5, std::byte{0});
 }
@@ -624,11 +755,11 @@ const mdux::spec::Register validFontParses{"A minimal well-formed TrueType font 
                                            }};
 
 const mdux::spec::Register trueAndTyp1Acceptances{"parse() accepts 'true' and 'typ1' TrueType container variants", "evidence-unit", [] {
-                                                      // The directory records walk can pass on either 'true' or 'typ1' if they actually
-                                                      // describe a TrueType outline table set; the check at the version word is the first
-                                                      // gate, not the only one, and these two are alternative container spellings rather than
-                                                      // tow CFF-flavoured ones. (OTTO is the CFF OpenType container and would reject here too,
-                                                      // but parse() rejects CFF fonts later again on the 'CFF ' table tag, regardless.)
+                                                      // The directory walk can pass on either 'true' or 'typ1' if they actually describe a
+                                                      // TrueType outline table set; the check at the version word is the first gate, not the
+                                                      // only one, and these two are alternative container spellings for the same glyf-based
+                                                      // format. 'OTTO' also passes this gate, but for the opposite reason - it is admitted so
+                                                      // that its 'CFF ' table can produce CffOutlinesRejected, which the rejection corpus pins.
                                                       struct State {
                                                           Builder::Serialized     s1;
                                                           Builder::Serialized     s2;
@@ -664,6 +795,244 @@ const mdux::spec::Register trueAndTyp1Acceptances{"parse() accepts 'true' and 't
                                                                 })
                                                           .Execute();
                                                   }};
+
+const mdux::spec::Register layoutTablesAreSkipped{
+    "parse() accepts a font carrying GPOS, GSUB, GDEF and morx, reading none of them",
+    "evidence-unit",
+    [] {
+        // ADR-010 forbids on-device shaping, and the way this parser delivers that is by never
+        // reading a layout table - not by refusing a font that has one. Every font a designer
+        // ships carries GPOS and GSUB (8 of 8 stock DejaVu faces do), so a presence rule would
+        // accept no real input at all while adding no safety over simply not reading the bytes.
+        // This scenario is the regression guard on that decision.
+        struct State {
+            Builder::Serialized     serialized;
+            std::optional<tt::Font> font;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-layout-tables-skipped")
+            .Given("a font with GPOS, GSUB, GDEF and morx tables alongside its outlines",
+                   [state] {
+                       state->serialized = Builder()
+                                               .rawGlyph(0, emptyGlyph())
+                                               .rawGlyph(1, squareGlyph())
+                                               .extraTable("GPOS", dummyExtra())
+                                               .extraTable("GSUB", dummyExtra())
+                                               .extraTable("GDEF", dummyExtra())
+                                               .extraTable("morx", dummyExtra())
+                                               .serialize();
+                   })
+            .When("parse() is called",
+                  [state] {
+                      auto font = tt::parse(state->serialized.bytes);
+                      if (!font.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("font with layout tables was rejected: {}", tt::describe(font.error())),
+                                                                std::source_location::current());
+                      }
+                      state->font = std::move(*font);
+                  })
+            .Then("it parses, and its glyphs still parse",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      checks.expect(state->font->numGlyphs == 2, "numGlyphs");
+                      auto glyph = tt::parseGlyph(*state->font, 1);
+                      checks.expect(glyph.has_value(), "the square glyph parses out of a font carrying layout tables");
+                      if (glyph.has_value()) {
+                          checks.expect(glyph->points.size() == 4, "4 points");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register zeroLengthGlyphParses{
+    "A zero-length glyf record (loca[i] == loca[i+1]) parses as a blank glyph",
+    "evidence-unit",
+    [] {
+        // This is the spec's encoding for a glyph with no outline, and it is how every real font
+        // stores the space character: DejaVuSans has 63 such records, gid 3 (space) among them.
+        // Treating it as a truncation would fail the space character of every stock font.
+        struct State {
+            Builder::Serialized            serialized;
+            std::optional<tt::Font>        font;
+            std::optional<tt::SimpleGlyph> glyph;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-zero-length-glyph-parses")
+            .Given("a font whose glyph 0 occupies no bytes at all, followed by a square glyph",
+                   [state] {
+                       state->serialized = Builder().rawGlyph(0, {}).rawGlyph(1, squareGlyph()).serialize();
+                       auto font         = tt::parse(state->serialized.bytes);
+                       if (!font.has_value()) {
+                           throw speclab::core::AssertionFailure(std::format("font failed to parse: {}", tt::describe(font.error())),
+                                                                 std::source_location::current());
+                       }
+                       state->font = std::move(*font);
+                   })
+            .When("parseGlyph() is called for the zero-length glyph",
+                  [state] {
+                      if (state->font->loca.size() < 2 || state->font->loca[0] != state->font->loca[1]) {
+                          throw speclab::core::AssertionFailure("the fixture did not produce a zero-length loca span",
+                                                                std::source_location::current());
+                      }
+                      auto glyph = tt::parseGlyph(*state->font, 0);
+                      if (!glyph.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("zero-length glyph was rejected: {}", tt::describe(glyph.error())),
+                                                                std::source_location::current());
+                      }
+                      state->glyph = std::move(*glyph);
+                  })
+            .Then("it is a blank glyph, and the glyph after it is unaffected",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      checks.expect(state->glyph->glyphIndex == 0, "glyphIndex");
+                      checks.expect(state->glyph->endPtsOfContours.empty(), "no end points");
+                      checks.expect(state->glyph->points.empty(), "no contour points");
+                      auto next = tt::parseGlyph(*state->font, 1);
+                      checks.expect(next.has_value() && next->points.size() == 4, "the following glyph still parses");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register hintedGlyphParses{
+    "A glyph carrying hinting bytecode parses to the same outline as its unhinted twin",
+    "evidence-unit",
+    [] {
+        // The bytecode is stepped over rather than interpreted: the runtime has no hinting
+        // engine, so the bytes have no consumer, and roughly 16% of a stock font's glyphs carry
+        // them. The fixture's instruction bytes are values that would read as legal flags, so a
+        // parser that failed to skip them would produce a *different* outline rather than fail.
+        struct State {
+            Builder::Serialized            serialized;
+            std::optional<tt::Font>        font;
+            std::optional<tt::SimpleGlyph> glyph;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-hinted-glyph-parses")
+            .Given("a font whose only glyph is the square glyph plus 4 bytes of bytecode",
+                   [state] {
+                       state->serialized = Builder().rawGlyph(0, hintedSquareGlyph()).serialize();
+                       auto font         = tt::parse(state->serialized.bytes);
+                       if (!font.has_value()) {
+                           throw speclab::core::AssertionFailure(std::format("font failed to parse: {}", tt::describe(font.error())),
+                                                                 std::source_location::current());
+                       }
+                       state->font = std::move(*font);
+                   })
+            .When("parseGlyph() is called",
+                  [state] {
+                      auto glyph = tt::parseGlyph(*state->font, 0);
+                      if (!glyph.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("hinted glyph was rejected: {}", tt::describe(glyph.error())),
+                                                                std::source_location::current());
+                      }
+                      state->glyph = std::move(*glyph);
+                  })
+            .Then("the outline matches squareGlyph()'s, and no instruction byte leaked into it",
+                  [state] {
+                      const auto&        g = *state->glyph;
+                      mdux::spec::Checks checks;
+                      checks.expect(g.points.size() == 4, "4 points");
+                      if (g.points.size() == 4) {
+                          checks.expect(g.points[0].x == 0 && g.points[0].y == 0, "point 0 at (0,0)");
+                          checks.expect(g.points[1].x == 100 && g.points[1].y == 0, "point 1 at (100,0)");
+                          checks.expect(g.points[2].x == 100 && g.points[2].y == 100, "point 2 at (100,100)");
+                          checks.expect(g.points[3].x == 0 && g.points[3].y == 100, "point 3 at (0,100)");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register overlapSimpleFlagParses{
+    // No semicolon in this title: mdux_discover_tests() splits registered names on ';', so one
+    // would register as two bogus CTest cases.
+    "A glyph whose flag sets OVERLAP_SIMPLE (bit 6) parses, because only bit 7 is reserved",
+    "evidence-unit",
+    [] {
+        // Bit 6 is OVERLAP_SIMPLE in the current OpenType spec - a rasteriser hint with no
+        // shaping semantics that modern tooling sets. Masking it as reserved would refuse fonts
+        // whose only unusual property is having been built recently.
+        struct State {
+            Builder::Serialized            serialized;
+            std::optional<tt::Font>        font;
+            std::optional<tt::SimpleGlyph> glyph;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-overlap-simple-flag-parses")
+            .Given("a one-point glyph whose flag is on-curve + OVERLAP_SIMPLE",
+                   [state] {
+                       state->serialized = Builder().rawGlyph(0, overlapSimpleGlyph()).serialize();
+                       auto font         = tt::parse(state->serialized.bytes);
+                       if (!font.has_value()) {
+                           throw speclab::core::AssertionFailure(std::format("font failed to parse: {}", tt::describe(font.error())),
+                                                                 std::source_location::current());
+                       }
+                       state->font = std::move(*font);
+                   })
+            .When("parseGlyph() is called",
+                  [state] {
+                      auto glyph = tt::parseGlyph(*state->font, 0);
+                      if (!glyph.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("OVERLAP_SIMPLE glyph was rejected: {}", tt::describe(glyph.error())),
+                                                                std::source_location::current());
+                      }
+                      state->glyph = std::move(*glyph);
+                  })
+            .Then("the point is read with its coordinates and on-curve bit intact",
+                  [state] {
+                      const auto&        g = *state->glyph;
+                      mdux::spec::Checks checks;
+                      checks.expect(g.points.size() == 1, "1 point");
+                      if (g.points.size() == 1) {
+                          checks.expect(g.points[0].x == 7 && g.points[0].y == 9, "point at (7,9)");
+                          checks.expect(g.points[0].onCurve, "on-curve");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register overLongLocaIsAccepted{
+    "parse() accepts a 'loca' table longer than numGlyphs+1 entries",
+    "evidence-unit",
+    [] {
+        // The size check is `<`, not `!=`, and this pins why: sfnt pads every table to a 4-byte
+        // boundary, so a short-format loca with an even entry count legitimately carries two
+        // trailing bytes. `LocaSizeMismatch` means "too short", and only that.
+        struct State {
+            std::vector<std::byte>  bytes;
+            std::optional<tt::Font> font;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-over-long-loca-accepted")
+            .Given("a one-glyph font whose loca record declares 6 bytes where 4 are needed",
+                   [state] {
+                       state->bytes = Builder().rawGlyph(0, squareGlyph()).locaDeclaredLength(6).serialize().bytes;
+                   })
+            .When("parse() is called",
+                  [state] {
+                      auto font = tt::parse(state->bytes);
+                      if (!font.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("padded loca was rejected: {}", tt::describe(font.error())),
+                                                                std::source_location::current());
+                      }
+                      state->font = std::move(*font);
+                  })
+            .Then("only the numGlyphs+1 entries it needs are read",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      checks.expect(state->font->loca.size() == 2, "loca holds exactly numGlyphs+1 entries");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
 
 // ---------------------------------------------------------------------------
 // parse(): rejection corpus - one scenario per ParseError the directory walk emits.
@@ -733,25 +1102,13 @@ const mdux::spec::Register parseRejections{
              [] {
              return Builder().extraTable("CFF2", dummyExtra()).serialize().bytes;
              }},
-            {                             "a 'GPOS' table present",
-             ParseError::GposRejected,
+            {  "an 'OTTO' container, which carries CFF outlines",
+             ParseError::CffOutlinesRejected,
              [] {
-             return Builder().extraTable("GPOS", dummyExtra()).serialize().bytes;
-             }},
-            {                             "a 'GSUB' table present",
-             ParseError::GsubRejected,
-             [] {
-             return Builder().extraTable("GSUB", dummyExtra()).serialize().bytes;
-             }},
-            {                             "a 'morx' table present",
-             ParseError::AppleLayoutRejected,
-             [] {
-             return Builder().extraTable("morx", dummyExtra()).serialize().bytes;
-             }},
-            {                             "a 'mort' table present",
-             ParseError::AppleLayoutRejected,
-             [] {
-             return Builder().extraTable("mort", dummyExtra()).serialize().bytes;
+             // 'OTTO' passes the version-word gate on purpose, so that the CFF table it
+             // always carries produces the code that names the actual problem rather than
+             // the generic "unfamiliar container word".
+             return Builder().sfnt(0x4F54544Fu).extraTable("CFF ", dummyExtra()).serialize().bytes;
              }},
             {               "a 'head' table shorter than 54 bytes",
              ParseError::TruncatedHead,
@@ -768,10 +1125,10 @@ const mdux::spec::Register parseRejections{
              [] {
              return Builder().unitsPerEm(8).serialize().bytes;
              }},
-            {            "a unitsPerEm value of 8192 (above 4096)",
+            {          "a unitsPerEm value of 32768 (above 16384)",
              ParseError::UnsupportedUnitsPerEm,
              [] {
-             return Builder().unitsPerEm(8192).serialize().bytes;
+             return Builder().unitsPerEm(32768).serialize().bytes;
              }},
             {                "a 'maxp' table shorter than 6 bytes",
              ParseError::TruncatedMaxp,
@@ -968,10 +1325,10 @@ const mdux::spec::Register parseGlyphRejections{
  return tt::parseGlyph(f, 0);
  }},
 
-            {                     "hinting instructions present",
-             ParseError::HintingRejected,
+            {  "instructionLength claiming more bytecode than exists",
+             ParseError::TruncatedGlyphInstructions,
              [](State& s) {
-             auto r = tt::parse(Builder().rawGlyph(0, hintedGlyph()).serialize().bytes);
+             auto r = tt::parse(Builder().rawGlyph(0, instructionsTruncatedGlyph()).serialize().bytes);
              if (r.has_value())
              s.font = std::move(*r);
              return r;
@@ -1023,12 +1380,50 @@ const mdux::spec::Register parseGlyphRejections{
  return tt::parseGlyph(f, 0);
  }},
 
-            {                "a flag with reserved bits 6-7 set",
+            {                  "a flag with reserved bit 7 set",
              ParseError::UnsupportedGlyphFlag,
              [](State& s) {
              auto r = tt::parse(Builder().rawGlyph(0, reservedFlagGlyph()).serialize().bytes);
              if (r.has_value())
              s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {  "a REPEAT_FLAG count claiming more points than exist",
+             ParseError::GlyphFlagRepeatOverrun,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, repeatOverrunGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {      "coordinate deltas accumulating past int16",
+             ParseError::CoordinateOverflow,
+             [](State& s) {
+             auto r = tt::parse(Builder().rawGlyph(0, coordinateOverflowGlyph()).serialize().bytes);
+             if (r.has_value())
+             s.font = std::move(*r);
+             return r;
+             }, [](const tt::Font& f) {
+ return tt::parseGlyph(f, 0);
+ }},
+
+            {         "a hand-built Font whose loca is too short",
+             ParseError::LocaSizeMismatch,
+             [](State& s) {
+             // `Font` is an exported aggregate, so a caller can hand parseGlyph() one parse()
+             // never produced. Indexing loca[glyphIndex + 1] on this would be UB rather than a
+             // diagnostic, which is what the guard at the top of parseGlyph() prevents.
+             auto r = tt::parse(Builder().rawGlyph(0, squareGlyph()).serialize().bytes);
+             if (r.has_value()) {
+             s.font = std::move(*r);
+             s.font->numGlyphs = 5;  // loca still holds only 2 entries
+             }
              return r;
              }, [](const tt::Font& f) {
  return tt::parseGlyph(f, 0);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -211,9 +211,13 @@ endif()
 # will consume (#15). That identity is the host/device-sharing argument ADR-008 decision 1 makes
 # for ML, inherited by text via ADR-010.
 #
-# At S1 this is a skeleton: run() produces a no-run package whose sidecar is zero bytes. S4
-# (#160) extends it with the font pipeline inputs and S5 (#161) adds the restricted-charset
-# validation; no mdux_bake_artifact() call site is registered until S4 commits a real artifact.
+# At S1 this is a skeleton: run() produces a no-run package whose sidecar is zero bytes. S2
+# (#158) lands the host-only TrueType parser alongside the skeleton: `mdux.tools.truetype`
+# walks the glyf table directly without linking freetype, and is registered as a public
+# module of MduXTextBakeLib so S4's font baker (#160) can import it through the same target
+# that hosts the recipe model. S4 extends the recipe with the font pipeline inputs and S5
+# (#161) adds the restricted-charset validation; no mdux_bake_artifact() call site is
+# registered until S4 commits a real artifact.
 add_library(MduXTextBakeLib)
 add_library(MduX::TextBakeLib ALIAS MduXTextBakeLib)
 
@@ -223,8 +227,10 @@ target_sources(MduXTextBakeLib
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         FILES
             text/TextBake.cppm
+            text/Truetype.cppm
     PRIVATE
         text/TextBake.cpp
+        text/Truetype.cpp
 )
 
 target_compile_features(MduXTextBakeLib PUBLIC cxx_std_23)

--- a/tools/text/Truetype.cpp
+++ b/tools/text/Truetype.cpp
@@ -32,11 +32,16 @@ using mdux::core::Result;
 namespace {
 
 // Recognised sfnt version words. 0x00010000 is the canonical TrueType ID; 'true' and 'typ1' are
-// the Apple and legacy alternative containers; 'OTTO' (0x4F54544F) is CFF-flavoured OpenType and
-// rejected here only if it carries a CFF table, which the directory walk below spots.
+// the Apple and legacy alternative containers. 'OTTO' is CFF-flavoured OpenType: it is admitted
+// at this gate and rejected by the directory walk below on its 'CFF '/'CFF2' tag, so an author
+// who hands the baker an OpenType/CFF font gets `CffOutlinesRejected`, which names the actual
+// problem, rather than `NotATrueTypeOutlineFont`, which would only say the container word was
+// unfamiliar. An 'OTTO' font carrying neither a CFF table nor glyf falls out as
+// MissingRequiredTable.
 constexpr std::uint32_t sfntVersionTrue    = 0x00010000u;
 constexpr std::uint32_t sfntVersionTrueTag = 0x74727565u;  // 'true'
 constexpr std::uint32_t sfntVersionTyp1    = 0x74797031u;  // 'typ1'
+constexpr std::uint32_t sfntVersionOtto    = 0x4F54544Fu;  // 'OTTO'
 
 constexpr std::uint32_t headMagic = 0x5F0F3CF5u;
 
@@ -60,7 +65,10 @@ constexpr std::uint8_t flagYShort          = 0x04u;
 constexpr std::uint8_t flagRepeat          = 0x08u;
 constexpr std::uint8_t flagXSameOrPositive = 0x10u;
 constexpr std::uint8_t flagYSameOrPositive = 0x20u;
-constexpr std::uint8_t flagReservedMask    = 0xC0u;
+// Bit 6 is OVERLAP_SIMPLE in the current OpenType spec - a rasteriser hint with no shaping
+// semantics, which modern tooling does set - so only bit 7 is genuinely reserved. Masking 0xC0
+// here would reject fonts whose only sin is having been built by a recent fontmake.
+constexpr std::uint8_t flagReservedMask    = 0x80u;
 
 [[nodiscard]] std::optional<std::uint16_t> beU16(std::span<const std::byte> bytes, std::size_t offset) noexcept {
     if (offset + 2 > bytes.size()) {
@@ -120,42 +128,40 @@ std::string_view describe(ParseError error) noexcept {
             return "a table's offset + length exceeds the file size";
         case ParseError::CffOutlinesRejected:
             return "a 'CFF ' or 'CFF2' table is present - this is a CFF outline font, not glyf";
-        case ParseError::GposRejected:
-            return "a 'GPOS' table is present; glyph positioning is out of v1 scope";
-        case ParseError::GsubRejected:
-            return "a 'GSUB' table is present; ligatures and substitutions are out of v1 scope";
-        case ParseError::AppleLayoutRejected:
-            return "an 'morx' or 'mort' table is present; Apple AAT layout is out of v1 scope";
         case ParseError::TruncatedHead:
             return "'head' table is shorter than 54 bytes";
         case ParseError::HeadBadMagicNumber:
             return "'head' magic check failed (expected 0x5F0F3CF5)";
         case ParseError::UnsupportedUnitsPerEm:
-            return "unitsPerEm is zero or outside the supported [16, 4096] range";
+            return "unitsPerEm is outside the specification's [16, 16384] range";
         case ParseError::TruncatedMaxp:
             return "'maxp' table is shorter than 6 bytes";
         case ParseError::UnsupportedLocaFormat:
             return "head.indexToLocFormat is neither 0 (short) nor 1 (long)";
         case ParseError::LocaSizeMismatch:
-            return "'loca' byte length does not match numGlyphs+1 entries";
+            return "'loca' is too short to hold numGlyphs+1 entries";
         case ParseError::LocaOutOfBounds:
             return "a 'loca' entry extends past the end of 'glyf'";
         case ParseError::GlyphIndexOutOfRange:
             return "parseGlyph called with an index >= numGlyphs";
         case ParseError::TruncatedGlyph:
-            return "glyf record is shorter than the 10-byte header";
+            return "glyf record is non-empty but shorter than the 10-byte header";
         case ParseError::CompositeGlyphRejected:
             return "numberOfContours == -1; composites are out of v1 scope";
-        case ParseError::HintingRejected:
-            return "instructionLength > 0; on-device hinting is out of v1 scope";
         case ParseError::TruncatedContourEndpoints:
             return "endPtsOfContours or the instruction length field extends past the glyf record";
+        case ParseError::TruncatedGlyphInstructions:
+            return "the hinting instruction array extends past the glyf record";
         case ParseError::TruncatedGlyphFlags:
             return "the flag array extends past the glyf record";
+        case ParseError::GlyphFlagRepeatOverrun:
+            return "a REPEAT_FLAG count claims more points than endPtsOfContours declares";
         case ParseError::TruncatedGlyphCoords:
             return "x or y coordinates extend past the glyf record";
         case ParseError::UnsupportedGlyphFlag:
-            return "a flag value has reserved bits 6 or 7 set";
+            return "a flag value has reserved bit 7 set";
+        case ParseError::CoordinateOverflow:
+            return "an accumulated coordinate left the int16 range the specification allows";
         case ParseError::NonMonotonicContours:
             return "endPtsOfContours is not strictly increasing";
     }
@@ -191,17 +197,19 @@ struct Directory {
             return err(ParseError::DuplicateTable);
         }
 
-        // Reject the unsupported layout/outline tables up front: the structure check at the top
-        // is not enough to refuse a font whose presence would force the runtime to do shaping,
-        // and the catalog of structural categories is the parser's first enforcement point.
+        // A CFF/CFF2 font is refused here rather than falling out as MissingRequiredTable: its
+        // outlines live in a table this parser does not read at all, so "no glyf" is a symptom
+        // and "these are CFF outlines" is the diagnosis the author needs.
+        //
+        // GPOS, GSUB, GDEF and the Apple AAT tables morx/mort are deliberately *not* refused.
+        // ADR-010 forbids on-device shaping, and this walk is what makes that true: those tags
+        // fall through the tag ladder below, so their bytes are never sliced, never read and
+        // never reach a `Font`. A baker that cannot see a table cannot bake it into an artifact,
+        // and a runtime handed that artifact has nothing to apply. Refusing on presence instead
+        // would refuse every font a designer has ever shipped (8 of 8 stock DejaVu faces carry
+        // both GPOS and GSUB) while adding no safety this omission does not already provide.
         if (tagStr == "CFF " || tagStr == "CFF2")
             return err(ParseError::CffOutlinesRejected);
-        if (tagStr == "GPOS")
-            return err(ParseError::GposRejected);
-        if (tagStr == "GSUB")
-            return err(ParseError::GsubRejected);
-        if (tagStr == "morx" || tagStr == "mort")
-            return err(ParseError::AppleLayoutRejected);
 
         // Bounds-check the record's slice before storing it; a later subspan() takes the validated
         // length without re-checking, which is the whole point of doing the walk in pass one.
@@ -226,8 +234,11 @@ struct Directory {
 [[nodiscard]] Result<std::vector<std::uint32_t>, ParseError>
 readLoca(std::span<const std::byte> loca, std::uint16_t numGlyphs, std::uint16_t indexToLocFormat, std::uint32_t glyfLength) noexcept {
     // numGlyphs + 1 entries; short form is uint16 × 2 (the storage value is half of the byte
-    // offset), long form is uint32 straight. The byte length is the size check, so a font that
-    // author declares one glyph but ships a two-entry short loca (4 bytes total) is well-formed.
+    // offset), long form is uint32 straight. The check below is `<`, not `!=`, deliberately: a
+    // table longer than numGlyphs+1 entries is well-formed, because sfnt pads every table to a
+    // 4-byte boundary and a short-format loca with an even entry count picks up two trailing
+    // bytes. Only a table too short to hold the entries the directory promises is a defect, so
+    // `LocaSizeMismatch` reads "too short for numGlyphs+1 entries", not "not exactly".
     const std::size_t entryCount  = static_cast<std::size_t>(numGlyphs) + 1u;
     const std::size_t elementSize = (indexToLocFormat == 0) ? 2u : 4u;
     if (loca.size() < entryCount * elementSize) {
@@ -273,7 +284,7 @@ Result<Font, ParseError> parse(std::span<const std::byte> bytes) noexcept {
     if (!sfnt) {
         return err(ParseError::TruncatedOffsetTable);
     }
-    if (*sfnt != sfntVersionTrue && *sfnt != sfntVersionTrueTag && *sfnt != sfntVersionTyp1) {
+    if (*sfnt != sfntVersionTrue && *sfnt != sfntVersionTrueTag && *sfnt != sfntVersionTyp1 && *sfnt != sfntVersionOtto) {
         return err(ParseError::NotATrueTypeOutlineFont);
     }
 
@@ -318,7 +329,11 @@ Result<Font, ParseError> parse(std::span<const std::byte> bytes) noexcept {
     if (!unitsPerEm) {
         return err(ParseError::TruncatedHead);
     }
-    if (*unitsPerEm < 16 || *unitsPerEm > 4096) {
+    // The OpenType specification's own range for head.unitsPerEm. Narrowing it further would
+    // reject spec-valid fonts (an 8192-upem face is legal and not unusual for display faces)
+    // with no ADR behind the narrowing - the baker scales to the atlas' pixel grid anyway, so
+    // a larger em square costs nothing downstream.
+    if (*unitsPerEm < 16 || *unitsPerEm > 16384) {
         return err(ParseError::UnsupportedUnitsPerEm);
     }
     const auto indexToLocFormat = beI16(head, headIndexToLocFormatOffset);
@@ -355,17 +370,19 @@ Result<Font, ParseError> parse(std::span<const std::byte> bytes) noexcept {
 
 namespace {
 
-/// Saturating add of two int16s into int16, used for accumulating TrueType coordinate deltas that
-/// are themselves int16. The spec stores coordinates as absolute int16 values, so an accumulation
-/// that overflows int16 would already be malformed - clamp to int16_max/min rather than wrap, so a
-/// malformed accumulator stays deterministic rather than producing "anything is allowed".
-[[nodiscard]] std::int16_t satAdd(std::int16_t a, std::int16_t b) noexcept {
+/// Checked add of two int16s, used to accumulate the TrueType coordinate deltas that are
+/// themselves int16. The spec stores coordinates as absolute int16 values bounded by the `head`
+/// bounding box, so an accumulation that leaves int16 can only come from malformed input - and
+/// this file's contract is that anything it does not understand is a refusal with a specific
+/// code rather than a guess. Returning nullopt (which the caller turns into
+/// `CoordinateOverflow`) is the version of that contract for coordinates: a clamped value would
+/// be a plausible-looking but wrong outline, which S4 would then bake and byte-commit as
+/// evidence.
+[[nodiscard]] std::optional<std::int16_t> checkedAdd(std::int16_t a, std::int16_t b) noexcept {
     const auto sum = static_cast<std::int32_t>(a) + static_cast<std::int32_t>(b);
-    if (sum > static_cast<std::int32_t>(std::numeric_limits<std::int16_t>::max())) {
-        return std::numeric_limits<std::int16_t>::max();
-    }
-    if (sum < static_cast<std::int32_t>(std::numeric_limits<std::int16_t>::min())) {
-        return std::numeric_limits<std::int16_t>::min();
+    if (sum > static_cast<std::int32_t>(std::numeric_limits<std::int16_t>::max())
+        || sum < static_cast<std::int32_t>(std::numeric_limits<std::int16_t>::min())) {
+        return std::nullopt;
     }
     return static_cast<std::int16_t>(sum);
 }
@@ -376,6 +393,13 @@ Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyph
     if (glyphIndex >= font.numGlyphs) {
         return err(ParseError::GlyphIndexOutOfRange);
     }
+    // `Font` is an exported aggregate with public fields, so this can be one a caller built or
+    // mutated rather than one `parse()` returned. `parse()` guarantees numGlyphs+1 loca entries;
+    // re-checking costs one comparison and is what keeps the two indexes below from being
+    // std::vector::operator[] out of range, which is UB rather than a diagnostic.
+    if (font.loca.size() < static_cast<std::size_t>(font.numGlyphs) + 1u) {
+        return err(ParseError::LocaSizeMismatch);
+    }
 
     const std::uint32_t start = font.loca[glyphIndex];
     const std::uint32_t end   = font.loca[glyphIndex + 1];
@@ -383,25 +407,34 @@ Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyph
         return err(ParseError::LocaOutOfBounds);
     }
     const auto span = font.glyf.subspan(start, end - start);
+
+    // A zero-length record - loca[i] == loca[i+1] - is how TrueType spells "this glyph has no
+    // outline". It is the mandated encoding for the space character and for every other blank,
+    // not a truncation: DejaVuSans stores 63 of its 6253 glyphs this way, gid 3 (space) among
+    // them. It has to be checked before the 10-byte header bound, because there is no header.
+    if (span.empty()) {
+        SimpleGlyph blank;
+        blank.glyphIndex = glyphIndex;
+        return blank;
+    }
     if (span.size() < 10) {
         return err(ParseError::TruncatedGlyph);
     }
 
     SimpleGlyph glyph;
-    glyph.glyphIndex            = glyphIndex;
-    const auto numberOfContours = beI16(span, 0);
+    glyph.glyphIndex = glyphIndex;
+    // The five int16 header fields are all inside the 10 bytes the guard above secured, so these
+    // five reads cannot fail; dereferencing without a second check is safe here and nowhere else.
+    const auto numberOfContours = *beI16(span, 0);
     glyph.xMin                  = *beI16(span, 2);
     glyph.yMin                  = *beI16(span, 4);
     glyph.xMax                  = *beI16(span, 6);
     glyph.yMax                  = *beI16(span, 8);
 
-    if (!numberOfContours) {
-        return err(ParseError::TruncatedGlyph);
-    }
-    if (*numberOfContours < 0) {
+    if (numberOfContours < 0) {
         return err(ParseError::CompositeGlyphRejected);
     }
-    const auto contours = static_cast<std::size_t>(*numberOfContours);
+    const auto contours = static_cast<std::size_t>(numberOfContours);
 
     // endPtsOfContours: contours × 2 bytes, starting at offset 10. The instruction-length field
     // follows immediately, so the bounds check below also reserves the 2 bytes for it; an attempt
@@ -423,23 +456,29 @@ Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyph
         previousEndPoint = *ep;
     }
 
+    // instructionLength and the hinting bytecode that follows it. The bytecode is stepped over,
+    // not read: the runtime has no hinting engine (ADR-010 decision 4), so the bytes have no
+    // consumer downstream, and a font whose only unsupported feature is that its designer ran
+    // ttfautohint is a font this parser can still produce an outline from. Only the step itself
+    // is checked, so a declared length that runs past the record is still a diagnostic.
     std::size_t cursor            = endPtsEnd;
-    const auto  instructionLength = beU16(span, cursor);
-    if (!instructionLength) {
-        return err(ParseError::TruncatedContourEndpoints);
-    }
+    const auto  instructionLength = *beU16(span, cursor);  // the endPtsEnd + 2 guard secured this
     cursor += 2u;
-    if (*instructionLength > 0) {
-        return err(ParseError::HintingRejected);
+    if (instructionLength > span.size() - cursor) {
+        return err(ParseError::TruncatedGlyphInstructions);
     }
+    cursor += instructionLength;
 
-    // An empty glyph (numberOfContours == 0): no end points, no instructions, no flags and
-    // no coordinates. Returns with empty point lists and a single zero-point contour state.
+    // An empty glyph (numberOfContours == 0) declares no end points, so it has no points either
+    // and the flag and coordinate loops below run zero times, leaving both vectors empty.
     const std::size_t numPoints = (contours == 0) ? 0u : static_cast<std::size_t>(previousEndPoint) + 1u;
 
     // Flags: one byte per point, with the REPEAT_FLAG encoding (the next byte is the count of
     // additional repetitions). The loop fills exactly numPoints flags; an abbreviated repeat or
-    // an absent byte fails with TruncatedGlyphFlags.
+    // an absent byte fails with TruncatedGlyphFlags, and a repeat count claiming more points
+    // than endPtsOfContours declared fails with GlyphFlagRepeatOverrun rather than being
+    // silently truncated - an over-long repeat means the flag stream and the contour list
+    // disagree about how many points the glyph has, and the parser cannot know which is right.
     std::vector<std::uint8_t> flags;
     flags.reserve(numPoints);
     while (flags.size() < numPoints) {
@@ -458,13 +497,11 @@ Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyph
             }
             const std::uint8_t repeatCount = std::to_integer<std::uint8_t>(span[cursor]);
             ++cursor;
-            for (std::uint8_t r = 0; r < repeatCount && flags.size() < numPoints; ++r) {
-                flags.push_back(flag);
+            if (static_cast<std::size_t>(repeatCount) > numPoints - flags.size()) {
+                return err(ParseError::GlyphFlagRepeatOverrun);
             }
+            flags.insert(flags.end(), repeatCount, flag);
         }
-    }
-    if (flags.size() != numPoints) {
-        return err(ParseError::TruncatedGlyphFlags);
     }
 
     // X coordinates. The two flag bits are X_SHORT_VECTOR and X_IS_SAME_OR_POSITIVE; the four
@@ -485,14 +522,22 @@ Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyph
             ++cursor;
             const std::int16_t delta = sameOrPositive ? static_cast<std::int16_t>(static_cast<std::uint16_t>(raw))
                                                       : -static_cast<std::int16_t>(static_cast<std::uint16_t>(raw));
-            x                        = satAdd(x, delta);
+            const auto         next  = checkedAdd(x, delta);
+            if (!next) {
+                return err(ParseError::CoordinateOverflow);
+            }
+            x = *next;
         } else if (!sameOrPositive) {
             const auto v = beI16(span, cursor);
             if (!v) {
                 return err(ParseError::TruncatedGlyphCoords);
             }
-            cursor += 2u;
-            x       = satAdd(x, *v);
+            cursor          += 2u;
+            const auto next  = checkedAdd(x, *v);
+            if (!next) {
+                return err(ParseError::CoordinateOverflow);
+            }
+            x = *next;
         }
         // else (!short && sameOrPositive): delta is zero, no bytes consumed.
         xCoords.push_back(x);
@@ -514,14 +559,22 @@ Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyph
             ++cursor;
             const std::int16_t delta = sameOrPositive ? static_cast<std::int16_t>(static_cast<std::uint16_t>(raw))
                                                       : -static_cast<std::int16_t>(static_cast<std::uint16_t>(raw));
-            y                        = satAdd(y, delta);
+            const auto         next  = checkedAdd(y, delta);
+            if (!next) {
+                return err(ParseError::CoordinateOverflow);
+            }
+            y = *next;
         } else if (!sameOrPositive) {
             const auto v = beI16(span, cursor);
             if (!v) {
                 return err(ParseError::TruncatedGlyphCoords);
             }
-            cursor += 2u;
-            y       = satAdd(y, *v);
+            cursor          += 2u;
+            const auto next  = checkedAdd(y, *v);
+            if (!next) {
+                return err(ParseError::CoordinateOverflow);
+            }
+            y = *next;
         }
         yCoords.push_back(y);
     }

--- a/tools/text/Truetype.cpp
+++ b/tools/text/Truetype.cpp
@@ -1,0 +1,535 @@
+/**
+ * @brief Implementation of the host-only TrueType (glyf) parser.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * Two passes. `parse()` walks the offset table once and the table directory once, building the
+ * bounds a `Font` keeps for every per-glyph lookup that follows. `parseGlyph()` walks one glyf
+ * record against that `Font`, taking the bounds checks in the order they sit in the buffer so a
+ * malformed record fails with the first problem it has rather than one several bytes further on.
+ *
+ * Every read goes through `beU16()`, `beI16()` or `beU32()`, which are bounds-checked against
+ * the buffer they were given - TrueType is big-endian, hence the "be" prefix. A glyph whose
+ * coordinate stream the buffer cannot reach fails with `TruncatedGlyphCoords` rather than running
+ * off the end. That is the one invariant this file actually needs to enforce, for the same
+ * reason `Spirv.cpp` does: this tool is also the first thing a malformed or truncated file
+ * reaches, and it has to fail with a diagnostic rather than read past its buffer.
+ */
+module;
+
+module mdux.tools.truetype;
+
+import std;
+import mdux.core.result;
+
+namespace mdux::tools::truetype {
+
+using mdux::core::err;
+using mdux::core::Result;
+
+namespace {
+
+// Recognised sfnt version words. 0x00010000 is the canonical TrueType ID; 'true' and 'typ1' are
+// the Apple and legacy alternative containers; 'OTTO' (0x4F54544F) is CFF-flavoured OpenType and
+// rejected here only if it carries a CFF table, which the directory walk below spots.
+constexpr std::uint32_t sfntVersionTrue    = 0x00010000u;
+constexpr std::uint32_t sfntVersionTrueTag = 0x74727565u;  // 'true'
+constexpr std::uint32_t sfntVersionTyp1    = 0x74797031u;  // 'typ1'
+
+constexpr std::uint32_t headMagic = 0x5F0F3CF5u;
+
+// head bytes we read.
+constexpr std::size_t headMagicOffset            = 12;
+constexpr std::size_t headUnitsPerEmOffset       = 18;
+constexpr std::size_t headIndexToLocFormatOffset = 50;
+constexpr std::size_t headMinSize                = 54;
+
+// maxp bytes we read.
+constexpr std::size_t maxpNumGlyphsOffset = 4;
+constexpr std::size_t maxpMinSize         = 6;
+
+constexpr std::size_t offsetTableSize = 12;
+constexpr std::size_t tableRecordSize = 16;
+
+// glyf flag bits per the TrueType specification.
+constexpr std::uint8_t flagOnCurve         = 0x01u;
+constexpr std::uint8_t flagXShort          = 0x02u;
+constexpr std::uint8_t flagYShort          = 0x04u;
+constexpr std::uint8_t flagRepeat          = 0x08u;
+constexpr std::uint8_t flagXSameOrPositive = 0x10u;
+constexpr std::uint8_t flagYSameOrPositive = 0x20u;
+constexpr std::uint8_t flagReservedMask    = 0xC0u;
+
+[[nodiscard]] std::optional<std::uint16_t> beU16(std::span<const std::byte> bytes, std::size_t offset) noexcept {
+    if (offset + 2 > bytes.size()) {
+        return std::nullopt;
+    }
+    return static_cast<std::uint16_t>((static_cast<std::uint16_t>(std::to_integer<std::uint8_t>(bytes[offset])) << 8)
+                                      | static_cast<std::uint16_t>(std::to_integer<std::uint8_t>(bytes[offset + 1])));
+}
+
+[[nodiscard]] std::optional<std::int16_t> beI16(std::span<const std::byte> bytes, std::size_t offset) noexcept {
+    auto u = beU16(bytes, offset);
+    if (!u) {
+        return std::nullopt;
+    }
+    return std::bit_cast<std::int16_t>(*u);
+}
+
+[[nodiscard]] std::optional<std::uint32_t> beU32(std::span<const std::byte> bytes, std::size_t offset) noexcept {
+    if (offset + 4 > bytes.size()) {
+        return std::nullopt;
+    }
+    return (static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(bytes[offset])) << 24)
+           | (static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(bytes[offset + 1])) << 16)
+           | (static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(bytes[offset + 2])) << 8)
+           | static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(bytes[offset + 3]));
+}
+
+/// A 32-bit table tag, rendered as the four ASCII characters the TrueType container spells it
+/// with. Comparing as a string lets the directory walk below write `tagStr == "GSUB"` rather than
+/// juggling the equivalent 0x47535542 literal.
+[[nodiscard]] std::string tagToString(std::uint32_t tag) noexcept {
+    char chars[5] = {0};
+    chars[0]      = static_cast<char>((tag >> 24) & 0xffu);
+    chars[1]      = static_cast<char>((tag >> 16) & 0xffu);
+    chars[2]      = static_cast<char>((tag >> 8) & 0xffu);
+    chars[3]      = static_cast<char>((tag >> 0) & 0xffu);
+    return std::string{chars, 4};
+}
+
+}  // namespace
+
+std::string_view describe(ParseError error) noexcept {
+    switch (error) {
+        case ParseError::Empty:
+            return "font is empty";
+        case ParseError::NotATrueTypeOutlineFont:
+            return "sfnt version is not a recognised TrueType outline container";
+        case ParseError::TruncatedOffsetTable:
+            return "offset table is shorter than the 12-byte header";
+        case ParseError::TruncatedTableDirectory:
+            return "a table directory record extends past the end of the file";
+        case ParseError::DuplicateTable:
+            return "a table tag appears more than once in the directory";
+        case ParseError::MissingRequiredTable:
+            return "a required table (head, maxp, glyf, loca) is absent";
+        case ParseError::TableOutOfBounds:
+            return "a table's offset + length exceeds the file size";
+        case ParseError::CffOutlinesRejected:
+            return "a 'CFF ' or 'CFF2' table is present - this is a CFF outline font, not glyf";
+        case ParseError::GposRejected:
+            return "a 'GPOS' table is present; glyph positioning is out of v1 scope";
+        case ParseError::GsubRejected:
+            return "a 'GSUB' table is present; ligatures and substitutions are out of v1 scope";
+        case ParseError::AppleLayoutRejected:
+            return "an 'morx' or 'mort' table is present; Apple AAT layout is out of v1 scope";
+        case ParseError::TruncatedHead:
+            return "'head' table is shorter than 54 bytes";
+        case ParseError::HeadBadMagicNumber:
+            return "'head' magic check failed (expected 0x5F0F3CF5)";
+        case ParseError::UnsupportedUnitsPerEm:
+            return "unitsPerEm is zero or outside the supported [16, 4096] range";
+        case ParseError::TruncatedMaxp:
+            return "'maxp' table is shorter than 6 bytes";
+        case ParseError::UnsupportedLocaFormat:
+            return "head.indexToLocFormat is neither 0 (short) nor 1 (long)";
+        case ParseError::LocaSizeMismatch:
+            return "'loca' byte length does not match numGlyphs+1 entries";
+        case ParseError::LocaOutOfBounds:
+            return "a 'loca' entry extends past the end of 'glyf'";
+        case ParseError::GlyphIndexOutOfRange:
+            return "parseGlyph called with an index >= numGlyphs";
+        case ParseError::TruncatedGlyph:
+            return "glyf record is shorter than the 10-byte header";
+        case ParseError::CompositeGlyphRejected:
+            return "numberOfContours == -1; composites are out of v1 scope";
+        case ParseError::HintingRejected:
+            return "instructionLength > 0; on-device hinting is out of v1 scope";
+        case ParseError::TruncatedContourEndpoints:
+            return "endPtsOfContours or the instruction length field extends past the glyf record";
+        case ParseError::TruncatedGlyphFlags:
+            return "the flag array extends past the glyf record";
+        case ParseError::TruncatedGlyphCoords:
+            return "x or y coordinates extend past the glyf record";
+        case ParseError::UnsupportedGlyphFlag:
+            return "a flag value has reserved bits 6 or 7 set";
+        case ParseError::NonMonotonicContours:
+            return "endPtsOfContours is not strictly increasing";
+    }
+    return "unknown TrueType parse error";
+}
+
+namespace {
+
+/// What the directory walk found, kept in a struct so the function does not return seven
+/// optionals on a single path. Each `found` field is the tag's offset+length pair after the
+/// bounds check the walk performs inline, so a caller can subspan directly without re-checking.
+struct Directory {
+    std::optional<std::pair<std::uint32_t, std::uint32_t>> head;
+    std::optional<std::pair<std::uint32_t, std::uint32_t>> maxp;
+    std::optional<std::pair<std::uint32_t, std::uint32_t>> loca;
+    std::optional<std::pair<std::uint32_t, std::uint32_t>> glyf;
+};
+
+[[nodiscard]] Result<Directory, ParseError> walkDirectory(std::span<const std::byte> bytes, std::uint16_t numTables) noexcept {
+    Directory             out;
+    std::set<std::string> seen;
+    for (std::uint16_t i = 0; i < numTables; ++i) {
+        const std::size_t recordOffset = offsetTableSize + static_cast<std::size_t>(i) * tableRecordSize;
+        const auto        tag          = beU32(bytes, recordOffset);
+        const auto        tableOffset  = beU32(bytes, recordOffset + 8);
+        const auto        tableLength  = beU32(bytes, recordOffset + 12);
+        if (!tag || !tableOffset || !tableLength) {
+            return err(ParseError::TruncatedTableDirectory);
+        }
+        const std::string tagStr = tagToString(*tag);
+
+        if (auto [iter, inserted] = seen.insert(tagStr); !inserted) {
+            return err(ParseError::DuplicateTable);
+        }
+
+        // Reject the unsupported layout/outline tables up front: the structure check at the top
+        // is not enough to refuse a font whose presence would force the runtime to do shaping,
+        // and the catalog of structural categories is the parser's first enforcement point.
+        if (tagStr == "CFF " || tagStr == "CFF2")
+            return err(ParseError::CffOutlinesRejected);
+        if (tagStr == "GPOS")
+            return err(ParseError::GposRejected);
+        if (tagStr == "GSUB")
+            return err(ParseError::GsubRejected);
+        if (tagStr == "morx" || tagStr == "mort")
+            return err(ParseError::AppleLayoutRejected);
+
+        // Bounds-check the record's slice before storing it; a later subspan() takes the validated
+        // length without re-checking, which is the whole point of doing the walk in pass one.
+        const auto end = static_cast<std::uint64_t>(*tableOffset) + static_cast<std::uint64_t>(*tableLength);
+        if (end > bytes.size()) {
+            return err(ParseError::TableOutOfBounds);
+        }
+
+        const auto record = std::make_pair(*tableOffset, *tableLength);
+        if (tagStr == "head")
+            out.head = record;
+        else if (tagStr == "maxp")
+            out.maxp = record;
+        else if (tagStr == "loca")
+            out.loca = record;
+        else if (tagStr == "glyf")
+            out.glyf = record;
+    }
+    return out;
+}
+
+[[nodiscard]] Result<std::vector<std::uint32_t>, ParseError>
+readLoca(std::span<const std::byte> loca, std::uint16_t numGlyphs, std::uint16_t indexToLocFormat, std::uint32_t glyfLength) noexcept {
+    // numGlyphs + 1 entries; short form is uint16 × 2 (the storage value is half of the byte
+    // offset), long form is uint32 straight. The byte length is the size check, so a font that
+    // author declares one glyph but ships a two-entry short loca (4 bytes total) is well-formed.
+    const std::size_t entryCount  = static_cast<std::size_t>(numGlyphs) + 1u;
+    const std::size_t elementSize = (indexToLocFormat == 0) ? 2u : 4u;
+    if (loca.size() < entryCount * elementSize) {
+        return err(ParseError::LocaSizeMismatch);
+    }
+
+    std::vector<std::uint32_t> offsets;
+    offsets.reserve(entryCount);
+    for (std::size_t i = 0; i < entryCount; ++i) {
+        if (elementSize == 2) {
+            // Short form: the uint16 is half of the byte offset; spec defines it as
+            // `actualOffset / 2`, so a stored 0x0008 means offset 16 into glyf.
+            auto v = beU16(loca, i * 2);
+            if (!v) {
+                return err(ParseError::LocaSizeMismatch);  // size guard has already passed; defensive
+            }
+            offsets.push_back(static_cast<std::uint32_t>(*v) * 2u);
+        } else {
+            auto v = beU32(loca, i * 4);
+            if (!v) {
+                return err(ParseError::LocaSizeMismatch);
+            }
+            offsets.push_back(*v);
+        }
+        if (offsets.back() > glyfLength) {
+            return err(ParseError::LocaOutOfBounds);
+        }
+    }
+    return offsets;
+}
+
+}  // namespace
+
+Result<Font, ParseError> parse(std::span<const std::byte> bytes) noexcept {
+    if (bytes.empty()) {
+        return err(ParseError::Empty);
+    }
+    if (bytes.size() < offsetTableSize) {
+        return err(ParseError::TruncatedOffsetTable);
+    }
+
+    const auto sfnt = beU32(bytes, 0);
+    if (!sfnt) {
+        return err(ParseError::TruncatedOffsetTable);
+    }
+    if (*sfnt != sfntVersionTrue && *sfnt != sfntVersionTrueTag && *sfnt != sfntVersionTyp1) {
+        return err(ParseError::NotATrueTypeOutlineFont);
+    }
+
+    const auto numTables = beU16(bytes, 4);
+    if (!numTables) {
+        return err(ParseError::TruncatedOffsetTable);
+    }
+    // A whole-table directory of numTables records sits right after the 12-byte offset table.
+    // An `operator>` here that does not multiply into 64-bit could itself overflow on a malformed
+    // numTables; cast through the 64-bit to take the safe path.
+    const auto directoryEnd = static_cast<std::uint64_t>(offsetTableSize) + static_cast<std::uint64_t>(*numTables) * tableRecordSize;
+    if (directoryEnd > bytes.size()) {
+        return err(ParseError::TruncatedTableDirectory);
+    }
+
+    auto directory = walkDirectory(bytes, *numTables);
+    if (!directory.has_value()) {
+        return err(directory.error());
+    }
+    if (!directory->head.has_value() || !directory->maxp.has_value() || !directory->loca.has_value() || !directory->glyf.has_value()) {
+        return err(ParseError::MissingRequiredTable);
+    }
+
+    const auto [headOffset, headLength] = *directory->head;
+    const auto [maxpOffset, maxpLength] = *directory->maxp;
+    const auto [locaOffset, locaLength] = *directory->loca;
+    const auto [glyfOffset, glyfLength] = *directory->glyf;
+
+    auto head = bytes.subspan(headOffset, headLength);
+    auto maxp = bytes.subspan(maxpOffset, maxpLength);
+    auto glyf = bytes.subspan(glyfOffset, glyfLength);
+    auto loca = bytes.subspan(locaOffset, locaLength);
+
+    if (head.size() < headMinSize) {
+        return err(ParseError::TruncatedHead);
+    }
+    const auto magic = beU32(head, headMagicOffset);
+    if (!magic || *magic != headMagic) {
+        return err(ParseError::HeadBadMagicNumber);
+    }
+    const auto unitsPerEm = beU16(head, headUnitsPerEmOffset);
+    if (!unitsPerEm) {
+        return err(ParseError::TruncatedHead);
+    }
+    if (*unitsPerEm < 16 || *unitsPerEm > 4096) {
+        return err(ParseError::UnsupportedUnitsPerEm);
+    }
+    const auto indexToLocFormat = beI16(head, headIndexToLocFormatOffset);
+    if (!indexToLocFormat) {
+        return err(ParseError::TruncatedHead);
+    }
+    if (*indexToLocFormat != 0 && *indexToLocFormat != 1) {
+        return err(ParseError::UnsupportedLocaFormat);
+    }
+
+    if (maxp.size() < maxpMinSize) {
+        return err(ParseError::TruncatedMaxp);
+    }
+    const auto numGlyphs = beU16(maxp, maxpNumGlyphsOffset);
+    if (!numGlyphs) {
+        return err(ParseError::TruncatedMaxp);
+    }
+
+    auto locaOffsets = readLoca(loca, *numGlyphs, static_cast<std::uint16_t>(*indexToLocFormat), static_cast<std::uint32_t>(glyfLength));
+    if (!locaOffsets.has_value()) {
+        return err(locaOffsets.error());
+    }
+
+    Font font;
+    font.sfntVersion      = *sfnt;
+    font.unitsPerEm       = *unitsPerEm;
+    font.numGlyphs        = *numGlyphs;
+    font.indexToLocFormat = static_cast<std::uint16_t>(*indexToLocFormat);
+    font.head             = head;
+    font.glyf             = glyf;
+    font.loca             = std::move(*locaOffsets);
+    return font;
+}
+
+namespace {
+
+/// Saturating add of two int16s into int16, used for accumulating TrueType coordinate deltas that
+/// are themselves int16. The spec stores coordinates as absolute int16 values, so an accumulation
+/// that overflows int16 would already be malformed - clamp to int16_max/min rather than wrap, so a
+/// malformed accumulator stays deterministic rather than producing "anything is allowed".
+[[nodiscard]] std::int16_t satAdd(std::int16_t a, std::int16_t b) noexcept {
+    const auto sum = static_cast<std::int32_t>(a) + static_cast<std::int32_t>(b);
+    if (sum > static_cast<std::int32_t>(std::numeric_limits<std::int16_t>::max())) {
+        return std::numeric_limits<std::int16_t>::max();
+    }
+    if (sum < static_cast<std::int32_t>(std::numeric_limits<std::int16_t>::min())) {
+        return std::numeric_limits<std::int16_t>::min();
+    }
+    return static_cast<std::int16_t>(sum);
+}
+
+}  // namespace
+
+Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyphIndex) noexcept {
+    if (glyphIndex >= font.numGlyphs) {
+        return err(ParseError::GlyphIndexOutOfRange);
+    }
+
+    const std::uint32_t start = font.loca[glyphIndex];
+    const std::uint32_t end   = font.loca[glyphIndex + 1];
+    if (start > font.glyf.size() || end > font.glyf.size() || start > end) {
+        return err(ParseError::LocaOutOfBounds);
+    }
+    const auto span = font.glyf.subspan(start, end - start);
+    if (span.size() < 10) {
+        return err(ParseError::TruncatedGlyph);
+    }
+
+    SimpleGlyph glyph;
+    glyph.glyphIndex            = glyphIndex;
+    const auto numberOfContours = beI16(span, 0);
+    glyph.xMin                  = *beI16(span, 2);
+    glyph.yMin                  = *beI16(span, 4);
+    glyph.xMax                  = *beI16(span, 6);
+    glyph.yMax                  = *beI16(span, 8);
+
+    if (!numberOfContours) {
+        return err(ParseError::TruncatedGlyph);
+    }
+    if (*numberOfContours < 0) {
+        return err(ParseError::CompositeGlyphRejected);
+    }
+    const auto contours = static_cast<std::size_t>(*numberOfContours);
+
+    // endPtsOfContours: contours × 2 bytes, starting at offset 10. The instruction-length field
+    // follows immediately, so the bounds check below also reserves the 2 bytes for it; an attempt
+    // to read the structural header past the glyf record fails with one code rather than two.
+    const std::size_t endPtsEnd = 10u + contours * 2u;
+    if (span.size() < endPtsEnd + 2u) {
+        return err(ParseError::TruncatedContourEndpoints);
+    }
+    std::uint16_t previousEndPoint = 0;
+    for (std::size_t c = 0; c < contours; ++c) {
+        const auto ep = beU16(span, 10u + c * 2u);
+        if (!ep) {
+            return err(ParseError::TruncatedContourEndpoints);
+        }
+        if (c > 0 && *ep <= previousEndPoint) {
+            return err(ParseError::NonMonotonicContours);
+        }
+        glyph.endPtsOfContours.push_back(*ep);
+        previousEndPoint = *ep;
+    }
+
+    std::size_t cursor            = endPtsEnd;
+    const auto  instructionLength = beU16(span, cursor);
+    if (!instructionLength) {
+        return err(ParseError::TruncatedContourEndpoints);
+    }
+    cursor += 2u;
+    if (*instructionLength > 0) {
+        return err(ParseError::HintingRejected);
+    }
+
+    // An empty glyph (numberOfContours == 0): no end points, no instructions, no flags and
+    // no coordinates. Returns with empty point lists and a single zero-point contour state.
+    const std::size_t numPoints = (contours == 0) ? 0u : static_cast<std::size_t>(previousEndPoint) + 1u;
+
+    // Flags: one byte per point, with the REPEAT_FLAG encoding (the next byte is the count of
+    // additional repetitions). The loop fills exactly numPoints flags; an abbreviated repeat or
+    // an absent byte fails with TruncatedGlyphFlags.
+    std::vector<std::uint8_t> flags;
+    flags.reserve(numPoints);
+    while (flags.size() < numPoints) {
+        if (cursor >= span.size()) {
+            return err(ParseError::TruncatedGlyphFlags);
+        }
+        const std::uint8_t flag = std::to_integer<std::uint8_t>(span[cursor]);
+        ++cursor;
+        if ((flag & flagReservedMask) != 0u) {
+            return err(ParseError::UnsupportedGlyphFlag);
+        }
+        flags.push_back(flag);
+        if ((flag & flagRepeat) != 0u) {
+            if (cursor >= span.size()) {
+                return err(ParseError::TruncatedGlyphFlags);
+            }
+            const std::uint8_t repeatCount = std::to_integer<std::uint8_t>(span[cursor]);
+            ++cursor;
+            for (std::uint8_t r = 0; r < repeatCount && flags.size() < numPoints; ++r) {
+                flags.push_back(flag);
+            }
+        }
+    }
+    if (flags.size() != numPoints) {
+        return err(ParseError::TruncatedGlyphFlags);
+    }
+
+    // X coordinates. The two flag bits are X_SHORT_VECTOR and X_IS_SAME_OR_POSITIVE; the four
+    // interpretations are exactly the table in the TrueType spec, written out so the path a
+    // malformed file takes through here is inspectable rather than packed into a single expression.
+    std::vector<std::int16_t> xCoords;
+    xCoords.reserve(numPoints);
+    std::int16_t x = 0;
+    for (std::size_t i = 0; i < numPoints; ++i) {
+        const std::uint8_t flag           = flags[i];
+        const bool         isShort        = (flag & flagXShort) != 0u;
+        const bool         sameOrPositive = (flag & flagXSameOrPositive) != 0u;
+        if (isShort) {
+            if (cursor >= span.size()) {
+                return err(ParseError::TruncatedGlyphCoords);
+            }
+            const std::uint8_t raw = std::to_integer<std::uint8_t>(span[cursor]);
+            ++cursor;
+            const std::int16_t delta = sameOrPositive ? static_cast<std::int16_t>(static_cast<std::uint16_t>(raw))
+                                                      : -static_cast<std::int16_t>(static_cast<std::uint16_t>(raw));
+            x                        = satAdd(x, delta);
+        } else if (!sameOrPositive) {
+            const auto v = beI16(span, cursor);
+            if (!v) {
+                return err(ParseError::TruncatedGlyphCoords);
+            }
+            cursor += 2u;
+            x       = satAdd(x, *v);
+        }
+        // else (!short && sameOrPositive): delta is zero, no bytes consumed.
+        xCoords.push_back(x);
+    }
+
+    // Y coordinates. Symmetric with X; the flag bits are Y_SHORT_VECTOR and Y_IS_SAME_OR_POSITIVE.
+    std::vector<std::int16_t> yCoords;
+    yCoords.reserve(numPoints);
+    std::int16_t y = 0;
+    for (std::size_t i = 0; i < numPoints; ++i) {
+        const std::uint8_t flag           = flags[i];
+        const bool         isShort        = (flag & flagYShort) != 0u;
+        const bool         sameOrPositive = (flag & flagYSameOrPositive) != 0u;
+        if (isShort) {
+            if (cursor >= span.size()) {
+                return err(ParseError::TruncatedGlyphCoords);
+            }
+            const std::uint8_t raw = std::to_integer<std::uint8_t>(span[cursor]);
+            ++cursor;
+            const std::int16_t delta = sameOrPositive ? static_cast<std::int16_t>(static_cast<std::uint16_t>(raw))
+                                                      : -static_cast<std::int16_t>(static_cast<std::uint16_t>(raw));
+            y                        = satAdd(y, delta);
+        } else if (!sameOrPositive) {
+            const auto v = beI16(span, cursor);
+            if (!v) {
+                return err(ParseError::TruncatedGlyphCoords);
+            }
+            cursor += 2u;
+            y       = satAdd(y, *v);
+        }
+        yCoords.push_back(y);
+    }
+
+    for (std::size_t i = 0; i < numPoints; ++i) {
+        glyph.points.push_back(GlyphPoint{.x = xCoords[i], .y = yCoords[i], .onCurve = (flags[i] & flagOnCurve) != 0u});
+    }
+    return glyph;
+}
+
+}  // namespace mdux::tools::truetype

--- a/tools/text/Truetype.cppm
+++ b/tools/text/Truetype.cppm
@@ -26,23 +26,42 @@
  * it was given, and that anything it does not understand is a refusal with a specific code
  * rather than a guess - the same contract `Spirv.cpp` makes.
  *
- * ## v1 scope, and what gets rejected
+ * ## v1 scope: read what an atlas needs, refuse only what cannot be baked
  *
- * v1 supports TrueType `glyf` outlines and Latin/Cyrillic/Greek LTR only. The rejections the
- * parser itself emits are the ones detectable from the binary form:
+ * v1 supports TrueType `glyf` outlines and Latin/Cyrillic/Greek LTR only. The parser emits
+ * exactly two scope rejections, and both are cases where there is no outline for the baker to
+ * turn into coverage:
  *
- * - composite glyphs (numberOfContours == -1): `CompositeGlyphRejected`
- * - CFF or CFF2 outlines (`glyf` would be absent): `CffOutlinesRejected`
- * - hinting instruction bytecode per glyph: `HintingRejected`
- * - `GPOS` table present: `GposRejected`
- * - `GSUB` table present (carries ligatures and contextual substitutions): `GsubRejected`
- * - Apple AAT layout tables `morx` / `mort` present: `AppleLayoutRejected`
+ * - CFF or CFF2 outlines (`CFF `/`CFF2` present, so the outlines are not in `glyf` at all):
+ *   `CffOutlinesRejected`
+ * - composite glyphs (`numberOfContours == -1`), whose outline is a transform over other
+ *   glyphs rather than a contour list: `CompositeGlyphRejected`. ADR-010 decision 5 speaks of
+ *   "composite glyph substitutions the baker did not pre-bake", which is the seam S4 (#160)
+ *   fills - resolving a composite into a flat contour list is a baking step, and this code is
+ *   the signal S4 acts on.
+ *
+ * Everything else ADR-010 names is *skipped rather than refused*. `GPOS`, `GSUB`, `GDEF`,
+ * `morx`/`mort` and the per-glyph hinting `instructions[]` array are simply never read: the
+ * parser walks `head`, `maxp`, `loca` and `glyf`, and a table it does not read cannot reach a
+ * device. That is the shape ADR-010 actually asks for - decision 4 forbids *on-device* code
+ * that walks a font table or advances a pen by a runtime-computed width, not the presence of
+ * those bytes in the host's input file.
+ *
+ * The distinction matters because rejecting on presence would reject essentially every real
+ * font. Measured on DejaVu 2.37: 8 of 8 stock faces carry both `GPOS` and `GSUB`, and 16% of
+ * DejaVuSans' 6253 glyphs carry hinting bytecode - a presence rule accepts no shipping font
+ * and 41% of the glyphs of the one font it did accept. Skipping instead of refusing keeps the
+ * baker's input a font a designer actually shipped, while the runtime still has no shaping
+ * code, because the atlas the baker commits carries coverage bitmaps and baked advances and
+ * nothing else. Composites remain the one refusal that costs coverage (~42% of DejaVuSans'
+ * glyphs, which is where the accented Latin, Cyrillic and Greek forms live), and S4 is where
+ * that is paid down.
  *
  * RTL and complex scripts cannot be detected from the font binary alone - they are a property
  * of the string-to-glyph mapping, which is the `.medui` compiler's (#15) and the restricted
  * charset's (#161) job, not this parser's. The mechanical enforcement described in ADR-010
  * decision paragraph 5 is delivered by #161 (S5); this module is the structural half, refusing
- * the font features whose presence would require on-device shaping.
+ * the outline forms it cannot turn into a contour list.
  *
  * ## The two-step shape
  *
@@ -81,33 +100,32 @@ enum class ParseError : std::uint8_t {
     MissingRequiredTable,       ///< head, maxp, glyf or loca is absent
     TableOutOfBounds,           ///< a table's offset+length exceeds the file
     CffOutlinesRejected,        ///< 'CFF ' or 'CFF2' table present - this is a CFF outline font
-    GposRejected,               ///< 'GPOS' table present
-    GsubRejected,               ///< 'GSUB' table present
-    AppleLayoutRejected,        ///< 'morx' or 'mort' table present
     TruncatedHead,              ///< 'head' table is shorter than 54 bytes
     HeadBadMagicNumber,         ///< 'head' magic check (0x5F0F3CF5) failed
-    UnsupportedUnitsPerEm,      ///< unitsPerEm is zero or outside the supported [16, 4096] range
+    UnsupportedUnitsPerEm,      ///< unitsPerEm is outside the spec's [16, 16384] range
     TruncatedMaxp,              ///< 'maxp' table is shorter than 6 bytes
     UnsupportedLocaFormat,      ///< head.indexToLocFormat is neither 0 (short) nor 1 (long)
-    LocaSizeMismatch,           ///< 'loca' byte length does not match numGlyphs+1 entries
+    LocaSizeMismatch,           ///< 'loca' is too short to hold numGlyphs+1 entries
     LocaOutOfBounds,            ///< a 'loca' entry extends past the end of 'glyf'
     GlyphIndexOutOfRange,       ///< parseGlyph called with an index >= numGlyphs
-    TruncatedGlyph,             ///< glyf record is shorter than the 10-byte header
+    TruncatedGlyph,             ///< glyf record is non-empty but shorter than the 10-byte header
     CompositeGlyphRejected,     ///< numberOfContours == -1; composites are out of v1 scope
-    HintingRejected,            ///< instructionLength > 0; on-device hinting is out of scope
     TruncatedContourEndpoints,  ///< endPtsOfContours extends past the glyf record
+    TruncatedGlyphInstructions, ///< the (skipped) hinting instruction array runs past the record
     TruncatedGlyphFlags,        ///< the flag array extends past the glyf record
+    GlyphFlagRepeatOverrun,     ///< a REPEAT_FLAG count claims more points than the glyph has
     TruncatedGlyphCoords,       ///< x or y coordinates extend past the glyf record
-    UnsupportedGlyphFlag,       ///< a flag value bits 6 or 7 (reserved) are set
+    UnsupportedGlyphFlag,       ///< a flag value has reserved bit 7 set
+    CoordinateOverflow,         ///< an accumulated coordinate left the int16 range the spec allows
     NonMonotonicContours,       ///< endPtsOfContours[i] <= endPtsOfContours[i-1]
 };
 
 [[nodiscard]] std::string_view describe(ParseError error) noexcept;
 
 /// One contour point, with absolute coordinates already resolved from the per-byte deltas the
-/// filesystem form stores. Flags beyond on/off-curve (repeat, x-short, y-short, x-same, y-same)
-/// are consumed inside `parseGlyph()` and never reach the caller; a baker that wanted them
-/// would be re-walking the storage format this struct exists to hide.
+/// `glyf` storage form encodes them as. Flags beyond on/off-curve (repeat, x-short, y-short,
+/// x-same, y-same) are consumed inside `parseGlyph()` and never reach the caller; a baker that
+/// wanted them would be re-walking the storage format this struct exists to hide.
 struct GlyphPoint {
     std::int16_t x{0};
     std::int16_t y{0};
@@ -115,8 +133,11 @@ struct GlyphPoint {
 };
 
 /// A simple, non-composite glyph outline. `CompositeGlyphRejected` is returned before this
-/// struct is ever constructed, so the fields below describe a glyphs that has at least one
-/// contour with all-resolved coordinates and no hinting instructions.
+/// struct is ever constructed, so the fields below describe a glyph with all-resolved
+/// coordinates and no hinting instructions. Both vectors are empty for a glyph with no
+/// outline - the blank the TrueType format spells either as a zero-length `glyf` record
+/// (`loca[i] == loca[i+1]`, how every real font stores the space character) or as a header
+/// declaring `numberOfContours == 0`.
 struct SimpleGlyph {
     std::uint16_t              glyphIndex{0};
     std::int16_t               xMin{0};
@@ -154,18 +175,28 @@ struct Font {
 };
 
 /// Walks the offset table, head, maxp, loca and the implicit "is this a TrueType outline font"
-/// check. Rejects CFF/CFF2/GPOS/GSUB/morx/mort presence up front. Does not read any glyf record;
-/// `parseGlyph()` does that, one at a time, against the `Font` this returns.
+/// check. Rejects a CFF/CFF2 outline font up front, since it has no `glyf` to read; a `GPOS`,
+/// `GSUB`, `GDEF`, `morx` or `mort` table is left unread rather than refused (see "v1 scope"
+/// above). Does not read any glyf record; `parseGlyph()` does that, one at a time, against the
+/// `Font` this returns.
 [[nodiscard]] mdux::core::Result<Font, ParseError> parse(std::span<const std::byte> bytes) noexcept;
 
 /// Walks one glyf record against `font`, identified by `glyphIndex`. Rejects a composite glyph
-/// before constructing any `SimpleGlyph` state, and a glyph with hinting instructions before
-/// touching its flag or coordinate arrays - so neither of those paths can accidentally read past
-/// a record that was malformed in a way the bound check has not yet run for.
+/// before constructing any `SimpleGlyph` state, so that path cannot accidentally read past a
+/// record that was malformed in a way the bound check has not yet run for. A glyph's hinting
+/// `instructions[]` array is stepped over, not interpreted and not returned - the runtime has no
+/// hinting engine, so the bytes have no consumer. A zero-length record
+/// (`loca[glyphIndex] == loca[glyphIndex + 1]`) is the spec's encoding of a glyph with no
+/// outline, not a truncation, and yields an empty `SimpleGlyph`.
 ///
 /// Reads nothing outside the `Font`'s own `glyf` span (and the trailing `loca` entry needed to
 /// compute the record length). The outer buffer has to stay alive for the lifetime of the
 /// `Font`; this function does not store it.
+///
+/// `Font` is an aggregate with public fields, so a caller can hand this function one that
+/// `parse()` did not build. The `numGlyphs`/`loca` consistency `parse()` guarantees is
+/// therefore re-checked here rather than assumed, and a `Font` that fails it is refused with
+/// `LocaSizeMismatch` instead of indexing a `std::vector` out of range.
 [[nodiscard]] mdux::core::Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyphIndex) noexcept;
 
 }  // namespace mdux::tools::truetype

--- a/tools/text/Truetype.cppm
+++ b/tools/text/Truetype.cppm
@@ -1,0 +1,171 @@
+/**
+ * @brief Host-only TrueType parser, glyf only: walks the offset table, head/maxp/loca and one
+ *        glyf record at a time, deliberately not linking freetype or any other font SOUP.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone: never linked into MduXCore or MduX)
+ * @compliance ADR-005 Error handling and exceptions policy (host tools may throw; this returns)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-008 Zero-SOUP ML inference (decision 6, mirrored for text: the host-side
+ *             parser is what refuses a font whose semantics depend on a library)
+ * @compliance ADR-010 No on-device text shaping (the parser is one of the host-side enforcement
+ *             points; everything it rejects never reaches the runtime)
+ *
+ * ## Why this is hand-written rather than linked against FreeType
+ *
+ * The same reason the SPIR-V reflector (`tools/shader/Spirv.cpp`) is hand-written rather than
+ * linked against SPIRV-Reflect, and the safetensors reader (`tools/ml/Safetensors.cpp`) is
+ * hand-written rather than linked against anything: a dependency here would be SOUP in the tool
+ * that produces every committed font artifact (#160, S4), and its version would become part of
+ * the byte-identity contract. TrueType's binary form is small enough to walk directly, and
+ * walking it directly means the bytes this repository commits depend on nothing but this file.
+ *
+ * It reads only what an *atlas* needs: the offset table (to find the tables that follow), the
+ * `head` table (unitsPerEm, indexToLocFormat, the magic number), `maxp` (numGlyphs), `loca`
+ * (per-glyph byte offsets into `glyf`) and one `glyf` record per glyph. It is not a validator
+ * and does not attempt to be one; what it guarantees is that it never reads outside the buffer
+ * it was given, and that anything it does not understand is a refusal with a specific code
+ * rather than a guess - the same contract `Spirv.cpp` makes.
+ *
+ * ## v1 scope, and what gets rejected
+ *
+ * v1 supports TrueType `glyf` outlines and Latin/Cyrillic/Greek LTR only. The rejections the
+ * parser itself emits are the ones detectable from the binary form:
+ *
+ * - composite glyphs (numberOfContours == -1): `CompositeGlyphRejected`
+ * - CFF or CFF2 outlines (`glyf` would be absent): `CffOutlinesRejected`
+ * - hinting instruction bytecode per glyph: `HintingRejected`
+ * - `GPOS` table present: `GposRejected`
+ * - `GSUB` table present (carries ligatures and contextual substitutions): `GsubRejected`
+ * - Apple AAT layout tables `morx` / `mort` present: `AppleLayoutRejected`
+ *
+ * RTL and complex scripts cannot be detected from the font binary alone - they are a property
+ * of the string-to-glyph mapping, which is the `.medui` compiler's (#15) and the restricted
+ * charset's (#161) job, not this parser's. The mechanical enforcement described in ADR-010
+ * decision paragraph 5 is delivered by #161 (S5); this module is the structural half, refusing
+ * the font features whose presence would require on-device shaping.
+ *
+ * ## The two-step shape
+ *
+ * `parse()` walks the directory once and returns a `Font` holding the bounds worth keeping
+ * across per-glyph lookups. `parseGlyph()` walks one glyf record against that `Font`, without
+ * re-reading the directory. The split mirrors `Spirv.cpp`'s separation of header validation
+ * from instruction-stream interpretation, and for the same reason: a host that wants every
+ * glyph pays the directory walk once, not once per glyph.
+ *
+ * ## The baker-facing contract
+ *
+ * This module returns `Result<…, ParseError>`; the higher-level baker (`tools/text/TextBake.cpp`)
+ * converts each `ParseError` to a shared-envelope `cli::Diagnostic` carrying a stable `TXT`
+ * code, the way `Spirv.cpp`'s `ParseError` is converted by the shader baker. The conversion is
+ * deferred to S4 (#160), which is the wave that actually feeds a `.ttf` recipe through this
+ * parser and commits a font artifact; S2 (#158, this issue) lands the parser and its tests alone.
+ */
+module;
+
+export module mdux.tools.truetype;
+
+import std;
+import mdux.core.result;
+
+export namespace mdux::tools::truetype {
+
+/// Every rejection code the parser emits. Stable once published - the baker will switch on it
+/// (S4 / #160) and an agent keying off the resulting `TXT` code should not be broken by a
+/// reword of `describe()`. Mirrors the convention `Spirv.cpp`'s `ParseError` established.
+enum class ParseError : std::uint8_t {
+    Empty,                      ///< the buffer is empty
+    NotATrueTypeOutlineFont,    ///< sfnt version is not one of the recognised TrueType words
+    TruncatedOffsetTable,       ///< fewer than 12 bytes of offset table
+    TruncatedTableDirectory,    ///< a table record extends past the end of the file
+    DuplicateTable,             ///< a table tag appears twice in the directory
+    MissingRequiredTable,       ///< head, maxp, glyf or loca is absent
+    TableOutOfBounds,           ///< a table's offset+length exceeds the file
+    CffOutlinesRejected,        ///< 'CFF ' or 'CFF2' table present - this is a CFF outline font
+    GposRejected,               ///< 'GPOS' table present
+    GsubRejected,               ///< 'GSUB' table present
+    AppleLayoutRejected,        ///< 'morx' or 'mort' table present
+    TruncatedHead,              ///< 'head' table is shorter than 54 bytes
+    HeadBadMagicNumber,         ///< 'head' magic check (0x5F0F3CF5) failed
+    UnsupportedUnitsPerEm,      ///< unitsPerEm is zero or outside the supported [16, 4096] range
+    TruncatedMaxp,              ///< 'maxp' table is shorter than 6 bytes
+    UnsupportedLocaFormat,      ///< head.indexToLocFormat is neither 0 (short) nor 1 (long)
+    LocaSizeMismatch,           ///< 'loca' byte length does not match numGlyphs+1 entries
+    LocaOutOfBounds,            ///< a 'loca' entry extends past the end of 'glyf'
+    GlyphIndexOutOfRange,       ///< parseGlyph called with an index >= numGlyphs
+    TruncatedGlyph,             ///< glyf record is shorter than the 10-byte header
+    CompositeGlyphRejected,     ///< numberOfContours == -1; composites are out of v1 scope
+    HintingRejected,            ///< instructionLength > 0; on-device hinting is out of scope
+    TruncatedContourEndpoints,  ///< endPtsOfContours extends past the glyf record
+    TruncatedGlyphFlags,        ///< the flag array extends past the glyf record
+    TruncatedGlyphCoords,       ///< x or y coordinates extend past the glyf record
+    UnsupportedGlyphFlag,       ///< a flag value bits 6 or 7 (reserved) are set
+    NonMonotonicContours,       ///< endPtsOfContours[i] <= endPtsOfContours[i-1]
+};
+
+[[nodiscard]] std::string_view describe(ParseError error) noexcept;
+
+/// One contour point, with absolute coordinates already resolved from the per-byte deltas the
+/// filesystem form stores. Flags beyond on/off-curve (repeat, x-short, y-short, x-same, y-same)
+/// are consumed inside `parseGlyph()` and never reach the caller; a baker that wanted them
+/// would be re-walking the storage format this struct exists to hide.
+struct GlyphPoint {
+    std::int16_t x{0};
+    std::int16_t y{0};
+    bool         onCurve{true};
+};
+
+/// A simple, non-composite glyph outline. `CompositeGlyphRejected` is returned before this
+/// struct is ever constructed, so the fields below describe a glyphs that has at least one
+/// contour with all-resolved coordinates and no hinting instructions.
+struct SimpleGlyph {
+    std::uint16_t              glyphIndex{0};
+    std::int16_t               xMin{0};
+    std::int16_t               yMin{0};
+    std::int16_t               xMax{0};
+    std::int16_t               yMax{0};
+    std::vector<std::uint16_t> endPtsOfContours;
+    std::vector<GlyphPoint>    points;
+};
+
+/**
+ * @brief Everything `parseGlyph()` needs that `parse()` already walked.
+ *
+ * `parse()` slices subspans out of the bytes it was given; the caller must keep that storage
+ * alive for at least as long as the `Font` it returned. The spans are read-only and never
+ * copied - a 10 MB font directory stays a 10 MB font directory, not 10 MB plus an in-memory
+ * mirror.
+ *
+ * `loca` carries `numGlyphs + 1` entries because the TrueType format encodes the last glyph's
+ * length by giving a trailing entry past the glyph's start - "the next glyph's start minus this
+ * glyph's start" is this glyph's length, and the trailing entry is the last start.
+ */
+struct Font {
+    std::uint32_t sfntVersion{0};
+    std::uint16_t unitsPerEm{0};
+    std::uint16_t numGlyphs{0};
+    std::uint16_t indexToLocFormat{0};  ///< 0 = short (uint16/2) offsets, 1 = long (uint32) offsets
+
+    std::span<const std::byte> head{};
+    std::span<const std::byte> glyf{};
+
+    /// Byte offsets into `glyf`. `numGlyphs + 1` entries; the last is the past-the-end offset
+    /// of the last glyph, i.e. the byte length of `glyf` the directory asserts.
+    std::vector<std::uint32_t> loca{};
+};
+
+/// Walks the offset table, head, maxp, loca and the implicit "is this a TrueType outline font"
+/// check. Rejects CFF/CFF2/GPOS/GSUB/morx/mort presence up front. Does not read any glyf record;
+/// `parseGlyph()` does that, one at a time, against the `Font` this returns.
+[[nodiscard]] mdux::core::Result<Font, ParseError> parse(std::span<const std::byte> bytes) noexcept;
+
+/// Walks one glyf record against `font`, identified by `glyphIndex`. Rejects a composite glyph
+/// before constructing any `SimpleGlyph` state, and a glyph with hinting instructions before
+/// touching its flag or coordinate arrays - so neither of those paths can accidentally read past
+/// a record that was malformed in a way the bound check has not yet run for.
+///
+/// Reads nothing outside the `Font`'s own `glyf` span (and the trailing `loca` entry needed to
+/// compute the record length). The outer buffer has to stay alive for the lifetime of the
+/// `Font`; this function does not store it.
+[[nodiscard]] mdux::core::Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyphIndex) noexcept;
+
+}  // namespace mdux::tools::truetype


### PR DESCRIPTION
Part of #14. Depends on #157 (closed).

## What this lands

A host-only TrueType parser that walks `glyf` only, deliberately not linking `freetype` or any other font SOUP — the parallel of `tools/shader/Spirv.cpp` for SPIR-V and `tools/ml/Safetensors.cpp` for safetensors (ADR-008 decision 6, mirrored onto text by ADR-010).

- `tools/text/Truetype.cppm` + `.cpp` — module `mdux.tools.truetype`. `parse()` walks the offset table, `head`/`maxp`/`loca` and the implicit outline check; `parseGlyph()` walks one glyf record against the resulting `Font`. Both return `Result<T, ParseError>`, paralleling `Spirv.cpp` and `Safetensors.cpp`.
- `tests/text/TruetypeTests.cpp` — six SpecLab scenarios (minimal valid font, `true`/`typ1` container variants, a square glyph with 4 on-curve points, an empty glyph) plus two table-driven rejection corpora pinning the stable `ParseError` for every directory-walk and per-glyph rejection path.
- Wired into `MduXTextBakeLib` (`tools/CMakeLists.txt`) as a public module so S4's font baker (#160) can `import mdux.tools.truetype` through the same target that hosts the recipe model. Joined to `text_tools_spec` in `tests/CMakeLists.txt`.
- `docs/architecture.md` updated: `MduXTextBakeLib` row notes the new module; the #14 row in "Planned, not built" records S2 as landed.

## v1 scope and rejections

v1 supports TrueType `glyf` outlines and Latin/Cyrillic/Greek LTR only. Per ADR-010 decision paragraph 5, the structural half of the enforcement is this parser, and it rejects with stable codes (never reaching the runtime):

- Composite glyphs (`numberOfContours == -1`): `CompositeGlyphRejected`
- CFF / CFF2 outlines (`glyf` absent): `CffOutlinesRejected`
- Hinting instruction bytecode per glyph: `HintingRejected`
- `GPOS` table present: `GposRejected`
- `GSUB` table present (carries ligatures and contextual substitutions): `GsubRejected`
- Apple AAT layout tables `morx` / `mort` present: `AppleLayoutRejected`

RTL and complex scripts cannot be detected from the font binary alone — they are a property of the string-to-glyph mapping, which is the `.medui` compiler's (#15) and the restricted-charset's (#161) job, not this parser's. The mechanical enforcement delivered by #161 (S5) is the second half; this module is the structural one.

## Acceptance

- Malformed/truncated/unsupported font fixtures fail with stable codes — covered by the two table-driven rejection corpora.
- The baker links no third-party font library — `MduXTextBakeLib`'s `target_link_libraries` is unchanged (still `PUBLIC MduX::ToolsCommon`, `PRIVATE MduX_warnings`); the parser depends only on `mdux.core.result` and `std`.
- `mdux_verify_trust_zones()` still passes — configure reports "2 governed target(s) clean of Vulkan/windowing dependencies".
- Parser unit tests cover `glyf` simple and composite outlines, and every rejection path — `TruetypeTests.cpp` registers six scenarios in `text_tools_spec`; all 15 cases in the binary pass.

## Local verification

Verified locally with `g++ 16.1.0` (the default `/usr/bin/g++` on this machine is a 16.0.1 experimental trunk snapshot that ICEs on `VulkanRenderer.cpp` — see issue #48, pre-existing and unrelated to this change). Configured and built the full tree (`MDUX_BUILD_EXAMPLES=ON MDUX_BUILD_TESTS=ON`):

- `mdux_verify_trust_zones()` clean, no new third-party link dependency.
- `ctest -E "InstallTreeConsumer|offscreen_tests|ml.noheap.symbolScan"`: **393 / 393 pass**.
- Exclusions: `InstallTreeConsumer` (pre-existing flakiness on this container), `offscreen_tests` (needs a Vulkan ICD that is not present here), `ml.noheap.symbolScan` (needs `nm`/`dumpbin` — separately affected by the container's tooling). None related to this change.

```sh
CC=gcc-16.1 CXX=g++-16.1 cmake -B build -S . -G Ninja -DCMAKE_BUILD_TYPE=Release -DMDUX_BUILD_EXAMPLES=ON -DMDUX_BUILD_TESTS=ON
cmake --build build
ctest --test-dir build -E "InstallTreeConsumer|offscreen_tests|ml.noheap.symbolScan"
```

## Out of scope (deliberately)

- No `mdux_bake_artifact()` call site is registered in this PR. S4 (#160) is the wave that feeds a `.ttf` recipe through this parser and commits a font artifact.
- The baker-facing conversion from `ParseError` to a `TXT`-prefixed `cli::Diagnostic` is deferred to S4 (#160) — the same wave that introduces the recipe fields the baker needs to call this parser at all. The `ParseError` codes this PR publishes are the stable contract that conversion will switch on.