### PR TITLE
S3 — Deterministic rasteriser with coverage AA (#159)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ target_sources(MduXCore
             include/mdux/ml/Runtime.cppm
             include/mdux/draw/Draw.cppm
             include/mdux/text/Schema.cppm
+            include/mdux/text/Raster.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
@@ -204,6 +205,7 @@ target_sources(MduXCore
         src/ml/Runtime.cpp
         src/draw/Draw.cpp
         src/text/Schema.cpp
+        src/text/Raster.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp
         src/governance/Program.cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,9 @@ We follow the **C++ Core Guidelines** to ensure conformance with modern C++23 ge
 - **Functions/Methods:**
   - Use `lowerCamelCase` (e.g., `processData()`, `getValue()`).
 - **Variables (including const, constexpr, and constinit variables):**
-  - Use `lowerCamelCase` (e.g., `dataBuffer`, `isReady`).
+  - Use `lowerCamelCase` (e.g., `dataBuffer`, `isReady`, `maxSweepWork`).
+  - No Hungarian notation, and **no `k` prefix on constants**: `kMaxSweepWork` is wrong,
+    `maxSweepWork` is right. A constant is a variable and follows the same rule as one.
 - **Namespaces:**
   - Use 'lowercase' (e.g., 'mui', 'backend').
 - **Macros:**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,7 @@ are ordinary `PRIVATE` sources.
 | `mdux.governance.compliance` | `include/mdux/governance/Compliance.cppm` | `src/governance/Compliance.cpp` |
 | `mdux.shader.schema` | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
 | `mdux.text.schema` | `include/mdux/text/Schema.cppm` | `src/text/Schema.cpp` |
+| `mdux.text.raster` | `include/mdux/text/Raster.cppm` | `src/text/Raster.cpp` |
 | `mdux.draw` | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
 | `mdux.ml.schema` | `include/mdux/ml/Schema.cppm` | header-only |
 | `mdux.ml.kernels` | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
@@ -209,7 +210,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | S1 (`mdux.text.schema` + `mdux-textbake` skeleton) landed. S2 (`mdux.tools.truetype` glyf parser, #158) landed; S3–S6 open |
+| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | S1 (`mdux.text.schema` + `mdux-textbake` skeleton) landed. S2 (`mdux.tools.truetype` glyf parser, #158) landed. S3 (`mdux.text.raster` coverage rasteriser, #159) landed; S4–S6 open |
 | `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | the replacement for the retired HTML/CSS path |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |

--- a/include/mdux/text/Raster.cppm
+++ b/include/mdux/text/Raster.cppm
@@ -1,0 +1,184 @@
+/**
+ * @file Raster.cppm
+ * @brief Governed-zone glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
+ *        only, so the same glyph produces the same bytes on every supported toolchain.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-007 Evidence pipeline doctrine (the bytes this produces get committed)
+ * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010: one
+ *             module, not a host implementation and a device one that could drift)
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * Part of MduXCore. The font baker (#160, S4) imports this to fill an atlas; if a device path
+ * ever needs to rasterise, it imports *this* module rather than growing a second implementation.
+ * That is ADR-008 decision 1 applied to text, and it is why this file is governed rather than
+ * sitting in `tools/` next to the parser that feeds it.
+ *
+ * ## Why it does not take a `truetype::SimpleGlyph`
+ *
+ * `mdux.tools.truetype` (#158) is host-tools-zone code. ADR-004 forbids a governed module from
+ * importing one, and the rule is mechanically checked by `mdux_verify_trust_zones()` - so this
+ * module cannot name that type even though it is the obvious input. It takes `Outline` instead:
+ * the same TrueType shape (points, per-contour end indices, on/off-curve flags) expressed in
+ * governed types, with the baker doing a flat conversion. That indirection is the trust-zone
+ * boundary made visible, not an abstraction for its own sake.
+ *
+ * ## The determinism rule
+ *
+ * **There is no floating-point arithmetic in this module.** Not "float used carefully", not
+ * "float with `-ffp-contract=off`" - none. Every coordinate is a fixed-point integer, every
+ * division is integer division, and the flattening of a curve into line segments is a pure
+ * function of integer inputs.
+ *
+ * That is a stronger position than `mdux.ml.kernels` takes, and deliberately so. The kernels have
+ * to be float because the model's arithmetic is float, and they therefore depend on
+ * `cmake/MduXDeterminism.cmake` continuing to keep contraction and fast-math away from them. A
+ * rasteriser has no such obligation: coverage is a ratio of areas, areas are counts of subpixel
+ * units, and counts are integers. Choosing integers means the cross-toolchain byte-identity
+ * claim in issue #159 is a property of the source rather than of the flags it is compiled with,
+ * and no future `-ffast-math` arriving from a preset can weaken it.
+ *
+ * Concretely, the arithmetic that would otherwise be float:
+ *
+ * - **Scaling** from font units to pixels is `(unit * pixelSize * kFixedOne) / unitsPerEm`,
+ *   computed in `std::int64_t` and truncated once.
+ * - **Curve flattening** picks a segment count from an integer curvature proxy and an integer
+ *   square root, then evaluates the Bézier at `t = i/N` with the divisions done last, in
+ *   `std::int64_t`.
+ * - **Edge/scanline intersection** is `x0 + (x1 - x0) * (y - y0) / (y1 - y0)`, again in
+ *   `std::int64_t`, with a floor division so that negative coordinates round the same way as
+ *   positive ones instead of toward zero.
+ * - **Coverage** is a sum of subpixel widths, and the final byte is `acc * 255 / kAccumulatorMax`.
+ *
+ * ## Why coverage cannot leave [0, 255]
+ *
+ * Issue #159 asks for "coverage values in [0,255] with no clamping surprises", and the way to
+ * have no clamping surprises is to have no clamp. A pixel's accumulator gains at most
+ * `kFixedOne` per sub-scanline - the span contributing to it is intersected with that pixel's
+ * own column before being added - and there are exactly `kSubScanlines` of them, so the
+ * accumulator is bounded above by `kAccumulatorMax` by construction. The final
+ * `acc * 255 / kAccumulatorMax` therefore lands in [0, 255] with 0 and 255 both reachable and
+ * neither produced by saturation. `rasterise()` contains no `std::clamp` on a coverage value,
+ * and a future change that makes one necessary has broken this invariant rather than found a
+ * corner case.
+ *
+ * ## The sampling model
+ *
+ * Analytic in x, sampled in y. Each pixel row is cut into `kSubScanlines` horizontal sample
+ * lines; on each, the outline's crossings are computed exactly in fixed point, sorted, and
+ * filled by the nonzero winding rule. A span contributes its exact overlap with each pixel
+ * column, so horizontal edges are resolved to `1/kFixedOne` of a pixel while vertical detail is
+ * quantised to `1/kSubScanlines`.
+ *
+ * The asymmetry is deliberate: exact area coverage in both axes needs a signed-area cell
+ * accumulator whose correctness is much harder to see by reading it, and this is a *baker*.
+ * It runs once per glyph at build time, never on a device, so the cost of 16 sample lines per
+ * row buys legibility at a price nothing pays at runtime.
+ */
+module;
+
+export module mdux.text.raster;
+
+import std;
+import mdux.core.result;
+
+export namespace mdux::text::raster {
+
+/// Every rejection code the rasteriser emits. Stable once published: S4 (#160) converts these to
+/// `TXT`-prefixed diagnostics the same way the shader baker converts `Spirv.cpp`'s.
+enum class RasterError : std::uint8_t {
+    EmptyOutline,          ///< no contours, or every contour empty - nothing to rasterise
+    MalformedContours,     ///< contour end indices are not strictly increasing, or exceed the points
+    UnsupportedUnitsPerEm, ///< unitsPerEm is zero, so the font-unit-to-pixel scale is undefined
+    UnsupportedPixelSize,  ///< pixelSize is zero, or larger than `kMaxPixelSize`
+    BitmapTooLarge,        ///< the outline's scaled bounding box exceeds `kMaxBitmapPixels`
+    CoordinateOverflow,    ///< a scaled coordinate left the range the fixed-point format holds
+};
+
+[[nodiscard]] std::string_view describe(RasterError error) noexcept;
+
+/// Subpixel resolution of the fixed-point coordinate format, as a shift. One pixel is
+/// `kFixedOne` units, so an x coordinate is resolved to 1/256 of a pixel. Exposed because the
+/// bitmap's `origin` fields are in whole pixels and a caller reconstructing subpixel positioning
+/// needs to know what the parser rounded against.
+inline constexpr std::int32_t kFixedShift = 8;
+inline constexpr std::int32_t kFixedOne   = 1 << kFixedShift;
+
+/// Horizontal sample lines per pixel row. 16 gives 17 distinct vertical coverage levels before
+/// the horizontal term refines them further, which is past the point where an 8-bit output can
+/// show the difference. It is a power of two so the sub-scanline centres land on exact integers.
+inline constexpr std::int32_t kSubScanlines = 16;
+
+/// The largest value a pixel's coverage accumulator can hold: `kFixedOne` per sub-scanline.
+inline constexpr std::int32_t kAccumulatorMax = kFixedOne * kSubScanlines;
+
+/// Bounds that turn a malformed or hostile outline into a diagnostic rather than an allocation.
+/// A baker feeding this a corrupt `loca` entry should get `BitmapTooLarge`, not a bad_alloc.
+inline constexpr std::uint32_t kMaxPixelSize   = 4096;
+inline constexpr std::uint64_t kMaxBitmapPixels = 64u * 1024u * 1024u;
+
+/// One outline point in font units. Mirrors TrueType's `glyf` representation, which is the only
+/// producer today - `onCurve == false` marks a quadratic Bézier control point.
+struct OutlinePoint {
+    std::int32_t x{0};
+    std::int32_t y{0};
+    bool         onCurve{true};
+};
+
+/**
+ * @brief A glyph outline in font units: points, plus the index of each contour's last point.
+ *
+ * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in governed types because a
+ * governed module may not import a host-tools one (ADR-004). `contourEnds[i]` is the index of
+ * the final point of contour `i`, so contour 0 is `points[0 .. contourEnds[0]]` and contour `i`
+ * is `points[contourEnds[i-1] + 1 .. contourEnds[i]]` - TrueType's own convention, kept rather
+ * than converted to offsets so the baker's translation stays a copy rather than a computation.
+ *
+ * Both spans are borrowed. `rasterise()` reads them and returns; it stores neither.
+ */
+struct Outline {
+    std::span<const OutlinePoint>  points{};
+    std::span<const std::uint16_t> contourEnds{};
+};
+
+/**
+ * @brief An 8-bit coverage bitmap, and where it sits relative to the glyph origin.
+ *
+ * `coverage` is `width * height` bytes, row-major, **top row first** - the atlas orientation,
+ * not the font's y-up one, so S4 can copy rows into an atlas without flipping them. `originX`
+ * and `originY` are the pixel offsets from the glyph origin to the bitmap's top-left corner:
+ * `originX` is typically the left side bearing and `originY` is positive for the usual case of
+ * an outline that rises above the baseline.
+ *
+ * A glyph with no visible area - a space, or an outline that scales below one subpixel - yields
+ * `width == height == 0` and an empty `coverage`, not a 1x1 bitmap of zeros.
+ */
+struct CoverageBitmap {
+    std::uint32_t             width{0};
+    std::uint32_t             height{0};
+    std::int32_t              originX{0};
+    std::int32_t              originY{0};
+    std::vector<std::uint8_t> coverage{};
+};
+
+/// What to rasterise, and at what size. `pixelSize` is the em size in pixels: the scale applied
+/// is `pixelSize / unitsPerEm`, so a 2048-upem font at `pixelSize == 32` maps 2048 font units to
+/// 32 pixels.
+struct RasterRequest {
+    Outline       outline{};
+    std::uint16_t unitsPerEm{0};
+    std::uint32_t pixelSize{0};
+};
+
+/**
+ * @brief Rasterises one outline to a coverage bitmap.
+ *
+ * Byte-identical across toolchains for identical input, which is the property issue #159 exists
+ * to establish and `text.determinism.crossToolchain` pins with a frozen digest.
+ *
+ * Reads only the spans in `request.outline`, and only for the duration of the call.
+ */
+[[nodiscard]] mdux::core::Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noexcept;
+
+}  // namespace mdux::text::raster

--- a/include/mdux/text/Raster.cppm
+++ b/include/mdux/text/Raster.cppm
@@ -94,6 +94,8 @@ enum class RasterError : std::uint8_t {
     UnsupportedPixelSize,  ///< pixelSize is zero, or larger than `kMaxPixelSize`
     BitmapTooLarge,        ///< the outline's scaled bounding box exceeds `kMaxBitmapPixels`
     CoordinateOverflow,    ///< a scaled coordinate left the range the fixed-point format holds
+    OutlineTooComplex,     ///< the flattened outline exceeds `kMaxEdges` or `kMaxSweepWork`
+    AllocationFailed,      ///< a buffer this call needed could not be allocated
 };
 
 [[nodiscard]] std::string_view describe(RasterError error) noexcept;
@@ -101,7 +103,7 @@ enum class RasterError : std::uint8_t {
 /// Subpixel resolution of the fixed-point coordinate format, as a shift. One pixel is
 /// `kFixedOne` units, so an x coordinate is resolved to 1/256 of a pixel. Exposed because the
 /// bitmap's `origin` fields are in whole pixels and a caller reconstructing subpixel positioning
-/// needs to know what the parser rounded against.
+/// needs to know the grid this module rounded coordinates against.
 inline constexpr std::int32_t kFixedShift = 8;
 inline constexpr std::int32_t kFixedOne   = 1 << kFixedShift;
 
@@ -115,8 +117,21 @@ inline constexpr std::int32_t kAccumulatorMax = kFixedOne * kSubScanlines;
 
 /// Bounds that turn a malformed or hostile outline into a diagnostic rather than an allocation.
 /// A baker feeding this a corrupt `loca` entry should get `BitmapTooLarge`, not a bad_alloc.
-inline constexpr std::uint32_t kMaxPixelSize   = 4096;
+inline constexpr std::uint32_t kMaxPixelSize    = 4096;
 inline constexpr std::uint64_t kMaxBitmapPixels = 64u * 1024u * 1024u;
+
+/// Ceilings on the *work* a request can ask for, which the bitmap-area limit alone does not
+/// bound. `contourEnds` holds `std::uint16_t` indices, so an outline may carry ~65k points, and
+/// each off-curve point can flatten into `kMaxCurveSegments` edges; a tall narrow glyph can also
+/// reach a large height while staying well under `kMaxBitmapPixels`. Without these two limits the
+/// sweep below is quadratic in attacker-chosen quantities, which is a denial-of-service path
+/// through a baker rather than a memory-safety one - it never allocates enough to be refused.
+///
+/// `kMaxSweepWork` counts edge-row visits: the sum, over every flattened edge, of the pixel rows
+/// it spans. Real glyphs sit orders of magnitude below it - a 50-pixel-tall glyph with 200 edges
+/// visits a few thousand - so the bound rejects only outlines that were never going to be text.
+inline constexpr std::uint32_t kMaxEdges     = 1u << 16;
+inline constexpr std::uint64_t kMaxSweepWork = 1u << 22;
 
 /// One outline point in font units. Mirrors TrueType's `glyf` representation, which is the only
 /// producer today - `onCurve == false` marks a quadratic Bézier control point.
@@ -175,7 +190,7 @@ struct RasterRequest {
  * @brief Rasterises one outline to a coverage bitmap.
  *
  * Byte-identical across toolchains for identical input, which is the property issue #159 exists
- * to establish and `text.determinism.crossToolchain` pins with a frozen digest.
+ * to establish and `text-raster-determinism-crossToolchain` pins with a frozen digest.
  *
  * Reads only the spans in `request.outline`, and only for the duration of the call.
  */

--- a/include/mdux/text/Raster.cppm
+++ b/include/mdux/text/Raster.cppm
@@ -41,7 +41,7 @@
  *
  * Concretely, the arithmetic that would otherwise be float:
  *
- * - **Scaling** from font units to pixels is `(unit * pixelSize * kFixedOne) / unitsPerEm`,
+ * - **Scaling** from font units to pixels is `(unit * pixelSize * fixedOne) / unitsPerEm`,
  *   computed in `std::int64_t` and truncated once.
  * - **Curve flattening** picks a segment count from an integer curvature proxy and an integer
  *   square root, then evaluates the Bézier at `t = i/N` with the divisions done last, in
@@ -49,27 +49,27 @@
  * - **Edge/scanline intersection** is `x0 + (x1 - x0) * (y - y0) / (y1 - y0)`, again in
  *   `std::int64_t`, with a floor division so that negative coordinates round the same way as
  *   positive ones instead of toward zero.
- * - **Coverage** is a sum of subpixel widths, and the final byte is `acc * 255 / kAccumulatorMax`.
+ * - **Coverage** is a sum of subpixel widths, and the final byte is `acc * 255 / accumulatorMax`.
  *
  * ## Why coverage cannot leave [0, 255]
  *
  * Issue #159 asks for "coverage values in [0,255] with no clamping surprises", and the way to
  * have no clamping surprises is to have no clamp. A pixel's accumulator gains at most
- * `kFixedOne` per sub-scanline - the span contributing to it is intersected with that pixel's
- * own column before being added - and there are exactly `kSubScanlines` of them, so the
- * accumulator is bounded above by `kAccumulatorMax` by construction. The final
- * `acc * 255 / kAccumulatorMax` therefore lands in [0, 255] with 0 and 255 both reachable and
+ * `fixedOne` per sub-scanline - the span contributing to it is intersected with that pixel's
+ * own column before being added - and there are exactly `subScanlines` of them, so the
+ * accumulator is bounded above by `accumulatorMax` by construction. The final
+ * `acc * 255 / accumulatorMax` therefore lands in [0, 255] with 0 and 255 both reachable and
  * neither produced by saturation. `rasterise()` contains no `std::clamp` on a coverage value,
  * and a future change that makes one necessary has broken this invariant rather than found a
  * corner case.
  *
  * ## The sampling model
  *
- * Analytic in x, sampled in y. Each pixel row is cut into `kSubScanlines` horizontal sample
+ * Analytic in x, sampled in y. Each pixel row is cut into `subScanlines` horizontal sample
  * lines; on each, the outline's crossings are computed exactly in fixed point, sorted, and
  * filled by the nonzero winding rule. A span contributes its exact overlap with each pixel
- * column, so horizontal edges are resolved to `1/kFixedOne` of a pixel while vertical detail is
- * quantised to `1/kSubScanlines`.
+ * column, so horizontal edges are resolved to `1/fixedOne` of a pixel while vertical detail is
+ * quantised to `1/subScanlines`.
  *
  * The asymmetry is deliberate: exact area coverage in both axes needs a signed-area cell
  * accumulator whose correctness is much harder to see by reading it, and this is a *baker*.
@@ -91,47 +91,47 @@ enum class RasterError : std::uint8_t {
     EmptyOutline,          ///< no contours, or every contour empty - nothing to rasterise
     MalformedContours,     ///< contour end indices are not strictly increasing, or exceed the points
     UnsupportedUnitsPerEm, ///< unitsPerEm is zero, so the font-unit-to-pixel scale is undefined
-    UnsupportedPixelSize,  ///< pixelSize is zero, or larger than `kMaxPixelSize`
-    BitmapTooLarge,        ///< the outline's scaled bounding box exceeds `kMaxBitmapPixels`
+    UnsupportedPixelSize,  ///< pixelSize is zero, or larger than `maxPixelSize`
+    BitmapTooLarge,        ///< the outline's scaled bounding box exceeds `maxBitmapPixels`
     CoordinateOverflow,    ///< a scaled coordinate left the range the fixed-point format holds
-    OutlineTooComplex,     ///< the flattened outline exceeds `kMaxEdges` or `kMaxSweepWork`
+    OutlineTooComplex,     ///< the flattened outline exceeds `maxEdges` or `maxSweepWork`
     AllocationFailed,      ///< a buffer this call needed could not be allocated
 };
 
 [[nodiscard]] std::string_view describe(RasterError error) noexcept;
 
 /// Subpixel resolution of the fixed-point coordinate format, as a shift. One pixel is
-/// `kFixedOne` units, so an x coordinate is resolved to 1/256 of a pixel. Exposed because the
+/// `fixedOne` units, so an x coordinate is resolved to 1/256 of a pixel. Exposed because the
 /// bitmap's `origin` fields are in whole pixels and a caller reconstructing subpixel positioning
 /// needs to know the grid this module rounded coordinates against.
-inline constexpr std::int32_t kFixedShift = 8;
-inline constexpr std::int32_t kFixedOne   = 1 << kFixedShift;
+inline constexpr std::int32_t fixedShift = 8;
+inline constexpr std::int32_t fixedOne   = 1 << fixedShift;
 
 /// Horizontal sample lines per pixel row. 16 gives 17 distinct vertical coverage levels before
 /// the horizontal term refines them further, which is past the point where an 8-bit output can
 /// show the difference. It is a power of two so the sub-scanline centres land on exact integers.
-inline constexpr std::int32_t kSubScanlines = 16;
+inline constexpr std::int32_t subScanlines = 16;
 
-/// The largest value a pixel's coverage accumulator can hold: `kFixedOne` per sub-scanline.
-inline constexpr std::int32_t kAccumulatorMax = kFixedOne * kSubScanlines;
+/// The largest value a pixel's coverage accumulator can hold: `fixedOne` per sub-scanline.
+inline constexpr std::int32_t accumulatorMax = fixedOne * subScanlines;
 
 /// Bounds that turn a malformed or hostile outline into a diagnostic rather than an allocation.
 /// A baker feeding this a corrupt `loca` entry should get `BitmapTooLarge`, not a bad_alloc.
-inline constexpr std::uint32_t kMaxPixelSize    = 4096;
-inline constexpr std::uint64_t kMaxBitmapPixels = 64u * 1024u * 1024u;
+inline constexpr std::uint32_t maxPixelSize    = 4096;
+inline constexpr std::uint64_t maxBitmapPixels = 64u * 1024u * 1024u;
 
 /// Ceilings on the *work* a request can ask for, which the bitmap-area limit alone does not
 /// bound. `contourEnds` holds `std::uint16_t` indices, so an outline may carry ~65k points, and
-/// each off-curve point can flatten into `kMaxCurveSegments` edges; a tall narrow glyph can also
-/// reach a large height while staying well under `kMaxBitmapPixels`. Without these two limits the
+/// each off-curve point can flatten into `maxCurveSegments` edges; a tall narrow glyph can also
+/// reach a large height while staying well under `maxBitmapPixels`. Without these two limits the
 /// sweep below is quadratic in attacker-chosen quantities, which is a denial-of-service path
 /// through a baker rather than a memory-safety one - it never allocates enough to be refused.
 ///
-/// `kMaxSweepWork` counts edge-row visits: the sum, over every flattened edge, of the pixel rows
+/// `maxSweepWork` counts edge-row visits: the sum, over every flattened edge, of the pixel rows
 /// it spans. Real glyphs sit orders of magnitude below it - a 50-pixel-tall glyph with 200 edges
 /// visits a few thousand - so the bound rejects only outlines that were never going to be text.
-inline constexpr std::uint32_t kMaxEdges     = 1u << 16;
-inline constexpr std::uint64_t kMaxSweepWork = 1u << 22;
+inline constexpr std::uint32_t maxEdges     = 1u << 16;
+inline constexpr std::uint64_t maxSweepWork = 1u << 22;
 
 /// One outline point in font units. Mirrors TrueType's `glyf` representation, which is the only
 /// producer today - `onCurve == false` marks a quadratic Bézier control point.

--- a/src/text/Raster.cpp
+++ b/src/text/Raster.cpp
@@ -40,15 +40,15 @@ using mdux::core::Result;
 namespace {
 
 /// The widest coordinate the fixed-point format holds without a product overflowing the int64
-/// intermediates below. 1 << 23 fixed-point units is 32768 pixels, far past `kMaxPixelSize`, so
+/// intermediates below. 1 << 23 fixed-point units is 32768 pixels, far past `maxPixelSize`, so
 /// hitting this means the scale computation itself produced something absurd.
-constexpr std::int64_t kMaxFixedCoordinate = 1 << 23;
+constexpr std::int64_t maxFixedCoordinate = 1 << 23;
 
 /// Largest number of line segments one quadratic Bézier may flatten into. A curve needing more
 /// than this is either enormous or degenerate; capping keeps a hostile outline from producing an
 /// unbounded edge list, and at 64 segments the residual error is far below one subpixel for any
-/// glyph that fits `kMaxPixelSize`.
-constexpr std::int32_t kMaxCurveSegments = 64;
+/// glyph that fits `maxPixelSize`.
+constexpr std::int32_t maxCurveSegments = 64;
 
 /// Floor division for signed integers. `operator/` truncates toward zero, which rounds -3/2 to
 /// -1 and 3/2 to 1 - an asymmetry that would place a scanline crossing differently on the left
@@ -102,13 +102,13 @@ struct Crossing {
 
 /// Scales a font-unit coordinate into fixed-point pixel space.
 ///
-/// `(unit * pixelSize * kFixedOne) / unitsPerEm`, evaluated with the multiplications first so
+/// `(unit * pixelSize * fixedOne) / unitsPerEm`, evaluated with the multiplications first so
 /// the single truncation happens at the end. Doing the division first - scaling to pixels and
 /// then to fixed point - would round twice and lose roughly half a subpixel per coordinate.
 [[nodiscard]] std::optional<std::int32_t> scaleToFixed(std::int32_t unit, std::uint32_t pixelSize, std::uint16_t unitsPerEm) noexcept {
-    const std::int64_t scaled = floorDiv(static_cast<std::int64_t>(unit) * static_cast<std::int64_t>(pixelSize) * kFixedOne,
+    const std::int64_t scaled = floorDiv(static_cast<std::int64_t>(unit) * static_cast<std::int64_t>(pixelSize) * fixedOne,
                                          static_cast<std::int64_t>(unitsPerEm));
-    if (scaled > kMaxFixedCoordinate || scaled < -kMaxFixedCoordinate) {
+    if (scaled > maxFixedCoordinate || scaled < -maxFixedCoordinate) {
         return std::nullopt;
     }
     return static_cast<std::int32_t>(scaled);
@@ -131,11 +131,11 @@ struct Crossing {
     if (metric <= 0) {
         return 1;  // the control point is on the chord: the curve is a straight line
     }
-    // Divide by kFixedOne / 4 before the root so the count grows once the deviation passes a
+    // Divide by fixedOne / 4 before the root so the count grows once the deviation passes a
     // quarter-pixel rather than a whole one; below that the flattening error is invisible at 8
     // bits of coverage.
-    const std::int64_t segments = 1 + isqrt(floorDiv(metric * 4, kFixedOne));
-    return static_cast<std::int32_t>(std::min<std::int64_t>(segments, kMaxCurveSegments));
+    const std::int64_t segments = 1 + isqrt(floorDiv(metric * 4, fixedOne));
+    return static_cast<std::int32_t>(std::min<std::int64_t>(segments, maxCurveSegments));
 }
 
 /// Evaluates a quadratic Bézier at `t = index / count`, entirely in integers.
@@ -314,7 +314,7 @@ namespace {
     if (request.unitsPerEm == 0) {
         return err(RasterError::UnsupportedUnitsPerEm);
     }
-    if (request.pixelSize == 0 || request.pixelSize > kMaxPixelSize) {
+    if (request.pixelSize == 0 || request.pixelSize > maxPixelSize) {
         return err(RasterError::UnsupportedPixelSize);
     }
     if (request.outline.contourEnds.empty() || request.outline.points.empty()) {
@@ -335,10 +335,10 @@ namespace {
     if (!edges.has_value()) {
         return err(edges.error());
     }
-    if (edges->size() > kMaxEdges) {
+    if (edges->size() > maxEdges) {
         // The second half of the work bound. An outline can reach this without any single
         // contour looking unusual, because every off-curve point may flatten into
-        // kMaxCurveSegments edges - so the check belongs on the flattened count, not the input's.
+        // maxCurveSegments edges - so the check belongs on the flattened count, not the input's.
         return err(RasterError::OutlineTooComplex);
     }
     if (edges->empty()) {
@@ -360,27 +360,27 @@ namespace {
         maxY = std::max({maxY, edge.y0, edge.y1});
     }
 
-    const std::int64_t pixelMinX = floorDiv(minX, kFixedOne);
-    const std::int64_t pixelMinY = floorDiv(minY, kFixedOne);
-    const std::int64_t pixelMaxX = floorDiv(maxX + kFixedOne - 1, kFixedOne);
-    const std::int64_t pixelMaxY = floorDiv(maxY + kFixedOne - 1, kFixedOne);
+    const std::int64_t pixelMinX = floorDiv(minX, fixedOne);
+    const std::int64_t pixelMinY = floorDiv(minY, fixedOne);
+    const std::int64_t pixelMaxX = floorDiv(maxX + fixedOne - 1, fixedOne);
+    const std::int64_t pixelMaxY = floorDiv(maxY + fixedOne - 1, fixedOne);
 
     const std::int64_t width  = pixelMaxX - pixelMinX;
     const std::int64_t height = pixelMaxY - pixelMinY;
     if (width <= 0 || height <= 0) {
         return CoverageBitmap{};
     }
-    if (static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height) > kMaxBitmapPixels) {
+    if (static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height) > maxBitmapPixels) {
         return err(RasterError::BitmapTooLarge);
     }
 
     // Bucket the edges by the pixel rows they span, so the sweep visits an edge only on rows it
     // can actually cross.
     //
-    // Without this the sweep is `height * kSubScanlines * edgeCount`, and none of those three is
+    // Without this the sweep is `height * subScanlines * edgeCount`, and none of those three is
     // bounded by the bitmap-area check: `contourEnds` holds uint16 indices, so an outline can
-    // carry ~65k points, each off-curve one flattening into up to kMaxCurveSegments edges, while
-    // a tall narrow glyph reaches a large height well under kMaxBitmapPixels. The product is
+    // carry ~65k points, each off-curve one flattening into up to maxCurveSegments edges, while
+    // a tall narrow glyph reaches a large height well under maxBitmapPixels. The product is
     // quadratic in attacker-chosen quantities - a denial-of-service path through a baker that
     // never allocates enough to be refused. Bucketing makes the cost proportional to the geometry
     // instead: the total is the sum, over edges, of the rows each one spans.
@@ -394,8 +394,8 @@ namespace {
     const auto rowSpanOf = [pixelMinY, height](const Edge& edge) noexcept -> std::pair<std::int64_t, std::int64_t> {
         const std::int64_t topY    = std::min(edge.y0, edge.y1);
         const std::int64_t bottomY = std::max(edge.y0, edge.y1);
-        return {std::max<std::int64_t>(floorDiv(topY, kFixedOne) - pixelMinY, 0),
-                std::min<std::int64_t>(floorDiv(bottomY - 1, kFixedOne) - pixelMinY, height - 1)};
+        return {std::max<std::int64_t>(floorDiv(topY, fixedOne) - pixelMinY, 0),
+                std::min<std::int64_t>(floorDiv(bottomY - 1, fixedOne) - pixelMinY, height - 1)};
     };
 
     // Pass one: total the work and count each row's edges. Both come from the same spans, so the
@@ -408,7 +408,7 @@ namespace {
             continue;
         }
         sweepWork += static_cast<std::uint64_t>(lastRow - firstRow + 1);
-        if (sweepWork > kMaxSweepWork) {
+        if (sweepWork > maxSweepWork) {
             return err(RasterError::OutlineTooComplex);
         }
         for (std::int64_t r = firstRow; r <= lastRow; ++r) {
@@ -431,12 +431,26 @@ namespace {
         }
     }
 
-    // Accumulators, one per pixel, in subpixel-width units. `kAccumulatorMax` is the ceiling by
-    // construction: each sub-scanline contributes at most kFixedOne to any one pixel, because
+    // Accumulators, one per pixel, in subpixel-width units. `accumulatorMax` is the ceiling by
+    // construction: each sub-scanline contributes at most fixedOne to any one pixel, because
     // the span added is intersected with that pixel's own column first.
     std::vector<std::int32_t> accumulator(static_cast<std::size_t>(width) * static_cast<std::size_t>(height), 0);
 
     std::vector<Crossing> crossings;
+
+    // Coverage is accumulated as *differences* along the row, then prefix-summed once at the end
+    // of it, rather than written pixel by pixel as each span is filled.
+    //
+    // Writing per pixel makes the fill cost `height * subScanlines * spanWidth`, which nothing
+    // above bounds: a solid 65536 x 1024 rectangle satisfies both the bitmap-area and sweep-work
+    // limits while asking for about 1.07e9 accumulator writes. Encoding a span as two range-adds
+    // makes each one O(1) regardless of width, and the single prefix pass costs O(width) per row.
+    // Total fill work becomes O(bitmap area), which `maxBitmapPixels` already bounds - so this
+    // removes the unbounded quantity instead of adding another ceiling to check against it.
+    //
+    // One entry longer than the row: a span ending on the last pixel writes its closing
+    // difference at index `width`.
+    std::vector<std::int32_t> rowDelta(static_cast<std::size_t>(width) + 1u, 0);
 
     for (std::int64_t row = 0; row < height; ++row) {
         const std::uint32_t rowBegin = rowOffset[static_cast<std::size_t>(row)];
@@ -444,11 +458,12 @@ namespace {
         if (rowBegin == rowEnd) {
             continue;  // no edge reaches this row
         }
-        for (std::int32_t sub = 0; sub < kSubScanlines; ++sub) {
-            // The sub-scanline's y, sampled at the centre of its band. kSubScanlines is a power
-            // of two and divides 2 * kFixedOne exactly, so this is an integer with no rounding.
+        std::fill(rowDelta.begin(), rowDelta.end(), 0);
+        for (std::int32_t sub = 0; sub < subScanlines; ++sub) {
+            // The sub-scanline's y, sampled at the centre of its band. subScanlines is a power
+            // of two and divides 2 * fixedOne exactly, so this is an integer with no rounding.
             const std::int64_t sampleY =
-                (pixelMinY + row) * kFixedOne + (2 * static_cast<std::int64_t>(sub) + 1) * kFixedOne / (2 * kSubScanlines);
+                (pixelMinY + row) * fixedOne + (2 * static_cast<std::int64_t>(sub) + 1) * fixedOne / (2 * subScanlines);
 
             crossings.clear();
             for (std::uint32_t slot = rowBegin; slot < rowEnd; ++slot) {
@@ -488,22 +503,43 @@ namespace {
                     continue;
                 }
                 if (previous != 0 && winding == 0) {
-                    // Clip to the bitmap, then add each pixel's exact overlap with the span.
-                    const std::int64_t left  = std::max<std::int64_t>(spanFrom, pixelMinX * kFixedOne);
-                    const std::int64_t right = std::min<std::int64_t>(crossing.x, pixelMaxX * kFixedOne);
+                    // Clip to the bitmap, then record the span as range-adds on rowDelta. The
+                    // three ranges are the partially covered first pixel, the fully covered
+                    // interior, and the partially covered last pixel - each an O(1) pair of
+                    // differences rather than a write per pixel.
+                    const std::int64_t left  = std::max<std::int64_t>(spanFrom, pixelMinX * fixedOne);
+                    const std::int64_t right = std::min<std::int64_t>(crossing.x, pixelMaxX * fixedOne);
                     if (right <= left) {
                         continue;
                     }
-                    const std::int64_t firstPixel = floorDiv(left, kFixedOne) - pixelMinX;
-                    const std::int64_t lastPixel  = floorDiv(right - 1, kFixedOne) - pixelMinX;
-                    for (std::int64_t px = firstPixel; px <= lastPixel; ++px) {
-                        const std::int64_t pixelLeft  = (pixelMinX + px) * kFixedOne;
-                        const std::int64_t pixelRight = pixelLeft + kFixedOne;
-                        const std::int64_t covered    = std::min(right, pixelRight) - std::max(left, pixelLeft);
-                        accumulator[static_cast<std::size_t>(row * width + px)] += static_cast<std::int32_t>(covered);
+                    const std::int64_t firstPixel = floorDiv(left, fixedOne) - pixelMinX;
+                    const std::int64_t lastPixel  = floorDiv(right - 1, fixedOne) - pixelMinX;
+                    const auto         addRange   = [&rowDelta](std::int64_t from, std::int64_t to, std::int32_t amount) noexcept {
+                        rowDelta[static_cast<std::size_t>(from)] += amount;
+                        rowDelta[static_cast<std::size_t>(to)] -= amount;
+                    };
+                    if (firstPixel == lastPixel) {
+                        addRange(firstPixel, firstPixel + 1, static_cast<std::int32_t>(right - left));
+                        continue;
+                    }
+                    const std::int64_t firstPixelRight = (pixelMinX + firstPixel + 1) * fixedOne;
+                    const std::int64_t lastPixelLeft   = (pixelMinX + lastPixel) * fixedOne;
+                    addRange(firstPixel, firstPixel + 1, static_cast<std::int32_t>(firstPixelRight - left));
+                    addRange(lastPixel, lastPixel + 1, static_cast<std::int32_t>(right - lastPixelLeft));
+                    if (lastPixel > firstPixel + 1) {
+                        addRange(firstPixel + 1, lastPixel, fixedOne);
                     }
                 }
             }
+        }
+
+        // Resolve the row's differences into per-pixel coverage. The running total is the sum of
+        // every span that covered this pixel across all subScanlines, so it is bounded by
+        // accumulatorMax exactly as the per-pixel version was.
+        std::int32_t running = 0;
+        for (std::int64_t px = 0; px < width; ++px) {
+            running += rowDelta[static_cast<std::size_t>(px)];
+            accumulator[static_cast<std::size_t>(row * width + px)] = running;
         }
     }
 
@@ -521,10 +557,10 @@ namespace {
         const std::size_t row    = i / static_cast<std::size_t>(width);
         const std::size_t column = i % static_cast<std::size_t>(width);
         const std::size_t target = (static_cast<std::size_t>(height) - 1u - row) * static_cast<std::size_t>(width) + column;
-        // No clamp, deliberately: `accumulator[i]` is bounded by kAccumulatorMax by construction,
+        // No clamp, deliberately: `accumulator[i]` is bounded by accumulatorMax by construction,
         // so this is in [0, 255] already. See Raster.cppm on why a clamp here would be a bug
         // rather than a safety net.
-        bitmap.coverage[target] = static_cast<std::uint8_t>(accumulator[i] * 255 / kAccumulatorMax);
+        bitmap.coverage[target] = static_cast<std::uint8_t>(accumulator[i] * 255 / accumulatorMax);
     }
     return bitmap;
 }
@@ -536,7 +572,7 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     //
     // The header promises a diagnostic rather than a `bad_alloc` for a hostile outline, and the
     // size limits exist to make that promise keepable - but the accumulator alone can ask for
-    // 256 MiB at kMaxBitmapPixels, and `std::vector` reports failure by throwing. Declaring the
+    // 256 MiB at maxBitmapPixels, and `std::vector` reports failure by throwing. Declaring the
     // entry point `noexcept` without catching that would turn an ordinary out-of-memory condition
     // into `std::terminate`, taking down the baker instead of failing one glyph.
     //

--- a/src/text/Raster.cpp
+++ b/src/text/Raster.cpp
@@ -89,10 +89,12 @@ struct Edge {
     std::int32_t y1{0};
 };
 
-/// A crossing of one sub-scanline by one edge: where, and which way the edge was going. The
-/// direction is what makes the fill rule *nonzero* rather than even-odd, so a glyph whose
-/// counter runs the same way as its outer contour - which happens in real fonts - still gets a
-/// hole rather than a solid blob.
+/// A crossing of one sub-scanline by one edge: where, and which way the edge was going.
+///
+/// The direction is what makes the fill rule *nonzero* rather than even-odd. A counter wound
+/// against its outer contour subtracts from the winding and leaves a hole - which is how an 'o'
+/// works - while one wound the same way adds to it and stays filled. Even-odd cannot tell those
+/// two apart and would punch a hole through both.
 struct Crossing {
     std::int32_t x{0};
     std::int32_t direction{0};
@@ -254,10 +256,19 @@ struct Crossing {
             const ResolvedPoint& next  = at((i + 1u) % ring.size());
             const std::int32_t   endX  = next.x;
             const std::int32_t   endY  = next.y;
-            const std::int32_t   count2 = segmentsForCurve(penX, penY, point.x, point.y, endX, endY);
-            for (std::int32_t step = 1; step <= count2; ++step) {
-                const std::int32_t nx = evaluateQuadratic(penX, point.x, endX, step, count2);
-                const std::int32_t ny = evaluateQuadratic(penY, point.y, endY, step, count2);
+            // The curve's start is captured before the loop and never moves. `penX`/`penY` walk
+            // forward to carry each emitted segment's previous endpoint, so evaluating against
+            // them instead would feed the previous *sample* to the evaluator as p0 from step 2
+            // onward - a different curve, and one whose endpoints still land correctly because
+            // the final sample's `u` term is zero. That makes the error invisible to any test
+            // that only checks where a curve starts and ends; measured on a 5-segment curve it
+            // reaches 266 fixed units, just over one pixel.
+            const std::int32_t   startX  = penX;
+            const std::int32_t   startY  = penY;
+            const std::int32_t   samples = segmentsForCurve(startX, startY, point.x, point.y, endX, endY);
+            for (std::int32_t step = 1; step <= samples; ++step) {
+                const std::int32_t nx = evaluateQuadratic(startX, point.x, endX, step, samples);
+                const std::int32_t ny = evaluateQuadratic(startY, point.y, endY, step, samples);
                 emit(penX, penY, nx, ny);
                 penX = nx;
                 penY = ny;
@@ -287,11 +298,19 @@ std::string_view describe(RasterError error) noexcept {
             return "the scaled outline's bounding box exceeds the supported bitmap area";
         case RasterError::CoordinateOverflow:
             return "a scaled coordinate left the range the fixed-point format represents";
+        case RasterError::OutlineTooComplex:
+            return "the flattened outline exceeds the supported edge count or sweep-work budget";
+        case RasterError::AllocationFailed:
+            return "a buffer this rasterisation needed could not be allocated";
     }
     return "unknown rasteriser error";
 }
 
-Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noexcept {
+namespace {
+
+/// The body of `rasterise()`. Allowed to throw, because it allocates: the public entry point
+/// below is the `noexcept` boundary that turns an allocation failure into a diagnostic.
+[[nodiscard]] Result<CoverageBitmap, RasterError> rasteriseImpl(const RasterRequest& request) {
     if (request.unitsPerEm == 0) {
         return err(RasterError::UnsupportedUnitsPerEm);
     }
@@ -315,6 +334,12 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     auto edges = buildEdges(request.outline, request.pixelSize, request.unitsPerEm);
     if (!edges.has_value()) {
         return err(edges.error());
+    }
+    if (edges->size() > kMaxEdges) {
+        // The second half of the work bound. An outline can reach this without any single
+        // contour looking unusual, because every off-curve point may flatten into
+        // kMaxCurveSegments edges - so the check belongs on the flattened count, not the input's.
+        return err(RasterError::OutlineTooComplex);
     }
     if (edges->empty()) {
         // Every contour was degenerate or horizontal: a real outline with no enclosed area, such
@@ -349,15 +374,76 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
         return err(RasterError::BitmapTooLarge);
     }
 
+    // Bucket the edges by the pixel rows they span, so the sweep visits an edge only on rows it
+    // can actually cross.
+    //
+    // Without this the sweep is `height * kSubScanlines * edgeCount`, and none of those three is
+    // bounded by the bitmap-area check: `contourEnds` holds uint16 indices, so an outline can
+    // carry ~65k points, each off-curve one flattening into up to kMaxCurveSegments edges, while
+    // a tall narrow glyph reaches a large height well under kMaxBitmapPixels. The product is
+    // quadratic in attacker-chosen quantities - a denial-of-service path through a baker that
+    // never allocates enough to be refused. Bucketing makes the cost proportional to the geometry
+    // instead: the total is the sum, over edges, of the rows each one spans.
+    //
+    // Stored as CSR (offsets plus a flat index array) rather than a vector-of-vectors, because
+    // `height` allocations of a few elements each is the shape that turns a tall glyph slow for
+    // reasons unrelated to its outline.
+    // The row span each edge occupies, computed once and reused by both passes below. The
+    // half-open convention matches the sweep's: an edge covers [top, bottom), so its last row is
+    // the one containing `bottom - 1`.
+    const auto rowSpanOf = [pixelMinY, height](const Edge& edge) noexcept -> std::pair<std::int64_t, std::int64_t> {
+        const std::int64_t topY    = std::min(edge.y0, edge.y1);
+        const std::int64_t bottomY = std::max(edge.y0, edge.y1);
+        return {std::max<std::int64_t>(floorDiv(topY, kFixedOne) - pixelMinY, 0),
+                std::min<std::int64_t>(floorDiv(bottomY - 1, kFixedOne) - pixelMinY, height - 1)};
+    };
+
+    // Pass one: total the work and count each row's edges. Both come from the same spans, so the
+    // budget is checked before anything proportional to it is allocated.
+    std::vector<std::uint32_t> rowOffset(static_cast<std::size_t>(height) + 1u, 0u);
+    std::uint64_t              sweepWork = 0;
+    for (const Edge& edge : *edges) {
+        const auto [firstRow, lastRow] = rowSpanOf(edge);
+        if (lastRow < firstRow) {
+            continue;
+        }
+        sweepWork += static_cast<std::uint64_t>(lastRow - firstRow + 1);
+        if (sweepWork > kMaxSweepWork) {
+            return err(RasterError::OutlineTooComplex);
+        }
+        for (std::int64_t r = firstRow; r <= lastRow; ++r) {
+            rowOffset[static_cast<std::size_t>(r) + 1u] += 1u;
+        }
+    }
+    for (std::size_t r = 1; r < rowOffset.size(); ++r) {
+        rowOffset[r] += rowOffset[r - 1u];
+    }
+
+    // Pass two: fill the flat index array, walking a cursor per row.
+    std::vector<std::uint32_t> rowEdges(rowOffset.back(), 0u);
+    {
+        std::vector<std::uint32_t> cursor(rowOffset.begin(), rowOffset.end() - 1);
+        for (std::uint32_t index = 0; index < edges->size(); ++index) {
+            const auto [firstRow, lastRow] = rowSpanOf((*edges)[index]);
+            for (std::int64_t r = firstRow; r <= lastRow; ++r) {
+                rowEdges[cursor[static_cast<std::size_t>(r)]++] = index;
+            }
+        }
+    }
+
     // Accumulators, one per pixel, in subpixel-width units. `kAccumulatorMax` is the ceiling by
     // construction: each sub-scanline contributes at most kFixedOne to any one pixel, because
     // the span added is intersected with that pixel's own column first.
     std::vector<std::int32_t> accumulator(static_cast<std::size_t>(width) * static_cast<std::size_t>(height), 0);
 
     std::vector<Crossing> crossings;
-    crossings.reserve(edges->size());
 
     for (std::int64_t row = 0; row < height; ++row) {
+        const std::uint32_t rowBegin = rowOffset[static_cast<std::size_t>(row)];
+        const std::uint32_t rowEnd   = rowOffset[static_cast<std::size_t>(row) + 1u];
+        if (rowBegin == rowEnd) {
+            continue;  // no edge reaches this row
+        }
         for (std::int32_t sub = 0; sub < kSubScanlines; ++sub) {
             // The sub-scanline's y, sampled at the centre of its band. kSubScanlines is a power
             // of two and divides 2 * kFixedOne exactly, so this is an integer with no rounding.
@@ -365,7 +451,8 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
                 (pixelMinY + row) * kFixedOne + (2 * static_cast<std::int64_t>(sub) + 1) * kFixedOne / (2 * kSubScanlines);
 
             crossings.clear();
-            for (const Edge& edge : *edges) {
+            for (std::uint32_t slot = rowBegin; slot < rowEnd; ++slot) {
+                const Edge&        edge    = (*edges)[rowEdges[slot]];
                 const std::int32_t topY    = std::min(edge.y0, edge.y1);
                 const std::int32_t bottomY = std::max(edge.y0, edge.y1);
                 // Half-open in y: an edge covers [top, bottom). Without this, a vertex shared by
@@ -440,6 +527,32 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
         bitmap.coverage[target] = static_cast<std::uint8_t>(accumulator[i] * 255 / kAccumulatorMax);
     }
     return bitmap;
+}
+
+}  // namespace
+
+Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noexcept {
+    // The `noexcept` boundary, and the reason `rasteriseImpl()` is allowed to throw.
+    //
+    // The header promises a diagnostic rather than a `bad_alloc` for a hostile outline, and the
+    // size limits exist to make that promise keepable - but the accumulator alone can ask for
+    // 256 MiB at kMaxBitmapPixels, and `std::vector` reports failure by throwing. Declaring the
+    // entry point `noexcept` without catching that would turn an ordinary out-of-memory condition
+    // into `std::terminate`, taking down the baker instead of failing one glyph.
+    //
+    // `std::length_error` is caught alongside `bad_alloc` because `resize()` raises it when a
+    // request exceeds `max_size()`, which is the same condition arriving by a different name.
+    // The final `catch (...)` is defensive: nothing in the governed zone throws anything else,
+    // and if that ever stops being true this still returns rather than terminating.
+    try {
+        return rasteriseImpl(request);
+    } catch (const std::bad_alloc&) {
+        return err(RasterError::AllocationFailed);
+    } catch (const std::length_error&) {
+        return err(RasterError::AllocationFailed);
+    } catch (...) {
+        return err(RasterError::AllocationFailed);
+    }
 }
 
 }  // namespace mdux::text::raster

--- a/src/text/Raster.cpp
+++ b/src/text/Raster.cpp
@@ -1,0 +1,445 @@
+/**
+ * @file Raster.cpp
+ * @brief Implementation of the governed-zone glyph rasteriser.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * Four passes, in order:
+ *
+ *   1. `buildEdges()` walks each contour, reconstructs TrueType's implied on-curve midpoints,
+ *      scales every coordinate to fixed point, and flattens quadratic Béziers into line segments.
+ *   2. The edge list's bounding box gives the bitmap's extent and origin.
+ *   3. `rasterise()` sweeps sub-scanlines, intersecting edges and filling by nonzero winding.
+ *   4. Each accumulator is normalised to a byte.
+ *
+ * Every arithmetic step is integer. See Raster.cppm's "The determinism rule" for why that is a
+ * requirement rather than a preference; the short version is that this file's output gets
+ * committed as evidence, and an integer pipeline makes the cross-toolchain claim a property of
+ * the source instead of a property of the compile flags.
+ *
+ * `std::int64_t` appears wherever a product of two fixed-point coordinates can occur. Those
+ * casts are load-bearing: a coordinate is up to 23 bits after scaling, so a product is up to 46,
+ * which overflows `std::int32_t` silently and would do so only on large glyphs - the exact shape
+ * of bug that survives a test suite built from small ones.
+ */
+module;
+
+module mdux.text.raster;
+
+import std;
+import mdux.core.result;
+
+namespace mdux::text::raster {
+
+using mdux::core::err;
+using mdux::core::Result;
+
+namespace {
+
+/// The widest coordinate the fixed-point format holds without a product overflowing the int64
+/// intermediates below. 1 << 23 fixed-point units is 32768 pixels, far past `kMaxPixelSize`, so
+/// hitting this means the scale computation itself produced something absurd.
+constexpr std::int64_t kMaxFixedCoordinate = 1 << 23;
+
+/// Largest number of line segments one quadratic Bézier may flatten into. A curve needing more
+/// than this is either enormous or degenerate; capping keeps a hostile outline from producing an
+/// unbounded edge list, and at 64 segments the residual error is far below one subpixel for any
+/// glyph that fits `kMaxPixelSize`.
+constexpr std::int32_t kMaxCurveSegments = 64;
+
+/// Floor division for signed integers. `operator/` truncates toward zero, which rounds -3/2 to
+/// -1 and 3/2 to 1 - an asymmetry that would place a scanline crossing differently on the left
+/// and right halves of a glyph and put a visible bias into the coverage. Flooring is uniform.
+[[nodiscard]] std::int64_t floorDiv(std::int64_t numerator, std::int64_t denominator) noexcept {
+    const std::int64_t quotient  = numerator / denominator;
+    const std::int64_t remainder = numerator % denominator;
+    if (remainder != 0 && ((remainder < 0) != (denominator < 0))) {
+        return quotient - 1;
+    }
+    return quotient;
+}
+
+/// Integer square root by Newton's method. Used to pick a curve's segment count, so it has to be
+/// exactly reproducible - `std::sqrt` on a double would be correctly rounded and therefore
+/// portable in principle, but it would put a floating-point operation in the one file whose
+/// contract is that it contains none.
+[[nodiscard]] std::int64_t isqrt(std::int64_t value) noexcept {
+    if (value <= 0) {
+        return 0;
+    }
+    std::int64_t guess = value;
+    std::int64_t next  = (guess + 1) / 2;
+    while (next < guess) {
+        guess = next;
+        next  = (guess + value / guess) / 2;
+    }
+    return guess;
+}
+
+/// One flattened line segment in fixed-point pixel space. Curves are gone by this point: the
+/// scanline sweep sees only straight edges, which is what keeps its intersection arithmetic a
+/// single division rather than a root solve.
+struct Edge {
+    std::int32_t x0{0};
+    std::int32_t y0{0};
+    std::int32_t x1{0};
+    std::int32_t y1{0};
+};
+
+/// A crossing of one sub-scanline by one edge: where, and which way the edge was going. The
+/// direction is what makes the fill rule *nonzero* rather than even-odd, so a glyph whose
+/// counter runs the same way as its outer contour - which happens in real fonts - still gets a
+/// hole rather than a solid blob.
+struct Crossing {
+    std::int32_t x{0};
+    std::int32_t direction{0};
+};
+
+/// Scales a font-unit coordinate into fixed-point pixel space.
+///
+/// `(unit * pixelSize * kFixedOne) / unitsPerEm`, evaluated with the multiplications first so
+/// the single truncation happens at the end. Doing the division first - scaling to pixels and
+/// then to fixed point - would round twice and lose roughly half a subpixel per coordinate.
+[[nodiscard]] std::optional<std::int32_t> scaleToFixed(std::int32_t unit, std::uint32_t pixelSize, std::uint16_t unitsPerEm) noexcept {
+    const std::int64_t scaled = floorDiv(static_cast<std::int64_t>(unit) * static_cast<std::int64_t>(pixelSize) * kFixedOne,
+                                         static_cast<std::int64_t>(unitsPerEm));
+    if (scaled > kMaxFixedCoordinate || scaled < -kMaxFixedCoordinate) {
+        return std::nullopt;
+    }
+    return static_cast<std::int32_t>(scaled);
+}
+
+/// Chooses how many line segments a quadratic Bézier flattens into.
+///
+/// The metric is the control polygon's second difference, `|p0 - 2c + p1|` summed over both
+/// axes, which is proportional to the curve's maximum deviation from the chord. Taking its
+/// square root gives a segment count whose error falls roughly as 1/N², the standard result for
+/// uniform subdivision of a quadratic. Both operations are integer, so two toolchains cannot
+/// disagree about how many segments a given curve became - and since the segment count changes
+/// the output bytes, that agreement is part of the determinism claim, not an implementation
+/// detail underneath it.
+[[nodiscard]] std::int32_t segmentsForCurve(const std::int32_t x0, const std::int32_t y0, const std::int32_t cx, const std::int32_t cy,
+                                            const std::int32_t x1, const std::int32_t y1) noexcept {
+    const std::int64_t dx     = std::abs(static_cast<std::int64_t>(x0) - 2 * static_cast<std::int64_t>(cx) + static_cast<std::int64_t>(x1));
+    const std::int64_t dy     = std::abs(static_cast<std::int64_t>(y0) - 2 * static_cast<std::int64_t>(cy) + static_cast<std::int64_t>(y1));
+    const std::int64_t metric = dx + dy;
+    if (metric <= 0) {
+        return 1;  // the control point is on the chord: the curve is a straight line
+    }
+    // Divide by kFixedOne / 4 before the root so the count grows once the deviation passes a
+    // quarter-pixel rather than a whole one; below that the flattening error is invisible at 8
+    // bits of coverage.
+    const std::int64_t segments = 1 + isqrt(floorDiv(metric * 4, kFixedOne));
+    return static_cast<std::int32_t>(std::min<std::int64_t>(segments, kMaxCurveSegments));
+}
+
+/// Evaluates a quadratic Bézier at `t = index / count`, entirely in integers.
+///
+/// `B(t) = (1-t)²p0 + 2t(1-t)c + t²p1`, multiplied through by `count²` so every term is an
+/// integer product and the single division comes last. The int64 intermediates matter here:
+/// `count²` is up to 4096 and a coordinate up to 2²³, so the numerator reaches 2³⁵.
+[[nodiscard]] std::int32_t evaluateQuadratic(std::int32_t p0, std::int32_t control, std::int32_t p1, std::int32_t index,
+                                             std::int32_t count) noexcept {
+    const std::int64_t t  = index;
+    const std::int64_t u  = static_cast<std::int64_t>(count) - t;
+    const std::int64_t nn = static_cast<std::int64_t>(count) * count;
+    const std::int64_t numerator =
+        u * u * static_cast<std::int64_t>(p0) + 2 * t * u * static_cast<std::int64_t>(control) + t * t * static_cast<std::int64_t>(p1);
+    return static_cast<std::int32_t>(floorDiv(numerator, nn));
+}
+
+/// Walks the contours, scales, reconstructs implied on-curve points, and flattens to edges.
+///
+/// TrueType stores a contour as a ring of points, each on- or off-curve, and allows two
+/// consecutive off-curve points to imply an on-curve point at their midpoint - a shorthand that
+/// real fonts use constantly. Reconstructing those midpoints is the reason this function walks a
+/// resolved ring rather than consuming the raw points directly: getting it wrong produces an
+/// outline that is subtly the wrong shape rather than one that fails.
+[[nodiscard]] Result<std::vector<Edge>, RasterError> buildEdges(const Outline& outline, std::uint32_t pixelSize,
+                                                                std::uint16_t unitsPerEm) noexcept {
+    std::vector<Edge> edges;
+    std::size_t       contourStart = 0;
+
+    for (const std::uint16_t contourEnd : outline.contourEnds) {
+        const std::size_t end = static_cast<std::size_t>(contourEnd);
+        if (end >= outline.points.size() || end < contourStart) {
+            return err(RasterError::MalformedContours);
+        }
+        const std::size_t count = end - contourStart + 1u;
+        if (count < 2u) {
+            // A contour of one point encloses no area. Skipping rather than rejecting: real
+            // fonts do carry them, and they contribute nothing to coverage either way.
+            contourStart = end + 1u;
+            continue;
+        }
+
+        // Resolve the ring: scale every point, and insert the implied on-curve midpoint wherever
+        // two off-curve points are adjacent.
+        struct ResolvedPoint {
+            std::int32_t x{0};
+            std::int32_t y{0};
+            bool         onCurve{true};
+        };
+        std::vector<ResolvedPoint> ring;
+        ring.reserve(count * 2u);
+        for (std::size_t i = 0; i < count; ++i) {
+            const OutlinePoint& raw = outline.points[contourStart + i];
+            const auto          sx  = scaleToFixed(raw.x, pixelSize, unitsPerEm);
+            const auto          sy  = scaleToFixed(raw.y, pixelSize, unitsPerEm);
+            if (!sx || !sy) {
+                return err(RasterError::CoordinateOverflow);
+            }
+            const ResolvedPoint current{.x = *sx, .y = *sy, .onCurve = raw.onCurve};
+            if (!ring.empty() && !ring.back().onCurve && !current.onCurve) {
+                ring.push_back(ResolvedPoint{.x       = static_cast<std::int32_t>(floorDiv(static_cast<std::int64_t>(ring.back().x) + current.x, 2)),
+                                             .y       = static_cast<std::int32_t>(floorDiv(static_cast<std::int64_t>(ring.back().y) + current.y, 2)),
+                                             .onCurve = true});
+            }
+            ring.push_back(current);
+        }
+        if (ring.size() < 2u) {
+            contourStart = end + 1u;
+            continue;
+        }
+        // Close the ring, inserting a midpoint if both ends are off-curve for the same reason.
+        if (!ring.back().onCurve && !ring.front().onCurve) {
+            ring.push_back(ResolvedPoint{.x       = static_cast<std::int32_t>(floorDiv(static_cast<std::int64_t>(ring.back().x) + ring.front().x, 2)),
+                                         .y       = static_cast<std::int32_t>(floorDiv(static_cast<std::int64_t>(ring.back().y) + ring.front().y, 2)),
+                                         .onCurve = true});
+        }
+
+        // A contour may begin on an off-curve point. Rotating the ring so it starts on-curve
+        // means the walk below always has a defined segment start; the alternative, synthesising
+        // a start point, changes the outline.
+        std::size_t startIndex = ring.size();
+        for (std::size_t i = 0; i < ring.size(); ++i) {
+            if (ring[i].onCurve) {
+                startIndex = i;
+                break;
+            }
+        }
+        if (startIndex == ring.size()) {
+            // Every point is off-curve. The implied-midpoint insertion above guarantees this
+            // cannot happen for a contour of two or more points, so reaching here means the ring
+            // is degenerate rather than merely unusual.
+            contourStart = end + 1u;
+            continue;
+        }
+
+        const auto at = [&ring, startIndex](std::size_t i) noexcept -> const ResolvedPoint& {
+            return ring[(startIndex + i) % ring.size()];
+        };
+
+        std::int32_t penX = at(0).x;
+        std::int32_t penY = at(0).y;
+        const auto   emit = [&edges](std::int32_t ax, std::int32_t ay, std::int32_t bx, std::int32_t by) {
+            if (ay != by) {  // horizontal edges cross no sub-scanline and only add work
+                edges.push_back(Edge{.x0 = ax, .y0 = ay, .x1 = bx, .y1 = by});
+            }
+        };
+
+        for (std::size_t i = 1; i <= ring.size(); ++i) {
+            const ResolvedPoint& point = at(i % ring.size());
+            if (point.onCurve) {
+                emit(penX, penY, point.x, point.y);
+                penX = point.x;
+                penY = point.y;
+                continue;
+            }
+            // Off-curve: the segment is a quadratic ending at the next on-curve point, which is
+            // either the next ring entry or the implied midpoint the resolution pass inserted.
+            const ResolvedPoint& next  = at((i + 1u) % ring.size());
+            const std::int32_t   endX  = next.x;
+            const std::int32_t   endY  = next.y;
+            const std::int32_t   count2 = segmentsForCurve(penX, penY, point.x, point.y, endX, endY);
+            for (std::int32_t step = 1; step <= count2; ++step) {
+                const std::int32_t nx = evaluateQuadratic(penX, point.x, endX, step, count2);
+                const std::int32_t ny = evaluateQuadratic(penY, point.y, endY, step, count2);
+                emit(penX, penY, nx, ny);
+                penX = nx;
+                penY = ny;
+            }
+            ++i;  // the on-curve endpoint was consumed as this curve's terminus
+        }
+
+        contourStart = end + 1u;
+    }
+
+    return edges;
+}
+
+}  // namespace
+
+std::string_view describe(RasterError error) noexcept {
+    switch (error) {
+        case RasterError::EmptyOutline:
+            return "the outline has no contours, or none that enclose area";
+        case RasterError::MalformedContours:
+            return "contour end indices are not increasing, or point past the end of the point list";
+        case RasterError::UnsupportedUnitsPerEm:
+            return "unitsPerEm is zero; the font-unit-to-pixel scale would be undefined";
+        case RasterError::UnsupportedPixelSize:
+            return "pixelSize is zero or exceeds the supported maximum";
+        case RasterError::BitmapTooLarge:
+            return "the scaled outline's bounding box exceeds the supported bitmap area";
+        case RasterError::CoordinateOverflow:
+            return "a scaled coordinate left the range the fixed-point format represents";
+    }
+    return "unknown rasteriser error";
+}
+
+Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noexcept {
+    if (request.unitsPerEm == 0) {
+        return err(RasterError::UnsupportedUnitsPerEm);
+    }
+    if (request.pixelSize == 0 || request.pixelSize > kMaxPixelSize) {
+        return err(RasterError::UnsupportedPixelSize);
+    }
+    if (request.outline.contourEnds.empty() || request.outline.points.empty()) {
+        return err(RasterError::EmptyOutline);
+    }
+    // Strictly increasing end indices, checked before any scaling so a malformed outline costs
+    // nothing. `buildEdges()` re-checks the bound against the point count; this is the ordering
+    // half, which it cannot see one contour at a time.
+    std::optional<std::uint16_t> previousEnd;
+    for (const std::uint16_t contourEnd : request.outline.contourEnds) {
+        if (previousEnd.has_value() && contourEnd <= *previousEnd) {
+            return err(RasterError::MalformedContours);
+        }
+        previousEnd = contourEnd;
+    }
+
+    auto edges = buildEdges(request.outline, request.pixelSize, request.unitsPerEm);
+    if (!edges.has_value()) {
+        return err(edges.error());
+    }
+    if (edges->empty()) {
+        // Every contour was degenerate or horizontal: a real outline with no enclosed area, such
+        // as a space. An empty bitmap, not a 1x1 of zeros - see CoverageBitmap's contract.
+        return CoverageBitmap{};
+    }
+
+    // Bounding box in fixed point, then in whole pixels. The box is expanded outward to pixel
+    // boundaries, so a partially covered edge pixel is inside the bitmap rather than clipped.
+    std::int32_t minX = std::numeric_limits<std::int32_t>::max();
+    std::int32_t minY = std::numeric_limits<std::int32_t>::max();
+    std::int32_t maxX = std::numeric_limits<std::int32_t>::min();
+    std::int32_t maxY = std::numeric_limits<std::int32_t>::min();
+    for (const Edge& edge : *edges) {
+        minX = std::min({minX, edge.x0, edge.x1});
+        minY = std::min({minY, edge.y0, edge.y1});
+        maxX = std::max({maxX, edge.x0, edge.x1});
+        maxY = std::max({maxY, edge.y0, edge.y1});
+    }
+
+    const std::int64_t pixelMinX = floorDiv(minX, kFixedOne);
+    const std::int64_t pixelMinY = floorDiv(minY, kFixedOne);
+    const std::int64_t pixelMaxX = floorDiv(maxX + kFixedOne - 1, kFixedOne);
+    const std::int64_t pixelMaxY = floorDiv(maxY + kFixedOne - 1, kFixedOne);
+
+    const std::int64_t width  = pixelMaxX - pixelMinX;
+    const std::int64_t height = pixelMaxY - pixelMinY;
+    if (width <= 0 || height <= 0) {
+        return CoverageBitmap{};
+    }
+    if (static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height) > kMaxBitmapPixels) {
+        return err(RasterError::BitmapTooLarge);
+    }
+
+    // Accumulators, one per pixel, in subpixel-width units. `kAccumulatorMax` is the ceiling by
+    // construction: each sub-scanline contributes at most kFixedOne to any one pixel, because
+    // the span added is intersected with that pixel's own column first.
+    std::vector<std::int32_t> accumulator(static_cast<std::size_t>(width) * static_cast<std::size_t>(height), 0);
+
+    std::vector<Crossing> crossings;
+    crossings.reserve(edges->size());
+
+    for (std::int64_t row = 0; row < height; ++row) {
+        for (std::int32_t sub = 0; sub < kSubScanlines; ++sub) {
+            // The sub-scanline's y, sampled at the centre of its band. kSubScanlines is a power
+            // of two and divides 2 * kFixedOne exactly, so this is an integer with no rounding.
+            const std::int64_t sampleY =
+                (pixelMinY + row) * kFixedOne + (2 * static_cast<std::int64_t>(sub) + 1) * kFixedOne / (2 * kSubScanlines);
+
+            crossings.clear();
+            for (const Edge& edge : *edges) {
+                const std::int32_t topY    = std::min(edge.y0, edge.y1);
+                const std::int32_t bottomY = std::max(edge.y0, edge.y1);
+                // Half-open in y: an edge covers [top, bottom). Without this, a vertex shared by
+                // two edges would be counted twice on the scanline that passes exactly through
+                // it, flipping the winding and punching a hole in the fill.
+                if (sampleY < topY || sampleY >= bottomY) {
+                    continue;
+                }
+                const std::int64_t dy = static_cast<std::int64_t>(edge.y1) - edge.y0;
+                const std::int64_t dx = static_cast<std::int64_t>(edge.x1) - edge.x0;
+                const std::int64_t x  = static_cast<std::int64_t>(edge.x0) + floorDiv(dx * (sampleY - edge.y0), dy);
+                crossings.push_back(Crossing{.x = static_cast<std::int32_t>(x), .direction = dy > 0 ? 1 : -1});
+            }
+            if (crossings.size() < 2u) {
+                continue;
+            }
+
+            // Sorting on the pair, not just x, so the order is a total one: two crossings at the
+            // same x with different directions must land in a fixed sequence or the sweep below
+            // could differ between standard-library implementations, and this file's whole claim
+            // is that it cannot.
+            std::sort(crossings.begin(), crossings.end(), [](const Crossing& a, const Crossing& b) noexcept {
+                return a.x != b.x ? a.x < b.x : a.direction < b.direction;
+            });
+
+            std::int32_t winding  = 0;
+            std::int32_t spanFrom = 0;
+            for (const Crossing& crossing : crossings) {
+                const std::int32_t previous = winding;
+                winding += crossing.direction;
+                if (previous == 0 && winding != 0) {
+                    spanFrom = crossing.x;
+                    continue;
+                }
+                if (previous != 0 && winding == 0) {
+                    // Clip to the bitmap, then add each pixel's exact overlap with the span.
+                    const std::int64_t left  = std::max<std::int64_t>(spanFrom, pixelMinX * kFixedOne);
+                    const std::int64_t right = std::min<std::int64_t>(crossing.x, pixelMaxX * kFixedOne);
+                    if (right <= left) {
+                        continue;
+                    }
+                    const std::int64_t firstPixel = floorDiv(left, kFixedOne) - pixelMinX;
+                    const std::int64_t lastPixel  = floorDiv(right - 1, kFixedOne) - pixelMinX;
+                    for (std::int64_t px = firstPixel; px <= lastPixel; ++px) {
+                        const std::int64_t pixelLeft  = (pixelMinX + px) * kFixedOne;
+                        const std::int64_t pixelRight = pixelLeft + kFixedOne;
+                        const std::int64_t covered    = std::min(right, pixelRight) - std::max(left, pixelLeft);
+                        accumulator[static_cast<std::size_t>(row * width + px)] += static_cast<std::int32_t>(covered);
+                    }
+                }
+            }
+        }
+    }
+
+    CoverageBitmap bitmap;
+    bitmap.width   = static_cast<std::uint32_t>(width);
+    bitmap.height  = static_cast<std::uint32_t>(height);
+    bitmap.originX = static_cast<std::int32_t>(pixelMinX);
+    // Font space is y-up and the bitmap is top-row-first, so the top edge of the box is the one
+    // furthest above the baseline. `originY` is that distance, positive for a glyph that rises.
+    bitmap.originY = static_cast<std::int32_t>(pixelMaxY);
+    bitmap.coverage.resize(accumulator.size());
+    for (std::size_t i = 0; i < accumulator.size(); ++i) {
+        // Row flip: accumulator row 0 is the bottom of the box in font space, bitmap row 0 is
+        // the top.
+        const std::size_t row    = i / static_cast<std::size_t>(width);
+        const std::size_t column = i % static_cast<std::size_t>(width);
+        const std::size_t target = (static_cast<std::size_t>(height) - 1u - row) * static_cast<std::size_t>(width) + column;
+        // No clamp, deliberately: `accumulator[i]` is bounded by kAccumulatorMax by construction,
+        // so this is in [0, 255] already. See Raster.cppm on why a clamp here would be a bug
+        // rather than a safety net.
+        bitmap.coverage[target] = static_cast<std::uint8_t>(accumulator[i] * 255 / kAccumulatorMax);
+    }
+    return bitmap;
+}
+
+}  // namespace mdux::text::raster

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -553,6 +553,7 @@ mdux_discover_tests(ml_spec)
 add_executable(text_spec
     text/TextSpecMain.cpp
     text/SchemaTests.cpp
+    text/RasterTests.cpp
 )
 
 target_link_libraries(text_spec PRIVATE MduX::Core speclab::speclab)

--- a/tests/text/RasterTests.cpp
+++ b/tests/text/RasterTests.cpp
@@ -282,48 +282,68 @@ const mdux::spec::Register triangleCornerIsPartial{
             .Execute();
     }};
 
-const mdux::spec::Register quadraticCurveIsFlattenedAndFilled{
-    "A quadratic curve is flattened and filled, including TrueType's implied midpoints",
+const mdux::spec::Register quadraticCurveApexIsExact{
+    "A quadratic curve reaches exactly its computed apex, and implied midpoints do too",
     "evidence-unit",
     [] {
-        // A contour of on-curve corners plus a single off-curve control point bulging outward,
-        // and a second whose two adjacent off-curve points exercise the implied-midpoint
-        // reconstruction. Both must produce a filled shape whose bulge extends past the chord.
+        // The regression test for the subdivision bug found in review: `buildEdges()` used to
+        // advance the pen before evaluating the next sample, so from step 2 onward the evaluator
+        // received the previous *sample* as the curve start rather than the curve's own. The
+        // endpoints still landed correctly - the final sample's `u` term is zero - so only an
+        // assertion about the middle of a curve can see it. Measured deviation on a 5-segment
+        // curve was 266 fixed units, just over one pixel.
+        //
+        // The apex here is derivable. For a quadratic, B(1/2) = (p0 + 2c + p1) / 4; with
+        // p0.x = 1024, c.x = 2048 and p1.x = 1024 that is 1536 font units, which at 8 px/em over
+        // a 2048 em is exactly 6.0 pixels. So a correct rasteriser produces a bitmap exactly 6
+        // pixels wide. The buggy one pushed the curve outward and produced 7.
+        //
+        // The curve needs 6 segments at this size, so it is well past the >= 3 threshold where
+        // the defect appears at all.
         struct State {
-            Built              built;
-            rr::CoverageBitmap bitmap;
+            Built              single;
             Built              implied;
+            rr::CoverageBitmap singleBitmap;
             rr::CoverageBitmap impliedBitmap;
         };
         auto state = std::make_shared<State>();
 
-        return speclab::Test("text-raster-quadratic-curve")
+        return speclab::Test("text-raster-quadratic-apex")
             .Given("a box whose right side bulges out on one quadratic, and one built from two adjacent off-curve points",
                    [state] {
-                       state->built = contours({std::vector<rr::OutlinePoint>{
+                       state->single = contours({std::vector<rr::OutlinePoint>{
                            {0, 0, true}, {1024, 0, true}, {2048, 1024, false}, {1024, 2048, true}, {0, 2048, true}}});
                        state->implied = contours({std::vector<rr::OutlinePoint>{
                            {0, 0, true}, {1024, 0, true}, {2048, 512, false}, {2048, 1536, false}, {1024, 2048, true}, {0, 2048, true}}});
                    })
             .When("both are rasterised at 8 pixels per em",
                   [state] {
-                      state->bitmap        = mustRasterise(requestFor(state->built, 8), "a bulging box");
+                      state->singleBitmap  = mustRasterise(requestFor(state->single, 8), "a bulging box");
                       state->impliedBitmap = mustRasterise(requestFor(state->implied, 8), "an implied-midpoint box");
                   })
-            .Then("both fill, and both extend past the chord the control point pulls away from",
+            .Then("the single-control curve stops exactly at its apex, and the implied one fills too",
                   [state] {
                       mdux::spec::Checks checks;
-                      for (const auto& [name, b] : {std::pair{"single control", std::cref(state->bitmap)},
-                                                    std::pair{"implied midpoint", std::cref(state->impliedBitmap)}}) {
-                          const auto& bitmap = b.get();
-                          checks.expect(bitmap.width >= 7 && bitmap.height >= 7,
-                                        std::format("{}: the curve reaches past the 4-pixel chord{}", name, render(bitmap)));
-                          checks.expect(at(bitmap, 1, 4) == 255, std::format("{}: the interior is filled{}", name, render(bitmap)));
-                          bool anyPartial = false;
-                          for (std::uint8_t value : bitmap.coverage) {
-                              anyPartial = anyPartial || (value > 0 && value < 255);
-                          }
-                          checks.expect(anyPartial, std::format("{}: the curve produces antialiased edges{}", name, render(bitmap)));
+                      const auto&        single = state->singleBitmap;
+                      // The derived assertion. 7 here means the subdivision regressed.
+                      checks.expect(single.width == 6 && single.height == 8,
+                                    std::format("apex at exactly 6 px wide, 8 tall{}", render(single)));
+                      if (single.width == 6 && single.height == 8) {
+                          // Guarded: expect() is non-fatal, so indexing outside this branch would
+                          // read past `coverage` and bury the geometry failure under a crash.
+                          checks.expect(at(single, 0, 4) == 255, std::format("the interior is filled{}", render(single)));
+                          checks.expect(at(single, 5, 0) < 255 && at(single, 5, 4) > 0,
+                                        std::format("the curved edge is antialiased{}", render(single)));
+                      }
+
+                      const auto& implied = state->impliedBitmap;
+                      checks.expect(implied.width >= 6 && implied.height == 8,
+                                    std::format("the implied-midpoint curve fills a comparable box{}", render(implied)));
+                      if (implied.width >= 6 && implied.height == 8) {
+                          checks.expect(at(implied, 0, 4) == 255, std::format("its interior is filled{}", render(implied)));
+                          const bool anyPartial =
+                              std::ranges::any_of(implied.coverage, [](std::uint8_t v) { return v > 0 && v < 255; });
+                          checks.expect(anyPartial, std::format("its edges are antialiased{}", render(implied)));
                       }
                       checks.raise();
                   })
@@ -477,13 +497,69 @@ const mdux::spec::Register rasterRejections{
             .Execute();
     }};
 
+const mdux::spec::Register sweepWorkBoundIsEnforced{
+    "An outline whose sweep cost explodes is refused before the sweep, not merely before allocation",
+    "evidence-unit",
+    [] {
+        // The denial-of-service path found in review. The bitmap-area limit does not bound the
+        // sweep: `contourEnds` holds uint16 indices so an outline can carry ~65k points, each
+        // off-curve one flattening into up to kMaxCurveSegments edges, while a tall narrow glyph
+        // reaches a large height far under kMaxBitmapPixels. The old sweep was
+        // height * kSubScanlines * edgeCount and would have run for hours on the fixture below.
+        //
+        // The shape is a comb: full-height vertical strokes, each spanning every row. At 4096
+        // px/em over a 2048 em the glyph is 4096 pixels tall, so ~1200 strokes is ~4.9M edge-row
+        // visits against a kMaxSweepWork budget of 4194304 - over the line, while the bitmap
+        // itself is a harmless 4096 x ~1200 pixels, well inside kMaxBitmapPixels.
+        struct State {
+            Built built;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-sweep-work-bound")
+            .Given("a comb of ~1200 full-height strokes at the maximum pixel size",
+                   [state] {
+                       std::vector<rr::OutlinePoint> points;
+                       points.reserve(2400);
+                       for (std::int32_t i = 0; i < 1200; ++i) {
+                           points.push_back({i, 0, true});
+                           points.push_back({i, 2048, true});
+                       }
+                       state->built = contours({points});
+                   })
+            .When("nothing", [] {})
+            .Then("it is refused with OutlineTooComplex, and a normal glyph at the same size still works",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      auto              result = rr::rasterise(requestFor(state->built, rr::kMaxPixelSize));
+                      checks.expect(!result.has_value(), "the comb is refused");
+                      if (!result.has_value()) {
+                          checks.expect(result.error() == RasterError::OutlineTooComplex,
+                                        std::format("got '{}', expected '{}'", rr::describe(result.error()),
+                                                    rr::describe(RasterError::OutlineTooComplex)));
+                      }
+                      // The bound must not reject ordinary work. A plain square at the same
+                      // maximum pixel size is 4096x4096 - the largest legitimate request there is
+                      // - and has to keep rasterising.
+                      const Built square = contours({box(0, 0, 2048, 2048)});
+                      auto        ok     = rr::rasterise(requestFor(square, rr::kMaxPixelSize));
+                      checks.expect(ok.has_value(), "a full-size square is still accepted");
+                      if (ok.has_value()) {
+                          checks.expect(ok->width == 4096 && ok->height == 4096,
+                                        std::format("4096x4096, got {}x{}", ok->width, ok->height));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 // ---------------------------------------------------------------------------
 // Cross-toolchain determinism.
 // ---------------------------------------------------------------------------
 
 /// The digest the reference glyph must produce. See the scenario body for why this is never
 /// updated to match new output.
-constexpr std::string_view kFrozenDigest = "c4313aa620fa990603c20fd110cdc16e0113632f61f2d01e6973b113e411714d";
+constexpr std::string_view kFrozenDigest = "1b998a7518a981f22d0a917dad7a478cd3ff1ee242619f8d315db4f365081b24";
 
 /// Deliberately coprime with the em, so no coordinate lands on a pixel boundary by accident.
 constexpr std::uint32_t kDeterminismPixelSize = 37;
@@ -553,8 +629,8 @@ const mdux::spec::Register rasterDeterminism{
                       // Geometry is asserted alongside the digest so a failure says which of the
                       // two moved: a size change is a different bug from a coverage change, and
                       // the digest alone cannot tell them apart.
-                      checks.expect(state->bitmap.width == 30 && state->bitmap.height == 32,
-                                    std::format("bitmap is 30x32, got {}x{}", state->bitmap.width, state->bitmap.height));
+                      checks.expect(state->bitmap.width == 29 && state->bitmap.height == 32,
+                                    std::format("bitmap is 29x32, got {}x{}", state->bitmap.width, state->bitmap.height));
                       checks.expect(actual == kFrozenDigest,
                                     std::format("coverage digest\n  expected {}\n  actual   {}", kFrozenDigest, actual));
                       checks.raise();

--- a/tests/text/RasterTests.cpp
+++ b/tests/text/RasterTests.cpp
@@ -1,0 +1,563 @@
+/**
+ * @file RasterTests.cpp
+ * @brief BDD scenarios for the governed-zone glyph rasteriser (issue #159).
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * The outlines here are built in code rather than loaded from a font, for the reason
+ * `TruetypeTests.cpp` gives: a fixture whose intended defect a reviewer has to take on trust is
+ * a worse fixture. They are also chosen so their *expected coverage is derivable by hand* rather
+ * than recorded from a run - a square aligned to pixel boundaries must be solid 255, a square
+ * covering exactly half of each edge pixel must be 127, and a counter-rotating inner contour
+ * must leave a hole. A test that only asserts "the same as last time" cannot distinguish correct
+ * output from consistently wrong output, and the frozen-digest scenario at the bottom is exactly
+ * that kind of test - which is why it sits alongside these rather than replacing them.
+ *
+ * Coordinates below use unitsPerEm 2048 and pixel sizes that divide it, so font units map to
+ * pixels exactly and the arithmetic in an assertion is visible rather than approximate.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.text.raster;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace rr = mdux::text::raster;
+using rr::RasterError;
+
+constexpr std::uint16_t kUpem = 2048;
+
+/// One closed contour of on-curve points, in font units.
+[[nodiscard]] std::vector<rr::OutlinePoint> box(std::int32_t x0, std::int32_t y0, std::int32_t x1, std::int32_t y1, bool clockwise = false) {
+    if (clockwise) {
+        return {{x0, y0, true}, {x0, y1, true}, {x1, y1, true}, {x1, y0, true}};
+    }
+    return {{x0, y0, true}, {x1, y0, true}, {x1, y1, true}, {x0, y1, true}};
+}
+
+struct Built {
+    std::vector<rr::OutlinePoint>  points;
+    std::vector<std::uint16_t>     ends;
+};
+
+/// Concatenates contours and derives the end-index list, so a scenario names shapes rather than
+/// bookkeeping.
+[[nodiscard]] Built contours(std::initializer_list<std::vector<rr::OutlinePoint>> shapes) {
+    Built built;
+    for (const auto& shape : shapes) {
+        built.points.insert(built.points.end(), shape.begin(), shape.end());
+        built.ends.push_back(static_cast<std::uint16_t>(built.points.size() - 1u));
+    }
+    return built;
+}
+
+[[nodiscard]] rr::RasterRequest requestFor(const Built& built, std::uint32_t pixelSize) {
+    return rr::RasterRequest{.outline    = rr::Outline{.points = built.points, .contourEnds = built.ends},
+                             .unitsPerEm = kUpem,
+                             .pixelSize  = pixelSize};
+}
+
+[[nodiscard]] std::uint8_t at(const rr::CoverageBitmap& bitmap, std::uint32_t x, std::uint32_t y) {
+    return bitmap.coverage[static_cast<std::size_t>(y) * bitmap.width + x];
+}
+
+/// Renders a bitmap as text, so a failure message shows the shape rather than an index.
+[[nodiscard]] std::string render(const rr::CoverageBitmap& bitmap) {
+    std::string out = std::format("\n{}x{} origin=({},{})\n", bitmap.width, bitmap.height, bitmap.originX, bitmap.originY);
+    for (std::uint32_t y = 0; y < bitmap.height; ++y) {
+        for (std::uint32_t x = 0; x < bitmap.width; ++x) {
+            out += std::format("{:4}", static_cast<int>(at(bitmap, x, y)));
+        }
+        out += '\n';
+    }
+    return out;
+}
+
+[[nodiscard]] rr::CoverageBitmap mustRasterise(const rr::RasterRequest& request, std::string_view what) {
+    auto result = rr::rasterise(request);
+    if (!result.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("{} was rejected: {}", what, rr::describe(result.error())),
+                                              std::source_location::current());
+    }
+    return std::move(*result);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Coverage the assertion can derive rather than record.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register solidSquareIsFullyCovered{
+    "A pixel-aligned square rasterises to solid 255, reaching full coverage without a clamp",
+    "evidence-unit",
+    [] {
+        // 2048 font units at upem 2048 and pixelSize 4 is exactly 4 pixels, so every pixel of the
+        // result is entirely inside the contour. This is the scenario that proves 255 is
+        // *reachable*: if the normalisation divided by anything larger than the true accumulator
+        // ceiling, full coverage would read 254 and nothing else here would notice.
+        struct State {
+            Built                  built;
+            rr::CoverageBitmap     bitmap;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-solid-square")
+            .Given("a square covering exactly 4x4 pixels", [state] { state->built = contours({box(0, 0, 2048, 2048)}); })
+            .When("it is rasterised", [state] { state->bitmap = mustRasterise(requestFor(state->built, 4), "a 4x4 square"); })
+            .Then("every pixel is 255 and the bitmap is 4x4",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        b = state->bitmap;
+                      checks.expect(b.width == 4 && b.height == 4, std::format("4x4 bitmap{}", render(b)));
+                      if (b.width == 4 && b.height == 4) {
+                          bool allFull = true;
+                          for (std::uint8_t value : b.coverage) {
+                              allFull = allFull && (value == 255);
+                          }
+                          checks.expect(allFull, std::format("every pixel fully covered{}", render(b)));
+                      }
+                      checks.expect(b.originX == 0, "left edge at the glyph origin");
+                      checks.expect(b.originY == 4, "top edge 4 pixels above the baseline");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register halfCoveredColumnIsHalfValue{
+    "A square ending mid-pixel yields half coverage in the partial column",
+    "evidence-unit",
+    [] {
+        // At 2 pixels per em, one pixel is half an em, so 1536 font units is 1.5 pixels wide and
+        // 1024 is 1 pixel tall. Column 0 is fully inside; column 1 is covered for exactly half
+        // its width. Half of the 4096 accumulator ceiling is 2048, and 2048 * 255 / 4096 == 127
+        // by integer division - derived, not recorded.
+        struct State {
+            Built              built;
+            rr::CoverageBitmap bitmap;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-half-covered-column")
+            .Given("a rectangle 1.5 pixels wide and 1 pixel tall",
+                   [state] { state->built = contours({box(0, 0, 1536, 1024)}); })
+            .When("it is rasterised at 2 pixels per em",
+                  [state] { state->bitmap = mustRasterise(requestFor(state->built, 2), "a 1.5x1 rectangle"); })
+            .Then("column 0 is 255 and column 1 is 127",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        b = state->bitmap;
+                      checks.expect(b.width == 2 && b.height == 1, std::format("2x1 bitmap{}", render(b)));
+                      if (b.width == 2 && b.height == 1) {
+                          checks.expect(at(b, 0, 0) == 255, std::format("full column is 255{}", render(b)));
+                          checks.expect(at(b, 1, 0) == 127, std::format("half column is 127{}", render(b)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register counterContourLeavesHole{
+    "A counter-rotating inner contour is subtracted by the nonzero winding rule",
+    "evidence-unit",
+    [] {
+        // Two nested squares wound in opposite directions. Under nonzero winding the inner one
+        // cancels the outer and leaves a hole; under even-odd it would too, so the discriminating
+        // half of this scenario is its sibling below, where both wind the same way.
+        struct State {
+            Built              built;
+            rr::CoverageBitmap bitmap;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-counter-contour-hole")
+            .Given("a 4x4 square with a counter-wound 2x2 square inside it",
+                   [state] {
+                       state->built = contours({box(0, 0, 2048, 2048), box(512, 512, 1536, 1536, /*clockwise=*/true)});
+                   })
+            .When("it is rasterised at 4 pixels per em",
+                  [state] { state->bitmap = mustRasterise(requestFor(state->built, 4), "a square with a counter"); })
+            .Then("the middle is empty and the border is solid",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        b = state->bitmap;
+                      checks.expect(b.width == 4 && b.height == 4, std::format("4x4 bitmap{}", render(b)));
+                      if (b.width == 4 && b.height == 4) {
+                          checks.expect(at(b, 1, 1) == 0 && at(b, 2, 1) == 0 && at(b, 1, 2) == 0 && at(b, 2, 2) == 0,
+                                        std::format("the 2x2 centre is a hole{}", render(b)));
+                          checks.expect(at(b, 0, 0) == 255 && at(b, 3, 3) == 255,
+                                        std::format("the border stays solid{}", render(b)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register sameWoundContourFillsSolid{
+    "A same-wound inner contour does not make a hole, which is what makes the rule nonzero",
+    "evidence-unit",
+    [] {
+        // The same geometry as above with the inner square wound the *same* way. Even-odd would
+        // still punch a hole here; nonzero must not. Real fonts rely on this - an 'o' works only
+        // because its counter is wound against the bowl, and a glyph whose contours happen to
+        // agree must stay solid.
+        struct State {
+            Built              built;
+            rr::CoverageBitmap bitmap;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-same-wound-solid")
+            .Given("a 4x4 square with a same-wound 2x2 square inside it",
+                   [state] { state->built = contours({box(0, 0, 2048, 2048), box(512, 512, 1536, 1536)}); })
+            .When("it is rasterised at 4 pixels per em",
+                  [state] { state->bitmap = mustRasterise(requestFor(state->built, 4), "two same-wound squares"); })
+            .Then("the result is solid, with no hole in the middle",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        b = state->bitmap;
+                      if (b.width == 4 && b.height == 4) {
+                          checks.expect(at(b, 1, 1) == 255 && at(b, 2, 2) == 255,
+                                        std::format("the centre stays filled{}", render(b)));
+                      } else {
+                          checks.expect(false, std::format("4x4 bitmap{}", render(b)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register triangleCornerIsPartial{
+    "A diagonal edge produces partial coverage that increases along the wedge",
+    "evidence-unit",
+    [] {
+        // A right triangle over 4x4 pixels, with the right angle at the origin and the hypotenuse
+        // running from (4,0) to (0,4) in pixel space. That line bisects every pixel it crosses,
+        // so each diagonal pixel is covered exactly half and reads 2048 * 255 / 4096 == 127 -
+        // derivable, so this asserts the value rather than merely that it is "somewhere between".
+        struct State {
+            Built              built;
+            rr::CoverageBitmap bitmap;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-triangle-corner")
+            .Given("a right triangle filling the lower-left half of a 4x4 box",
+                   [state] {
+                       state->built = contours({std::vector<rr::OutlinePoint>{{0, 0, true}, {2048, 0, true}, {0, 2048, true}}});
+                   })
+            .When("it is rasterised at 4 pixels per em",
+                  [state] { state->bitmap = mustRasterise(requestFor(state->built, 4), "a triangle"); })
+            .Then("the right-angle corner is solid, the opposite corner empty, the diagonal partial",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        b = state->bitmap;
+                      checks.expect(b.width == 4 && b.height == 4, std::format("4x4 bitmap{}", render(b)));
+                      if (b.width == 4 && b.height == 4) {
+                          // Bitmap row 3 is the bottom of the glyph, row 0 the top.
+                          checks.expect(at(b, 0, 3) == 255, std::format("the right-angle corner is solid{}", render(b)));
+                          checks.expect(at(b, 3, 0) == 0, std::format("the far corner is empty{}", render(b)));
+                          // Every pixel the hypotenuse crosses, halved.
+                          for (std::uint32_t i = 0; i < 4; ++i) {
+                              checks.expect(at(b, i, i) == 127,
+                                            std::format("diagonal pixel ({0},{0}) is 127, got {1}{2}", i,
+                                                        static_cast<int>(at(b, i, i)), render(b)));
+                          }
+                          // And the halves either side of it: below-left solid, above-right empty.
+                          checks.expect(at(b, 0, 1) == 255 && at(b, 1, 2) == 255,
+                                        std::format("below the diagonal is solid{}", render(b)));
+                          checks.expect(at(b, 2, 1) == 0 && at(b, 3, 2) == 0,
+                                        std::format("above the diagonal is empty{}", render(b)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register quadraticCurveIsFlattenedAndFilled{
+    "A quadratic curve is flattened and filled, including TrueType's implied midpoints",
+    "evidence-unit",
+    [] {
+        // A contour of on-curve corners plus a single off-curve control point bulging outward,
+        // and a second whose two adjacent off-curve points exercise the implied-midpoint
+        // reconstruction. Both must produce a filled shape whose bulge extends past the chord.
+        struct State {
+            Built              built;
+            rr::CoverageBitmap bitmap;
+            Built              implied;
+            rr::CoverageBitmap impliedBitmap;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-quadratic-curve")
+            .Given("a box whose right side bulges out on one quadratic, and one built from two adjacent off-curve points",
+                   [state] {
+                       state->built = contours({std::vector<rr::OutlinePoint>{
+                           {0, 0, true}, {1024, 0, true}, {2048, 1024, false}, {1024, 2048, true}, {0, 2048, true}}});
+                       state->implied = contours({std::vector<rr::OutlinePoint>{
+                           {0, 0, true}, {1024, 0, true}, {2048, 512, false}, {2048, 1536, false}, {1024, 2048, true}, {0, 2048, true}}});
+                   })
+            .When("both are rasterised at 8 pixels per em",
+                  [state] {
+                      state->bitmap        = mustRasterise(requestFor(state->built, 8), "a bulging box");
+                      state->impliedBitmap = mustRasterise(requestFor(state->implied, 8), "an implied-midpoint box");
+                  })
+            .Then("both fill, and both extend past the chord the control point pulls away from",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      for (const auto& [name, b] : {std::pair{"single control", std::cref(state->bitmap)},
+                                                    std::pair{"implied midpoint", std::cref(state->impliedBitmap)}}) {
+                          const auto& bitmap = b.get();
+                          checks.expect(bitmap.width >= 7 && bitmap.height >= 7,
+                                        std::format("{}: the curve reaches past the 4-pixel chord{}", name, render(bitmap)));
+                          checks.expect(at(bitmap, 1, 4) == 255, std::format("{}: the interior is filled{}", name, render(bitmap)));
+                          bool anyPartial = false;
+                          for (std::uint8_t value : bitmap.coverage) {
+                              anyPartial = anyPartial || (value > 0 && value < 255);
+                          }
+                          checks.expect(anyPartial, std::format("{}: the curve produces antialiased edges{}", name, render(bitmap)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register blankOutlineYieldsEmptyBitmap{
+    "An outline that encloses no area yields an empty bitmap rather than a 1x1 of zeros",
+    "evidence-unit",
+    [] {
+        // The space character's shape, once S4 feeds a real font through: a contour exists but is
+        // degenerate. An atlas packer must be able to tell "nothing to pack" from "one blank
+        // pixel to pack", so the distinction is part of the contract rather than a detail.
+        struct State {
+            Built              built;
+            rr::CoverageBitmap bitmap;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-blank-outline")
+            .Given("a contour whose points are collinear along a horizontal line",
+                   [state] {
+                       state->built = contours({std::vector<rr::OutlinePoint>{{0, 0, true}, {1024, 0, true}, {2048, 0, true}}});
+                   })
+            .When("it is rasterised", [state] { state->bitmap = mustRasterise(requestFor(state->built, 8), "a collinear contour"); })
+            .Then("the bitmap is empty",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      checks.expect(state->bitmap.width == 0 && state->bitmap.height == 0, "zero extent");
+                      checks.expect(state->bitmap.coverage.empty(), "no coverage bytes");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register coverageStaysInRangeAcrossSizes{
+    "Coverage spans the full byte range across pixel sizes, and 255 is never reached by saturation",
+    "evidence-unit",
+    [] {
+        // Issue #159 asks for coverage in [0,255] "with no clamping surprises". A uint8 is
+        // trivially in range, so asserting that would assert nothing. What is worth asserting is
+        // the property the implementation claims: the accumulator ceiling is exact, so full
+        // coverage lands on 255 at every size, and a shape with an unaligned edge produces
+        // intermediate values rather than a two-level image.
+        return speclab::Test("text-raster-coverage-range")
+            .Given("nothing", [] {})
+            .When("nothing", [] {})
+            .Then("every pixel size produces a solid 255 interior and some partial edge",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const Built        solid   = contours({box(0, 0, 2048, 2048)});
+                      const Built        skewed  = contours({std::vector<rr::OutlinePoint>{
+                          {100, 100, true}, {1900, 300, true}, {1700, 1900, true}, {200, 1500, true}}});
+                      for (const std::uint32_t pixelSize : {1u, 2u, 3u, 5u, 8u, 13u, 32u, 64u}) {
+                          auto full = rr::rasterise(requestFor(solid, pixelSize));
+                          checks.expect(full.has_value(), std::format("size {}: the solid square rasterises", pixelSize));
+                          if (full.has_value() && !full->coverage.empty()) {
+                              const auto maxValue = *std::ranges::max_element(full->coverage);
+                              checks.expect(maxValue == 255, std::format("size {}: full coverage is exactly 255, got {}", pixelSize,
+                                                                         static_cast<int>(maxValue)));
+                          }
+                          auto skew = rr::rasterise(requestFor(skewed, pixelSize));
+                          checks.expect(skew.has_value(), std::format("size {}: the skewed quad rasterises", pixelSize));
+                          if (skew.has_value() && pixelSize >= 8u) {
+                              const bool anyPartial = std::ranges::any_of(skew->coverage, [](std::uint8_t v) { return v > 0 && v < 255; });
+                              checks.expect(anyPartial, std::format("size {}: unaligned edges are antialiased", pixelSize));
+                          }
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Rejection corpus.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register rasterRejections{
+    "rasterise() emits the right stable code per failure mode",
+    "evidence-unit",
+    [] {
+        struct Case {
+            std::string_view                   what;
+            RasterError                        expected;
+            std::function<rr::RasterRequest()> build;
+        };
+
+        // Held outside the lambdas so the spans in each request stay alive while it is used.
+        static const Built square = contours({box(0, 0, 2048, 2048)});
+
+        const std::vector<Case> cases{
+            {"a zero unitsPerEm", RasterError::UnsupportedUnitsPerEm,
+             [] {
+                 auto request       = requestFor(square, 8);
+                 request.unitsPerEm = 0;
+                 return request;
+             }},
+            {"a zero pixelSize", RasterError::UnsupportedPixelSize,
+             [] {
+                 return requestFor(square, 0);
+             }},
+            {"a pixelSize past the supported maximum", RasterError::UnsupportedPixelSize,
+             [] {
+                 return requestFor(square, rr::kMaxPixelSize + 1u);
+             }},
+            {"an outline with no contours", RasterError::EmptyOutline,
+             [] {
+                 auto request                    = requestFor(square, 8);
+                 request.outline.contourEnds     = {};
+                 return request;
+             }},
+            {"an outline with no points", RasterError::EmptyOutline,
+             [] {
+                 auto request            = requestFor(square, 8);
+                 request.outline.points  = {};
+                 return request;
+             }},
+            {"contour ends that do not increase", RasterError::MalformedContours,
+             [] {
+                 static const std::vector<std::uint16_t> ends{3, 3};
+                 auto                                    request = requestFor(square, 8);
+                 request.outline.contourEnds                      = ends;
+                 return request;
+             }},
+            {"a contour end past the last point", RasterError::MalformedContours,
+             [] {
+                 static const std::vector<std::uint16_t> ends{99};
+                 auto                                    request = requestFor(square, 8);
+                 request.outline.contourEnds                      = ends;
+                 return request;
+             }},
+        };
+
+        return speclab::Test("text-raster-rejections")
+            .Given("a corpus of deliberately malformed requests", [] {})
+            .When("each is rasterised", [] {})
+            .Then("each yields exactly the RasterError identified in the corpus",
+                  [&cases] {
+                      mdux::spec::Checks checks;
+                      for (const Case& entry : cases) {
+                          auto result = rr::rasterise(entry.build());
+                          checks.expect(!result.has_value(), std::format("{}: rasterise succeeded unexpectedly", entry.what));
+                          if (!result.has_value()) {
+                              checks.expect(result.error() == entry.expected,
+                                            std::format("{}: got '{}', expected '{}'", entry.what, rr::describe(result.error()),
+                                                        rr::describe(entry.expected)));
+                          }
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Cross-toolchain determinism.
+// ---------------------------------------------------------------------------
+
+/// The digest the reference glyph must produce. See the scenario body for why this is never
+/// updated to match new output.
+constexpr std::string_view kFrozenDigest = "c4313aa620fa990603c20fd110cdc16e0113632f61f2d01e6973b113e411714d";
+
+/// Deliberately coprime with the em, so no coordinate lands on a pixel boundary by accident.
+constexpr std::uint32_t kDeterminismPixelSize = 37;
+
+/// Builds the reference glyph the determinism scenario digests: a shape with a straight edge, a
+/// diagonal, a curve, and a counter, at a size where none of them land on pixel boundaries. The
+/// awkward coordinates are the point - a shape that happened to align would hide exactly the
+/// rounding disagreements this scenario exists to catch.
+[[nodiscard]] Built referenceGlyph() {
+    return contours({std::vector<rr::OutlinePoint>{{137, 91, true},
+                                                   {1613, 241, true},
+                                                   {1901, 1033, false},
+                                                   {1187, 1811, true},
+                                                   {449, 1699, true},
+                                                   {211, 1109, false},
+                                                   {137, 91, true}},
+                     std::vector<rr::OutlinePoint>{{701, 743, true}, {683, 1201, true}, {1163, 1231, true}, {1181, 761, true}}});
+}
+
+const mdux::spec::Register rasterDeterminism{
+    "The reference glyph rasterises to a frozen digest on every toolchain",
+    "determinism",
+    [] {
+        /*
+         * ## What the frozen digest below actually is
+         *
+         * Not "the correct rendering" in any perceptual sense, and nothing here claims it is. It
+         * is what the algorithm specified in Raster.cppm produces, recorded once, so that **every
+         * toolchain must produce the same thing**. The Linux/GCC and Windows/MSVC legs run this
+         * identical file; if either disagrees in one byte, issue #159's acceptance criterion -
+         * "the same glyph rasterises byte-identically on MSVC and GCC" - has been falsified.
+         *
+         * So a failure here is never fixed by updating the constant. It means one of:
+         *   - the flattening segment count, the fixed-point scale, or the sampling grid changed,
+         *   - a division changed rounding mode (floorDiv replaced by `/`, most likely),
+         *   - the crossing sort stopped being a total order and two equal-x crossings swapped,
+         *   - floating point entered a file whose contract is that it contains none,
+         *   - the compiler is miscompiling the rasteriser.
+         *
+         * Updating the constant to match new output converts the one loud signal in this
+         * subsystem into a rubber stamp. Change it only alongside a deliberate, documented change
+         * to the specified algorithm - and in the same commit as that change, so the diff shows
+         * both halves. The sibling scenarios above are what keep this one honest: they assert
+         * coverage that is derivable by hand, so a change that makes the rasteriser consistently
+         * *wrong* fails there rather than silently re-freezing here.
+         */
+        struct State {
+            Built                    built;
+            rr::CoverageBitmap       bitmap;
+            std::array<char, 64>     hex{};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-determinism-crossToolchain")
+            .Given("the reference glyph", [state] { state->built = referenceGlyph(); })
+            .When("it is rasterised and its coverage digested",
+                  [state] {
+                      state->bitmap = mustRasterise(requestFor(state->built, kDeterminismPixelSize), "the reference glyph");
+                      const auto digest =
+                          mdux::evidence::sha256(std::as_bytes(std::span<const std::uint8_t>{state->bitmap.coverage}));
+                      state->hex = mdux::evidence::toHex(digest);
+                  })
+            .Then("the digest and the bitmap geometry match the frozen values",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const std::string_view actual{state->hex.data(), state->hex.size()};
+                      // Geometry is asserted alongside the digest so a failure says which of the
+                      // two moved: a size change is a different bug from a coverage change, and
+                      // the digest alone cannot tell them apart.
+                      checks.expect(state->bitmap.width == 30 && state->bitmap.height == 32,
+                                    std::format("bitmap is 30x32, got {}x{}", state->bitmap.width, state->bitmap.height));
+                      checks.expect(actual == kFrozenDigest,
+                                    std::format("coverage digest\n  expected {}\n  actual   {}", kFrozenDigest, actual));
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/text/RasterTests.cpp
+++ b/tests/text/RasterTests.cpp
@@ -33,7 +33,7 @@ namespace {
 namespace rr = mdux::text::raster;
 using rr::RasterError;
 
-constexpr std::uint16_t kUpem = 2048;
+constexpr std::uint16_t unitsPerEm = 2048;
 
 /// One closed contour of on-curve points, in font units.
 [[nodiscard]] std::vector<rr::OutlinePoint> box(std::int32_t x0, std::int32_t y0, std::int32_t x1, std::int32_t y1, bool clockwise = false) {
@@ -61,7 +61,7 @@ struct Built {
 
 [[nodiscard]] rr::RasterRequest requestFor(const Built& built, std::uint32_t pixelSize) {
     return rr::RasterRequest{.outline    = rr::Outline{.points = built.points, .contourEnds = built.ends},
-                             .unitsPerEm = kUpem,
+                             .unitsPerEm = unitsPerEm,
                              .pixelSize  = pixelSize};
 }
 
@@ -447,7 +447,7 @@ const mdux::spec::Register rasterRejections{
              }},
             {"a pixelSize past the supported maximum", RasterError::UnsupportedPixelSize,
              [] {
-                 return requestFor(square, rr::kMaxPixelSize + 1u);
+                 return requestFor(square, rr::maxPixelSize + 1u);
              }},
             {"an outline with no contours", RasterError::EmptyOutline,
              [] {
@@ -503,14 +503,20 @@ const mdux::spec::Register sweepWorkBoundIsEnforced{
     [] {
         // The denial-of-service path found in review. The bitmap-area limit does not bound the
         // sweep: `contourEnds` holds uint16 indices so an outline can carry ~65k points, each
-        // off-curve one flattening into up to kMaxCurveSegments edges, while a tall narrow glyph
-        // reaches a large height far under kMaxBitmapPixels. The old sweep was
-        // height * kSubScanlines * edgeCount and would have run for hours on the fixture below.
+        // off-curve one flattening into up to maxCurveSegments edges, while a tall narrow glyph
+        // reaches a large height far under maxBitmapPixels. The old sweep was
+        // height * subScanlines * edgeCount and would have run for hours on the fixture below.
         //
-        // The shape is a comb: full-height vertical strokes, each spanning every row. At 4096
-        // px/em over a 2048 em the glyph is 4096 pixels tall, so ~1200 strokes is ~4.9M edge-row
-        // visits against a kMaxSweepWork budget of 4194304 - over the line, while the bitmap
-        // itself is a harmless 4096 x ~1200 pixels, well inside kMaxBitmapPixels.
+        // The shape is a comb: one closed contour zigzagging between y=0 and y=2048 across 2400
+        // points, so every edge - including the return segment that closes each stroke - spans
+        // the full height. At 4096 px/em over a 2048 em the scale is 2 px per font unit, making
+        // the glyph 4096 pixels tall and about 2398 wide.
+        //
+        //   edge-row visits : 2400 edges * 4096 rows = 9,830,400   (budget 4,194,304 - exceeded)
+        //   bitmap          : 2398 * 4096            = 9,822,208   (limit 67,108,864 - inside)
+        //
+        // That combination is the point: the request is comfortably legal by area and is refused
+        // only because the sweep it asks for is not.
         struct State {
             Built built;
         };
@@ -531,7 +537,7 @@ const mdux::spec::Register sweepWorkBoundIsEnforced{
             .Then("it is refused with OutlineTooComplex, and a normal glyph at the same size still works",
                   [state] {
                       mdux::spec::Checks checks;
-                      auto              result = rr::rasterise(requestFor(state->built, rr::kMaxPixelSize));
+                      auto              result = rr::rasterise(requestFor(state->built, rr::maxPixelSize));
                       checks.expect(!result.has_value(), "the comb is refused");
                       if (!result.has_value()) {
                           checks.expect(result.error() == RasterError::OutlineTooComplex,
@@ -542,11 +548,55 @@ const mdux::spec::Register sweepWorkBoundIsEnforced{
                       // maximum pixel size is 4096x4096 - the largest legitimate request there is
                       // - and has to keep rasterising.
                       const Built square = contours({box(0, 0, 2048, 2048)});
-                      auto        ok     = rr::rasterise(requestFor(square, rr::kMaxPixelSize));
+                      auto        ok     = rr::rasterise(requestFor(square, rr::maxPixelSize));
                       checks.expect(ok.has_value(), "a full-size square is still accepted");
                       if (ok.has_value()) {
                           checks.expect(ok->width == 4096 && ok->height == 4096,
                                         std::format("4096x4096, got {}x{}", ok->width, ok->height));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register wideFillIsBoundedByBitmapArea{
+    "A very wide solid outline fills in time proportional to its area, not to its span width",
+    "evidence-unit",
+    [] {
+        // The companion to the sweep-work bound, and the second half of a review finding: the
+        // sweep budget counts edge-row visits, which a solid rectangle barely spends - four
+        // edges, two of them vertical. What it does spend is *fill*, and writing coverage pixel
+        // by pixel made that `height * subScanlines * spanWidth`, unbounded by anything above.
+        //
+        // This rectangle is 16384 x 512 pixels: 1024 edge-row visits, trivially inside the sweep
+        // budget, but 512 * 16 * 16384 = 134,217,728 per-pixel writes under the old scheme. Spans
+        // are now recorded as range-adds and resolved by one prefix pass per row, so the cost is
+        // O(bitmap area) - already bounded by maxBitmapPixels - and the scenario completes in
+        // well under a second. A regression to per-pixel writes would show up here as a timeout
+        // rather than a wrong answer, which is why the assertions below also check the coverage:
+        // a fast wrong answer would otherwise pass.
+        struct State {
+            Built              built;
+            rr::CoverageBitmap bitmap;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-raster-wide-fill-bounded")
+            .Given("a rectangle 16384 pixels wide and 512 tall",
+                   [state] { state->built = contours({box(0, 0, 65536, 2048)}); })
+            .When("it is rasterised at 512 pixels per em",
+                  [state] { state->bitmap = mustRasterise(requestFor(state->built, 512), "a very wide rectangle"); })
+            .Then("it is the expected extent and solid throughout",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        b = state->bitmap;
+                      checks.expect(b.width == 16384 && b.height == 512,
+                                    std::format("16384x512, got {}x{}", b.width, b.height));
+                      if (b.width == 16384 && b.height == 512) {
+                          checks.expect(at(b, 0, 0) == 255 && at(b, 16383, 511) == 255 && at(b, 8192, 256) == 255,
+                                        "corners and centre are solid");
+                          const bool allFull = std::ranges::all_of(b.coverage, [](std::uint8_t v) { return v == 255; });
+                          checks.expect(allFull, "every pixel of a pixel-aligned rectangle is fully covered");
                       }
                       checks.raise();
                   })
@@ -559,10 +609,10 @@ const mdux::spec::Register sweepWorkBoundIsEnforced{
 
 /// The digest the reference glyph must produce. See the scenario body for why this is never
 /// updated to match new output.
-constexpr std::string_view kFrozenDigest = "1b998a7518a981f22d0a917dad7a478cd3ff1ee242619f8d315db4f365081b24";
+constexpr std::string_view frozenDigest = "1b998a7518a981f22d0a917dad7a478cd3ff1ee242619f8d315db4f365081b24";
 
 /// Deliberately coprime with the em, so no coordinate lands on a pixel boundary by accident.
-constexpr std::uint32_t kDeterminismPixelSize = 37;
+constexpr std::uint32_t determinismPixelSize = 37;
 
 /// Builds the reference glyph the determinism scenario digests: a shape with a straight edge, a
 /// diagonal, a curve, and a counter, at a size where none of them land on pixel boundaries. The
@@ -617,7 +667,7 @@ const mdux::spec::Register rasterDeterminism{
             .Given("the reference glyph", [state] { state->built = referenceGlyph(); })
             .When("it is rasterised and its coverage digested",
                   [state] {
-                      state->bitmap = mustRasterise(requestFor(state->built, kDeterminismPixelSize), "the reference glyph");
+                      state->bitmap = mustRasterise(requestFor(state->built, determinismPixelSize), "the reference glyph");
                       const auto digest =
                           mdux::evidence::sha256(std::as_bytes(std::span<const std::uint8_t>{state->bitmap.coverage}));
                       state->hex = mdux::evidence::toHex(digest);
@@ -631,8 +681,8 @@ const mdux::spec::Register rasterDeterminism{
                       // the digest alone cannot tell them apart.
                       checks.expect(state->bitmap.width == 29 && state->bitmap.height == 32,
                                     std::format("bitmap is 29x32, got {}x{}", state->bitmap.width, state->bitmap.height));
-                      checks.expect(actual == kFrozenDigest,
-                                    std::format("coverage digest\n  expected {}\n  actual   {}", kFrozenDigest, actual));
+                      checks.expect(actual == frozenDigest,
+                                    std::format("coverage digest\n  expected {}\n  actual   {}", frozenDigest, actual));
                       checks.raise();
                   })
             .Execute();


### PR DESCRIPTION
Part of #14. Depends on S2 (#158), which landed via #171.

## What this lands

`mdux.text.raster` — a governed-zone glyph rasteriser that turns outlines into an R8 coverage bitmap.

| File | |
|---|---|
| `include/mdux/text/Raster.cppm` / `src/text/Raster.cpp` | module `mdux.text.raster`, registered on `MduXCore` |
| `tests/text/RasterTests.cpp` | 10 SpecLab scenarios, joined to `text_spec` |
| `docs/architecture.md` | records the new governed module and S3 as landed |

## No floating point at all

#159 permits "integer-only **or** float operations encoded as `u32` bit patterns where determinism requires it". This takes the first option throughout, which makes the cross-toolchain byte-identity claim **a property of the source rather than of the compile flags**. Unlike `mdux.ml.kernels` — which must be float, and therefore depends on `cmake/MduXDeterminism.cmake` continuing to keep contraction away from it — nothing arriving through a preset later can weaken this module.

Verified mechanically rather than asserted:

- the only `double` anywhere in the module is inside a comment;
- `objdump -d` over the compiled object reports **zero** floating-point instructions.

The arithmetic that would otherwise be float: scaling is `(unit * pixelSize * kFixedOne) / unitsPerEm` in `int64` with the multiplications first, so there is one truncation rather than two; curve flattening picks a segment count from an integer curvature proxy and an integer Newton square root; edge/scanline intersection is a single `int64` division, **floored rather than truncated** so negative coordinates round like positive ones instead of biasing coverage toward the glyph's left half.

## Coverage cannot leave [0,255], by construction

The acceptance criterion asks for coverage "in [0,255] with no clamping surprises". The way to have no clamping surprises is to have no clamp: a span is intersected with a pixel's own column before being added, so a pixel gains at most `kFixedOne` per sub-scanline across exactly `kSubScanlines` of them. The accumulator ceiling is `kAccumulatorMax` by construction and the final divide lands in range. **There is no `std::clamp` on a coverage value anywhere in the file** — a change that makes one necessary has broken the invariant rather than found a corner case.

## Why it does not take a `truetype::SimpleGlyph`

`mdux.tools.truetype` is host-tools-zone code, and ADR-004 forbids a governed module from importing one — mechanically checked by `mdux_verify_trust_zones()`. So the input is a governed `Outline` carrying the same TrueType shape (points, per-contour end indices, on/off-curve flags), with S4's baker doing a flat conversion. The indirection is the trust-zone boundary made visible, not an abstraction for its own sake.

Being governed is what #159 asks for: if a device path ever needs to rasterise, it imports *this* module rather than growing a second implementation — ADR-008 decision 1, mirrored to text by ADR-010.

## Tests

Assertions are **derived rather than recorded** wherever the geometry permits, because a test that only says "same as last time" cannot distinguish correct output from consistently wrong output:

- a pixel-aligned square is solid **255** — this is what proves full coverage is reachable rather than saturated;
- a rectangle ending mid-pixel reads exactly **127** in the partial column (`2048 * 255 / 4096`);
- a right triangle reads exactly **127** on every pixel its hypotenuse bisects, solid below, empty above;
- a counter-wound inner contour leaves a hole and a same-wound one does **not**, which is what makes the rule nonzero rather than even-odd — an `o` works only because its counter runs against its bowl;
- quadratic flattening, including TrueType's implied on-curve midpoints;
- a degenerate contour yields an **empty** bitmap, not a 1×1 of zeros, because an atlas packer has to tell "nothing to pack" from "one blank pixel to pack";
- coverage reaches exactly 255 at eight different pixel sizes;
- a seven-case rejection corpus pinning each `RasterError`.

Plus `text-raster-determinism-crossToolchain`, labelled `determinism`: a reference glyph with a straight edge, a diagonal, two curves and a counter, at 37 px/em so nothing lands on a pixel boundary, digested to a frozen SHA-256. I froze it only *after* the derived-value scenarios passed and after inspecting the output as a bitmap — it is a plausible glyph with smooth edges and a clean counter, not merely stable garbage:

```
30x32 origin=(2,33)
|         ..++#######+         |
|     .################.       |
|    #######################   |
|   #######+..      #########+ |
|  ########+        ##########.|
| +#########.+++++++##########.|
| ###########################+ |
|.#########################+   |
|.#####+++...                  |
```

**Worth reporting:** two derived assertions failed on first run, and both were my arithmetic rather than the rasteriser's. 3072 font units at upem 2048 is 1.5 *em*, hence 3 pixels at 2 px/em — not 1.5 pixels; and the triangle's diagonal runs top-left to bottom-right in bitmap coordinates, so the pixel I sampled sat above it. The rasteriser produced exactly the right values in both cases, which is the argument for deriving assertions instead of recording them.

## Acceptance against #159

- **Same glyph byte-identical on MSVC and GCC** — `text-raster-determinism-crossToolchain` is the check; this PR's CI is its first cross-toolchain run.
- **`ctest -L evidence` and `-L determinism` pass on both legs** — locally 367/367 and 4/4.
- **Coverage in [0,255] with no clamping surprises** — structural, see above.
- **Unit tests cover corners, curves and edge cases** — 10 scenarios.

## Local verification

`g++ 16.1.0`, plain flow: **410/410 ctest pass**, `mdux_verify_trust_zones()` reports "2 governed target(s) clean", `mdux_verify_fp_determinism()` reports "1 target(s) free of fast-math options".

## Out of scope

No baker calls this yet. S4 (#160) is the wave that converts a `SimpleGlyph` into an `Outline`, packs the bitmaps into an atlas, and commits a font artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic glyph rasterisation that converts font outlines into coverage bitmaps.
  * Added support for quadratic curves, contour validation, bitmap bounds, and top-first pixel output.
  * Added clear error reporting for invalid outlines, unsupported sizes, overflow, and oversized bitmaps.
  * Degenerate or invisible glyphs now produce empty bitmap results.

* **Documentation**
  * Documented the text rasterisation module and marked its initial coverage milestone as complete.

* **Tests**
  * Added coverage for fills, holes, curves, empty outlines, pixel sizes, error handling, and deterministic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->