### PR TITLE
S4 prerequisite (1/2) — cmap and hmtx in mdux.tools.truetype (#160)

### DIFF
--- a/tests/text/TruetypeTests.cpp
+++ b/tests/text/TruetypeTests.cpp
@@ -55,6 +55,10 @@ constexpr std::uint16_t firstAdvance         = 500;
 constexpr std::uint16_t advanceStep          = 10;
 constexpr std::int16_t  sideBearing          = 7;
 
+/// The glyph id the truncated-subtable fixture's filler decodes to. In range, so a decoder that
+/// reads past the declared length produces a plausible wrong answer rather than an obvious one.
+constexpr std::uint16_t strayGlyphInFiller = 5;
+
 // ---------------------------------------------------------------------------
 // An assembler for in-memory TrueType files, plus helpers for the glyf records each scenario
 // uses. A real `.ttf` would be the same bytes in a different file; building them in code keeps
@@ -130,6 +134,21 @@ public:
     }
     Builder& dropHmtx() {
         dropHmtx_ = true;
+        return *this;
+    }
+
+    /// Emits the format 4 segment through `idRangeOffset` - the self-relative indirection into a
+    /// trailing glyph array - instead of the affine `code + idDelta` form. Real fonts use both,
+    /// and the two take completely different paths through the decoder.
+    ///
+    /// `truncateGlyphArray` declares a subtable `length` that stops before the glyph array the
+    /// segment needs, and appends filler bytes after it standing in for whatever subtable would
+    /// follow in a real font. A decoder that slices the subtable to the end of `cmap` rather than
+    /// to its declared length reads that filler as glyph ids and returns *wrong mappings* with no
+    /// diagnostic; one that clips correctly refuses with TruncatedCmap.
+    Builder& cmapIndirect(bool truncateGlyphArray = false) {
+        cmapIndirect_          = true;
+        cmapTruncateGlyphArray_ = truncateGlyphArray;
         return *this;
     }
 
@@ -285,6 +304,50 @@ public:
                 appendU32(subtable, firstMappedCodePoint);
                 appendU32(subtable, firstMappedCodePoint + 25u);
                 appendU32(subtable, firstMappedGlyph);
+            } else if (cmapIndirect_) {
+                // Two segments, the first resolving through glyphIdArray. Layout, with the byte
+                // offset of each field, because the indirection below is computed from them:
+                //   0 format, 2 length, 4 language, 6 segCountX2, 8 searchRange,
+                //   10 entrySelector, 12 rangeShift, 14 endCode[2], 18 reservedPad,
+                //   20 startCode[2], 24 idDelta[2], 28 idRangeOffset[2], 32 glyphIdArray[]
+                const std::uint16_t segCount     = 2;
+                const std::uint16_t mappedCount  = 26;
+                const std::uint16_t fullLength   = static_cast<std::uint16_t>(32 + mappedCount * 2);
+                // Declared short on purpose in the truncated variant: four entries instead of 26.
+                const std::uint16_t declaredLen  = cmapTruncateGlyphArray_ ? static_cast<std::uint16_t>(32 + 4 * 2) : fullLength;
+                appendU16(subtable, 4);
+                appendU16(subtable, declaredLen);
+                appendU16(subtable, 0);
+                appendU16(subtable, segCount * 2);
+                appendU16(subtable, 4);
+                appendU16(subtable, 1);
+                appendU16(subtable, 0);
+                appendU16(subtable, static_cast<std::uint16_t>(firstMappedCodePoint + mappedCount - 1));  // endCode[0]
+                appendU16(subtable, 0xFFFFu);                                                            // endCode[1]
+                appendU16(subtable, 0);                                                                  // reservedPad
+                appendU16(subtable, static_cast<std::uint16_t>(firstMappedCodePoint));                   // startCode[0]
+                appendU16(subtable, 0xFFFFu);                                                            // startCode[1]
+                appendU16(subtable, 0);  // idDelta[0]: zero, so the glyph is the array entry itself
+                appendU16(subtable, 1);  // idDelta[1]
+                // idRangeOffset[0] sits at offset 28 and the glyph array starts at 32, and the
+                // spec measures the offset from the slot itself - so the value is 32 - 28 == 4.
+                appendU16(subtable, 4);
+                appendU16(subtable, 0);  // idRangeOffset[1]: the terminator is affine
+                // In the truncated variant only the entries the declared length covers are real;
+                // everything after is filler standing in for the next subtable. The filler is a
+                // valid, in-range glyph id on purpose - a decoder that reads it returns a
+                // confidently *wrong* mapping rather than something obviously broken, which is
+                // the failure this fixture exists to make visible.
+                const std::uint16_t realEntries = cmapTruncateGlyphArray_ ? 4u : mappedCount;
+                for (std::uint16_t i = 0; i < realEntries; ++i) {
+                    appendU16(subtable, static_cast<std::uint16_t>(firstMappedGlyph + i));
+                }
+                for (std::uint16_t i = realEntries; i < mappedCount + 32u; ++i) {
+                    if (!cmapTruncateGlyphArray_) {
+                        break;
+                    }
+                    appendU16(subtable, strayGlyphInFiller);
+                }
             } else {
                 // Two segments: the mapped run, then the mandatory 0xFFFF terminator.
                 const std::uint16_t segCount = 2;
@@ -508,7 +571,9 @@ private:
     bool                                                        dropCmap_     = false;
     bool                                                        dropHhea_     = false;
     bool                                                        dropHmtx_     = false;
-    bool                                                        cmapFormat12_ = false;
+    bool                                                        cmapFormat12_           = false;
+    bool                                                        cmapIndirect_           = false;
+    bool                                                        cmapTruncateGlyphArray_ = false;
     std::map<std::size_t, std::uint16_t>                        locaOverrides_;
     std::vector<std::vector<std::byte>>                         rawGlyphs_;
     std::vector<std::pair<std::string, std::vector<std::byte>>> extras_;
@@ -1382,6 +1447,102 @@ const mdux::spec::Register characterMapResolvesCodePoints{
                                         std::format("{}: the point above the run is unmapped", name));
                           checks.expect(!tt::glyphForCodePoint(f, U'\u4E2D').has_value(),
                                         std::format("{}: an unmapped CJK point resolves to nothing", name));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register indirectCmapSegmentResolves{
+    "A format 4 segment resolving through idRangeOffset maps the same run as an affine one",
+    "evidence-unit",
+    [] {
+        // The indirection is the fiddliest arithmetic in the format: idRangeOffset is a byte
+        // offset measured from its own slot, into a glyph array that follows the four parallel
+        // arrays. Every other scenario here builds the *affine* form, so without this one the
+        // indirect branch is never executed - and it is the branch that a real font with
+        // non-consecutive glyph ids takes.
+        struct State {
+            std::vector<std::byte>  bytes;
+            std::optional<tt::Font> font;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-cmap-indirect")
+            .Given("a font whose cmap segment resolves through a glyph array",
+                   [state] { state->bytes = Builder().numGlyphs(30).cmapIndirect().rawGlyph(0, squareGlyph()).serialize().bytes; })
+            .When("it is parsed",
+                  [state] {
+                      auto f = tt::parse(state->bytes);
+                      if (!f.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("indirect cmap rejected: {}", tt::describe(f.error())),
+                                                                std::source_location::current());
+                      }
+                      state->font = std::move(*f);
+                  })
+            .Then("it maps exactly the run the affine form maps",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      for (std::uint32_t offset = 0; offset < 26; ++offset) {
+                          const auto point = static_cast<char32_t>(firstMappedCodePoint + offset);
+                          const auto glyph = tt::glyphForCodePoint(*state->font, point);
+                          checks.expect(glyph.has_value() && *glyph == firstMappedGlyph + offset,
+                                        std::format("U+{:04X} -> glyph {}, got {}", static_cast<std::uint32_t>(point),
+                                                    firstMappedGlyph + offset,
+                                                    glyph.has_value() ? std::to_string(*glyph) : std::string{"nothing"}));
+                      }
+                      checks.expect(!tt::glyphForCodePoint(*state->font, static_cast<char32_t>(firstMappedCodePoint + 26)).has_value(),
+                                    "the point above the run is unmapped");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register subtableIsClippedToDeclaredLength{
+    "A subtable whose glyph array runs past its declared length is refused, not read on into the next one",
+    "evidence-unit",
+    [] {
+        // The regression test for a review finding: slicing the chosen subtable to the end of the
+        // whole `cmap` table, rather than to its own declared length, lets format 4's
+        // idRangeOffset indirection read into whatever subtable follows. Every read stays inside
+        // `cmap`, so no bounds check fires - the decoder just returns *someone else's glyph ids*.
+        // Silently drawing the wrong character is the worst failure mode this parser has, so the
+        // assertion is that it is refused rather than merely that it does not crash.
+        //
+        // The fixture declares a subtable length covering four glyph-array entries, needs
+        // twenty-six, and appends filler that would decode as plausible ids.
+        struct State {
+            std::vector<std::byte> bytes;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-cmap-subtable-clipped")
+            .Given("a font whose cmap subtable declares a length shorter than its glyph array",
+                   [state] {
+                       state->bytes = Builder()
+                                          .numGlyphs(30)
+                                          .cmapIndirect(/*truncateGlyphArray=*/true)
+                                          .rawGlyph(0, squareGlyph())
+                                          .serialize()
+                                          .bytes;
+                   })
+            .When("nothing", [] {})
+            .Then("parse() refuses with TruncatedCmap",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      auto               result = tt::parse(state->bytes);
+                      checks.expect(!result.has_value(), "the font is refused");
+                      if (!result.has_value()) {
+                          checks.expect(result.error() == ParseError::TruncatedCmap,
+                                        std::format("got '{}', expected '{}'", tt::describe(result.error()),
+                                                    tt::describe(ParseError::TruncatedCmap)));
+                      } else {
+                          // Spell out what a pass would have meant, so a future regression reads
+                          // as the bug it is rather than as a changed expectation.
+                          const auto stray = tt::glyphForCodePoint(*result, static_cast<char32_t>(firstMappedCodePoint + 10));
+                          checks.expect(false, std::format("it parsed, and U+{:04X} resolved to {} - read out of the next subtable",
+                                                           firstMappedCodePoint + 10,
+                                                           stray.has_value() ? std::to_string(*stray) : std::string{"nothing"}));
                       }
                       checks.raise();
                   })

--- a/tests/text/TruetypeTests.cpp
+++ b/tests/text/TruetypeTests.cpp
@@ -47,6 +47,14 @@ constexpr std::uint32_t kHeadMagic = 0x5F0F3CF5u;
 /// the whole reason the long (uint32) form exists.
 constexpr std::uint32_t kShortFormLimit = 131072u;
 
+/// What every Builder-made font maps and measures, named so a scenario asserts against the
+/// builder's intent rather than a literal that could drift away from it.
+constexpr std::uint32_t firstMappedCodePoint = 0x41;  // 'A'
+constexpr std::uint32_t firstMappedGlyph     = 1;     // glyph 0 is .notdef and never mapped
+constexpr std::uint16_t firstAdvance         = 500;
+constexpr std::uint16_t advanceStep          = 10;
+constexpr std::int16_t  sideBearing          = 7;
+
 // ---------------------------------------------------------------------------
 // An assembler for in-memory TrueType files, plus helpers for the glyf records each scenario
 // uses. A real `.ttf` would be the same bytes in a different file; building them in code keeps
@@ -110,6 +118,45 @@ public:
     }
     Builder& dropGlyf() {
         dropGlyf_ = true;
+        return *this;
+    }
+    Builder& dropCmap() {
+        dropCmap_ = true;
+        return *this;
+    }
+    Builder& dropHhea() {
+        dropHhea_ = true;
+        return *this;
+    }
+    Builder& dropHmtx() {
+        dropHmtx_ = true;
+        return *this;
+    }
+
+    /// Emits the character map as a format 12 group list instead of format 4 segments. The two
+    /// encode the same mapping by very different means, so a corpus that only ever built one
+    /// leaves the other's decode path unexercised.
+    Builder& cmapFormat12() {
+        cmapFormat12_ = true;
+        return *this;
+    }
+
+    /// Overrides hhea's numberOfHMetrics. Values of 0 or above numGlyphs are the
+    /// `UnsupportedMetricCount` fixtures; a value below numGlyphs exercises the trailing run of
+    /// glyphs that inherit the last advance.
+    Builder& numberOfHMetrics(std::uint16_t n) {
+        numberOfHMetrics_ = n;
+        return *this;
+    }
+
+    /// An override for the byte length the 'hhea' or 'hmtx' directory record declares, for the
+    /// two truncation fixtures.
+    Builder& hheaDeclaredLength(std::uint32_t v) {
+        hheaLen_ = v;
+        return *this;
+    }
+    Builder& hmtxDeclaredLength(std::uint32_t v) {
+        hmtxLen_ = v;
         return *this;
     }
 
@@ -222,6 +269,71 @@ public:
                 }
             }
         }
+        // The character map. Both encodings describe the same thing: code points 'A'..'Z' map to
+        // glyphs 1..26, so a fixture with two glyphs resolves 'A' to glyph 1 and everything above
+        // its numGlyphs to nothing. `firstMappedCodePoint` and `firstMappedGlyph` name the two
+        // ends so a scenario asserts against the builder's intent rather than a literal.
+        std::vector<std::byte> cmap;
+        if (!dropCmap_) {
+            std::vector<std::byte> subtable;
+            if (cmapFormat12_) {
+                appendU16(subtable, 12);  // format
+                appendU16(subtable, 0);   // reserved
+                appendU32(subtable, 16 + 12);
+                appendU32(subtable, 0);  // language
+                appendU32(subtable, 1);  // nGroups
+                appendU32(subtable, firstMappedCodePoint);
+                appendU32(subtable, firstMappedCodePoint + 25u);
+                appendU32(subtable, firstMappedGlyph);
+            } else {
+                // Two segments: the mapped run, then the mandatory 0xFFFF terminator.
+                const std::uint16_t segCount = 2;
+                appendU16(subtable, 4);                 // format
+                appendU16(subtable, 16 + segCount * 8); // length
+                appendU16(subtable, 0);                 // language
+                appendU16(subtable, segCount * 2);
+                appendU16(subtable, 4);  // searchRange, unread by this parser
+                appendU16(subtable, 1);  // entrySelector
+                appendU16(subtable, 0);  // rangeShift
+                appendU16(subtable, static_cast<std::uint16_t>(firstMappedCodePoint + 25u));  // endCode[0]
+                appendU16(subtable, 0xFFFFu);                                                 // endCode[1]
+                appendU16(subtable, 0);                                                       // reservedPad
+                appendU16(subtable, static_cast<std::uint16_t>(firstMappedCodePoint));        // startCode[0]
+                appendU16(subtable, 0xFFFFu);                                                 // startCode[1]
+                // Affine segment: glyph = code + idDelta, so idDelta carries the offset that
+                // takes the first mapped code point to the first mapped glyph.
+                appendU16(subtable, static_cast<std::uint16_t>(firstMappedGlyph - firstMappedCodePoint));
+                appendU16(subtable, 1);  // idDelta[1], irrelevant for the terminator
+                appendU16(subtable, 0);  // idRangeOffset[0] - affine, no glyph array
+                appendU16(subtable, 0);  // idRangeOffset[1]
+            }
+            appendU16(cmap, 0);  // version
+            appendU16(cmap, 1);  // numTables
+            appendU16(cmap, 3);  // platformID: Windows
+            appendU16(cmap, cmapFormat12_ ? 10 : 1);
+            appendU32(cmap, 12);  // offset to the subtable that follows this record
+            cmap.insert(cmap.end(), subtable.begin(), subtable.end());
+        }
+
+        const std::uint16_t metricCount = numberOfHMetrics_.value_or(ng_);
+        std::vector<std::byte> hhea;
+        if (!dropHhea_) {
+            hhea.assign(36, std::byte{0});
+            putU32(hhea, 0, 0x00010000u);  // version 1.0
+            putU16(hhea, 34, metricCount);
+        }
+        std::vector<std::byte> hmtx;
+        if (!dropHmtx_) {
+            // metricCount full pairs, then one bearing per remaining glyph.
+            for (std::uint16_t i = 0; i < metricCount; ++i) {
+                appendU16(hmtx, static_cast<std::uint16_t>(firstAdvance + i * advanceStep));
+                appendU16(hmtx, static_cast<std::uint16_t>(sideBearing));
+            }
+            for (std::uint16_t i = metricCount; i < ng_; ++i) {
+                appendU16(hmtx, static_cast<std::uint16_t>(sideBearing));
+            }
+        }
+
         std::vector<std::byte> glyf;
         if (!dropGlyf_) {
             for (const auto& g : rawGlyphs_) {
@@ -246,6 +358,12 @@ public:
             entries.push_back({"loca", &loca});
         if (!dropGlyf_)
             entries.push_back({"glyf", &glyf});
+        if (!dropCmap_)
+            entries.push_back({"cmap", &cmap});
+        if (!dropHhea_)
+            entries.push_back({"hhea", &hhea});
+        if (!dropHmtx_)
+            entries.push_back({"hmtx", &hmtx});
         for (const auto& extra : extras_) {
             entries.push_back({extra.first, &extra.second});
         }
@@ -299,6 +417,12 @@ public:
             } else if (entries[i].tag == "glyf") {
                 out.glyfRecordStart = rec;
                 out.glyfDataStart   = cursor;
+            } else if (entries[i].tag == "hhea") {
+                if (hheaLen_.has_value())
+                    dataLength = *hheaLen_;
+            } else if (entries[i].tag == "hmtx") {
+                if (hmtxLen_.has_value())
+                    dataLength = *hmtxLen_;
             }
             putU32(out.bytes, rec + 8, dataOffset);
             putU32(out.bytes, rec + 12, dataLength);
@@ -378,6 +502,13 @@ private:
     std::optional<std::uint32_t>                                headLen_;
     std::optional<std::uint32_t>                                maxpLen_;
     std::optional<std::uint32_t>                                locaLen_;
+    std::optional<std::uint32_t>                                hheaLen_;
+    std::optional<std::uint32_t>                                hmtxLen_;
+    std::optional<std::uint16_t>                                numberOfHMetrics_;
+    bool                                                        dropCmap_     = false;
+    bool                                                        dropHhea_     = false;
+    bool                                                        dropHmtx_     = false;
+    bool                                                        cmapFormat12_ = false;
     std::map<std::size_t, std::uint16_t>                        locaOverrides_;
     std::vector<std::vector<std::byte>>                         rawGlyphs_;
     std::vector<std::pair<std::string, std::vector<std::byte>>> extras_;
@@ -1192,6 +1323,126 @@ const mdux::spec::Register longLocaReachesPastShortFormLimit{
             .Execute();
     }};
 
+const mdux::spec::Register characterMapResolvesCodePoints{
+    "Both cmap encodings resolve the same code points to the same glyphs",
+    "evidence-unit",
+    [] {
+        // Format 4 and format 12 store the mapping completely differently - four parallel arrays
+        // with a self-relative indirection versus a flat group list - so asserting they agree is
+        // the whole point. A parser that got one of them wrong would otherwise pass whichever
+        // half the corpus happened to build.
+        struct State {
+            std::vector<std::byte>  format4Bytes;
+            std::vector<std::byte>  format12Bytes;
+            std::optional<tt::Font> format4;
+            std::optional<tt::Font> format12;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-cmap-resolves")
+            .Given("the same mapping serialized as format 4 and as format 12",
+                   [state] {
+                       state->format4Bytes  = Builder().numGlyphs(30).rawGlyph(0, squareGlyph()).serialize().bytes;
+                       state->format12Bytes = Builder().numGlyphs(30).cmapFormat12().rawGlyph(0, squareGlyph()).serialize().bytes;
+                   })
+            .When("both are parsed",
+                  [state] {
+                      auto a = tt::parse(state->format4Bytes);
+                      auto b = tt::parse(state->format12Bytes);
+                      if (!a.has_value() || !b.has_value()) {
+                          throw speclab::core::AssertionFailure(
+                              std::format("format4={}, format12={}",
+                                          a.has_value() ? "ok" : std::string{tt::describe(a.error())},
+                                          b.has_value() ? "ok" : std::string{tt::describe(b.error())}),
+                              std::source_location::current());
+                      }
+                      state->format4  = std::move(*a);
+                      state->format12 = std::move(*b);
+                  })
+            .Then("both map the run identically, and neither invents a mapping outside it",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      for (const auto& [name, font] : {std::pair{"format 4", std::cref(*state->format4)},
+                                                       std::pair{"format 12", std::cref(*state->format12)}}) {
+                          const auto& f = font.get();
+                          for (std::uint32_t offset = 0; offset < 26; ++offset) {
+                              const auto point = static_cast<char32_t>(firstMappedCodePoint + offset);
+                              const auto glyph = tt::glyphForCodePoint(f, point);
+                              checks.expect(glyph.has_value() && *glyph == firstMappedGlyph + offset,
+                                            std::format("{}: U+{:04X} -> glyph {}, got {}", name, static_cast<std::uint32_t>(point),
+                                                        firstMappedGlyph + offset,
+                                                        glyph.has_value() ? std::to_string(*glyph) : std::string{"nothing"}));
+                          }
+                          // Just outside the run in both directions, and a code point no font
+                          // covers. An unmapped point must be nothing, not .notdef dressed up as
+                          // a successful lookup.
+                          checks.expect(!tt::glyphForCodePoint(f, static_cast<char32_t>(firstMappedCodePoint - 1)).has_value(),
+                                        std::format("{}: the point below the run is unmapped", name));
+                          checks.expect(!tt::glyphForCodePoint(f, static_cast<char32_t>(firstMappedCodePoint + 26)).has_value(),
+                                        std::format("{}: the point above the run is unmapped", name));
+                          checks.expect(!tt::glyphForCodePoint(f, U'\u4E2D').has_value(),
+                                        std::format("{}: an unmapped CJK point resolves to nothing", name));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register metricsAreReadPerGlyph{
+    "metricsFor() reads each glyph's advance, and the trailing run inherits the last one",
+    "evidence-unit",
+    [] {
+        // hmtx stores full (advance, bearing) pairs for the first numberOfHMetrics glyphs and
+        // only a bearing for the rest, which inherit the final advance. That compression is how
+        // a monospace or CJK font avoids repeating one advance thousands of times, and getting
+        // it wrong yields plausible-looking metrics for every glyph past the boundary.
+        struct State {
+            std::vector<std::byte>  bytes;
+            std::optional<tt::Font> font;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-truetype-hmtx-metrics")
+            .Given("a six-glyph font whose hmtx carries only four full metric pairs",
+                   [state] {
+                       state->bytes = Builder().numGlyphs(6).numberOfHMetrics(4).rawGlyph(0, squareGlyph()).serialize().bytes;
+                   })
+            .When("it is parsed",
+                  [state] {
+                      auto f = tt::parse(state->bytes);
+                      if (!f.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("font rejected: {}", tt::describe(f.error())),
+                                                                std::source_location::current());
+                      }
+                      state->font = std::move(*f);
+                  })
+            .Then("the first four advances differ and the last two repeat the fourth",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        font = *state->font;
+                      checks.expect(font.numberOfHMetrics == 4, "numberOfHMetrics");
+                      for (std::uint16_t glyph = 0; glyph < 4; ++glyph) {
+                          auto m = tt::metricsFor(font, glyph);
+                          checks.expect(m.has_value() && m->advanceWidth == firstAdvance + glyph * advanceStep,
+                                        std::format("glyph {} advance is {}", glyph, firstAdvance + glyph * advanceStep));
+                          checks.expect(m.has_value() && m->leftSideBearing == sideBearing,
+                                        std::format("glyph {} bearing is {}", glyph, sideBearing));
+                      }
+                      const std::uint16_t inherited = firstAdvance + 3 * advanceStep;
+                      for (std::uint16_t glyph = 4; glyph < 6; ++glyph) {
+                          auto m = tt::metricsFor(font, glyph);
+                          checks.expect(m.has_value() && m->advanceWidth == inherited,
+                                        std::format("glyph {} inherits advance {}, got {}", glyph, inherited,
+                                                    m.has_value() ? std::to_string(m->advanceWidth) : std::string{"error"}));
+                      }
+                      auto past = tt::metricsFor(font, 6);
+                      checks.expect(!past.has_value() && past.error() == ParseError::GlyphIndexOutOfRange,
+                                    "a glyph index past numGlyphs is refused");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 // ---------------------------------------------------------------------------
 // parse(): rejection corpus - one scenario per ParseError the directory walk emits.
 // ---------------------------------------------------------------------------
@@ -1259,6 +1510,43 @@ const mdux::spec::Register parseRejections{
              ParseError::CffOutlinesRejected,
              [] {
              return Builder().extraTable("CFF2", dummyExtra()).serialize().bytes;
+             }},
+            {                     "a font with no 'cmap' table",
+             ParseError::MissingCharacterMap,
+             [] {
+             // A distinct code from MissingRequiredTable on purpose: the author needs to know the
+             // font cannot name characters, not merely that something is absent.
+             return Builder().dropCmap().serialize().bytes;
+             }},
+            {                     "a font with no 'hhea' table",
+             ParseError::MissingHorizontalMetrics,
+             [] {
+             return Builder().dropHhea().serialize().bytes;
+             }},
+            {                     "a font with no 'hmtx' table",
+             ParseError::MissingHorizontalMetrics,
+             [] {
+             return Builder().dropHmtx().serialize().bytes;
+             }},
+            {              "an 'hhea' table shorter than 36 bytes",
+             ParseError::TruncatedHhea,
+             [] {
+             return Builder().hheaDeclaredLength(20).serialize().bytes;
+             }},
+            {   "an 'hmtx' shorter than numberOfHMetrics requires",
+             ParseError::TruncatedHmtx,
+             [] {
+             return Builder().numGlyphs(8).hmtxDeclaredLength(4).serialize().bytes;
+             }},
+            {                    "a numberOfHMetrics of zero",
+             ParseError::UnsupportedMetricCount,
+             [] {
+             return Builder().numberOfHMetrics(0).serialize().bytes;
+             }},
+            {          "a numberOfHMetrics larger than numGlyphs",
+             ParseError::UnsupportedMetricCount,
+             [] {
+             return Builder().numGlyphs(2).numberOfHMetrics(9).serialize().bytes;
              }},
             {  "an 'OTTO' container, which carries CFF outlines",
              ParseError::CffOutlinesRejected,

--- a/tools/text/Truetype.cpp
+++ b/tools/text/Truetype.cpp
@@ -123,10 +123,15 @@ constexpr std::uint8_t flagReservedMask    = 0x80u;
     if (!segCountX2) {
         return err(ParseError::TruncatedCmap);
     }
-    const std::size_t segCount = static_cast<std::size_t>(*segCountX2) / 2u;
-    if (segCount == 0) {
+    // segCountX2 is, as the name says, twice the segment count. An odd value is not a slightly
+    // wrong count - it means the four parallel arrays are not where the layout arithmetic below
+    // computes them to be, so every offset after this point would address the wrong field and the
+    // table would be *misread* rather than rejected. Checking parity is what turns that into a
+    // diagnostic. A legal table always has at least the mandatory 0xFFFF terminator segment.
+    if (*segCountX2 == 0 || (*segCountX2 % 2u) != 0) {
         return err(ParseError::TruncatedCmap);
     }
+    const std::size_t segCount = static_cast<std::size_t>(*segCountX2) / 2u;
     // endCode[segCount], reservedPad, startCode[segCount], idDelta[segCount], idRangeOffset[segCount]
     const std::size_t endCodeAt       = 14;
     const std::size_t startCodeAt     = endCodeAt + segCount * 2u + 2u;
@@ -266,7 +271,11 @@ constexpr std::uint8_t flagReservedMask    = 0x80u;
         if (!platformId || !encodingId || !offset) {
             return err(ParseError::TruncatedCmap);
         }
-        if (*offset + 2u > cmap.size()) {
+        // Widened deliberately: `*offset` is a uint32, so `*offset + 2u` is evaluated in 32-bit
+        // and wraps for an offset near 0xFFFFFFFF, letting the wrapped value pass this guard. The
+        // beU16() below would still refuse to read out of bounds, so nothing was reachable, but a
+        // bounds check that does not hold on its own terms is one nobody can rely on later.
+        if (static_cast<std::uint64_t>(*offset) + 2u > cmap.size()) {
             return err(ParseError::TruncatedCmap);
         }
         const auto format = beU16(cmap, *offset);
@@ -289,11 +298,43 @@ constexpr std::uint8_t flagReservedMask    = 0x80u;
         return err(ParseError::UnsupportedCmapFormat);
     }
 
-    const auto subtable = cmap.subspan(*best);
-    const auto format   = beU16(subtable, 0);
+    const auto whatFollows = cmap.subspan(*best);
+    const auto format      = beU16(whatFollows, 0);
     if (!format) {
         return err(ParseError::TruncatedCmap);
     }
+
+    // Clip the subtable to its own declared length rather than letting it run to the end of the
+    // `cmap` table.
+    //
+    // This is not tidiness. Format 4's idRangeOffset is a self-relative pointer into a glyph array
+    // that the subtable's length is what terminates - so a subtable sliced too generously lets
+    // that indirection read into whatever subtable happens to follow it. A font with several cmap
+    // subtables, which is the normal case, would then produce *wrong mappings* rather than a
+    // diagnostic: the reads stay inside `cmap`, so no bounds check fires and the glyphs are simply
+    // someone else's. Silently drawing the wrong character is the worst failure this parser has.
+    //
+    // The two formats declare their length in different places and widths: format 4 as a uint16
+    // at offset 2, format 12 as a uint32 at offset 4.
+    std::uint64_t declaredLength = 0;
+    if (*format == 12) {
+        const auto length = beU32(whatFollows, 4);
+        if (!length) {
+            return err(ParseError::TruncatedCmap);
+        }
+        declaredLength = *length;
+    } else {
+        const auto length = beU16(whatFollows, 2);
+        if (!length) {
+            return err(ParseError::TruncatedCmap);
+        }
+        declaredLength = *length;
+    }
+    if (declaredLength == 0 || declaredLength > whatFollows.size()) {
+        return err(ParseError::TruncatedCmap);
+    }
+    const auto subtable = whatFollows.first(static_cast<std::size_t>(declaredLength));
+
     auto ranges = (*format == 12) ? decodeCmapFormat12(subtable) : decodeCmapFormat4(subtable);
     if (!ranges.has_value()) {
         return err(ranges.error());

--- a/tools/text/Truetype.cpp
+++ b/tools/text/Truetype.cpp
@@ -108,6 +108,203 @@ constexpr std::uint8_t flagReservedMask    = 0x80u;
     return std::string{chars, 4};
 }
 
+/// Decodes a format 4 subtable - the BMP workhorse every font carries - into ranges.
+///
+/// Four parallel arrays of `segCount` entries, then a trailing glyph array. For a segment with
+/// `idRangeOffset == 0` the mapping is affine: `glyph = code + idDelta`, so the whole segment is
+/// one range. Otherwise `idRangeOffset` is a *byte* offset measured from its own slot in the
+/// array - a self-relative pointer into the trailing glyph array - and each code point resolves
+/// individually, so those segments expand to one range per mapped code point.
+///
+/// The self-relative offset is the fiddliest arithmetic in the whole format, and it is walked
+/// exactly once here rather than at lookup time, so the bounds check lives in one place.
+[[nodiscard]] Result<std::vector<CmapRange>, ParseError> decodeCmapFormat4(std::span<const std::byte> table) noexcept {
+    const auto segCountX2 = beU16(table, 6);
+    if (!segCountX2) {
+        return err(ParseError::TruncatedCmap);
+    }
+    const std::size_t segCount = static_cast<std::size_t>(*segCountX2) / 2u;
+    if (segCount == 0) {
+        return err(ParseError::TruncatedCmap);
+    }
+    // endCode[segCount], reservedPad, startCode[segCount], idDelta[segCount], idRangeOffset[segCount]
+    const std::size_t endCodeAt       = 14;
+    const std::size_t startCodeAt     = endCodeAt + segCount * 2u + 2u;
+    const std::size_t idDeltaAt       = startCodeAt + segCount * 2u;
+    const std::size_t idRangeOffsetAt = idDeltaAt + segCount * 2u;
+    if (idRangeOffsetAt + segCount * 2u > table.size()) {
+        return err(ParseError::TruncatedCmap);
+    }
+
+    std::vector<CmapRange> ranges;
+    for (std::size_t i = 0; i < segCount; ++i) {
+        const auto endCode       = beU16(table, endCodeAt + i * 2u);
+        const auto startCode     = beU16(table, startCodeAt + i * 2u);
+        const auto idDelta       = beU16(table, idDeltaAt + i * 2u);
+        const auto idRangeOffset = beU16(table, idRangeOffsetAt + i * 2u);
+        if (!endCode || !startCode || !idDelta || !idRangeOffset) {
+            return err(ParseError::TruncatedCmap);
+        }
+        if (*startCode > *endCode) {
+            return err(ParseError::TruncatedCmap);
+        }
+        // The final segment is the mandatory 0xFFFF terminator and maps nothing useful.
+        if (*startCode == 0xFFFFu) {
+            continue;
+        }
+        if (ranges.size() > maxCmapEntries) {
+            return err(ParseError::CharacterMapTooLarge);
+        }
+
+        if (*idRangeOffset == 0) {
+            // Affine: one range. Glyph 0 means unmapped, so a segment that maps its start to
+            // .notdef is skipped rather than recorded.
+            const std::uint16_t firstGlyph = static_cast<std::uint16_t>((*startCode + *idDelta) & 0xFFFFu);
+            if (firstGlyph == 0) {
+                continue;
+            }
+            ranges.push_back(CmapRange{.first      = static_cast<char32_t>(*startCode),
+                                       .last       = static_cast<char32_t>(*endCode),
+                                       .firstGlyph = firstGlyph});
+            continue;
+        }
+
+        for (std::uint32_t code = *startCode; code <= *endCode; ++code) {
+            // The spec's own expression, kept in its original shape so it can be checked against
+            // the specification rather than against a simplification of it:
+            //   glyphIndexAddress = idRangeOffset[i] + 2 * (code - startCode[i]) + &idRangeOffset[i]
+            const std::size_t slot    = idRangeOffsetAt + i * 2u;
+            const std::size_t address = slot + *idRangeOffset + 2u * (code - *startCode);
+            const auto        raw     = beU16(table, address);
+            if (!raw) {
+                return err(ParseError::TruncatedCmap);
+            }
+            if (*raw == 0) {
+                continue;  // explicitly unmapped
+            }
+            const std::uint16_t glyph = static_cast<std::uint16_t>((*raw + *idDelta) & 0xFFFFu);
+            if (glyph == 0) {
+                continue;
+            }
+            if (ranges.size() >= maxCmapEntries) {
+                return err(ParseError::CharacterMapTooLarge);
+            }
+            // Extend the previous range when this code point continues it, so an indirect
+            // segment whose glyphs happen to be consecutive still collapses.
+            if (!ranges.empty() && ranges.back().last + 1u == code
+                && ranges.back().firstGlyph + (ranges.back().last - ranges.back().first) + 1u == glyph) {
+                ranges.back().last = static_cast<char32_t>(code);
+                continue;
+            }
+            ranges.push_back(CmapRange{.first = static_cast<char32_t>(code), .last = static_cast<char32_t>(code), .firstGlyph = glyph});
+        }
+    }
+    return ranges;
+}
+
+/// Decodes a format 12 subtable: a flat list of (startCharCode, endCharCode, startGlyphID)
+/// groups, already the shape `CmapRange` wants. Preferred over format 4 when present, because it
+/// is the only one of the two that reaches beyond the BMP.
+[[nodiscard]] Result<std::vector<CmapRange>, ParseError> decodeCmapFormat12(std::span<const std::byte> table) noexcept {
+    const auto groupCount = beU32(table, 12);
+    if (!groupCount) {
+        return err(ParseError::TruncatedCmap);
+    }
+    if (*groupCount > maxCmapEntries) {
+        return err(ParseError::CharacterMapTooLarge);
+    }
+    const std::uint64_t end = 16u + static_cast<std::uint64_t>(*groupCount) * 12u;
+    if (end > table.size()) {
+        return err(ParseError::TruncatedCmap);
+    }
+    std::vector<CmapRange> ranges;
+    ranges.reserve(*groupCount);
+    for (std::uint32_t g = 0; g < *groupCount; ++g) {
+        const std::size_t at         = 16u + static_cast<std::size_t>(g) * 12u;
+        const auto        startCode  = beU32(table, at);
+        const auto        endCode    = beU32(table, at + 4);
+        const auto        startGlyph = beU32(table, at + 8);
+        if (!startCode || !endCode || !startGlyph) {
+            return err(ParseError::TruncatedCmap);
+        }
+        if (*startCode > *endCode || *startGlyph > 0xFFFFu) {
+            return err(ParseError::TruncatedCmap);
+        }
+        if (*startGlyph == 0) {
+            continue;
+        }
+        ranges.push_back(CmapRange{.first      = static_cast<char32_t>(*startCode),
+                                   .last       = static_cast<char32_t>(*endCode),
+                                   .firstGlyph = static_cast<std::uint16_t>(*startGlyph)});
+    }
+    return ranges;
+}
+
+/// Picks a subtable out of `cmap` and decodes it.
+///
+/// Preference order is (3,10) format 12, then (3,1) format 4, then (0,*) - Windows full-Unicode,
+/// Windows BMP, then Unicode-platform as a fallback. A font carrying only a Macintosh (1,0)
+/// byte-encoding table is refused with `UnsupportedCmapFormat` rather than decoded, because that
+/// table maps bytes through a legacy codepage rather than code points, and guessing the codepage
+/// is exactly the kind of inference this parser refuses to make.
+[[nodiscard]] Result<std::vector<CmapRange>, ParseError> decodeCmap(std::span<const std::byte> cmap) noexcept {
+    const auto numTables = beU16(cmap, 2);
+    if (!numTables) {
+        return err(ParseError::TruncatedCmap);
+    }
+    if (4u + static_cast<std::size_t>(*numTables) * 8u > cmap.size()) {
+        return err(ParseError::TruncatedCmap);
+    }
+
+    std::optional<std::size_t> best;
+    int                        bestRank = -1;
+    for (std::uint16_t i = 0; i < *numTables; ++i) {
+        const std::size_t at         = 4u + static_cast<std::size_t>(i) * 8u;
+        const auto        platformId = beU16(cmap, at);
+        const auto        encodingId = beU16(cmap, at + 2);
+        const auto        offset     = beU32(cmap, at + 4);
+        if (!platformId || !encodingId || !offset) {
+            return err(ParseError::TruncatedCmap);
+        }
+        if (*offset + 2u > cmap.size()) {
+            return err(ParseError::TruncatedCmap);
+        }
+        const auto format = beU16(cmap, *offset);
+        if (!format) {
+            return err(ParseError::TruncatedCmap);
+        }
+        int rank = -1;
+        if (*platformId == 3 && *encodingId == 10 && *format == 12)
+            rank = 3;
+        else if (*platformId == 3 && *encodingId == 1 && *format == 4)
+            rank = 2;
+        else if (*platformId == 0 && (*format == 4 || *format == 12))
+            rank = 1;
+        if (rank > bestRank) {
+            bestRank = rank;
+            best     = *offset;
+        }
+    }
+    if (!best.has_value() || bestRank < 0) {
+        return err(ParseError::UnsupportedCmapFormat);
+    }
+
+    const auto subtable = cmap.subspan(*best);
+    const auto format   = beU16(subtable, 0);
+    if (!format) {
+        return err(ParseError::TruncatedCmap);
+    }
+    auto ranges = (*format == 12) ? decodeCmapFormat12(subtable) : decodeCmapFormat4(subtable);
+    if (!ranges.has_value()) {
+        return err(ranges.error());
+    }
+    // Sorted so glyphForCodePoint() can binary-search. Format 12 groups and format 4 segments are
+    // both specified as ascending, but sorting rather than trusting that is one line and removes
+    // a silent-wrong-answer path for a font that violates it.
+    std::sort(ranges->begin(), ranges->end(), [](const CmapRange& a, const CmapRange& b) noexcept { return a.first < b.first; });
+    return ranges;
+}
+
 }  // namespace
 
 std::string_view describe(ParseError error) noexcept {
@@ -164,6 +361,22 @@ std::string_view describe(ParseError error) noexcept {
             return "an accumulated coordinate left the int16 range the specification allows";
         case ParseError::NonMonotonicContours:
             return "endPtsOfContours is not strictly increasing";
+        case ParseError::MissingCharacterMap:
+            return "'cmap' is absent; no code point can be resolved to a glyph";
+        case ParseError::TruncatedCmap:
+            return "a 'cmap' header, encoding record or subtable extends past the table";
+        case ParseError::UnsupportedCmapFormat:
+            return "'cmap' carries no subtable in a supported format (4 or 12, Unicode-encoded)";
+        case ParseError::CharacterMapTooLarge:
+            return "'cmap' declares more mappings than the supported maximum";
+        case ParseError::MissingHorizontalMetrics:
+            return "'hhea' or 'hmtx' is absent; no glyph has a known advance width";
+        case ParseError::TruncatedHhea:
+            return "'hhea' table is shorter than 36 bytes";
+        case ParseError::TruncatedHmtx:
+            return "'hmtx' is shorter than hhea.numberOfHMetrics requires";
+        case ParseError::UnsupportedMetricCount:
+            return "hhea.numberOfHMetrics is zero or exceeds maxp.numGlyphs";
     }
     return "unknown TrueType parse error";
 }
@@ -178,6 +391,9 @@ struct Directory {
     std::optional<std::pair<std::uint32_t, std::uint32_t>> maxp;
     std::optional<std::pair<std::uint32_t, std::uint32_t>> loca;
     std::optional<std::pair<std::uint32_t, std::uint32_t>> glyf;
+    std::optional<std::pair<std::uint32_t, std::uint32_t>> cmap;
+    std::optional<std::pair<std::uint32_t, std::uint32_t>> hhea;
+    std::optional<std::pair<std::uint32_t, std::uint32_t>> hmtx;
 };
 
 [[nodiscard]] Result<Directory, ParseError> walkDirectory(std::span<const std::byte> bytes, std::uint16_t numTables) noexcept {
@@ -227,6 +443,12 @@ struct Directory {
             out.loca = record;
         else if (tagStr == "glyf")
             out.glyf = record;
+        else if (tagStr == "cmap")
+            out.cmap = record;
+        else if (tagStr == "hhea")
+            out.hhea = record;
+        else if (tagStr == "hmtx")
+            out.hmtx = record;
     }
     return out;
 }
@@ -307,11 +529,25 @@ Result<Font, ParseError> parse(std::span<const std::byte> bytes) noexcept {
     if (!directory->head.has_value() || !directory->maxp.has_value() || !directory->loca.has_value() || !directory->glyf.has_value()) {
         return err(ParseError::MissingRequiredTable);
     }
+    // `cmap` and `hhea`/`hmtx` are required rather than optional, and the codes are distinct from
+    // MissingRequiredTable so an author learns which capability is missing. Without `cmap` a
+    // recipe cannot name a character; without `hmtx` a baked glyph has no advance, and ADR-010
+    // defines the baked unit as a glyph at a known slot *with a known advance*. A font missing
+    // either is not one this pipeline can bake, whatever its outlines look like.
+    if (!directory->cmap.has_value()) {
+        return err(ParseError::MissingCharacterMap);
+    }
+    if (!directory->hhea.has_value() || !directory->hmtx.has_value()) {
+        return err(ParseError::MissingHorizontalMetrics);
+    }
 
     const auto [headOffset, headLength] = *directory->head;
     const auto [maxpOffset, maxpLength] = *directory->maxp;
     const auto [locaOffset, locaLength] = *directory->loca;
     const auto [glyfOffset, glyfLength] = *directory->glyf;
+    const auto [cmapOffset, cmapLength] = *directory->cmap;
+    const auto [hheaOffset, hheaLength] = *directory->hhea;
+    const auto [hmtxOffset, hmtxLength] = *directory->hmtx;
 
     auto head = bytes.subspan(headOffset, headLength);
     auto maxp = bytes.subspan(maxpOffset, maxpLength);
@@ -365,6 +601,35 @@ Result<Font, ParseError> parse(std::span<const std::byte> bytes) noexcept {
     font.head             = head;
     font.glyf             = glyf;
     font.loca             = std::move(*locaOffsets);
+
+    // hhea's numberOfHMetrics sits at offset 34, the last field of a 36-byte table.
+    auto hhea = bytes.subspan(hheaOffset, hheaLength);
+    if (hhea.size() < 36u) {
+        return err(ParseError::TruncatedHhea);
+    }
+    const auto numberOfHMetrics = beU16(hhea, 34);
+    if (!numberOfHMetrics) {
+        return err(ParseError::TruncatedHhea);
+    }
+    if (*numberOfHMetrics == 0 || *numberOfHMetrics > *numGlyphs) {
+        return err(ParseError::UnsupportedMetricCount);
+    }
+    auto hmtx = bytes.subspan(hmtxOffset, hmtxLength);
+    // numberOfHMetrics full pairs, then one int16 bearing for each remaining glyph.
+    const std::uint64_t hmtxNeeded = static_cast<std::uint64_t>(*numberOfHMetrics) * 4u
+                                     + (static_cast<std::uint64_t>(*numGlyphs) - *numberOfHMetrics) * 2u;
+    if (hmtx.size() < hmtxNeeded) {
+        return err(ParseError::TruncatedHmtx);
+    }
+    font.numberOfHMetrics = *numberOfHMetrics;
+    font.hmtx             = hmtx;
+
+    auto ranges = decodeCmap(bytes.subspan(cmapOffset, cmapLength));
+    if (!ranges.has_value()) {
+        return err(ranges.error());
+    }
+    font.characterMap = std::move(*ranges);
+
     return font;
 }
 
@@ -583,6 +848,53 @@ Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyph
         glyph.points.push_back(GlyphPoint{.x = xCoords[i], .y = yCoords[i], .onCurve = (flags[i] & flagOnCurve) != 0u});
     }
     return glyph;
+}
+
+std::optional<std::uint16_t> glyphForCodePoint(const Font& font, char32_t codePoint) noexcept {
+    // Ranges are sorted and non-overlapping, so the last one starting at or below the code point
+    // is the only candidate.
+    const auto it = std::upper_bound(font.characterMap.begin(), font.characterMap.end(), codePoint,
+                                     [](char32_t value, const CmapRange& range) noexcept { return value < range.first; });
+    if (it == font.characterMap.begin()) {
+        return std::nullopt;
+    }
+    const CmapRange& range = *std::prev(it);
+    if (codePoint > range.last) {
+        return std::nullopt;
+    }
+    const std::uint32_t glyph = static_cast<std::uint32_t>(range.firstGlyph) + (codePoint - range.first);
+    if (glyph >= font.numGlyphs) {
+        // A cmap that names a glyph the font does not have. Refusing beats returning an index
+        // parseGlyph() would then reject with a less specific code.
+        return std::nullopt;
+    }
+    return static_cast<std::uint16_t>(glyph);
+}
+
+Result<GlyphMetrics, ParseError> metricsFor(const Font& font, std::uint16_t glyphIndex) noexcept {
+    if (glyphIndex >= font.numGlyphs) {
+        return err(ParseError::GlyphIndexOutOfRange);
+    }
+    if (font.numberOfHMetrics == 0) {
+        return err(ParseError::UnsupportedMetricCount);
+    }
+    // Past the last full pair, the advance is the last one stored and only the bearing is
+    // per-glyph - the format's compression for a trailing run of equal-width glyphs.
+    const bool          hasOwnAdvance = glyphIndex < font.numberOfHMetrics;
+    const std::uint16_t advanceSlot   = hasOwnAdvance ? glyphIndex : static_cast<std::uint16_t>(font.numberOfHMetrics - 1u);
+    const auto          advance       = beU16(font.hmtx, static_cast<std::size_t>(advanceSlot) * 4u);
+    if (!advance) {
+        return err(ParseError::TruncatedHmtx);
+    }
+    const std::size_t bearingAt = hasOwnAdvance
+                                      ? static_cast<std::size_t>(glyphIndex) * 4u + 2u
+                                      : static_cast<std::size_t>(font.numberOfHMetrics) * 4u
+                                            + (static_cast<std::size_t>(glyphIndex) - font.numberOfHMetrics) * 2u;
+    const auto bearing = beI16(font.hmtx, bearingAt);
+    if (!bearing) {
+        return err(ParseError::TruncatedHmtx);
+    }
+    return GlyphMetrics{.advanceWidth = *advance, .leftSideBearing = *bearing};
 }
 
 }  // namespace mdux::tools::truetype

--- a/tools/text/Truetype.cppm
+++ b/tools/text/Truetype.cppm
@@ -126,6 +126,14 @@ enum class ParseError : std::uint8_t {
     UnsupportedGlyphFlag,       ///< a flag value has reserved bit 7 set
     CoordinateOverflow,         ///< an accumulated coordinate left the int16 range the spec allows
     NonMonotonicContours,       ///< endPtsOfContours[i] <= endPtsOfContours[i-1]
+    MissingCharacterMap,        ///< 'cmap' is absent, so no code point can be resolved to a glyph
+    TruncatedCmap,              ///< a 'cmap' header, encoding record or subtable runs past the table
+    UnsupportedCmapFormat,      ///< 'cmap' carries no subtable in a format this parser reads
+    CharacterMapTooLarge,       ///< 'cmap' declares more mappings than `maxCmapEntries` allows
+    MissingHorizontalMetrics,   ///< 'hhea' or 'hmtx' is absent, so no glyph has a known advance
+    TruncatedHhea,              ///< 'hhea' is shorter than 36 bytes
+    TruncatedHmtx,              ///< 'hmtx' is shorter than numberOfHMetrics requires
+    UnsupportedMetricCount,     ///< hhea.numberOfHMetrics is zero, or exceeds maxp.numGlyphs
 };
 
 [[nodiscard]] std::string_view describe(ParseError error) noexcept;
@@ -156,6 +164,43 @@ struct SimpleGlyph {
     std::vector<GlyphPoint>    points;
 };
 
+/// The largest number of `cmap` ranges `parse()` will build. A font mapping more than this is
+/// either enormous or hostile; the cap turns the second case into `CharacterMapTooLarge` rather
+/// than an allocation sized by a malformed table.
+inline constexpr std::size_t maxCmapEntries = 1u << 16;
+
+/**
+ * @brief One run of consecutive code points mapping to consecutive glyph indices.
+ *
+ * `cmap` is decoded into a sorted list of these rather than kept in its on-disk shape, because
+ * the two formats this parser reads store the same information very differently: format 4 uses
+ * four parallel arrays plus an `idRangeOffset` indirection into a trailing glyph array, and
+ * format 12 uses a flat group list. Normalising both at parse time means `glyphForCodePoint()`
+ * is one binary search with no format switch, and the format-4 indirection - the fiddliest part
+ * of the table - is walked exactly once, where it can be bounds-checked in one place.
+ *
+ * A segment whose glyphs are not consecutive (format 4's indirect case) decodes into one range
+ * per code point, so `first == last` there. That costs entries but keeps the lookup uniform.
+ */
+struct CmapRange {
+    char32_t      first{0};       ///< first code point in the run
+    char32_t      last{0};        ///< last code point, inclusive
+    std::uint16_t firstGlyph{0};  ///< glyph index for `first`; the run is consecutive from there
+};
+
+/**
+ * @brief One glyph's horizontal metrics, in font units.
+ *
+ * `advanceWidth` is the quantity ADR-010 requires a baked glyph to carry: the runtime advances a
+ * pen by a value the baker computed, never by one it derives at runtime. `leftSideBearing` is the
+ * gap from the pen position to the glyph's left edge, which the atlas packer needs to place a
+ * coverage bitmap against the origin the advance is measured from.
+ */
+struct GlyphMetrics {
+    std::uint16_t advanceWidth{0};
+    std::int16_t  leftSideBearing{0};
+};
+
 /**
  * @brief Everything `parseGlyph()` needs that `parse()` already walked.
  *
@@ -180,6 +225,21 @@ struct Font {
     /// Byte offsets into `glyf`. `numGlyphs + 1` entries; the last is the past-the-end offset
     /// of the last glyph, i.e. the byte length of `glyf` the directory asserts.
     std::vector<std::uint32_t> loca{};
+
+    /// How many leading glyphs `hmtx` gives a full (advance, bearing) pair for. Glyphs past this
+    /// carry only a bearing and reuse the last advance - the format's compression for the run of
+    /// equal-width glyphs a monospace or CJK font ends with.
+    std::uint16_t numberOfHMetrics{0};
+
+    /// The `hmtx` table, sliced but not decoded. `metricsFor()` reads one glyph's pair from it,
+    /// the same way `parseGlyph()` reads one record from `glyf` - a font with 6000 glyphs should
+    /// not pay for 6000 metric structs when a baker asks for ninety-five of them.
+    std::span<const std::byte> hmtx{};
+
+    /// Code-point ranges resolved out of `cmap`, sorted by `first` and non-overlapping.
+    /// `glyphForCodePoint()` binary-searches this; see `CmapRange` for why the decoded form is a
+    /// range list rather than the format-4 segment arrays it usually comes from.
+    std::vector<CmapRange> characterMap{};
 };
 
 /// Walks the offset table, head, maxp, loca and the implicit "is this a TrueType outline font"
@@ -206,5 +266,26 @@ struct Font {
 /// therefore re-checked here rather than assumed, and a `Font` that fails it is refused with
 /// `LocaSizeMismatch` instead of indexing a `std::vector` out of range.
 [[nodiscard]] mdux::core::Result<SimpleGlyph, ParseError> parseGlyph(const Font& font, std::uint16_t glyphIndex) noexcept;
+
+/**
+ * @brief Resolves a code point to a glyph index, or nullopt when the font does not map it.
+ *
+ * Binary search over `font.characterMap`. Returns nullopt rather than glyph 0 for an unmapped
+ * code point, deliberately: glyph 0 is `.notdef`, a real glyph with a real outline, and a baker
+ * that silently baked it for every missing character would produce an atlas full of tofu boxes
+ * that looked like a successful bake. The caller decides whether a miss is fatal - for the font
+ * baker (#160) it is, because the recipe named a character the font cannot draw.
+ */
+[[nodiscard]] std::optional<std::uint16_t> glyphForCodePoint(const Font& font, char32_t codePoint) noexcept;
+
+/**
+ * @brief Reads one glyph's horizontal metrics out of `hmtx`.
+ *
+ * Glyphs at or past `numberOfHMetrics` have no advance of their own and inherit the last one the
+ * table stores, which is how the format compresses the trailing run of equal-width glyphs. That
+ * is not an error and this function resolves it silently; `TruncatedHmtx` means the table is
+ * genuinely too short for the metrics it promised.
+ */
+[[nodiscard]] mdux::core::Result<GlyphMetrics, ParseError> metricsFor(const Font& font, std::uint16_t glyphIndex) noexcept;
 
 }  // namespace mdux::tools::truetype


### PR DESCRIPTION
Part of #14, prerequisite for S4 (#160). **First of two stacked PRs.**

> ### Reviewers: what is deliberately not here
>
> **This PR adds no atlas packing, no baking, no committed font, and no recipe changes.** All of that is in the second PR of the stack, which targets *this* branch:
>
> | | |
> |---|---|
> | **1/2 — this PR** | `cmap` + `hmtx` in `mdux.tools.truetype`. Table decoding only. |
> | **2/2 — follows** | Shelf atlas packer, `mdux-textbake` completion, `TXT` diagnostics, `mdux_bake_artifact()` registration, the committed DejaVu Sans source asset and `generated/font/<id>/`, SOUP register entry. |
>
> So: no `AtlasPacker`, no `atlas.bin`, no `package.json` for a font, and `TextBake.cpp` is untouched. If you are looking for the thing that *uses* `glyphForCodePoint()`, it is in 2/2 — nothing in this branch calls it outside the tests, by design.
>
> The split exists because S3's 600-line change attracted four real defects in review; folding a table decoder into a baker would have made both harder to see.

## Why this is not in #160's text

S4 asks for glyphs packed into an atlas and a committed font package. Neither was expressible: the parser walked `head`, `maxp`, `loca` and `glyf` only, so there was

- **no code-point-to-glyph mapping** — a recipe naming a charset had nothing to resolve it against, and
- **no advance widths at all** — though ADR-010 defines the baked unit as "one glyph baked at a known atlas slot **with a known advance**" and lists "glyph advances" among a font package's contents.

The epic's chain (S2 → S3 → S4) doesn't capture this. I found it while planning S4 and stopped rather than discover it mid-baker.

## `cmap`

Both Unicode formats a real font carries, normalised into one sorted `CmapRange` list:

- **format 4**, the BMP workhorse — four parallel arrays plus an `idRangeOffset` that is a byte offset measured *from its own slot*, a self-relative pointer into the trailing glyph array. That indirection is the fiddliest arithmetic in the format; it is walked exactly once here so its bounds check lives in one place rather than at every lookup.
- **format 12**, the only one of the two that reaches past the BMP.

Preference is (3,10) format 12 → (3,1) format 4 → Unicode-platform. A font carrying only a Macintosh (1,0) table is **refused**, not decoded: that table maps bytes through a legacy codepage, and guessing which codepage is exactly the inference this parser exists not to make.

An unmapped code point returns `nullopt`, **not glyph 0**. Returning `.notdef` would let a baker fill an atlas with tofu boxes and report a successful bake.

## `hmtx`

Sliced, not decoded — `metricsFor()` reads one glyph's pair on demand, the way `parseGlyph()` reads one `glyf` record. A 6253-glyph font shouldn't pay for 6253 metric structs when a recipe asks for ninety-five.

Glyphs at or past `numberOfHMetrics` inherit the last advance and carry only a bearing. That's the format's compression for a trailing run of equal-width glyphs, not an error.

## Verified against a real font, not only fixtures

DejaVuSans 2.37 through this parser:

```
parsed: numGlyphs=6253 upem=2048 cmapRanges=281 numberOfHMetrics=6238
ASCII 0x20-0x7E: mapped=95/95  outlines ok=95  composites=0
  'A'     gid=36 advance=1401 lsb=16
  'space' gid=3  advance=651  lsb=0
  '0'     gid=19 advance=1303 lsb=135
  'W'     gid=58 advance=2025 lsb=68
```

Two things fall out that matter for 2/2. **Printable ASCII is entirely composite-free in DejaVuSans**, so the first baked artifact needs no composite pre-baking — which is why 2/2 can ship without touching `CompositeGlyphRejected`. And `numberOfHMetrics` (6238) is below `numGlyphs` (6253), so a real font exercises the inherited-advance path rather than just the fixture.

## Tests

The `Builder` now emits `cmap`, `hhea` and `hmtx` by default, so every pre-existing scenario keeps working, with controls for the new rejection paths.

- **`text-truetype-cmap-resolves`** builds the same mapping in *both* encodings and asserts they agree code point by code point, plus that points either side of the run and an unmapped CJK point resolve to nothing. Formats 4 and 12 share no code, so their agreement is the assertion that carries weight.
- **`text-truetype-hmtx-metrics`** uses a six-glyph font with four metric pairs: the first four advances differ, the last two inherit the fourth.
- **Seven new rejection rows** — `MissingCharacterMap`, `MissingHorizontalMetrics` (hhea and hmtx separately), `TruncatedHhea`, `TruncatedHmtx`, `UnsupportedMetricCount` at both ends.

`cmap` and `hmtx` are now **required** tables with their own codes rather than folding into `MissingRequiredTable`, so an author learns which capability is missing.

24 scenarios, **414/414 ctest**, clean under `-fsanitize=address`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving Unicode characters to glyphs from TrueType character maps in formats 4 and 12.
  * Added retrieval of glyph advance widths and side bearings, including shared metric handling.
* **Bug Fixes**
  * Improved validation and error reporting for missing, truncated, oversized, unsupported, or malformed character-map and horizontal-metrics data.
  * Added safeguards for invalid metric counts and out-of-range glyph or character lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->