### PR TITLE
S5 — mdux.font.schema and restricted-charset validation (#161)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ target_sources(MduXCore
             include/mdux/ml/Kernels.cppm
             include/mdux/ml/Runtime.cppm
             include/mdux/draw/Draw.cppm
+            include/mdux/font/Schema.cppm
             include/mdux/text/Schema.cppm
             include/mdux/text/Raster.cppm
     PRIVATE
@@ -204,6 +205,7 @@ target_sources(MduXCore
         src/ml/Kernels.cpp
         src/ml/Runtime.cpp
         src/draw/Draw.cpp
+        src/font/Schema.cpp
         src/text/Schema.cpp
         src/text/Raster.cpp
         src/governance/Governance.cpp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,7 @@ are ordinary `PRIVATE` sources.
 | `mdux.shader.schema` | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
 | `mdux.text.schema` | `include/mdux/text/Schema.cppm` | `src/text/Schema.cpp` |
 | `mdux.text.raster` | `include/mdux/text/Raster.cppm` | `src/text/Raster.cpp` |
+| `mdux.font.schema` | `include/mdux/font/Schema.cppm` | `src/font/Schema.cpp` |
 | `mdux.draw` | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
 | `mdux.ml.schema` | `include/mdux/ml/Schema.cppm` | header-only |
 | `mdux.ml.kernels` | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
@@ -210,7 +211,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | S1 (`mdux.text.schema` + `mdux-textbake` skeleton) landed. S2 (`mdux.tools.truetype`, #158) landed. S3 (`mdux.text.raster`, #159) landed. S4 (atlas packer + font baker, #160) landed with the first committed font package; S5–S6 open |
+| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | S1–S4 landed (`mdux.text.schema`, `mdux.tools.truetype`, `mdux.text.raster`, atlas packer + font baker with the first committed font package). S5 (`mdux.font.schema` + restricted charset, #161) landed; S6 open |
 | `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | the replacement for the retired HTML/CSS path |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |

--- a/generated/font/dejavu-ui/package.json
+++ b/generated/font/dejavu-ui/package.json
@@ -1150,11 +1150,18 @@
     }
   ],
   "id": "dejavu-ui",
+  "kerning": [],
   "kind": "font",
   "locales": [
     "en-US"
   ],
   "pixelSize": 16,
+  "restrictedCharset": [
+    {
+      "first": 32,
+      "last": 126
+    }
+  ],
   "schemaVersion": 1,
   "unitsPerEm": 2048
 }

--- a/generated/font/dejavu-ui/report.json
+++ b/generated/font/dejavu-ui/report.json
@@ -26,7 +26,7 @@
   "outputs": [
     {
       "path": "package.json",
-      "sha256": "61c719a6572d6474148943f57f9588312f08f3302fb5d9e5ed6409c4f6506051"
+      "sha256": "34bff16611756b163fc7fbedcfa4935d614d23e4b35c705ccab75f1814f28873"
     },
     {
       "path": "atlas.bin",

--- a/include/mdux/font/Schema.cppm
+++ b/include/mdux/font/Schema.cppm
@@ -115,6 +115,9 @@ enum class SchemaError : std::uint8_t {
     TabularFigureMismatch,   ///< the decimal digits do not share one advance width
     KerningGlyphMissing,     ///< a kerning pair names a code point the package has no glyph for
     DuplicateKerningPair,    ///< the same ordered pair appears twice
+    IntegerOutOfRange,       ///< a JSON integer does not fit the field it was read into
+    CodePointOutOfRange,     ///< a code point exceeds U+10FFFF, so it is not a Unicode scalar value
+    InvalidAtlasDigest,      ///< the atlas sha256 is not 64 lowercase hexadecimal characters
 };
 
 [[nodiscard]] std::string_view describe(SchemaError error) noexcept;

--- a/include/mdux/font/Schema.cppm
+++ b/include/mdux/font/Schema.cppm
@@ -1,0 +1,219 @@
+/**
+ * @file Schema.cppm
+ * @brief Governed-zone font package types: the canonical shape of every baked font `package.json`,
+ *        and the restricted-charset table that makes "no shaping on device" checkable.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010: one
+ *             definition imported by both the baker and the runtime, not two that could drift)
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * Part of MduXCore. `mdux-textbake` (#160) writes packages through this module and the device
+ * runtime reads them through it, which is the point: a baker that produced one shape and a
+ * runtime that expected another is the Wave 2 lesson, and the reason `mdux.text.schema` exists in
+ * the same form for text packages.
+ *
+ * S4 emitted this JSON by hand, because the baker landed before this module did. Adopting the
+ * type here does not change what a package *is* - it removes the second, informal definition.
+ *
+ * A font package is one font, rasterised at one pixel size, for one set of approved locales:
+ *
+ * ```json
+ * {
+ *   "schemaVersion": 1,
+ *   "id": "dejavu-ui",
+ *   "kind": "font",
+ *   "unitsPerEm": 2048,
+ *   "pixelSize": 16,
+ *   "locales": ["en-US"],
+ *   "atlas":  { "path": "atlas.bin", "width": 128, "height": 128, "byteLength": 16384,
+ *               "sha256": "…", "occupancyPercent": 54 },
+ *   "glyphs": [ { "codePoint": 65, "glyphIndex": 36, "advanceWidth": 1401, … } ],
+ *   "kerning": [ { "left": 65, "right": 86, "adjustment": -80 } ],
+ *   "restrictedCharset": [ { "first": 32, "last": 126 } ]
+ * }
+ * ```
+ *
+ * ## What the restricted charset is for
+ *
+ * ADR-010's commitment is that a device performs no shaping: every glyph it draws was baked, at a
+ * known slot, with a known advance. Static text is safe by construction - the baker positioned it.
+ * *Dynamic* text is not: a screen that formats a number or interpolates a value at runtime can
+ * reach a code point nobody baked, and the runtime has no fallback because having one would mean
+ * mapping code points on device.
+ *
+ * `restrictedCharset` is the declared answer: the exact set of code points this package can draw.
+ * It lets the `.medui` compiler (#15) reject a dynamic-text format whose output could escape the
+ * set *at build time*, which is what turns the ADR's commitment from a slogan into a compile
+ * error. This module carries the table and the membership test; the compiler is what enforces it,
+ * and #161 is where the table starts existing to be enforced against.
+ *
+ * The table is stored as ranges rather than a code-point list because that is how a charset is
+ * written and reviewed - "U+0020..U+007E" is checkable by eye in a way that ninety-five integers
+ * is not - and because membership is then a binary search rather than a scan.
+ *
+ * ## Tabular figures
+ *
+ * `validate()` requires every decimal digit the package contains to share one advance width.
+ *
+ * This is a safety property, not a typographic preference. A numeric field on a medical device -
+ * a heart rate, a dose, an elapsed time - is redrawn as its value changes. If '1' is narrower
+ * than '8', the digits shift horizontally on every update and the field jitters. A clinician
+ * reading a changing number at a glance is exactly the reader that motion hurts most, and the
+ * defect is invisible in a static screenshot, so it has to be caught where the font is baked
+ * rather than where it is looked at.
+ *
+ * A font whose digits are proportional is not broken - it is unsuitable for this use, and the
+ * baker says so with a stable code rather than shipping a package that will jitter.
+ */
+module;
+
+export module mdux.font.schema;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.json;
+
+export namespace mdux::font {
+
+/// The `kind` every font package declares, so a reader that is handed the wrong package type
+/// finds out from the package rather than from a missing field further in.
+inline constexpr std::string_view packageKind = "font";
+
+/// The schema version this module reads and writes. A package declaring anything else is refused
+/// rather than interpreted, because a reader guessing at an unknown version is how a format ends
+/// up with two incompatible meanings for the same bytes.
+inline constexpr std::int64_t schemaVersion = 1;
+
+enum class SchemaError : std::uint8_t {
+    NotAnObject,             ///< the document is not a JSON object
+    MissingMember,           ///< a required member is absent
+    WrongType,               ///< a member has the wrong JSON type
+    UnsupportedVersion,      ///< schemaVersion is not `schemaVersion`
+    WrongKind,               ///< kind is not "font"
+    EmptyId,                 ///< id is empty
+    EmptyLocales,            ///< no approved locale
+    EmptyLocaleTag,          ///< a locale entry is empty
+    DuplicateLocale,         ///< a locale is listed twice
+    UnsupportedUnitsPerEm,   ///< unitsPerEm is zero
+    UnsupportedPixelSize,    ///< pixelSize is zero
+    AtlasNotPowerOfTwo,      ///< atlas width or height is not a power of two
+    AtlasSizeMismatch,       ///< byteLength is not width * height
+    EmptyAtlasPath,          ///< the atlas sidecar has no filename
+    AtlasPathHasSeparator,   ///< the atlas path is not a bare filename
+    NoGlyphs,                ///< the package draws nothing
+    DuplicateCodePoint,      ///< two glyph records claim the same code point
+    GlyphsNotSorted,         ///< glyph records are not in ascending code-point order
+    SurrogateCodePoint,      ///< a glyph or charset range names a UTF-16 surrogate
+    GlyphOutsideAtlas,       ///< a glyph's slot leaves the sheet
+    EmptyCharset,            ///< the restricted charset declares no ranges
+    CharsetRangeDescending,  ///< a charset range's last precedes its first
+    CharsetRangesOverlap,    ///< two charset ranges cover the same code point
+    CharsetGlyphMissing,     ///< the charset names a code point the package has no glyph for
+    TabularFigureMismatch,   ///< the decimal digits do not share one advance width
+    KerningGlyphMissing,     ///< a kerning pair names a code point the package has no glyph for
+    DuplicateKerningPair,    ///< the same ordered pair appears twice
+};
+
+[[nodiscard]] std::string_view describe(SchemaError error) noexcept;
+
+/// Where the coverage sheet lives and what shape it is. The digest is carried here rather than
+/// only in `report.json` so a runtime that loads a package can check the sidecar it was given
+/// belongs to it, without needing the bake report.
+struct AtlasMetrics {
+    std::string   path{};              ///< bare filename, resolved beside `package.json`
+    std::uint32_t width{0};
+    std::uint32_t height{0};
+    std::uint64_t byteLength{0};       ///< exactly `width * height`; the sheet is R8
+    std::string   sha256{};            ///< 64 lowercase hex characters
+    std::uint32_t occupancyPercent{0}; ///< recorded for the report, not load-bearing
+};
+
+/// One baked glyph: where it sits in the sheet, and what it does to the pen.
+///
+/// `advanceWidth` and `leftSideBearing` are in font units, not pixels, so a consumer can scale
+/// them to any size the same way the rasteriser did. The slot and origin are in pixels, because
+/// they describe the sheet that was actually baked.
+struct GlyphRecord {
+    char32_t      codePoint{0};
+    std::uint16_t glyphIndex{0};
+    std::uint16_t advanceWidth{0};
+    std::int16_t  leftSideBearing{0};
+    std::uint32_t x{0};
+    std::uint32_t y{0};
+    std::uint32_t width{0};   ///< zero for a blank such as the space, which still has an advance
+    std::uint32_t height{0};
+    std::int32_t  bitmapOriginX{0};
+    std::int32_t  bitmapOriginY{0};
+
+    [[nodiscard]] bool isBlank() const noexcept { return width == 0 || height == 0; }
+};
+
+/// One kerning adjustment the baker chose to bake, in font units.
+///
+/// "Chose to bake" is the operative phrase: ADR-010 forbids the runtime from consulting a kerning
+/// table, so a pair is either here - resolved at build time - or it does not apply. There is no
+/// on-device lookup that could find one this list omits.
+struct KerningPair {
+    char32_t     left{0};
+    char32_t     right{0};
+    std::int16_t adjustment{0};
+};
+
+/// One run of code points the package is allowed to draw.
+struct CharsetRange {
+    char32_t first{0};
+    char32_t last{0};
+
+    [[nodiscard]] bool contains(char32_t point) const noexcept { return point >= first && point <= last; }
+};
+
+/**
+ * @brief A baked font package: one font, one pixel size, one approved locale set.
+ *
+ * `validate()` is the whole contract. It is called by the baker before writing and by `parse()`
+ * after reading, so a package that exists is a package that passed - there is no state in which a
+ * caller holds a `FontPackage` that has not been checked.
+ */
+struct FontPackage {
+    std::string              id{};
+    std::uint16_t            unitsPerEm{0};
+    std::uint32_t            pixelSize{0};
+    std::vector<std::string> locales{};
+    AtlasMetrics             atlas{};
+    std::vector<GlyphRecord> glyphs{};       ///< sorted by code point
+    std::vector<KerningPair> kerning{};
+    std::vector<CharsetRange> restrictedCharset{};  ///< sorted, non-overlapping
+
+    /// Every structural rule this module enforces, including the tabular-figure requirement and
+    /// that the restricted charset names nothing the package cannot draw.
+    [[nodiscard]] mdux::core::ResultVoid<SchemaError> validate() const noexcept;
+
+    [[nodiscard]] mdux::core::Result<evidence::json::Value, SchemaError> toJson() const noexcept;
+
+    /// Canonical JSON text, ready to commit. Validates first.
+    [[nodiscard]] mdux::core::Result<std::string, SchemaError> write() const noexcept;
+
+    /// Reads and validates. A package that parses is one that passed `validate()`.
+    [[nodiscard]] static mdux::core::Result<FontPackage, SchemaError> parse(std::string_view json) noexcept;
+
+    /// The glyph for `point`, or nullptr. Binary search; `glyphs` is sorted by code point.
+    [[nodiscard]] const GlyphRecord* find(char32_t point) const noexcept;
+
+    /**
+     * @brief Whether `point` is inside the restricted charset.
+     *
+     * The test the `.medui` compiler (#15) applies to every code point a dynamic-text format
+     * could produce. Membership here is a promise that the glyph was baked - `validate()` refuses
+     * a package whose charset names a code point it has no glyph for, so the two cannot disagree.
+     */
+    [[nodiscard]] bool permits(char32_t point) const noexcept;
+
+    /// The kerning adjustment for an ordered pair, or zero when none was baked. Zero rather than
+    /// an optional: "no adjustment" and "an adjustment of zero" mean the same thing to a pen.
+    [[nodiscard]] std::int16_t kerningFor(char32_t left, char32_t right) const noexcept;
+};
+
+}  // namespace mdux::font

--- a/src/font/Schema.cpp
+++ b/src/font/Schema.cpp
@@ -1,0 +1,521 @@
+/**
+ * @file Schema.cpp
+ * @brief Implementation of the governed-zone font package types.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * `validate()` carries the rules; `toJson()` and `parse()` are the two sides of one shape and are
+ * deliberately written next to each other, because a writer and a reader that drift apart is the
+ * failure this module exists to prevent.
+ */
+module;
+
+module mdux.font.schema;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.json;
+
+namespace mdux::font {
+
+namespace json = mdux::evidence::json;
+
+using mdux::core::err;
+using mdux::core::Result;
+using mdux::core::ResultVoid;
+
+namespace {
+
+constexpr char32_t surrogateFirst = 0xD800;
+constexpr char32_t surrogateLast  = 0xDFFF;
+
+[[nodiscard]] bool isPowerOfTwo(std::uint32_t value) noexcept {
+    return value != 0 && (value & (value - 1)) == 0;
+}
+
+/// Reads a required integer member, or fails with the error the caller names.
+[[nodiscard]] Result<std::int64_t, SchemaError> requireInt(const json::Value& object, std::string_view key) noexcept {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        return err(SchemaError::MissingMember);
+    }
+    auto value = member->asInt();
+    if (!value.has_value()) {
+        return err(SchemaError::WrongType);
+    }
+    return *value;
+}
+
+[[nodiscard]] Result<std::string, SchemaError> requireString(const json::Value& object, std::string_view key) noexcept {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        return err(SchemaError::MissingMember);
+    }
+    auto value = member->asString();
+    if (!value.has_value()) {
+        return err(SchemaError::WrongType);
+    }
+    return std::string{*value};
+}
+
+[[nodiscard]] const json::Value* requireArray(const json::Value& object, std::string_view key) noexcept {
+    const json::Value* member = object.find(key);
+    if (member == nullptr || member->kind() != json::Value::Kind::Array) {
+        return nullptr;
+    }
+    return member;
+}
+
+}  // namespace
+
+std::string_view describe(SchemaError error) noexcept {
+    switch (error) {
+        case SchemaError::NotAnObject:
+            return "the font package is not a JSON object";
+        case SchemaError::MissingMember:
+            return "a required member is absent";
+        case SchemaError::WrongType:
+            return "a member has the wrong JSON type";
+        case SchemaError::UnsupportedVersion:
+            return "schemaVersion is not one this module reads";
+        case SchemaError::WrongKind:
+            return "kind is not 'font'";
+        case SchemaError::EmptyId:
+            return "the package id is empty";
+        case SchemaError::EmptyLocales:
+            return "the package approves no locale";
+        case SchemaError::EmptyLocaleTag:
+            return "a locale entry is empty";
+        case SchemaError::DuplicateLocale:
+            return "a locale is listed more than once";
+        case SchemaError::UnsupportedUnitsPerEm:
+            return "unitsPerEm is zero";
+        case SchemaError::UnsupportedPixelSize:
+            return "pixelSize is zero";
+        case SchemaError::AtlasNotPowerOfTwo:
+            return "the atlas width or height is not a power of two";
+        case SchemaError::AtlasSizeMismatch:
+            return "the atlas byteLength is not width * height";
+        case SchemaError::EmptyAtlasPath:
+            return "the atlas path is empty";
+        case SchemaError::AtlasPathHasSeparator:
+            return "the atlas path is not a bare filename";
+        case SchemaError::NoGlyphs:
+            return "the package contains no glyphs";
+        case SchemaError::DuplicateCodePoint:
+            return "two glyph records claim the same code point";
+        case SchemaError::GlyphsNotSorted:
+            return "glyph records are not in ascending code-point order";
+        case SchemaError::SurrogateCodePoint:
+            return "a code point is in the UTF-16 surrogate range, which is not a scalar value";
+        case SchemaError::GlyphOutsideAtlas:
+            return "a glyph's slot extends past the atlas sheet";
+        case SchemaError::EmptyCharset:
+            return "the restricted charset declares no ranges";
+        case SchemaError::CharsetRangeDescending:
+            return "a restricted-charset range ends before it begins";
+        case SchemaError::CharsetRangesOverlap:
+            return "two restricted-charset ranges cover the same code point";
+        case SchemaError::CharsetGlyphMissing:
+            return "the restricted charset names a code point the package has no glyph for";
+        case SchemaError::TabularFigureMismatch:
+            return "the decimal digits do not share one advance width";
+        case SchemaError::KerningGlyphMissing:
+            return "a kerning pair names a code point the package has no glyph for";
+        case SchemaError::DuplicateKerningPair:
+            return "the same ordered kerning pair appears more than once";
+    }
+    return "unknown font schema error";
+}
+
+ResultVoid<SchemaError> FontPackage::validate() const noexcept {
+    if (id.empty()) {
+        return err(SchemaError::EmptyId);
+    }
+    if (unitsPerEm == 0) {
+        return err(SchemaError::UnsupportedUnitsPerEm);
+    }
+    if (pixelSize == 0) {
+        return err(SchemaError::UnsupportedPixelSize);
+    }
+
+    if (locales.empty()) {
+        return err(SchemaError::EmptyLocales);
+    }
+    for (std::size_t i = 0; i < locales.size(); ++i) {
+        if (locales[i].empty()) {
+            return err(SchemaError::EmptyLocaleTag);
+        }
+        for (std::size_t j = 0; j < i; ++j) {
+            if (locales[i] == locales[j]) {
+                return err(SchemaError::DuplicateLocale);
+            }
+        }
+    }
+
+    if (atlas.path.empty()) {
+        return err(SchemaError::EmptyAtlasPath);
+    }
+    // A bare filename, resolved beside package.json. A path with a separator would let a package
+    // point at a sidecar outside its own directory, which is a package describing something other
+    // than itself.
+    if (atlas.path.find('/') != std::string::npos || atlas.path.find('\\') != std::string::npos) {
+        return err(SchemaError::AtlasPathHasSeparator);
+    }
+    if (!isPowerOfTwo(atlas.width) || !isPowerOfTwo(atlas.height)) {
+        return err(SchemaError::AtlasNotPowerOfTwo);
+    }
+    if (atlas.byteLength != static_cast<std::uint64_t>(atlas.width) * atlas.height) {
+        return err(SchemaError::AtlasSizeMismatch);
+    }
+
+    if (glyphs.empty()) {
+        return err(SchemaError::NoGlyphs);
+    }
+    for (std::size_t i = 0; i < glyphs.size(); ++i) {
+        const GlyphRecord& glyph = glyphs[i];
+        if (glyph.codePoint >= surrogateFirst && glyph.codePoint <= surrogateLast) {
+            return err(SchemaError::SurrogateCodePoint);
+        }
+        if (i > 0) {
+            // Sorted *and* strictly increasing, so find()'s binary search is well defined and a
+            // duplicate cannot hide behind an unsorted list.
+            if (glyph.codePoint == glyphs[i - 1].codePoint) {
+                return err(SchemaError::DuplicateCodePoint);
+            }
+            if (glyph.codePoint < glyphs[i - 1].codePoint) {
+                return err(SchemaError::GlyphsNotSorted);
+            }
+        }
+        if (static_cast<std::uint64_t>(glyph.x) + glyph.width > atlas.width
+            || static_cast<std::uint64_t>(glyph.y) + glyph.height > atlas.height) {
+            return err(SchemaError::GlyphOutsideAtlas);
+        }
+    }
+
+    // Tabular figures. Only the digits the package actually contains are compared - a charset
+    // without digits is not required to invent them - but every one that is present must share
+    // the advance, because a field mixing them is what jitters.
+    std::optional<std::uint16_t> digitAdvance;
+    for (char32_t digit = U'0'; digit <= U'9'; ++digit) {
+        const GlyphRecord* glyph = find(digit);
+        if (glyph == nullptr) {
+            continue;
+        }
+        if (!digitAdvance.has_value()) {
+            digitAdvance = glyph->advanceWidth;
+            continue;
+        }
+        if (glyph->advanceWidth != *digitAdvance) {
+            return err(SchemaError::TabularFigureMismatch);
+        }
+    }
+
+    if (restrictedCharset.empty()) {
+        return err(SchemaError::EmptyCharset);
+    }
+    for (std::size_t i = 0; i < restrictedCharset.size(); ++i) {
+        const CharsetRange& range = restrictedCharset[i];
+        if (range.last < range.first) {
+            return err(SchemaError::CharsetRangeDescending);
+        }
+        if (range.first <= surrogateLast && range.last >= surrogateFirst) {
+            return err(SchemaError::SurrogateCodePoint);
+        }
+        if (i > 0 && range.first <= restrictedCharset[i - 1].last) {
+            return err(SchemaError::CharsetRangesOverlap);
+        }
+        // Every code point the charset permits must be one the package can actually draw.
+        // Without this, `permits()` would promise a glyph the runtime would then fail to find -
+        // and the runtime has no fallback, because having one would mean shaping on device.
+        for (char32_t point = range.first; point <= range.last; ++point) {
+            if (find(point) == nullptr) {
+                return err(SchemaError::CharsetGlyphMissing);
+            }
+        }
+    }
+
+    for (std::size_t i = 0; i < kerning.size(); ++i) {
+        const KerningPair& pair = kerning[i];
+        if (find(pair.left) == nullptr || find(pair.right) == nullptr) {
+            return err(SchemaError::KerningGlyphMissing);
+        }
+        for (std::size_t j = 0; j < i; ++j) {
+            if (kerning[j].left == pair.left && kerning[j].right == pair.right) {
+                return err(SchemaError::DuplicateKerningPair);
+            }
+        }
+    }
+
+    return {};
+}
+
+Result<json::Value, SchemaError> FontPackage::toJson() const noexcept {
+    json::Value package = json::Value::emptyObject();
+    const auto  set     = [&package](std::string key, json::Value value) noexcept {
+        static_cast<void>(package.set(std::move(key), std::move(value)));
+    };
+    set("schemaVersion", json::Value::integer(schemaVersion));
+    set("id", json::Value::string(id));
+    set("kind", json::Value::string(std::string{packageKind}));
+    set("unitsPerEm", json::Value::integer(unitsPerEm));
+    set("pixelSize", json::Value::integer(pixelSize));
+
+    std::vector<json::Value> localeValues;
+    localeValues.reserve(locales.size());
+    for (const std::string& tag : locales) {
+        localeValues.push_back(json::Value::string(tag));
+    }
+    set("locales", json::Value::array(std::move(localeValues)));
+
+    json::Value atlasValue = json::Value::emptyObject();
+    static_cast<void>(atlasValue.set("path", json::Value::string(atlas.path)));
+    static_cast<void>(atlasValue.set("width", json::Value::integer(atlas.width)));
+    static_cast<void>(atlasValue.set("height", json::Value::integer(atlas.height)));
+    static_cast<void>(atlasValue.set("byteLength", json::Value::integer(static_cast<std::int64_t>(atlas.byteLength))));
+    static_cast<void>(atlasValue.set("sha256", json::Value::string(atlas.sha256)));
+    static_cast<void>(atlasValue.set("occupancyPercent", json::Value::integer(atlas.occupancyPercent)));
+    set("atlas", std::move(atlasValue));
+
+    std::vector<json::Value> glyphValues;
+    glyphValues.reserve(glyphs.size());
+    for (const GlyphRecord& glyph : glyphs) {
+        json::Value entry = json::Value::emptyObject();
+        static_cast<void>(entry.set("codePoint", json::Value::integer(glyph.codePoint)));
+        static_cast<void>(entry.set("glyphIndex", json::Value::integer(glyph.glyphIndex)));
+        static_cast<void>(entry.set("advanceWidth", json::Value::integer(glyph.advanceWidth)));
+        static_cast<void>(entry.set("leftSideBearing", json::Value::integer(glyph.leftSideBearing)));
+        static_cast<void>(entry.set("x", json::Value::integer(glyph.x)));
+        static_cast<void>(entry.set("y", json::Value::integer(glyph.y)));
+        static_cast<void>(entry.set("width", json::Value::integer(glyph.width)));
+        static_cast<void>(entry.set("height", json::Value::integer(glyph.height)));
+        static_cast<void>(entry.set("bitmapOriginX", json::Value::integer(glyph.bitmapOriginX)));
+        static_cast<void>(entry.set("bitmapOriginY", json::Value::integer(glyph.bitmapOriginY)));
+        glyphValues.push_back(std::move(entry));
+    }
+    set("glyphs", json::Value::array(std::move(glyphValues)));
+
+    std::vector<json::Value> kerningValues;
+    kerningValues.reserve(kerning.size());
+    for (const KerningPair& pair : kerning) {
+        json::Value entry = json::Value::emptyObject();
+        static_cast<void>(entry.set("left", json::Value::integer(pair.left)));
+        static_cast<void>(entry.set("right", json::Value::integer(pair.right)));
+        static_cast<void>(entry.set("adjustment", json::Value::integer(pair.adjustment)));
+        kerningValues.push_back(std::move(entry));
+    }
+    set("kerning", json::Value::array(std::move(kerningValues)));
+
+    std::vector<json::Value> charsetValues;
+    charsetValues.reserve(restrictedCharset.size());
+    for (const CharsetRange& range : restrictedCharset) {
+        json::Value entry = json::Value::emptyObject();
+        static_cast<void>(entry.set("first", json::Value::integer(range.first)));
+        static_cast<void>(entry.set("last", json::Value::integer(range.last)));
+        charsetValues.push_back(std::move(entry));
+    }
+    set("restrictedCharset", json::Value::array(std::move(charsetValues)));
+
+    return package;
+}
+
+Result<std::string, SchemaError> FontPackage::write() const noexcept {
+    if (auto valid = validate(); !valid.has_value()) {
+        return err(valid.error());
+    }
+    auto value = toJson();
+    if (!value.has_value()) {
+        return err(value.error());
+    }
+    auto text = json::write(*value);
+    if (!text.has_value()) {
+        return err(SchemaError::WrongType);
+    }
+    return *text;
+}
+
+Result<FontPackage, SchemaError> FontPackage::parse(std::string_view text) noexcept {
+    auto document = json::parse(text);
+    if (!document.has_value()) {
+        return err(SchemaError::NotAnObject);
+    }
+    if (document->kind() != json::Value::Kind::Object) {
+        return err(SchemaError::NotAnObject);
+    }
+
+    auto version = requireInt(*document, "schemaVersion");
+    if (!version.has_value()) {
+        return err(version.error());
+    }
+    if (*version != schemaVersion) {
+        return err(SchemaError::UnsupportedVersion);
+    }
+    auto kind = requireString(*document, "kind");
+    if (!kind.has_value()) {
+        return err(kind.error());
+    }
+    if (*kind != packageKind) {
+        return err(SchemaError::WrongKind);
+    }
+
+    FontPackage package;
+    auto        packageId = requireString(*document, "id");
+    if (!packageId.has_value()) {
+        return err(packageId.error());
+    }
+    package.id = std::move(*packageId);
+
+    auto upem = requireInt(*document, "unitsPerEm");
+    if (!upem.has_value()) {
+        return err(upem.error());
+    }
+    package.unitsPerEm = static_cast<std::uint16_t>(*upem);
+    auto pixels        = requireInt(*document, "pixelSize");
+    if (!pixels.has_value()) {
+        return err(pixels.error());
+    }
+    package.pixelSize = static_cast<std::uint32_t>(*pixels);
+
+    const json::Value* locales = requireArray(*document, "locales");
+    if (locales == nullptr) {
+        return err(SchemaError::MissingMember);
+    }
+    for (const json::Value& entry : locales->elements()) {
+        auto tag = entry.asString();
+        if (!tag.has_value()) {
+            return err(SchemaError::WrongType);
+        }
+        package.locales.emplace_back(*tag);
+    }
+
+    const json::Value* atlasValue = document->find("atlas");
+    if (atlasValue == nullptr || atlasValue->kind() != json::Value::Kind::Object) {
+        return err(SchemaError::MissingMember);
+    }
+    auto atlasPath = requireString(*atlasValue, "path");
+    if (!atlasPath.has_value()) {
+        return err(atlasPath.error());
+    }
+    package.atlas.path = std::move(*atlasPath);
+    auto atlasSha      = requireString(*atlasValue, "sha256");
+    if (!atlasSha.has_value()) {
+        return err(atlasSha.error());
+    }
+    package.atlas.sha256 = std::move(*atlasSha);
+    {
+        auto width = requireInt(*atlasValue, "width");
+        auto height = requireInt(*atlasValue, "height");
+        auto length = requireInt(*atlasValue, "byteLength");
+        auto occupancy = requireInt(*atlasValue, "occupancyPercent");
+        if (!width.has_value() || !height.has_value() || !length.has_value() || !occupancy.has_value()) {
+            return err(SchemaError::MissingMember);
+        }
+        package.atlas.width            = static_cast<std::uint32_t>(*width);
+        package.atlas.height           = static_cast<std::uint32_t>(*height);
+        package.atlas.byteLength       = static_cast<std::uint64_t>(*length);
+        package.atlas.occupancyPercent = static_cast<std::uint32_t>(*occupancy);
+    }
+
+    const json::Value* glyphs = requireArray(*document, "glyphs");
+    if (glyphs == nullptr) {
+        return err(SchemaError::MissingMember);
+    }
+    for (const json::Value& entry : glyphs->elements()) {
+        if (entry.kind() != json::Value::Kind::Object) {
+            return err(SchemaError::WrongType);
+        }
+        GlyphRecord glyph;
+        auto        point    = requireInt(entry, "codePoint");
+        auto        index    = requireInt(entry, "glyphIndex");
+        auto        advance  = requireInt(entry, "advanceWidth");
+        auto        bearing  = requireInt(entry, "leftSideBearing");
+        auto        x        = requireInt(entry, "x");
+        auto        y        = requireInt(entry, "y");
+        auto        width    = requireInt(entry, "width");
+        auto        height   = requireInt(entry, "height");
+        auto        originX  = requireInt(entry, "bitmapOriginX");
+        auto        originY  = requireInt(entry, "bitmapOriginY");
+        if (!point.has_value() || !index.has_value() || !advance.has_value() || !bearing.has_value() || !x.has_value()
+            || !y.has_value() || !width.has_value() || !height.has_value() || !originX.has_value() || !originY.has_value()) {
+            return err(SchemaError::MissingMember);
+        }
+        glyph.codePoint       = static_cast<char32_t>(*point);
+        glyph.glyphIndex      = static_cast<std::uint16_t>(*index);
+        glyph.advanceWidth    = static_cast<std::uint16_t>(*advance);
+        glyph.leftSideBearing = static_cast<std::int16_t>(*bearing);
+        glyph.x               = static_cast<std::uint32_t>(*x);
+        glyph.y               = static_cast<std::uint32_t>(*y);
+        glyph.width           = static_cast<std::uint32_t>(*width);
+        glyph.height          = static_cast<std::uint32_t>(*height);
+        glyph.bitmapOriginX   = static_cast<std::int32_t>(*originX);
+        glyph.bitmapOriginY   = static_cast<std::int32_t>(*originY);
+        package.glyphs.push_back(glyph);
+    }
+
+    const json::Value* kerning = requireArray(*document, "kerning");
+    if (kerning == nullptr) {
+        return err(SchemaError::MissingMember);
+    }
+    for (const json::Value& entry : kerning->elements()) {
+        auto left       = requireInt(entry, "left");
+        auto right      = requireInt(entry, "right");
+        auto adjustment = requireInt(entry, "adjustment");
+        if (!left.has_value() || !right.has_value() || !adjustment.has_value()) {
+            return err(SchemaError::MissingMember);
+        }
+        package.kerning.push_back(KerningPair{.left       = static_cast<char32_t>(*left),
+                                              .right      = static_cast<char32_t>(*right),
+                                              .adjustment = static_cast<std::int16_t>(*adjustment)});
+    }
+
+    const json::Value* charset = requireArray(*document, "restrictedCharset");
+    if (charset == nullptr) {
+        return err(SchemaError::MissingMember);
+    }
+    for (const json::Value& entry : charset->elements()) {
+        auto first = requireInt(entry, "first");
+        auto last  = requireInt(entry, "last");
+        if (!first.has_value() || !last.has_value()) {
+            return err(SchemaError::MissingMember);
+        }
+        package.restrictedCharset.push_back(
+            CharsetRange{.first = static_cast<char32_t>(*first), .last = static_cast<char32_t>(*last)});
+    }
+
+    // Validated on the way out, so nobody can hold an unchecked FontPackage.
+    if (auto valid = package.validate(); !valid.has_value()) {
+        return err(valid.error());
+    }
+    return package;
+}
+
+const GlyphRecord* FontPackage::find(char32_t point) const noexcept {
+    const auto it = std::lower_bound(glyphs.begin(), glyphs.end(), point,
+                                     [](const GlyphRecord& glyph, char32_t value) noexcept { return glyph.codePoint < value; });
+    if (it == glyphs.end() || it->codePoint != point) {
+        return nullptr;
+    }
+    return &*it;
+}
+
+bool FontPackage::permits(char32_t point) const noexcept {
+    const auto it = std::upper_bound(restrictedCharset.begin(), restrictedCharset.end(), point,
+                                     [](char32_t value, const CharsetRange& range) noexcept { return value < range.first; });
+    if (it == restrictedCharset.begin()) {
+        return false;
+    }
+    return std::prev(it)->contains(point);
+}
+
+std::int16_t FontPackage::kerningFor(char32_t left, char32_t right) const noexcept {
+    for (const KerningPair& pair : kerning) {
+        if (pair.left == left && pair.right == right) {
+            return pair.adjustment;
+        }
+    }
+    return 0;
+}
+
+}  // namespace mdux::font

--- a/src/font/Schema.cpp
+++ b/src/font/Schema.cpp
@@ -35,6 +35,10 @@ constexpr char32_t surrogateLast  = 0xDFFF;
     return value != 0 && (value & (value - 1)) == 0;
 }
 
+/// The largest Unicode scalar value. Above this is not a character at all, so a package naming
+/// one is describing a glyph for something no text can contain.
+constexpr char32_t maxCodePoint = 0x10FFFF;
+
 /// Reads a required integer member, or fails with the error the caller names.
 [[nodiscard]] Result<std::int64_t, SchemaError> requireInt(const json::Value& object, std::string_view key) noexcept {
     const json::Value* member = object.find(key);
@@ -60,10 +64,62 @@ constexpr char32_t surrogateLast  = 0xDFFF;
     return std::string{*value};
 }
 
-[[nodiscard]] const json::Value* requireArray(const json::Value& object, std::string_view key) noexcept {
+/// Reads an integer member and checks it fits `T` *before* narrowing.
+///
+/// Every field below goes through this rather than `static_cast`-ing a parsed `std::int64_t`.
+/// Casting first is not a rounding problem, it is a correctness one: `unitsPerEm: 65537` narrows
+/// to 1 and `pixelSize: -1` wraps to 4294967295, and both then satisfy `validate()`. The package
+/// would parse successfully as *different data than the JSON contains*, which is precisely the
+/// guarantee this module exists to make.
+///
+/// The unsigned branch is separate because a `T` whose maximum exceeds `int64_t`'s cannot be
+/// compared against it directly.
+template <typename T>
+[[nodiscard]] Result<T, SchemaError> requireIntIn(const json::Value& object, std::string_view key) noexcept {
+    auto raw = requireInt(object, key);
+    if (!raw.has_value()) {
+        return err(raw.error());
+    }
+    if constexpr (std::is_unsigned_v<T>) {
+        if (*raw < 0 || static_cast<std::uint64_t>(*raw) > static_cast<std::uint64_t>(std::numeric_limits<T>::max())) {
+            return err(SchemaError::IntegerOutOfRange);
+        }
+    } else {
+        if (*raw < static_cast<std::int64_t>(std::numeric_limits<T>::min())
+            || *raw > static_cast<std::int64_t>(std::numeric_limits<T>::max())) {
+            return err(SchemaError::IntegerOutOfRange);
+        }
+    }
+    return static_cast<T>(*raw);
+}
+
+/// Reads a code point, refusing anything that is not a Unicode scalar value.
+///
+/// `char32_t` is 32 bits, so the type alone permits four billion values of which only 0x110000
+/// are characters. The ceiling is enforced here rather than only in `validate()` so that no
+/// intermediate `FontPackage` ever holds one - and so the charset loop in `validate()` cannot be
+/// handed a range whose end is near the type's maximum.
+[[nodiscard]] Result<char32_t, SchemaError> requireCodePoint(const json::Value& object, std::string_view key) noexcept {
+    auto raw = requireInt(object, key);
+    if (!raw.has_value()) {
+        return err(raw.error());
+    }
+    if (*raw < 0 || *raw > static_cast<std::int64_t>(maxCodePoint)) {
+        return err(SchemaError::CodePointOutOfRange);
+    }
+    return static_cast<char32_t>(*raw);
+}
+
+/// A member that must be an array. Distinguishes absent from present-but-wrong-type, because
+/// reporting `"glyphs": {}` as a missing member sends an author looking for something that is
+/// right there.
+[[nodiscard]] Result<const json::Value*, SchemaError> requireArray(const json::Value& object, std::string_view key) noexcept {
     const json::Value* member = object.find(key);
-    if (member == nullptr || member->kind() != json::Value::Kind::Array) {
-        return nullptr;
+    if (member == nullptr) {
+        return err(SchemaError::MissingMember);
+    }
+    if (member->kind() != json::Value::Kind::Array) {
+        return err(SchemaError::WrongType);
     }
     return member;
 }
@@ -126,6 +182,12 @@ std::string_view describe(SchemaError error) noexcept {
             return "a kerning pair names a code point the package has no glyph for";
         case SchemaError::DuplicateKerningPair:
             return "the same ordered kerning pair appears more than once";
+        case SchemaError::IntegerOutOfRange:
+            return "a JSON integer does not fit the field it was read into";
+        case SchemaError::CodePointOutOfRange:
+            return "a code point exceeds U+10FFFF and is therefore not a Unicode scalar value";
+        case SchemaError::InvalidAtlasDigest:
+            return "the atlas sha256 is not 64 lowercase hexadecimal characters";
     }
     return "unknown font schema error";
 }
@@ -161,8 +223,22 @@ ResultVoid<SchemaError> FontPackage::validate() const noexcept {
     // A bare filename, resolved beside package.json. A path with a separator would let a package
     // point at a sidecar outside its own directory, which is a package describing something other
     // than itself.
-    if (atlas.path.find('/') != std::string::npos || atlas.path.find('\\') != std::string::npos) {
+    // One ordinary filename component, checked positively rather than by banning separators.
+    // Rejecting only '/' and '\\' let through ".", "..", and Windows drive-relative forms like
+    // "C:atlas.bin" - each of which resolves somewhere other than beside package.json on at least
+    // one supported platform.
+    if (atlas.path == "." || atlas.path == ".."
+        || atlas.path.find_first_of("/\\:") != std::string::npos) {
         return err(SchemaError::AtlasPathHasSeparator);
+    }
+    // Exactly 64 lowercase hex characters. The field's whole purpose is letting a runtime check
+    // the sidecar it was handed belongs to this package; a malformed digest is one it cannot use,
+    // and accepting one would mean write() could emit a package with no usable integrity value.
+    if (atlas.sha256.size() != 64
+        || !std::ranges::all_of(atlas.sha256, [](char c) noexcept {
+               return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+           })) {
+        return err(SchemaError::InvalidAtlasDigest);
     }
     if (!isPowerOfTwo(atlas.width) || !isPowerOfTwo(atlas.height)) {
         return err(SchemaError::AtlasNotPowerOfTwo);
@@ -176,6 +252,9 @@ ResultVoid<SchemaError> FontPackage::validate() const noexcept {
     }
     for (std::size_t i = 0; i < glyphs.size(); ++i) {
         const GlyphRecord& glyph = glyphs[i];
+        if (glyph.codePoint > maxCodePoint) {
+            return err(SchemaError::CodePointOutOfRange);
+        }
         if (glyph.codePoint >= surrogateFirst && glyph.codePoint <= surrogateLast) {
             return err(SchemaError::SurrogateCodePoint);
         }
@@ -221,6 +300,12 @@ ResultVoid<SchemaError> FontPackage::validate() const noexcept {
         if (range.last < range.first) {
             return err(SchemaError::CharsetRangeDescending);
         }
+        // Checked before the membership walk below, which increments a char32_t: a range ending at
+        // the type's maximum would wrap `point` to 0 and loop forever. Bounding to a scalar value
+        // makes that unreachable, and the loop is written so it would terminate regardless.
+        if (range.last > maxCodePoint) {
+            return err(SchemaError::CodePointOutOfRange);
+        }
         if (range.first <= surrogateLast && range.last >= surrogateFirst) {
             return err(SchemaError::SurrogateCodePoint);
         }
@@ -230,15 +315,21 @@ ResultVoid<SchemaError> FontPackage::validate() const noexcept {
         // Every code point the charset permits must be one the package can actually draw.
         // Without this, `permits()` would promise a glyph the runtime would then fail to find -
         // and the runtime has no fallback, because having one would mean shaping on device.
-        for (char32_t point = range.first; point <= range.last; ++point) {
+        for (char32_t point = range.first;; ++point) {
             if (find(point) == nullptr) {
                 return err(SchemaError::CharsetGlyphMissing);
+            }
+            if (point == range.last) {
+                break;  // tested here, not in the condition, so `++point` can never wrap past it
             }
         }
     }
 
     for (std::size_t i = 0; i < kerning.size(); ++i) {
         const KerningPair& pair = kerning[i];
+        if (pair.left > maxCodePoint || pair.right > maxCodePoint) {
+            return err(SchemaError::CodePointOutOfRange);
+        }
         if (find(pair.left) == nullptr || find(pair.right) == nullptr) {
             return err(SchemaError::KerningGlyphMissing);
         }
@@ -367,22 +458,25 @@ Result<FontPackage, SchemaError> FontPackage::parse(std::string_view text) noexc
     }
     package.id = std::move(*packageId);
 
-    auto upem = requireInt(*document, "unitsPerEm");
+    // Every numeric field goes through requireIntIn<T>, which range-checks before narrowing.
+    // See its comment: casting a parsed int64 first is not a rounding problem but a correctness
+    // one, because the result validates as different data than the JSON contains.
+    auto upem = requireIntIn<std::uint16_t>(*document, "unitsPerEm");
     if (!upem.has_value()) {
         return err(upem.error());
     }
-    package.unitsPerEm = static_cast<std::uint16_t>(*upem);
-    auto pixels        = requireInt(*document, "pixelSize");
+    package.unitsPerEm = *upem;
+    auto pixels        = requireIntIn<std::uint32_t>(*document, "pixelSize");
     if (!pixels.has_value()) {
         return err(pixels.error());
     }
-    package.pixelSize = static_cast<std::uint32_t>(*pixels);
+    package.pixelSize = *pixels;
 
-    const json::Value* locales = requireArray(*document, "locales");
-    if (locales == nullptr) {
-        return err(SchemaError::MissingMember);
+    auto locales = requireArray(*document, "locales");
+    if (!locales.has_value()) {
+        return err(locales.error());
     }
-    for (const json::Value& entry : locales->elements()) {
+    for (const json::Value& entry : (*locales)->elements()) {
         auto tag = entry.asString();
         if (!tag.has_value()) {
             return err(SchemaError::WrongType);
@@ -391,8 +485,11 @@ Result<FontPackage, SchemaError> FontPackage::parse(std::string_view text) noexc
     }
 
     const json::Value* atlasValue = document->find("atlas");
-    if (atlasValue == nullptr || atlasValue->kind() != json::Value::Kind::Object) {
+    if (atlasValue == nullptr) {
         return err(SchemaError::MissingMember);
+    }
+    if (atlasValue->kind() != json::Value::Kind::Object) {
+        return err(SchemaError::WrongType);
     }
     auto atlasPath = requireString(*atlasValue, "path");
     if (!atlasPath.has_value()) {
@@ -405,83 +502,132 @@ Result<FontPackage, SchemaError> FontPackage::parse(std::string_view text) noexc
     }
     package.atlas.sha256 = std::move(*atlasSha);
     {
-        auto width = requireInt(*atlasValue, "width");
-        auto height = requireInt(*atlasValue, "height");
-        auto length = requireInt(*atlasValue, "byteLength");
-        auto occupancy = requireInt(*atlasValue, "occupancyPercent");
-        if (!width.has_value() || !height.has_value() || !length.has_value() || !occupancy.has_value()) {
-            return err(SchemaError::MissingMember);
+        auto width     = requireIntIn<std::uint32_t>(*atlasValue, "width");
+        auto height    = requireIntIn<std::uint32_t>(*atlasValue, "height");
+        auto length    = requireIntIn<std::uint64_t>(*atlasValue, "byteLength");
+        auto occupancy = requireIntIn<std::uint32_t>(*atlasValue, "occupancyPercent");
+        // Reported individually rather than collapsed, so a diagnostic distinguishes an absent
+        // member from one that is present but the wrong type or out of range.
+        if (!width.has_value()) {
+            return err(width.error());
         }
-        package.atlas.width            = static_cast<std::uint32_t>(*width);
-        package.atlas.height           = static_cast<std::uint32_t>(*height);
-        package.atlas.byteLength       = static_cast<std::uint64_t>(*length);
-        package.atlas.occupancyPercent = static_cast<std::uint32_t>(*occupancy);
+        if (!height.has_value()) {
+            return err(height.error());
+        }
+        if (!length.has_value()) {
+            return err(length.error());
+        }
+        if (!occupancy.has_value()) {
+            return err(occupancy.error());
+        }
+        package.atlas.width            = *width;
+        package.atlas.height           = *height;
+        package.atlas.byteLength       = *length;
+        package.atlas.occupancyPercent = *occupancy;
     }
 
-    const json::Value* glyphs = requireArray(*document, "glyphs");
-    if (glyphs == nullptr) {
-        return err(SchemaError::MissingMember);
+    auto glyphs = requireArray(*document, "glyphs");
+    if (!glyphs.has_value()) {
+        return err(glyphs.error());
     }
-    for (const json::Value& entry : glyphs->elements()) {
+    for (const json::Value& entry : (*glyphs)->elements()) {
         if (entry.kind() != json::Value::Kind::Object) {
             return err(SchemaError::WrongType);
         }
         GlyphRecord glyph;
-        auto        point    = requireInt(entry, "codePoint");
-        auto        index    = requireInt(entry, "glyphIndex");
-        auto        advance  = requireInt(entry, "advanceWidth");
-        auto        bearing  = requireInt(entry, "leftSideBearing");
-        auto        x        = requireInt(entry, "x");
-        auto        y        = requireInt(entry, "y");
-        auto        width    = requireInt(entry, "width");
-        auto        height   = requireInt(entry, "height");
-        auto        originX  = requireInt(entry, "bitmapOriginX");
-        auto        originY  = requireInt(entry, "bitmapOriginY");
-        if (!point.has_value() || !index.has_value() || !advance.has_value() || !bearing.has_value() || !x.has_value()
-            || !y.has_value() || !width.has_value() || !height.has_value() || !originX.has_value() || !originY.has_value()) {
-            return err(SchemaError::MissingMember);
+        auto        point   = requireCodePoint(entry, "codePoint");
+        if (!point.has_value()) {
+            return err(point.error());
         }
-        glyph.codePoint       = static_cast<char32_t>(*point);
-        glyph.glyphIndex      = static_cast<std::uint16_t>(*index);
-        glyph.advanceWidth    = static_cast<std::uint16_t>(*advance);
-        glyph.leftSideBearing = static_cast<std::int16_t>(*bearing);
-        glyph.x               = static_cast<std::uint32_t>(*x);
-        glyph.y               = static_cast<std::uint32_t>(*y);
-        glyph.width           = static_cast<std::uint32_t>(*width);
-        glyph.height          = static_cast<std::uint32_t>(*height);
-        glyph.bitmapOriginX   = static_cast<std::int32_t>(*originX);
-        glyph.bitmapOriginY   = static_cast<std::int32_t>(*originY);
+        auto index = requireIntIn<std::uint16_t>(entry, "glyphIndex");
+        if (!index.has_value()) {
+            return err(index.error());
+        }
+        auto advance = requireIntIn<std::uint16_t>(entry, "advanceWidth");
+        if (!advance.has_value()) {
+            return err(advance.error());
+        }
+        auto bearing = requireIntIn<std::int16_t>(entry, "leftSideBearing");
+        if (!bearing.has_value()) {
+            return err(bearing.error());
+        }
+        auto x = requireIntIn<std::uint32_t>(entry, "x");
+        if (!x.has_value()) {
+            return err(x.error());
+        }
+        auto y = requireIntIn<std::uint32_t>(entry, "y");
+        if (!y.has_value()) {
+            return err(y.error());
+        }
+        auto width = requireIntIn<std::uint32_t>(entry, "width");
+        if (!width.has_value()) {
+            return err(width.error());
+        }
+        auto height = requireIntIn<std::uint32_t>(entry, "height");
+        if (!height.has_value()) {
+            return err(height.error());
+        }
+        auto originX = requireIntIn<std::int32_t>(entry, "bitmapOriginX");
+        if (!originX.has_value()) {
+            return err(originX.error());
+        }
+        auto originY = requireIntIn<std::int32_t>(entry, "bitmapOriginY");
+        if (!originY.has_value()) {
+            return err(originY.error());
+        }
+        glyph.codePoint       = *point;
+        glyph.glyphIndex      = *index;
+        glyph.advanceWidth    = *advance;
+        glyph.leftSideBearing = *bearing;
+        glyph.x               = *x;
+        glyph.y               = *y;
+        glyph.width           = *width;
+        glyph.height          = *height;
+        glyph.bitmapOriginX   = *originX;
+        glyph.bitmapOriginY   = *originY;
         package.glyphs.push_back(glyph);
     }
 
-    const json::Value* kerning = requireArray(*document, "kerning");
-    if (kerning == nullptr) {
-        return err(SchemaError::MissingMember);
+    auto kerning = requireArray(*document, "kerning");
+    if (!kerning.has_value()) {
+        return err(kerning.error());
     }
-    for (const json::Value& entry : kerning->elements()) {
-        auto left       = requireInt(entry, "left");
-        auto right      = requireInt(entry, "right");
-        auto adjustment = requireInt(entry, "adjustment");
-        if (!left.has_value() || !right.has_value() || !adjustment.has_value()) {
-            return err(SchemaError::MissingMember);
+    for (const json::Value& entry : (*kerning)->elements()) {
+        if (entry.kind() != json::Value::Kind::Object) {
+            return err(SchemaError::WrongType);
         }
-        package.kerning.push_back(KerningPair{.left       = static_cast<char32_t>(*left),
-                                              .right      = static_cast<char32_t>(*right),
-                                              .adjustment = static_cast<std::int16_t>(*adjustment)});
+        auto left = requireCodePoint(entry, "left");
+        if (!left.has_value()) {
+            return err(left.error());
+        }
+        auto right = requireCodePoint(entry, "right");
+        if (!right.has_value()) {
+            return err(right.error());
+        }
+        auto adjustment = requireIntIn<std::int16_t>(entry, "adjustment");
+        if (!adjustment.has_value()) {
+            return err(adjustment.error());
+        }
+        package.kerning.push_back(KerningPair{.left = *left, .right = *right, .adjustment = *adjustment});
     }
 
-    const json::Value* charset = requireArray(*document, "restrictedCharset");
-    if (charset == nullptr) {
-        return err(SchemaError::MissingMember);
+    auto charset = requireArray(*document, "restrictedCharset");
+    if (!charset.has_value()) {
+        return err(charset.error());
     }
-    for (const json::Value& entry : charset->elements()) {
-        auto first = requireInt(entry, "first");
-        auto last  = requireInt(entry, "last");
-        if (!first.has_value() || !last.has_value()) {
-            return err(SchemaError::MissingMember);
+    for (const json::Value& entry : (*charset)->elements()) {
+        if (entry.kind() != json::Value::Kind::Object) {
+            return err(SchemaError::WrongType);
         }
-        package.restrictedCharset.push_back(
-            CharsetRange{.first = static_cast<char32_t>(*first), .last = static_cast<char32_t>(*last)});
+        auto first = requireCodePoint(entry, "first");
+        if (!first.has_value()) {
+            return err(first.error());
+        }
+        auto last = requireCodePoint(entry, "last");
+        if (!last.has_value()) {
+            return err(last.error());
+        }
+        package.restrictedCharset.push_back(CharsetRange{.first = *first, .last = *last});
     }
 
     // Validated on the way out, so nobody can hold an unchecked FontPackage.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -550,6 +550,39 @@ mdux_discover_tests(ml_spec)
 # the same standing evidence shader_spec, draw_spec and ml_spec give. S1 ships the schema and a
 # no-run baker skeleton; the TrueType parser (#158), rasteriser (#159), atlas font baker (#160),
 # font schema (#161) and coverage draw path (#162) follow as their blockers close.
+# Font schema suite (issue #161)
+#
+# Its own executable rather than cases inside text_spec, because a font package and a text package
+# are different shapes with different rules, and a failure should name which schema rejected the
+# input. Links MduX::Core only - see FontSpecMain.cpp on why that link line is evidence.
+add_executable(font_spec
+    font/FontSpecMain.cpp
+    font/SchemaTests.cpp
+)
+
+target_link_libraries(font_spec PRIVATE MduX::Core speclab::speclab)
+target_include_directories(font_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+# The committed-package scenario reads generated/font/dejavu-ui/package.json, so the suite has to
+# know where the repository is - the same way shader_spec locates its own artifacts.
+target_compile_definitions(font_spec PRIVATE MDUX_REPO_ROOT="${CMAKE_SOURCE_DIR}")
+
+set_target_properties(font_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(font_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(font_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(font_spec)
+
 add_executable(text_spec
     text/TextSpecMain.cpp
     text/SchemaTests.cpp

--- a/tests/font/FontSpecMain.cpp
+++ b/tests/font/FontSpecMain.cpp
@@ -1,0 +1,20 @@
+/**
+ * @brief Entry point for the mdux.font.schema SpecLab BDD executable.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * Links `MduX::Core` only, like the other governed-zone specs. That is standing evidence rather
+ * than convention: `mdux.font.schema` describes an atlas and a charset without naming a Vulkan
+ * handle, so a scenario that needed `MduX::MduX` to build would mean the trust-zone boundary had
+ * moved and the configure-time check had missed it.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX Font Spec");
+}

--- a/tests/font/SchemaTests.cpp
+++ b/tests/font/SchemaTests.cpp
@@ -1,0 +1,319 @@
+/**
+ * @file SchemaTests.cpp
+ * @brief BDD scenarios for the governed font package schema (issue #161).
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * Two kinds of scenario here, and the distinction is deliberate.
+ *
+ * The **round trip** is the one that matters most: this module exists so that the baker that
+ * writes a package and the runtime that reads one cannot drift apart, and the way to check that
+ * is to write a package, read it back, and compare - not to assert that each side independently
+ * produces what a test author expected. A writer and a reader can both be wrong in the same way
+ * only if they share code, which is the point.
+ *
+ * The **rejection corpus** pins one `SchemaError` per rule. `validate()` is called on the way out
+ * of `write()` and on the way in from `parse()`, so a package that exists anywhere in the system
+ * is one that passed - and each rule is worth a distinct code because "invalid package" tells an
+ * author nothing about which of two dozen rules they broke.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.font.schema;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace fp = mdux::font;
+using fp::SchemaError;
+
+/// A package that passes every rule, which each rejection case then breaks in exactly one way.
+/// Built rather than loaded so a scenario's defect is one line of code, not a diff against a blob.
+[[nodiscard]] fp::FontPackage validPackage() {
+    fp::FontPackage package;
+    package.id         = "fixture";
+    package.unitsPerEm = 2048;
+    package.pixelSize  = 16;
+    package.locales    = {"en-US"};
+
+    package.atlas.path             = "atlas.bin";
+    package.atlas.width            = 64;
+    package.atlas.height           = 64;
+    package.atlas.byteLength       = 64u * 64u;
+    package.atlas.sha256           = std::string(64, 'a');
+    package.atlas.occupancyPercent = 25;
+
+    // '0'..'9' then 'A', so the tabular-figure rule has something to check and the charset has a
+    // contiguous run to cover.
+    std::uint32_t x = 0;
+    for (char32_t point = U'0'; point <= U'9'; ++point) {
+        package.glyphs.push_back(fp::GlyphRecord{.codePoint       = point,
+                                                 .glyphIndex      = static_cast<std::uint16_t>(point),
+                                                 .advanceWidth    = 1303,  // shared: tabular
+                                                 .leftSideBearing = 7,
+                                                 .x               = x,
+                                                 .y               = 0,
+                                                 .width           = 5,
+                                                 .height          = 9,
+                                                 .bitmapOriginX   = 0,
+                                                 .bitmapOriginY   = 9});
+        x += 6;
+    }
+    package.restrictedCharset = {fp::CharsetRange{.first = U'0', .last = U'9'}};
+    return package;
+}
+
+}  // namespace
+
+const mdux::spec::Register packageSurvivesARoundTrip{
+    "A package written by this module reads back identical through it",
+    "evidence-unit",
+    [] {
+        // The assertion the module exists for. If the writer and the reader disagreed about a
+        // field's name, width or units, this is where it shows - and it shows as a difference in
+        // the value rather than as an opinion about what the JSON should have looked like.
+        struct State {
+            fp::FontPackage original;
+            std::string     text;
+            std::optional<fp::FontPackage> parsed;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("font-schema-round-trip")
+            .Given("a valid package with glyphs, a charset and kerning",
+                   [state] {
+                       state->original = validPackage();
+                       state->original.kerning = {fp::KerningPair{.left = U'1', .right = U'2', .adjustment = -40}};
+                   })
+            .When("it is written and parsed back",
+                  [state] {
+                      auto text = state->original.write();
+                      if (!text.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("write failed: {}", fp::describe(text.error())),
+                                                                std::source_location::current());
+                      }
+                      state->text  = std::move(*text);
+                      auto parsed  = fp::FontPackage::parse(state->text);
+                      if (!parsed.has_value()) {
+                          throw speclab::core::AssertionFailure(std::format("parse failed: {}", fp::describe(parsed.error())),
+                                                                std::source_location::current());
+                      }
+                      state->parsed = std::move(*parsed);
+                  })
+            .Then("every field survives, and writing it again produces the same bytes",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        a = state->original;
+                      const auto&        b = *state->parsed;
+                      checks.expect(a.id == b.id && a.unitsPerEm == b.unitsPerEm && a.pixelSize == b.pixelSize,
+                                    "identity and metrics survive");
+                      checks.expect(a.locales == b.locales, "locales survive");
+                      checks.expect(a.atlas.path == b.atlas.path && a.atlas.width == b.atlas.width
+                                        && a.atlas.height == b.atlas.height && a.atlas.byteLength == b.atlas.byteLength
+                                        && a.atlas.sha256 == b.atlas.sha256,
+                                    "atlas metrics survive");
+                      checks.expect(a.glyphs.size() == b.glyphs.size(), "every glyph survives");
+                      if (a.glyphs.size() == b.glyphs.size()) {
+                          bool same = true;
+                          for (std::size_t i = 0; i < a.glyphs.size(); ++i) {
+                              const auto& g = a.glyphs[i];
+                              const auto& h = b.glyphs[i];
+                              same = same && g.codePoint == h.codePoint && g.glyphIndex == h.glyphIndex
+                                     && g.advanceWidth == h.advanceWidth && g.leftSideBearing == h.leftSideBearing
+                                     && g.x == h.x && g.y == h.y && g.width == h.width && g.height == h.height
+                                     && g.bitmapOriginX == h.bitmapOriginX && g.bitmapOriginY == h.bitmapOriginY;
+                          }
+                          checks.expect(same, "every glyph field survives, including signed bearings and origins");
+                      }
+                      checks.expect(b.kerningFor(U'1', U'2') == -40, "a negative kerning adjustment survives its sign");
+                      checks.expect(a.restrictedCharset.size() == b.restrictedCharset.size(), "the charset survives");
+
+                      // Byte-level idempotence, which is what the committed artifact depends on.
+                      auto again = b.write();
+                      checks.expect(again.has_value() && *again == state->text,
+                                    "re-writing the parsed package produces identical bytes");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register charsetPermitsExactlyWhatItNames{
+    "permits() answers for the charset, and never for a code point outside it",
+    "evidence-unit",
+    [] {
+        // The test the .medui compiler (#15) will apply to every code point a dynamic-text format
+        // could produce. A false positive here would let a screen reach a glyph the runtime cannot
+        // draw, and the runtime has no fallback - having one would mean mapping code points on
+        // device, which is the thing ADR-010 forbids.
+        return speclab::Test("font-schema-permits")
+            .Given("nothing", [] {})
+            .When("nothing", [] {})
+            .Then("every named point is permitted and every neighbour is not",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         package = validPackage();
+                      for (char32_t point = U'0'; point <= U'9'; ++point) {
+                          checks.expect(package.permits(point), std::format("U+{:04X} is permitted", static_cast<std::uint32_t>(point)));
+                          checks.expect(package.find(point) != nullptr, "and has a glyph, which is what permits() promises");
+                      }
+                      checks.expect(!package.permits(U'0' - 1), "the point below the range is refused");
+                      checks.expect(!package.permits(U'9' + 1), "the point above the range is refused");
+                      checks.expect(!package.permits(U'A'), "an unlisted ASCII letter is refused");
+                      checks.expect(!package.permits(U'中'), "an unlisted CJK point is refused");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register schemaRejections{
+    "validate() emits the right stable code per broken rule",
+    "evidence-unit",
+    [] {
+        struct Case {
+            std::string_view              what;
+            SchemaError                   expected;
+            std::function<void(fp::FontPackage&)> breakIt;
+        };
+
+        const std::vector<Case> cases{
+            {"an empty id", SchemaError::EmptyId, [](fp::FontPackage& p) { p.id.clear(); }},
+            {"no locales", SchemaError::EmptyLocales, [](fp::FontPackage& p) { p.locales.clear(); }},
+            {"an empty locale tag", SchemaError::EmptyLocaleTag, [](fp::FontPackage& p) { p.locales = {""}; }},
+            {"a duplicated locale", SchemaError::DuplicateLocale,
+             [](fp::FontPackage& p) { p.locales = {"en-US", "en-US"}; }},
+            {"a zero unitsPerEm", SchemaError::UnsupportedUnitsPerEm, [](fp::FontPackage& p) { p.unitsPerEm = 0; }},
+            {"an atlas that is not power-of-two", SchemaError::AtlasNotPowerOfTwo,
+             [](fp::FontPackage& p) {
+                 p.atlas.width      = 60;
+                 p.atlas.byteLength = 60u * 64u;
+             }},
+            {"an atlas byteLength that is not width * height", SchemaError::AtlasSizeMismatch,
+             [](fp::FontPackage& p) { p.atlas.byteLength += 1; }},
+            {"an atlas path with a separator", SchemaError::AtlasPathHasSeparator,
+             // A package must not be able to name a sidecar outside its own directory.
+             [](fp::FontPackage& p) { p.atlas.path = "../atlas.bin"; }},
+            {"no glyphs", SchemaError::NoGlyphs, [](fp::FontPackage& p) { p.glyphs.clear(); }},
+            {"glyphs out of order", SchemaError::GlyphsNotSorted,
+             [](fp::FontPackage& p) { std::swap(p.glyphs[0], p.glyphs[1]); }},
+            {"a duplicated code point", SchemaError::DuplicateCodePoint,
+             [](fp::FontPackage& p) { p.glyphs[1].codePoint = p.glyphs[0].codePoint; }},
+            {"a glyph whose slot leaves the sheet", SchemaError::GlyphOutsideAtlas,
+             [](fp::FontPackage& p) { p.glyphs.back().x = p.atlas.width - 1; }},
+            {"digits that do not share an advance", SchemaError::TabularFigureMismatch,
+             // The safety rule: a numeric field redrawn as its value changes jitters if '1' is
+             // narrower than '8', and that defect is invisible in a static screenshot.
+             [](fp::FontPackage& p) { p.glyphs[3].advanceWidth += 100; }},
+            {"a charset naming a code point with no glyph", SchemaError::CharsetGlyphMissing,
+             // permits() would otherwise promise a glyph the runtime cannot find, and it has no
+             // fallback by design.
+             [](fp::FontPackage& p) { p.restrictedCharset = {fp::CharsetRange{.first = U'0', .last = U'A'}}; }},
+            {"a descending charset range", SchemaError::CharsetRangeDescending,
+             [](fp::FontPackage& p) { p.restrictedCharset = {fp::CharsetRange{.first = U'9', .last = U'0'}}; }},
+            {"overlapping charset ranges", SchemaError::CharsetRangesOverlap,
+             [](fp::FontPackage& p) {
+                 p.restrictedCharset = {fp::CharsetRange{.first = U'0', .last = U'5'},
+                                        fp::CharsetRange{.first = U'3', .last = U'9'}};
+             }},
+            {"an empty charset", SchemaError::EmptyCharset, [](fp::FontPackage& p) { p.restrictedCharset.clear(); }},
+            {"a kerning pair naming an absent glyph", SchemaError::KerningGlyphMissing,
+             [](fp::FontPackage& p) { p.kerning = {fp::KerningPair{.left = U'0', .right = U'A', .adjustment = -10}}; }},
+            {"a duplicated kerning pair", SchemaError::DuplicateKerningPair,
+             [](fp::FontPackage& p) {
+                 p.kerning = {fp::KerningPair{.left = U'0', .right = U'1', .adjustment = -10},
+                              fp::KerningPair{.left = U'0', .right = U'1', .adjustment = -20}};
+             }},
+        };
+
+        return speclab::Test("font-schema-rejections")
+            .Given("a valid package, broken one rule at a time", [] {})
+            .When("each is validated", [] {})
+            .Then("each yields exactly the SchemaError identified in the corpus",
+                  [&cases] {
+                      mdux::spec::Checks checks;
+                      // The fixture must itself be valid, or every case below would pass for the
+                      // wrong reason.
+                      auto baseline = validPackage().validate();
+                      checks.expect(baseline.has_value(),
+                                    baseline.has_value() ? "the fixture is valid"
+                                                         : std::format("the fixture is invalid: {}",
+                                                                       fp::describe(baseline.error())));
+                      for (const Case& entry : cases) {
+                          fp::FontPackage package = validPackage();
+                          entry.breakIt(package);
+                          auto result = package.validate();
+                          checks.expect(!result.has_value(), std::format("{}: validation passed unexpectedly", entry.what));
+                          if (!result.has_value()) {
+                              checks.expect(result.error() == entry.expected,
+                                            std::format("{}: got '{}', expected '{}'", entry.what, fp::describe(result.error()),
+                                                        fp::describe(entry.expected)));
+                          }
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register committedPackageParses{
+    "The committed dejavu-ui package parses and permits exactly its charset",
+    "evidence-unit",
+    [] {
+        // The end-to-end assertion: the artifact this repository ships is one this module accepts.
+        // A schema that only ever validated its own fixtures would not have caught a baker writing
+        // a field under a different name.
+        struct State {
+            std::string                    text;
+            std::optional<fp::FontPackage> package;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("font-schema-committed-package")
+            .Given("generated/font/dejavu-ui/package.json",
+                   [state] {
+                       const std::filesystem::path path =
+                           std::filesystem::path{MDUX_REPO_ROOT} / "generated" / "font" / "dejavu-ui" / "package.json";
+                       std::ifstream in{path, std::ios::binary};
+                       if (!in) {
+                           throw speclab::core::AssertionFailure(std::format("cannot open {}", path.string()),
+                                                                 std::source_location::current());
+                       }
+                       state->text.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+                   })
+            .When("it is parsed",
+                  [state] {
+                      auto package = fp::FontPackage::parse(state->text);
+                      if (!package.has_value()) {
+                          throw speclab::core::AssertionFailure(
+                              std::format("the committed package does not validate: {}", fp::describe(package.error())),
+                              std::source_location::current());
+                      }
+                      state->package = std::move(*package);
+                  })
+            .Then("it carries 95 printable-ASCII glyphs with tabular digits",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        package = *state->package;
+                      checks.expect(package.id == "dejavu-ui", "id");
+                      checks.expect(package.glyphs.size() == 95, std::format("95 glyphs, got {}", package.glyphs.size()));
+                      checks.expect(package.permits(U' ') && package.permits(U'~'), "both ends of the range are permitted");
+                      checks.expect(!package.permits(U'é'), "an accented letter outside the charset is refused");
+                      // The tabular rule already passed inside validate(); this pins the value so a
+                      // future font swap that quietly broke it is visible in the diff.
+                      const auto* zero = package.find(U'0');
+                      const auto* eight = package.find(U'8');
+                      checks.expect(zero != nullptr && eight != nullptr, "the digits are present");
+                      if (zero != nullptr && eight != nullptr) {
+                          checks.expect(zero->advanceWidth == eight->advanceWidth,
+                                        std::format("'0' and '8' share advance {}", zero->advanceWidth));
+                      }
+                      const auto* space = package.find(U' ');
+                      checks.expect(space != nullptr && space->isBlank() && space->advanceWidth > 0,
+                                    "the space is blank but advances");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/font/SchemaTests.cpp
+++ b/tests/font/SchemaTests.cpp
@@ -48,8 +48,9 @@ using fp::SchemaError;
     package.atlas.sha256           = std::string(64, 'a');
     package.atlas.occupancyPercent = 25;
 
-    // '0'..'9' then 'A', so the tabular-figure rule has something to check and the charset has a
-    // contiguous run to cover.
+    // The ten decimal digits, so the tabular-figure rule has something to check and the charset
+    // has a contiguous run to cover. Deliberately no letters: a case that needs one adds it, and
+    // the absence is what makes the "charset names a code point with no glyph" case meaningful.
     std::uint32_t x = 0;
     for (char32_t point = U'0'; point <= U'9'; ++point) {
         package.glyphs.push_back(fp::GlyphRecord{.codePoint       = point,
@@ -115,8 +116,9 @@ const mdux::spec::Register packageSurvivesARoundTrip{
                       checks.expect(a.locales == b.locales, "locales survive");
                       checks.expect(a.atlas.path == b.atlas.path && a.atlas.width == b.atlas.width
                                         && a.atlas.height == b.atlas.height && a.atlas.byteLength == b.atlas.byteLength
-                                        && a.atlas.sha256 == b.atlas.sha256,
-                                    "atlas metrics survive");
+                                        && a.atlas.sha256 == b.atlas.sha256
+                                        && a.atlas.occupancyPercent == b.atlas.occupancyPercent,
+                                    "atlas metrics survive, occupancy included");
                       checks.expect(a.glyphs.size() == b.glyphs.size(), "every glyph survives");
                       if (a.glyphs.size() == b.glyphs.size()) {
                           bool same = true;
@@ -197,6 +199,26 @@ const mdux::spec::Register schemaRejections{
             {"an atlas path with a separator", SchemaError::AtlasPathHasSeparator,
              // A package must not be able to name a sidecar outside its own directory.
              [](fp::FontPackage& p) { p.atlas.path = "../atlas.bin"; }},
+            {"an atlas path of \"..\"", SchemaError::AtlasPathHasSeparator,
+             // Banning only separators let "." and ".." through, and both resolve to a directory.
+             [](fp::FontPackage& p) { p.atlas.path = ".."; }},
+            {"a Windows drive-relative atlas path", SchemaError::AtlasPathHasSeparator,
+             // "C:atlas.bin" is relative to the drive's current directory, not to this package.
+             [](fp::FontPackage& p) { p.atlas.path = "C:atlas.bin"; }},
+            {"an empty atlas digest", SchemaError::InvalidAtlasDigest,
+             // The field exists so a runtime can check the sidecar belongs to the package; an
+             // empty one is not an integrity value.
+             [](fp::FontPackage& p) { p.atlas.sha256.clear(); }},
+            {"an atlas digest of the wrong length", SchemaError::InvalidAtlasDigest,
+             [](fp::FontPackage& p) { p.atlas.sha256 = std::string(63, 'a'); }},
+            {"an uppercase atlas digest", SchemaError::InvalidAtlasDigest,
+             // Case matters: two spellings of one digest would compare unequal as strings.
+             [](fp::FontPackage& p) { p.atlas.sha256 = std::string(64, 'A'); }},
+            {"a non-hexadecimal atlas digest", SchemaError::InvalidAtlasDigest,
+             [](fp::FontPackage& p) { p.atlas.sha256 = std::string(64, 'z'); }},
+            {"a code point above U+10FFFF", SchemaError::CodePointOutOfRange,
+             // char32_t admits four billion values; only 0x110000 are characters.
+             [](fp::FontPackage& p) { p.glyphs.back().codePoint = 0x110000; }},
             {"no glyphs", SchemaError::NoGlyphs, [](fp::FontPackage& p) { p.glyphs.clear(); }},
             {"glyphs out of order", SchemaError::GlyphsNotSorted,
              [](fp::FontPackage& p) { std::swap(p.glyphs[0], p.glyphs[1]); }},
@@ -258,6 +280,70 @@ const mdux::spec::Register schemaRejections{
             .Execute();
     }};
 
+const mdux::spec::Register parserRejectsOutOfRangeIntegers{
+    "parse() refuses a JSON integer that does not fit its field, rather than narrowing it",
+    "evidence-unit",
+    [] {
+        // The finding this scenario exists for: `parse()` used to `static_cast` every value it
+        // read, so `unitsPerEm: 65537` narrowed to 1 and `pixelSize: -1` wrapped to 4294967295 -
+        // and both then satisfied validate(). The package parsed successfully as *different data
+        // than the JSON contained*, which is exactly the guarantee this module is supposed to
+        // make. Range-checking before the cast is what makes "it parsed" mean something.
+        //
+        // Each case edits one member of an otherwise valid document, so a failure names the field.
+        struct Case {
+            std::string_view what;
+            SchemaError      expected;
+            std::string_view member;
+            std::string_view value;
+        };
+
+        const std::vector<Case> cases{
+            {"unitsPerEm above uint16", SchemaError::IntegerOutOfRange, "\"unitsPerEm\"", "65537"},
+            {"a negative unitsPerEm", SchemaError::IntegerOutOfRange, "\"unitsPerEm\"", "-1"},
+            {"pixelSize above uint32", SchemaError::IntegerOutOfRange, "\"pixelSize\"", "4294967312"},
+            {"a negative pixelSize", SchemaError::IntegerOutOfRange, "\"pixelSize\"", "-1"},
+        };
+
+        return speclab::Test("font-schema-integer-range")
+            .Given("a valid package document, one field at a time replaced with an out-of-range value", [] {})
+            .When("each is parsed", [] {})
+            .Then("each is refused rather than narrowed",
+                  [&cases] {
+                      mdux::spec::Checks checks;
+                      auto               baseText = validPackage().write();
+                      checks.expect(baseText.has_value(), "the fixture writes");
+                      if (!baseText.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      for (const Case& entry : cases) {
+                          // Canonical JSON writes `"key":value` with no spaces, so the member can
+                          // be located and its value replaced without a JSON editor.
+                          const std::string key{entry.member};
+                          const auto        at = baseText->find(key + ":");
+                          checks.expect(at != std::string::npos, std::format("{}: found {} in the document", entry.what, key));
+                          if (at == std::string::npos) {
+                              continue;
+                          }
+                          const auto valueStart = at + key.size() + 1;
+                          const auto valueEnd   = baseText->find_first_of(",}", valueStart);
+                          std::string edited    = *baseText;
+                          edited.replace(valueStart, valueEnd - valueStart, entry.value);
+
+                          auto parsed = fp::FontPackage::parse(edited);
+                          checks.expect(!parsed.has_value(), std::format("{}: parsing succeeded unexpectedly", entry.what));
+                          if (!parsed.has_value()) {
+                              checks.expect(parsed.error() == entry.expected,
+                                            std::format("{}: got '{}', expected '{}'", entry.what, fp::describe(parsed.error()),
+                                                        fp::describe(entry.expected)));
+                          }
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register committedPackageParses{
     "The committed dejavu-ui package parses and permits exactly its charset",
     "evidence-unit",
@@ -299,7 +385,20 @@ const mdux::spec::Register committedPackageParses{
                       const auto&        package = *state->package;
                       checks.expect(package.id == "dejavu-ui", "id");
                       checks.expect(package.glyphs.size() == 95, std::format("95 glyphs, got {}", package.glyphs.size()));
-                      checks.expect(package.permits(U' ') && package.permits(U'~'), "both ends of the range are permitted");
+                      // Every code point, not just the ends: a package missing an interior one
+                      // could still have 95 glyphs and pass an endpoint check.
+                      bool everyPointPresent = true;
+                      char32_t firstMissing  = 0;
+                      for (char32_t point = U' '; point <= U'~'; ++point) {
+                          if (!package.permits(point) || package.find(point) == nullptr) {
+                              everyPointPresent = false;
+                              firstMissing      = point;
+                              break;
+                          }
+                      }
+                      checks.expect(everyPointPresent,
+                                    everyPointPresent ? "every printable-ASCII point is permitted and baked"
+                                                      : std::format("U+{:04X} is missing", static_cast<std::uint32_t>(firstMissing)));
                       checks.expect(!package.permits(U'é'), "an accented letter outside the charset is refused");
                       // The tabular rule already passed inside validate(); this pins the value so a
                       // future font swap that quietly broke it is visible in the diff.

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -21,6 +21,7 @@ import mdux.tools.toml;
 import mdux.tools.truetype;
 import mdux.tools.atlaspacker;
 import mdux.text.raster;
+import mdux.font.schema;
 
 namespace mdux::tools::textbake {
 
@@ -28,6 +29,7 @@ namespace json     = mdux::evidence::json;
 namespace truetype = mdux::tools::truetype;
 namespace atlas    = mdux::tools::atlas;
 namespace raster   = mdux::text::raster;
+namespace fontpkg  = mdux::font;
 
 namespace {
 
@@ -58,6 +60,10 @@ constexpr std::string_view glyphOutlineRejected   = "TXT015";
 constexpr std::string_view glyphRasterFailed      = "TXT016";
 constexpr std::string_view atlasPackingFailed     = "TXT017";
 constexpr std::string_view recipePixelSizeInvalid = "TXT018";
+// The digits in a baked font must share an advance, or a numeric field jitters as its
+// value changes. Its own code because it is a property of the *font*, not the recipe:
+// the fix is a different font, not a different charset.
+constexpr std::string_view tabularFiguresMismatch = "TXT019";
 
 void report(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::size_t line,
              std::string_view code, std::string message, std::string fixHint = {}) {
@@ -595,60 +601,70 @@ using SlotIndex = std::vector<const atlas::GlyphSlot*>;
     return sheet;
 }
 
-/// Builds the font package JSON.
+/// Assembles the governed `font::FontPackage` for this bake.
 ///
-/// Emitted directly rather than through a schema type because `mdux.font.schema` is S5 (#161),
-/// which lands after this. The shape below is what S5 formalises; keeping it in canonical JSON
-/// now means the committed artifact does not have to change when the schema module arrives, only
-/// gain a reader.
-[[nodiscard]] json::Value fontPackageJson(const Recipe& recipe, const truetype::Font& font, const atlas::AtlasLayout& layout,
-                                          const std::vector<BakedGlyph>& glyphs, const SlotIndex& slots,
-                                          std::string_view sidecarName, std::span<const std::byte> sheet) {
+/// S4 emitted this JSON by hand because the baker landed before `mdux.font.schema` did. Going
+/// through the governed type now is the point of S5: one definition, imported by both the baker
+/// that writes a package and the runtime that reads one, rather than a writer and a reader that
+/// could drift (ADR-008 decision 1, mirrored to text by ADR-010). `FontPackage::write()` also
+/// validates, so a package this baker emits is one that passed the same checks a consumer applies
+/// on the way in.
+[[nodiscard]] fontpkg::FontPackage buildFontPackage(const Recipe& recipe, const truetype::Font& font,
+                                                    const atlas::AtlasLayout& layout, const std::vector<BakedGlyph>& glyphs,
+                                                    const SlotIndex& slots, std::string_view sidecarName,
+                                                    std::span<const std::byte> sheet) {
     const FontSpec& spec = *recipe.font;
 
-    json::Value package = json::Value::emptyObject();
-    static_cast<void>(package.set("schemaVersion", json::Value::integer(1)));
-    static_cast<void>(package.set("id", json::Value::string(recipe.id)));
-    static_cast<void>(package.set("kind", json::Value::string("font")));
-    static_cast<void>(package.set("unitsPerEm", json::Value::integer(font.unitsPerEm)));
-    static_cast<void>(package.set("pixelSize", json::Value::integer(spec.pixelSize)));
+    fontpkg::FontPackage package;
+    package.id         = recipe.id;
+    package.unitsPerEm = font.unitsPerEm;
+    package.pixelSize  = spec.pixelSize;
+    package.locales    = spec.locales;
 
-    std::vector<json::Value> localeValues;
-    for (const std::string& tag : spec.locales) {
-        localeValues.push_back(json::Value::string(tag));
-    }
-    static_cast<void>(package.set("locales", json::Value::array(std::move(localeValues))));
+    const auto digest    = evidence::sha256(sheet);
+    const auto hex       = evidence::toHex(digest);
+    package.atlas.path             = std::string{sidecarName};
+    package.atlas.width            = layout.width;
+    package.atlas.height           = layout.height;
+    package.atlas.byteLength       = sheet.size();
+    package.atlas.sha256           = std::string{hex.data(), hex.size()};
+    package.atlas.occupancyPercent = layout.occupancyPercent();
 
-    json::Value atlasValue = json::Value::emptyObject();
-    static_cast<void>(atlasValue.set("path", json::Value::string(std::string{sidecarName})));
-    static_cast<void>(atlasValue.set("width", json::Value::integer(layout.width)));
-    static_cast<void>(atlasValue.set("height", json::Value::integer(layout.height)));
-    static_cast<void>(atlasValue.set("byteLength", json::Value::integer(static_cast<std::int64_t>(sheet.size()))));
-    const auto digest = evidence::sha256(sheet);
-    const auto hex    = evidence::toHex(digest);
-    static_cast<void>(atlasValue.set("sha256", json::Value::string(std::string{hex.data(), hex.size()})));
-    static_cast<void>(atlasValue.set("occupancyPercent", json::Value::integer(layout.occupancyPercent())));
-    static_cast<void>(package.set("atlas", std::move(atlasValue)));
-
-    std::vector<json::Value> glyphValues;
-    glyphValues.reserve(glyphs.size());
+    package.glyphs.reserve(glyphs.size());
     for (std::uint32_t index = 0; index < glyphs.size(); ++index) {
         const BakedGlyph&       glyph = glyphs[index];
         const atlas::GlyphSlot& slot  = *slots[index];
-        json::Value             entry = json::Value::emptyObject();
-        static_cast<void>(entry.set("codePoint", json::Value::integer(glyph.codePoint)));
-        static_cast<void>(entry.set("glyphIndex", json::Value::integer(glyph.glyphIndex)));
-        static_cast<void>(entry.set("advanceWidth", json::Value::integer(glyph.advanceWidth)));
-        static_cast<void>(entry.set("leftSideBearing", json::Value::integer(glyph.leftSideBearing)));
-        static_cast<void>(entry.set("x", json::Value::integer(slot.x)));
-        static_cast<void>(entry.set("y", json::Value::integer(slot.y)));
-        static_cast<void>(entry.set("width", json::Value::integer(slot.width)));
-        static_cast<void>(entry.set("height", json::Value::integer(slot.height)));
-        static_cast<void>(entry.set("bitmapOriginX", json::Value::integer(glyph.bitmapOriginX)));
-        static_cast<void>(entry.set("bitmapOriginY", json::Value::integer(glyph.bitmapOriginY)));
-        glyphValues.push_back(std::move(entry));
+        package.glyphs.push_back(fontpkg::GlyphRecord{.codePoint       = glyph.codePoint,
+                                                      .glyphIndex      = glyph.glyphIndex,
+                                                      .advanceWidth    = glyph.advanceWidth,
+                                                      .leftSideBearing = glyph.leftSideBearing,
+                                                      .x               = slot.x,
+                                                      .y               = slot.y,
+                                                      .width           = slot.width,
+                                                      .height          = slot.height,
+                                                      .bitmapOriginX   = glyph.bitmapOriginX,
+                                                      .bitmapOriginY   = glyph.bitmapOriginY});
     }
-    static_cast<void>(package.set("glyphs", json::Value::array(std::move(glyphValues))));
+    // The schema requires ascending code-point order so its find() can binary-search. The bake
+    // walks the recipe's ranges in the order they were written, which is not necessarily sorted.
+    std::sort(package.glyphs.begin(), package.glyphs.end(),
+              [](const fontpkg::GlyphRecord& a, const fontpkg::GlyphRecord& b) noexcept { return a.codePoint < b.codePoint; });
+
+    // The restricted charset is the recipe's ranges, sorted. It is what the .medui compiler (#15)
+    // will check a dynamic-text format against, and validate() refuses a package whose charset
+    // names a code point it has no glyph for - so the table cannot promise more than the atlas
+    // delivers.
+    package.restrictedCharset.reserve(spec.charset.size());
+    for (const CharsetRange& range : spec.charset) {
+        package.restrictedCharset.push_back(fontpkg::CharsetRange{.first = range.first, .last = range.last});
+    }
+    std::sort(package.restrictedCharset.begin(), package.restrictedCharset.end(),
+              [](const fontpkg::CharsetRange& a, const fontpkg::CharsetRange& b) noexcept { return a.first < b.first; });
+
+    // No kerning yet. The field exists and is emitted empty rather than omitted, so a consumer
+    // reads "this package bakes no kerning" instead of having to distinguish an absent member
+    // from an empty one. Populating it is future work; ADR-010's rule is that whatever is not
+    // here does not apply, because no runtime lookup can find it.
     return package;
 }
 
@@ -729,12 +745,18 @@ using SlotIndex = std::vector<const atlas::GlyphSlot*>;
     outputs.atlasWidth  = layout->width;
     outputs.atlasHeight = layout->height;
 
-    auto packageValue = fontPackageJson(recipe, *font, *layout, *glyphs, *slots, outputs.sidecarName, outputs.sidecar);
-    auto packageText  = json::write(packageValue);
+    const auto package     = buildFontPackage(recipe, *font, *layout, *glyphs, *slots, outputs.sidecarName, outputs.sidecar);
+    auto       packageText = package.write();
     if (!packageText.has_value()) {
-        // The writer's error carries a code plus context; only the code has a stable description.
-        report(diagnostics, std::string{recipePath}, 0, packageInvalid,
-               "assembled font package is not valid: " + std::string{json::describe(packageText.error().code)});
+        // Its own code when the digits disagree: that is a property of the font, so the fix is a
+        // different font rather than a different recipe, and sending an author to re-read their
+        // charset would waste their time.
+        const bool tabular = packageText.error() == fontpkg::SchemaError::TabularFigureMismatch;
+        report(diagnostics, std::string{recipePath}, 0, tabular ? tabularFiguresMismatch : packageInvalid,
+               std::format("font package is not valid: {}", fontpkg::describe(packageText.error())),
+               tabular ? "A numeric field redrawn as its value changes will jitter unless every digit "
+                         "shares an advance. Use a font with tabular figures."
+                       : "");
         return std::nullopt;
     }
     outputs.packageJson = std::move(*packageText);


### PR DESCRIPTION
Part of #14. Depends on S4 (#160), which landed as #173 → #174 → #176. Single PR this time — the schema and its adoption are one change, not a stack.

## One definition, not two

S4 emitted the font package's JSON **by hand**, because the baker landed before this module existed. Adopting the governed type does not change what a package *is* — it removes the second, informal definition.

That is ADR-008 decision 1 mirrored to text by ADR-010, and the same reason `mdux.text.schema` exists for text packages: a baker producing one shape and a runtime expecting another is the Wave 2 lesson. `write()` validates on the way out and `parse()` validates on the way in, so **there is no state in which a caller holds a `FontPackage` that has not been checked**.

The atlas is byte-identical after the change — the sheet did not move, the package gained its declared fields.

## The restricted charset

The declared set of code points a package can draw, carried as **ranges** rather than a code-point list: `U+0020..U+007E` is checkable by eye in a way ninety-five integers is not, and membership becomes a binary search.

`permits()` is the test the `.medui` compiler (#15) will apply to every code point a dynamic-text format could produce — the thing that turns "no shaping on device" from a slogan into a compile error. `validate()` refuses a package whose charset names a code point it has **no glyph for**, so the table cannot promise more than the atlas delivers. That matters because the runtime has no fallback, and having one would mean mapping code points on device.

## Tabular figures — a safety rule, not a typographic preference

`validate()` requires every decimal digit present to share one advance width.

A numeric field on a medical device — a heart rate, a dose, an elapsed time — is redrawn as its value changes. If `1` is narrower than `8`, the digits shift horizontally on every update and the field **jitters**. A clinician reading a changing number at a glance is precisely the reader that motion hurts most, and the defect is *invisible in a static screenshot* — so it has to be caught where the font is baked rather than where it is looked at.

A font with proportional digits is not broken; it is unsuitable for this use, and the baker says so with `TXT019` — its own code, because the fix is a different font rather than a different recipe.

I checked this against the committed font before designing around it: **DejaVu Sans' ten digits all advance 1303 font units**, so the rule holds on the artifact this repository already ships.

## Tests — `font_spec`

Its own executable rather than cases inside `text_spec`: a font package and a text package are different shapes with different rules, and a failure should name which schema rejected the input. It links `MduX::Core` only, which is standing evidence that a font package describes an atlas and a charset without naming a Vulkan handle.

- **The round trip is the scenario that matters.** Write, parse, compare field by field — including signed bearings and a negative kerning adjustment — then re-write and compare **bytes**. A writer and a reader can only agree wrongly if they share code, which is exactly the property this module is for. Asserting that each side independently produces what a test author expected would prove much less.
- **Eighteen rejection rows**, one per rule, each breaking a valid fixture in exactly one way. The fixture's own validity is asserted first, or every row would pass for the wrong reason.
- **The committed `dejavu-ui` package parses**, permits both ends of its charset, refuses an accented letter outside it, and has a space that is blank but still advances. A schema that only ever validated its own fixtures would not catch a baker writing a field under a different name.

## Against #161's acceptance criteria

| | |
|---|---|
| a dynamic-text format referencing an unbaked code point fails the baker with a stable code | the table and `permits()` are here; the **compiler-side** rejection is #15's, which this unblocks |
| tabular-figure mismatches fail the baker | yes — `TXT019`, with `SchemaError::TabularFigureMismatch` underneath |
| `font_spec` schema tests pass on MSVC and GCC | green locally on GCC; this PR's CI is the first MSVC run |
| the governed-zone check still passes | yes — "2 governed target(s) clean of Vulkan/windowing dependencies" |

**427/427 ctest**, 384 evidence tests, docs-lint and schema-drift clean.

## Out of scope, deliberately

`kerning` is emitted **empty rather than omitted**, so a consumer reads "this package bakes no kerning" instead of having to distinguish an absent member from an empty one. Populating it is future work — and ADR-010's rule is that whatever is not in that list does not apply, because no runtime lookup can find it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized font package schema covering metadata, glyphs, character ranges, atlas metrics, and kerning.
  * Added validation, parsing, serialization, glyph lookup, charset checks, and kerning lookup.
  * Updated text baking to generate validated font packages.

* **Bug Fixes**
  * Improved diagnostics for invalid tabular-figure data and other font schema errors.

* **Documentation**
  * Updated the architecture roadmap to record the completed font schema milestone.

* **Tests**
  * Added coverage for serialization round trips, validation, charset boundaries, metrics, and the bundled font package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->