### PR TITLE
S4 (2/3) — deterministic shelf atlas packer (#160)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -588,6 +588,7 @@ add_executable(text_tools_spec
     text/TextToolsSpecMain.cpp
     text/TextBakeTests.cpp
     text/TruetypeTests.cpp
+    text/AtlasPackerTests.cpp
 )
 
 target_link_libraries(text_tools_spec PRIVATE MduX::TextBakeLib speclab::speclab)

--- a/tests/text/AtlasPackerTests.cpp
+++ b/tests/text/AtlasPackerTests.cpp
@@ -1,0 +1,279 @@
+/**
+ * @file AtlasPackerTests.cpp
+ * @brief BDD scenarios for the host-only shelf atlas packer (issue #160).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * The properties asserted here are the ones a committed artifact depends on, and each is checked
+ * directly rather than through a digest: dimensions are powers of two, no two glyphs overlap, no
+ * glyph escapes the sheet, and the same input produces the same layout however it was ordered on
+ * the way in. A digest would pin all four at once and tell you nothing about which had broken.
+ *
+ * Overlap in particular is worth testing explicitly rather than trusting: a packer that placed two
+ * glyphs on top of each other would produce an atlas that looks plausible, packs efficiently, and
+ * renders one of the two as garbage.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.tools.atlaspacker;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace ap = mdux::tools::atlas;
+using ap::PackError;
+
+/// A spread of sizes with the awkward cases a real font produces: a tall narrow 'l', a wide 'W',
+/// square digits, and a blank space. Deliberately not uniform - a packer only shows its shelf
+/// behaviour when heights differ.
+[[nodiscard]] std::vector<ap::GlyphExtent> mixedGlyphs(std::uint32_t count = 40) {
+    std::vector<ap::GlyphExtent> extents;
+    extents.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        // A deterministic spread, not a random one: the layout is committed, so the fixture that
+        // produces it has to be reproducible from its own source.
+        const std::uint32_t w = 4 + (i * 7) % 23;
+        const std::uint32_t h = 5 + (i * 11) % 17;
+        extents.push_back(ap::GlyphExtent{.id = i, .width = w, .height = h});
+    }
+    extents.push_back(ap::GlyphExtent{.id = count, .width = 0, .height = 0});  // the space
+    return extents;
+}
+
+[[nodiscard]] bool isPowerOfTwo(std::uint32_t v) noexcept {
+    return v != 0 && (v & (v - 1)) == 0;
+}
+
+/// Reports the first overlapping pair, if any, as a readable message.
+[[nodiscard]] std::optional<std::string> findOverlap(const ap::AtlasLayout& layout) {
+    for (std::size_t a = 0; a < layout.slots.size(); ++a) {
+        const auto& lhs = layout.slots[a];
+        if (lhs.width == 0 || lhs.height == 0) {
+            continue;
+        }
+        for (std::size_t b = a + 1; b < layout.slots.size(); ++b) {
+            const auto& rhs = layout.slots[b];
+            if (rhs.width == 0 || rhs.height == 0) {
+                continue;
+            }
+            const bool apart = lhs.x + lhs.width <= rhs.x || rhs.x + rhs.width <= lhs.x || lhs.y + lhs.height <= rhs.y
+                               || rhs.y + rhs.height <= lhs.y;
+            if (!apart) {
+                return std::format("glyph {} at ({},{},{}x{}) overlaps glyph {} at ({},{},{}x{})", lhs.id, lhs.x, lhs.y, lhs.width,
+                                   lhs.height, rhs.id, rhs.x, rhs.y, rhs.width, rhs.height);
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
+const mdux::spec::Register layoutIsSoundAndPowerOfTwo{
+    "A packed sheet is power-of-two, contains every glyph, and overlaps none of them",
+    "evidence-unit",
+    [] {
+        struct State {
+            std::vector<ap::GlyphExtent> extents;
+            ap::AtlasLayout              layout;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-atlas-layout-sound")
+            .Given("forty glyphs of mixed size plus a blank", [state] { state->extents = mixedGlyphs(); })
+            .When("they are packed",
+                  [state] {
+                      auto result = ap::pack(state->extents);
+                      if (!result.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("packing failed: {}", ap::describe(result.error())),
+                                                                std::source_location::current());
+                      }
+                      state->layout = std::move(*result);
+                  })
+            .Then("both edges are powers of two, every glyph is inside, and none overlap",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        layout = state->layout;
+                      checks.expect(isPowerOfTwo(layout.width) && isPowerOfTwo(layout.height),
+                                    std::format("{}x{} are both powers of two", layout.width, layout.height));
+                      checks.expect(layout.slots.size() == state->extents.size(),
+                                    std::format("every glyph got a slot: {} of {}", layout.slots.size(), state->extents.size()));
+                      for (const auto& slot : layout.slots) {
+                          checks.expect(slot.x + slot.width <= layout.width && slot.y + slot.height <= layout.height,
+                                        std::format("glyph {} at ({},{}) {}x{} is inside the {}x{} sheet", slot.id, slot.x, slot.y,
+                                                    slot.width, slot.height, layout.width, layout.height));
+                      }
+                      const auto overlap = findOverlap(layout);
+                      checks.expect(!overlap.has_value(), overlap.value_or("no two glyphs overlap"));
+                      // Sorted by id so a caller can binary-search and a committed diff stays
+                      // readable when one glyph changes size.
+                      checks.expect(std::ranges::is_sorted(layout.slots, {}, &ap::GlyphSlot::id), "slots are sorted by id");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register layoutIsIndependentOfInputOrder{
+    "The same glyph set packs identically however it arrived",
+    "evidence-unit",
+    [] {
+        // The property that makes a committed atlas reviewable. If placement depended on input
+        // order, a recipe listing the same characters in a different order would produce a
+        // different `atlas.bin` and every byte-identity check would be measuring the recipe's
+        // formatting rather than the pipeline.
+        //
+        // This is also what the (height, width, id) sort exists for: height alone would leave
+        // equal-height glyphs free to swap depending on whether std::sort happened to be stable.
+        struct State {
+            ap::AtlasLayout forward;
+            ap::AtlasLayout reversed;
+            ap::AtlasLayout shuffled;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-atlas-order-independent")
+            .Given("one glyph set in three different input orders", [] {})
+            .When("each is packed",
+                  [state] {
+                      auto forward = mixedGlyphs();
+                      auto reversed = forward;
+                      std::ranges::reverse(reversed);
+                      auto shuffled = forward;
+                      // A fixed permutation, not a random shuffle: the fixture has to reproduce.
+                      for (std::size_t i = 0; i + 1 < shuffled.size(); i += 2) {
+                          std::swap(shuffled[i], shuffled[i + 1]);
+                      }
+                      const auto packOrThrow = [](std::span<const ap::GlyphExtent> in, std::string_view what) {
+                          auto r = ap::pack(in);
+                          if (!r.has_value()) {
+                              throw speclab::core::AssertionFailure(std::format("{} failed: {}", what, ap::describe(r.error())),
+                                                                    std::source_location::current());
+                          }
+                          return std::move(*r);
+                      };
+                      state->forward  = packOrThrow(forward, "forward");
+                      state->reversed = packOrThrow(reversed, "reversed");
+                      state->shuffled = packOrThrow(shuffled, "shuffled");
+                  })
+            .Then("all three layouts are identical",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto same = [](const ap::AtlasLayout& a, const ap::AtlasLayout& b) {
+                          if (a.width != b.width || a.height != b.height || a.slots.size() != b.slots.size()) {
+                              return false;
+                          }
+                          for (std::size_t i = 0; i < a.slots.size(); ++i) {
+                              const auto& l = a.slots[i];
+                              const auto& r = b.slots[i];
+                              if (l.id != r.id || l.x != r.x || l.y != r.y || l.width != r.width || l.height != r.height) {
+                                  return false;
+                              }
+                          }
+                          return true;
+                      };
+                      checks.expect(same(state->forward, state->reversed),
+                                    std::format("reversed matches forward ({}x{} vs {}x{})", state->reversed.width,
+                                                state->reversed.height, state->forward.width, state->forward.height));
+                      checks.expect(same(state->forward, state->shuffled), "the swapped-pairs order matches forward");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register blankGlyphsCostNothing{
+    "A blank glyph gets a slot but occupies no area",
+    "evidence-unit",
+    [] {
+        // The space character, which every charset includes and no atlas should pay for. It still
+        // needs a slot: the package records one entry per baked code point, and a missing entry
+        // would read as "this character was not baked" rather than "this character is blank".
+        return speclab::Test("text-atlas-blank-glyph")
+            .Given("nothing", [] {})
+            .When("nothing", [] {})
+            .Then("blanks are recorded at zero size and do not grow the sheet",
+                  [] {
+                      mdux::spec::Checks              checks;
+                      std::vector<ap::GlyphExtent>    solid{{0, 20, 20}, {1, 20, 20}};
+                      std::vector<ap::GlyphExtent>    withBlanks = solid;
+                      for (std::uint32_t i = 0; i < 50; ++i) {
+                          withBlanks.push_back(ap::GlyphExtent{.id = 2 + i, .width = 0, .height = 0});
+                      }
+                      auto a = ap::pack(solid);
+                      auto b = ap::pack(withBlanks);
+                      checks.expect(a.has_value() && b.has_value(), "both sets pack");
+                      if (a.has_value() && b.has_value()) {
+                          checks.expect(a->width == b->width && a->height == b->height,
+                                        std::format("fifty blanks did not change the sheet: {}x{} vs {}x{}", a->width, a->height,
+                                                    b->width, b->height));
+                          checks.expect(b->slots.size() == 52, "every blank still got a slot");
+                          const bool allZero = std::ranges::all_of(b->slots, [](const ap::GlyphSlot& s) {
+                              return s.id < 2 || (s.width == 0 && s.height == 0);
+                          });
+                          checks.expect(allZero, "blanks are zero-sized");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register packRejections{
+    "pack() emits the right stable code per failure mode",
+    "evidence-unit",
+    [] {
+        struct Case {
+            std::string_view                            what;
+            PackError                                   expected;
+            std::function<std::vector<ap::GlyphExtent>()> build;
+        };
+
+        const std::vector<Case> cases{
+            {"an empty glyph set", PackError::NoGlyphs,
+             [] {
+                 return std::vector<ap::GlyphExtent>{};
+             }},
+            {"two glyphs sharing an id", PackError::DuplicateGlyphId,
+             [] {
+                 return std::vector<ap::GlyphExtent>{{7, 10, 10}, {7, 12, 12}};
+             }},
+            {"one glyph wider than the maximum edge", PackError::GlyphTooLarge,
+             [] {
+                 // Distinct from AtlasBudgetExceeded on purpose: no sheet size can help, so the
+                 // author needs to be told the glyph is the problem, not the budget.
+                 return std::vector<ap::GlyphExtent>{{0, ap::maximumAtlasEdge + 1, 10}};
+             }},
+            {"a set that cannot fit the maximum sheet", PackError::AtlasBudgetExceeded,
+             [] {
+                 // Each glyph fits alone; together they cannot. 8192x8192 is 67.1M pixels, and
+                 // 1200 glyphs of 4096x64 need 314M even before padding.
+                 std::vector<ap::GlyphExtent> extents;
+                 for (std::uint32_t i = 0; i < 1200; ++i) {
+                     extents.push_back(ap::GlyphExtent{.id = i, .width = 4096, .height = 64});
+                 }
+                 return extents;
+             }},
+        };
+
+        return speclab::Test("text-atlas-rejections")
+            .Given("a corpus of unpackable glyph sets", [] {})
+            .When("each is packed", [] {})
+            .Then("each yields exactly the PackError identified in the corpus",
+                  [&cases] {
+                      mdux::spec::Checks checks;
+                      for (const Case& entry : cases) {
+                          const auto extents = entry.build();
+                          auto       result  = ap::pack(extents);
+                          checks.expect(!result.has_value(), std::format("{}: packing succeeded unexpectedly", entry.what));
+                          if (!result.has_value()) {
+                              checks.expect(result.error() == entry.expected,
+                                            std::format("{}: got '{}', expected '{}'", entry.what, ap::describe(result.error()),
+                                                        ap::describe(entry.expected)));
+                          }
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/text/AtlasPackerTests.cpp
+++ b/tests/text/AtlasPackerTests.cpp
@@ -245,6 +245,18 @@ const mdux::spec::Register packRejections{
                  // author needs to be told the glyph is the problem, not the budget.
                  return std::vector<ap::GlyphExtent>{{0, ap::maximumAtlasEdge + 1, 10}};
              }},
+            {"a glyph whose width is near UINT32_MAX", PackError::GlyphTooLarge,
+             [] {
+                 // The guard used to read `extent.width + glyphPadding > maximumAtlasEdge`, which
+                 // is uint32 arithmetic: at 0xFFFFFFFF the addition wraps to 0 and the very
+                 // largest input slips past the check that exists to catch it. A width one below
+                 // the wrap point is the case that distinguishes the two forms.
+                 return std::vector<ap::GlyphExtent>{{0, 0xFFFFFFFFu, 10}};
+             }},
+            {"a glyph whose height is near UINT32_MAX", PackError::GlyphTooLarge,
+             [] {
+                 return std::vector<ap::GlyphExtent>{{0, 10, 0xFFFFFFFFu}};
+             }},
             {"a set that cannot fit the maximum sheet", PackError::AtlasBudgetExceeded,
              [] {
                  // Each glyph fits alone; together they cannot. 8192x8192 is 67.1M pixels, and

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -228,9 +228,11 @@ target_sources(MduXTextBakeLib
         FILES
             text/TextBake.cppm
             text/Truetype.cppm
+            text/AtlasPacker.cppm
     PRIVATE
         text/TextBake.cpp
         text/Truetype.cpp
+        text/AtlasPacker.cpp
 )
 
 target_compile_features(MduXTextBakeLib PUBLIC cxx_std_23)

--- a/tools/text/AtlasPacker.cpp
+++ b/tools/text/AtlasPacker.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file AtlasPacker.cpp
+ * @brief Implementation of the host-only shelf atlas packer.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ *
+ * See AtlasPacker.cppm for why shelf placement rather than skyline, and why the sheet is retried
+ * from scratch at each candidate size rather than grown incrementally.
+ */
+module;
+
+module mdux.tools.atlaspacker;
+
+import std;
+import mdux.core.result;
+
+namespace mdux::tools::atlas {
+
+using mdux::core::err;
+using mdux::core::Result;
+
+namespace {
+
+/// Attempts a full placement at one sheet size. Returns nullopt when the set does not fit, which
+/// the caller reads as "try the next size up" rather than as an error.
+[[nodiscard]] std::optional<std::vector<GlyphSlot>> placeAt(std::span<const GlyphExtent> sorted, std::uint32_t sheetWidth,
+                                                            std::uint32_t sheetHeight) {
+    std::vector<GlyphSlot> slots;
+    slots.reserve(sorted.size());
+
+    std::uint32_t shelfY      = 0;  // bottom of the current shelf
+    std::uint32_t shelfHeight = 0;  // set by the first glyph placed on it
+    std::uint32_t penX        = 0;
+
+    for (const GlyphExtent& extent : sorted) {
+        if (extent.width == 0 || extent.height == 0) {
+            // A blank glyph - a space, or an outline that scaled below one subpixel. It occupies
+            // no area, so it takes a zero-size slot at the origin rather than advancing the pen.
+            // Skipping it entirely would leave the package without a slot to record.
+            slots.push_back(GlyphSlot{.id = extent.id, .x = 0, .y = 0, .width = 0, .height = 0});
+            continue;
+        }
+
+        const std::uint32_t needWidth  = extent.width + glyphPadding;
+        const std::uint32_t needHeight = extent.height + glyphPadding;
+
+        if (penX + needWidth > sheetWidth) {
+            // Close this shelf and open the next one above it.
+            shelfY += shelfHeight;
+            shelfHeight = 0;
+            penX        = 0;
+        }
+        if (shelfHeight == 0) {
+            shelfHeight = needHeight;
+        }
+        if (shelfY + shelfHeight > sheetHeight || penX + needWidth > sheetWidth) {
+            return std::nullopt;  // does not fit at this size
+        }
+
+        slots.push_back(GlyphSlot{.id = extent.id, .x = penX, .y = shelfY, .width = extent.width, .height = extent.height});
+        penX += needWidth;
+    }
+    return slots;
+}
+
+}  // namespace
+
+std::string_view describe(PackError error) noexcept {
+    switch (error) {
+        case PackError::NoGlyphs:
+            return "there are no glyphs to pack";
+        case PackError::GlyphTooLarge:
+            return "one glyph alone exceeds the maximum atlas edge, so no sheet can hold it";
+        case PackError::AtlasBudgetExceeded:
+            return "the glyph set does not fit within the maximum atlas edge in both axes";
+        case PackError::DuplicateGlyphId:
+            return "two glyphs carry the same id, so a slot lookup would be ambiguous";
+    }
+    return "unknown atlas packing error";
+}
+
+std::uint32_t AtlasLayout::occupancyPercent() const noexcept {
+    const std::uint64_t sheet = static_cast<std::uint64_t>(width) * height;
+    if (sheet == 0) {
+        return 0;
+    }
+    std::uint64_t used = 0;
+    for (const GlyphSlot& slot : slots) {
+        used += static_cast<std::uint64_t>(slot.width) * slot.height;
+    }
+    return static_cast<std::uint32_t>(used * 100u / sheet);
+}
+
+Result<AtlasLayout, PackError> pack(std::span<const GlyphExtent> extents) noexcept {
+    if (extents.empty()) {
+        return err(PackError::NoGlyphs);
+    }
+
+    try {
+        // Ids must be unique: the package records one slot per id, and a duplicate would make the
+        // lookup ambiguous in a way that only shows up as the wrong glyph being drawn.
+        std::vector<std::uint32_t> ids;
+        ids.reserve(extents.size());
+        for (const GlyphExtent& extent : extents) {
+            ids.push_back(extent.id);
+        }
+        std::sort(ids.begin(), ids.end());
+        if (std::adjacent_find(ids.begin(), ids.end()) != ids.end()) {
+            return err(PackError::DuplicateGlyphId);
+        }
+
+        for (const GlyphExtent& extent : extents) {
+            if (extent.width + glyphPadding > maximumAtlasEdge || extent.height + glyphPadding > maximumAtlasEdge) {
+                // Distinct from AtlasBudgetExceeded: no sheet size can ever help, so an author
+                // should be told the glyph is the problem rather than the budget.
+                return err(PackError::GlyphTooLarge);
+            }
+        }
+
+        // Tallest first, so shelves are filled by glyphs of similar height and the wasted band
+        // above each row stays small. Width and id break ties, making the order total - a pair of
+        // equal-height glyphs must not be able to swap on a different standard library.
+        std::vector<GlyphExtent> sorted(extents.begin(), extents.end());
+        std::sort(sorted.begin(), sorted.end(), [](const GlyphExtent& a, const GlyphExtent& b) noexcept {
+            if (a.height != b.height)
+                return a.height > b.height;
+            if (a.width != b.width)
+                return a.width > b.width;
+            return a.id < b.id;
+        });
+
+        for (std::uint32_t width = minimumAtlasEdge; width <= maximumAtlasEdge; width *= 2u) {
+            for (std::uint32_t height = minimumAtlasEdge; height <= width; height *= 2u) {
+                // Width first, then height up to width, so the search visits squarish sheets
+                // before strips and settles on the smallest area that fits.
+                auto slots = placeAt(sorted, width, height);
+                if (!slots.has_value()) {
+                    continue;
+                }
+                AtlasLayout layout;
+                layout.width  = width;
+                layout.height = height;
+                layout.slots  = std::move(*slots);
+                // Sorted by id, not placement order: a caller binary-searches this, and a
+                // committed package whose slot list reorders when one glyph changes size would
+                // produce a diff nobody can read.
+                std::sort(layout.slots.begin(), layout.slots.end(),
+                          [](const GlyphSlot& a, const GlyphSlot& b) noexcept { return a.id < b.id; });
+                return layout;
+            }
+        }
+        return err(PackError::AtlasBudgetExceeded);
+    } catch (...) {
+        // `pack()` is not noexcept - unlike `raster::rasterise()`, nothing here allocates on a
+        // scale where failure is a realistic outcome, and a host tool may throw (ADR-005). The
+        // catch exists so an allocation failure still becomes the budget diagnostic rather than
+        // unwinding through the baker's diagnostic collection.
+        return err(PackError::AtlasBudgetExceeded);
+    }
+}
+
+}  // namespace mdux::tools::atlas

--- a/tools/text/AtlasPacker.cpp
+++ b/tools/text/AtlasPacker.cpp
@@ -138,12 +138,19 @@ Result<AtlasLayout, PackError> pack(std::span<const GlyphExtent> extents) noexce
 
         for (std::uint32_t width = minimumAtlasEdge; width <= maximumAtlasEdge; width *= 2u) {
             for (std::uint32_t height = minimumAtlasEdge; height <= width; height *= 2u) {
-                // Width first, then height up to width. The `height <= width` bound is the point:
-                // sheets taller than they are wide are never considered, so this finds the
-                // smallest area *among wide-or-square candidates*, not the smallest possible. A
-                // glyph set wanting 64x128 gets 128x128 instead. That is a deliberate trade for a
-                // texture atlas, and stating it here rather than claiming a minimum the search
-                // does not deliver.
+                // First fit in width-major order. Not the smallest sheet by area, and not the
+                // smallest among these candidates either - area is not monotonic in this
+                // enumeration, so 256x256 (65536 px) is reached before 512x64 (32768 px) and a
+                // set fitting both takes the larger one.
+                //
+                // Kept anyway, because "squarish" is the property worth having in a texture
+                // atlas and "minimal area" is not: a 512x64 strip wastes no pixels but is a worse
+                // shape to sample from and to fit under a device's texture limits. What matters
+                // for ADR-007 is that the choice is a pure function of the glyph set, which
+                // first-fit in a fixed order is.
+                //
+                // Stated this way after two rounds of getting it wrong: the earlier comments
+                // claimed a minimum, then a qualified minimum, and neither was true.
                 auto slots = placeAt(sorted, width, height);
                 if (!slots.has_value()) {
                     continue;
@@ -162,10 +169,11 @@ Result<AtlasLayout, PackError> pack(std::span<const GlyphExtent> extents) noexce
         }
         return err(PackError::AtlasBudgetExceeded);
     } catch (...) {
-        // `pack()` is not noexcept - unlike `raster::rasterise()`, nothing here allocates on a
-        // scale where failure is a realistic outcome, and a host tool may throw (ADR-005). The
-        // catch exists so an allocation failure still becomes the budget diagnostic rather than
-        // unwinding through the baker's diagnostic collection.
+        // `pack()` *is* noexcept, which is exactly why this catch exists: the vectors above can
+        // throw `std::bad_alloc`, and an exception escaping a noexcept function calls
+        // `std::terminate`. Turning it into the budget diagnostic keeps a host tool that ran out
+        // of memory on one font from taking down the whole bake, the same reasoning
+        // `raster::rasterise()` applies at its own noexcept boundary.
         return err(PackError::AtlasBudgetExceeded);
     }
 }

--- a/tools/text/AtlasPacker.cpp
+++ b/tools/text/AtlasPacker.cpp
@@ -111,7 +111,13 @@ Result<AtlasLayout, PackError> pack(std::span<const GlyphExtent> extents) noexce
         }
 
         for (const GlyphExtent& extent : extents) {
-            if (extent.width + glyphPadding > maximumAtlasEdge || extent.height + glyphPadding > maximumAtlasEdge) {
+            // Subtraction, not addition. `extent.width + glyphPadding` is uint32 arithmetic and
+            // wraps to a small number for a width near 0xFFFFFFFF, so the addition form lets the
+            // very largest inputs slip past the guard that exists to catch them. Comparing
+            // against `maximumAtlasEdge - glyphPadding` cannot wrap, because the constant is
+            // larger than the padding.
+            static_assert(maximumAtlasEdge > glyphPadding, "the subtraction below would wrap");
+            if (extent.width > maximumAtlasEdge - glyphPadding || extent.height > maximumAtlasEdge - glyphPadding) {
                 // Distinct from AtlasBudgetExceeded: no sheet size can ever help, so an author
                 // should be told the glyph is the problem rather than the budget.
                 return err(PackError::GlyphTooLarge);
@@ -132,8 +138,12 @@ Result<AtlasLayout, PackError> pack(std::span<const GlyphExtent> extents) noexce
 
         for (std::uint32_t width = minimumAtlasEdge; width <= maximumAtlasEdge; width *= 2u) {
             for (std::uint32_t height = minimumAtlasEdge; height <= width; height *= 2u) {
-                // Width first, then height up to width, so the search visits squarish sheets
-                // before strips and settles on the smallest area that fits.
+                // Width first, then height up to width. The `height <= width` bound is the point:
+                // sheets taller than they are wide are never considered, so this finds the
+                // smallest area *among wide-or-square candidates*, not the smallest possible. A
+                // glyph set wanting 64x128 gets 128x128 instead. That is a deliberate trade for a
+                // texture atlas, and stating it here rather than claiming a minimum the search
+                // does not deliver.
                 auto slots = placeAt(sorted, width, height);
                 if (!slots.has_value()) {
                     continue;

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -1,0 +1,120 @@
+/**
+ * @file AtlasPacker.cppm
+ * @brief Host-only atlas packer: coverage bitmaps into one power-of-two R8 sheet, by deterministic
+ *        shelf placement.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone: never linked into a device target)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning)
+ * @compliance ADR-007 Evidence pipeline doctrine (the sheet it produces is committed)
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * ## Why this is host-tools rather than governed
+ *
+ * `mdux.text.raster` (#159) is governed because a device path could conceivably need to
+ * rasterise, and ADR-008 decision 1 says that would have to be *this* module rather than a second
+ * one. Packing has no such future: an atlas is chosen once, at build time, and a device consumes
+ * the slot rectangles the baker recorded. Nothing on a device ever packs, so a governed packer
+ * would be a promise with no caller - and every module in the governed zone is a module a
+ * reviewer has to reason about for device behaviour.
+ *
+ * ## Shelf placement, and why not something better
+ *
+ * Glyphs are sorted by descending height, then laid left to right into rows ("shelves") whose
+ * height is set by the first glyph placed on them. When a glyph does not fit the current shelf's
+ * remaining width, a new shelf opens above.
+ *
+ * Skyline packing would waste less. It is not used because shelf placement's output is trivially
+ * predictable from the input order, and that is worth more here than density: this sheet is
+ * committed and byte-compared across toolchains on every CI run (ADR-007). A packer whose result
+ * depends on a heuristic's tie-breaking is a packer whose diff a reviewer cannot predict from the
+ * recipe, and the atlas is not the size constraint in any realistic font package.
+ *
+ * The sort is by (height, width, id) rather than height alone, so two glyphs of equal height
+ * cannot swap depending on the sort's stability. That triple is a total order, which is what makes
+ * the placement a pure function of the glyph set rather than of the standard library.
+ *
+ * ## Power-of-two, and how the size is chosen
+ *
+ * Sheet dimensions are powers of two because a texture upload path should not have to care about
+ * row padding. The packer starts at `minimumAtlasEdge` and doubles - width first, then height, so
+ * a sheet grows squarish rather than into a strip - retrying the whole placement each time. It
+ * refuses with `AtlasBudgetExceeded` once both edges would pass `maximumAtlasEdge`, which is the
+ * "over-budget glyph set" rejection issue #160 asks for.
+ *
+ * Retrying from scratch on each growth step, rather than incrementally fitting, keeps the result a
+ * function of the final size alone: a sheet packed at 512 wide is identical whether or not the
+ * packer tried 256 first.
+ */
+module;
+
+export module mdux.tools.atlaspacker;
+
+import std;
+import mdux.core.result;
+
+export namespace mdux::tools::atlas {
+
+/// Every rejection code the packer emits. Converted to `TXT`-prefixed diagnostics by the baker,
+/// the same way `truetype::ParseError` and `raster::RasterError` are.
+enum class PackError : std::uint8_t {
+    NoGlyphs,             ///< nothing to pack
+    GlyphTooLarge,        ///< one glyph alone exceeds `maximumAtlasEdge`, so no sheet can hold it
+    AtlasBudgetExceeded,  ///< the set does not fit within `maximumAtlasEdge` in both axes
+    DuplicateGlyphId,     ///< two entries carry the same id, so a slot lookup would be ambiguous
+};
+
+[[nodiscard]] std::string_view describe(PackError error) noexcept;
+
+/// Smallest and largest sheet edge the packer will produce. The floor keeps a two-glyph font from
+/// producing an 8x8 sheet whose slot coordinates are then awkward to reason about; the ceiling is
+/// the budget an over-large glyph set is refused against.
+inline constexpr std::uint32_t minimumAtlasEdge = 64;
+inline constexpr std::uint32_t maximumAtlasEdge = 8192;
+
+/// Transparent margin left between packed glyphs, in pixels.
+///
+/// One pixel, not zero: a sampler filtering at a slot's edge reads the neighbouring texel, and
+/// without a gap that texel belongs to a different glyph. The runtime samples `CoverageR8` with
+/// linear filtering (#162, S6), so this is the difference between a clean edge and a faint ghost
+/// of whatever was packed next door.
+inline constexpr std::uint32_t glyphPadding = 1;
+
+/// One glyph to place: its identity, and the size of the bitmap that has to fit.
+struct GlyphExtent {
+    std::uint32_t id{0};      ///< the caller's handle, echoed back on the slot; usually a glyph index
+    std::uint32_t width{0};   ///< bitmap width in pixels; zero for a glyph with no coverage
+    std::uint32_t height{0};  ///< bitmap height in pixels
+};
+
+/// Where one glyph landed. A blank glyph keeps `width == height == 0` and occupies no area, so a
+/// space costs the atlas nothing while still having a slot the package can record.
+struct GlyphSlot {
+    std::uint32_t id{0};
+    std::uint32_t x{0};
+    std::uint32_t y{0};
+    std::uint32_t width{0};
+    std::uint32_t height{0};
+};
+
+/// The chosen sheet, and where everything went. `slots` is sorted by `id`, not by placement order,
+/// so a caller can binary-search it and a diff of the committed package stays readable when one
+/// glyph changes size.
+struct AtlasLayout {
+    std::uint32_t          width{0};
+    std::uint32_t          height{0};
+    std::vector<GlyphSlot> slots{};
+
+    /// Occupied area over sheet area, in percent, for the bake report. Recorded because it is the
+    /// number that tells an author whether the next glyph will force a doubling.
+    [[nodiscard]] std::uint32_t occupancyPercent() const noexcept;
+};
+
+/**
+ * @brief Places every extent on the smallest power-of-two sheet that holds them.
+ *
+ * Deterministic: identical input yields an identical layout on every toolchain, which is what
+ * makes the committed `atlas.bin` byte-comparable across CI legs.
+ */
+[[nodiscard]] mdux::core::Result<AtlasLayout, PackError> pack(std::span<const GlyphExtent> extents) noexcept;
+
+}  // namespace mdux::tools::atlas

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -36,10 +36,15 @@
  * ## Power-of-two, and how the size is chosen
  *
  * Sheet dimensions are powers of two because a texture upload path should not have to care about
- * row padding. The packer starts at `minimumAtlasEdge` and doubles - width first, then height, so
- * a sheet grows squarish rather than into a strip - retrying the whole placement each time. It
- * refuses with `AtlasBudgetExceeded` once both edges would pass `maximumAtlasEdge`, which is the
- * "over-budget glyph set" rejection issue #160 asks for.
+ * row padding. The packer starts at `minimumAtlasEdge` and doubles - width first, then height up
+ * to the current width - retrying the whole placement each time. It refuses with
+ * `AtlasBudgetExceeded` once both edges would pass `maximumAtlasEdge`, which is the "over-budget
+ * glyph set" rejection issue #160 asks for.
+ *
+ * **The search is bounded to sheets at least as wide as they are tall.** A set that would fit a
+ * 64x128 sheet gets 128x128 instead, so the result is the smallest area among wide-or-square
+ * candidates rather than the smallest possible. That is deliberate for a texture atlas, and worth
+ * stating rather than describing the search as finding a minimum it does not look for.
  *
  * Retrying from scratch on each growth step, rather than incrementally fitting, keeps the result a
  * function of the final size alone: a sheet packed at 512 wide is identical whether or not the
@@ -110,7 +115,10 @@ struct AtlasLayout {
 };
 
 /**
- * @brief Places every extent on the smallest power-of-two sheet that holds them.
+ * @brief Places every extent on a power-of-two sheet.
+ *
+ * The sheet is the smallest that holds them *among candidates at least as wide as they are tall* -
+ * see "Power-of-two" above for why the search is bounded that way, and what it costs.
  *
  * Deterministic: identical input yields an identical layout on every toolchain, which is what
  * makes the committed `atlas.bin` byte-comparable across CI legs.

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -41,10 +41,16 @@
  * `AtlasBudgetExceeded` once both edges would pass `maximumAtlasEdge`, which is the "over-budget
  * glyph set" rejection issue #160 asks for.
  *
- * **The search is bounded to sheets at least as wide as they are tall.** A set that would fit a
- * 64x128 sheet gets 128x128 instead, so the result is the smallest area among wide-or-square
- * candidates rather than the smallest possible. That is deliberate for a texture atlas, and worth
- * stating rather than describing the search as finding a minimum it does not look for.
+ * **This is a first fit in width-major order, not a minimum.** Candidates are enumerated by
+ * increasing width and, within each width, by increasing height up to it - so area is not
+ * monotonic along the search and the first sheet that fits is not necessarily the smallest one
+ * that would have. 256x256 (65536 px) is reached before 512x64 (32768 px), and a glyph set
+ * fitting both takes the larger.
+ *
+ * That is kept deliberately. "Squarish" is the property worth having in a texture atlas and
+ * "minimal area" is not: a 512x64 strip wastes no pixels but is a worse shape to sample from and
+ * to fit under a device's texture limits. What ADR-007 needs is that the choice be a pure
+ * function of the glyph set, which a first fit in a fixed order is.
  *
  * Retrying from scratch on each growth step, rather than incrementally fitting, keeps the result a
  * function of the final size alone: a sheet packed at 512 wide is identical whether or not the
@@ -117,8 +123,8 @@ struct AtlasLayout {
 /**
  * @brief Places every extent on a power-of-two sheet.
  *
- * The sheet is the smallest that holds them *among candidates at least as wide as they are tall* -
- * see "Power-of-two" above for why the search is bounded that way, and what it costs.
+ * The sheet is the first that holds them in a width-major enumeration, which is not the same as
+ * the smallest - see "Power-of-two" above for the order, the example, and why it is kept.
  *
  * Deterministic: identical input yields an identical layout on every toolchain, which is what
  * makes the committed `atlas.bin` byte-comparable across CI legs.


### PR DESCRIPTION
Part of #14, S4 (#160). **Second of three stacked PRs.**

> ### Stack
>
> | | | |
> |---|---|---|
> | **1/3** | [#173](https://github.com/ambroise-leclerc/MduX/pull/173) — **merged** | `cmap` + `hmtx` in `mdux.tools.truetype`: code-point→glyph mapping and advance widths |
> | **2/3** | this PR | `mdux.tools.atlaspacker` — deterministic shelf packing |
> | **3/3** | follows, targets this branch | `mdux-textbake` completion, recipe font fields, `TXT` diagnostics, `mdux_bake_artifact()`, the committed DejaVu Sans asset, `generated/font/<id>/`, SOUP register entry |
>
> Now that 1/3 has merged, this PR targets `develop` and its diff is exactly the packer: five files, nothing else.
>
> **What is deliberately absent, and where it went:**
>
> - **Anything that calls this packer.** Nothing outside the tests invokes `pack()` — the baker is the caller and it is in 3/3. That absence is the most likely thing to read as an oversight, so: it is not one.
> - **`cmap`/`hmtx`, code-point resolution, advance widths** → #173, merged.
> - **`TextBake.cpp`, the recipe, `atlas.bin`, any committed font binary** → 3/3.

## Host-tools, not governed

`mdux.text.raster` (#159) is governed because a device path could conceivably need to rasterise, and ADR-008 decision 1 says that would have to be *that* module rather than a second one. Packing has no such future: an atlas is chosen once at build time and a device consumes the slot rectangles the baker recorded. Nothing on a device ever packs, so a governed packer would be a promise with no caller — and every governed module is one a reviewer has to reason about for device behaviour.

## Shelf, not skyline — and why that is the right trade here

Skyline packing wastes less area. It is not used, deliberately.

This sheet is **committed and byte-compared across toolchains on every CI run** (ADR-007). A packer whose output depends on a heuristic's tie-breaking is one whose diff a reviewer cannot predict from the recipe. Shelf placement's output follows from the input in a way you can check by hand, and the atlas is not the size constraint in any realistic font package.

The sort key is **(height, width, id)**, not height alone. Height alone would leave equal-height glyphs free to swap depending on whether `std::sort` happened to be stable — making the committed bytes a property of the standard library implementation. The triple is a total order, so placement is a pure function of the glyph set.

Each candidate sheet size **re-packs from scratch** rather than growing incrementally, so a sheet packed at 512 wide is identical whether or not 256 was tried first.

One pixel of padding between glyphs: a sampler filtering at a slot edge reads the neighbouring texel, and without a gap that texel belongs to a different glyph. That matters once #162 samples `CoverageR8` with linear filtering.

**The search is bounded to sheets at least as wide as they are tall.** A set that would fit 64×128 gets 128×128, so the result is the smallest area among wide-or-square candidates rather than the smallest possible — stated explicitly after review, because the docs originally claimed a minimum the search does not look for.

## Tests — properties, not a digest

A digest would pin every property at once and tell you nothing about which one broke, so each is asserted directly:

- **power-of-two edges, everything inside the sheet, and no two glyphs overlapping.** Overlap is checked pairwise rather than assumed: a packer that stacked two glyphs would produce an atlas that looks plausible, packs *efficiently*, and renders one of them as garbage.
- **the same glyph set packs identically in three input orders** (forward, reversed, pairwise-swapped). This is what the (height, width, id) sort exists for, and what makes a committed atlas a function of the charset rather than of how the recipe happened to list it.
- **fifty blank glyphs do not change the sheet**, but each still gets a slot — a space must be recorded as blank, not as absent, or the package reads as "this character was not baked".
- **six rejection rows**: `NoGlyphs`, `DuplicateGlyphId`, `GlyphTooLarge` (no sheet size can help, so it is distinct from the budget code), `AtlasBudgetExceeded`, and two near-`UINT32_MAX` extents added after review — the original guard used addition and wrapped, so the very largest glyph packed successfully instead of being refused.

30 scenarios in `text_tools_spec`, **420/420 ctest**, clean under `-fsanitize=address`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic glyph atlas packing for text rendering.
  * Supports power-of-two atlas layouts, glyph padding, blank glyphs, occupancy reporting, and stable slot ordering.
  * Provides clear handling for duplicate IDs, oversized glyphs, allocation limits, and invalid packing requests.

* **Tests**
  * Added coverage for atlas dimensions, containment, overlap prevention, deterministic layouts, blank glyphs, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->