### PR TITLE
feat(text): coverage draw path and text pixel tests (#162)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,9 @@
 name: "MduX CodeQL config"
 
-# ninja-gcc (binaryDir build-gcc) sets MDUX_BUILD_TESTS/MDUX_BUILD_EXAMPLES=ON, so CPM.cmake
-# fetches Catch2 and glfw into build-gcc/_deps/ and CodeQL would otherwise extract and alert on
-# that third-party source too - longer runs, noise that is not this repository's code to fix.
+# This job extracts without building (see codeql.yml), so there is no build-gcc/_deps/ tree of
+# fetched Catch2 and glfw sources to exclude - CPM.cmake never runs. The entry is kept, scoped to
+# any build directory, so a future traced build cannot silently start reporting alerts against
+# third-party source that is not this repository's to fix.
 paths-ignore:
-  - build-gcc/_deps/**
+  - '**/_deps/**'
+  - 'build*/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,6 +82,13 @@ jobs:
         ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/ctest /usr/bin/ctest
         cmake --version
 
+    # The container runs as root while the checkout is owned by the runner user, so every git
+    # command the CodeQL action issues fails with "detected dubious ownership" and it falls back to
+    # the commit SHA from the environment. On a pull_request event that is the merge commit rather
+    # than the head, so alerts would be attributed to a commit that exists in no branch.
+    - name: Trust the workspace checkout
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
@@ -96,8 +103,31 @@ jobs:
     # options change.
     - name: Configure and build
       run: |
+        # CodeQL sets LD_PRELOAD to the `${LIB}_${PLATFORM}_trace.so` form, whose ld.so tokens this
+        # container's dynamic linker does not expand: it reports "cannot be preloaded ... ignored"
+        # and then every compiler invocation runs untraced. The job still passed, because an empty
+        # database analyses cleanly - 397 compiled translation units were producing a 7.76 KiB
+        # source archive and 20 KiB of relations. Pointing LD_PRELOAD at the concrete 64-bit tracer
+        # the same environment already exports is what makes the extraction real.
+        export LD_PRELOAD="${SEMMLE_PRELOAD_libtrace64:-$LD_PRELOAD}"
         cmake --preset ninja-gcc
         cmake --build --preset ninja-gcc
+
+    # A CodeQL run that extracted nothing reports success, which is the worst of both worlds: a
+    # green check and no analysis. Nothing upstream fails on it, so the check has to be here, and
+    # it has to be a count rather than a warning scan - the tracer's own failure was already
+    # printed as an ERROR line in a passing job for months.
+    - name: Verify the tracer actually saw the code
+      run: |
+        archive="${RUNNER_TEMP}/codeql_databases/cpp/src"
+        extracted=$(find "$archive" \( -name '*.cpp' -o -name '*.cppm' -o -name '*.hpp' \) 2>/dev/null | wc -l)
+        echo "CodeQL extracted ${extracted} C++ source files"
+        # The tree holds over a thousand; a working extraction reaches the hundreds, and a broken
+        # one lands in single digits. 200 separates those without tracking the exact figure.
+        if [ "${extracted}" -lt 200 ]; then
+          echo "::error::CodeQL extracted only ${extracted} source files - the build tracer is not attached, so the analysis below would be vacuous"
+          exit 1
+        fi
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,6 @@ jobs:
   analyze:
     name: Analyze (C++)
     runs-on: ubuntu-latest
-    container: gcc:16
     permissions:
       security-events: write
       actions: read
@@ -30,106 +29,53 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # No step here performs an authenticated Git operation, so the checkout token has no
-      # reason to survive into .git/config where any later build or test step could read it
-      # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
+      # reason to survive into .git/config where any later step could read it (OpenSSF
+      # Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
         persist-credentials: false
 
-    # Matches the build-time subset of linux-gcc16-build.yml's dependency list (the ninja-gcc
-    # preset below builds the same MDUX_BUILD_EXAMPLES/MDUX_BUILD_TESTS=ON surface, including
-    # glfw-linked examples). Purely runtime packages that leg needs only to run tests
-    # (xvfb, mesa-vulkan-drivers, vulkan-validationlayers, wayland-utils) are omitted here since
-    # this job compiles but never executes anything.
-    - name: Install dependencies
-      run: |
-        apt-get update
-        apt-get install -y \
-          cmake \
-          ninja-build \
-          pkg-config \
-          libvulkan-dev \
-          vulkan-tools \
-          vulkan-utility-libraries-dev \
-          spirv-tools \
-          libglfw3-dev \
-          libwayland-dev \
-          wayland-protocols \
-          libwayland-egl1 \
-          libxkbcommon-dev \
-          libx11-dev \
-          libxrandr-dev \
-          libxinerama-dev \
-          libxcursor-dev \
-          libxi-dev \
-          wget \
-          gnupg
-
-    - name: Install latest CMake
-      run: |
-        # Install CMake 4.x for C++23 import std support via direct download
-        # Avoid libssl1.1 dependency issues in Debian containers
-        CMAKE_VERSION="4.1.1"
-        # Pinned SHA-256 from Kitware's own cmake-4.1.1-SHA-256.txt manifest. The tarball is
-        # unpacked into /opt and put on PATH, so it builds everything this job touches; verifying
-        # it is the same supply-chain discipline the SHA-pinned actions above apply. `sha256sum -c`
-        # exits non-zero on a mismatch and `set -e` is on by default in a `run:` block, so
-        # extraction cannot proceed past a bad or substituted download.
-        CMAKE_SHA256="5a6c61cb62b38e153148a2c8d4af7b3d387f0c8c32b6dbceb5eb4af113efd65a"
-        wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz
-        echo "${CMAKE_SHA256}  cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz" | sha256sum -c -
-        tar -xzf cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz -C /opt/
-        ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/cmake /usr/bin/cmake
-        ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/ctest /usr/bin/ctest
-        cmake --version
-
-    # The container runs as root while the checkout is owned by the runner user, so every git
-    # command the CodeQL action issues fails with "detected dubious ownership" and it falls back to
-    # the commit SHA from the environment. On a pull_request event that is the merge commit rather
-    # than the head, so alerts would be attributed to a commit that exists in no branch.
-    - name: Trust the workspace checkout
-      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
+    # `build-mode: none`, not `manual`. This job used to run in a gcc:16 container and build the
+    # whole project so CodeQL's tracer could watch the compiler - and the tracer never attached.
+    # Its LD_PRELOAD entry uses the `${LIB}_${PLATFORM}` ld.so tokens, the container's linker
+    # reported "cannot be preloaded ... ignored", and every compile then ran untraced. The job
+    # passed anyway, because an empty database analyses cleanly: 397 translation units compiled
+    # into a 7.76 KiB source archive holding two files. Pointing LD_PRELOAD at the concrete
+    # lib64trace.so the same environment exports made the error go away without extracting any
+    # more code, so the tracer is not the thing to keep fixing.
+    #
+    # Buildless extraction reads the sources directly. It resolves fewer includes than a traced
+    # build would, which is a real cost - but the comparison is against two files, not against a
+    # working traced build. The compile itself is not lost either: linux-gcc16-build.yml and
+    # windows-build.yml both build this tree on every PR, so nothing here was the only thing
+    # proving it compiles.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: cpp
-        build-mode: manual
+        build-mode: none
         config-file: ./.github/codeql/codeql-config.yml
-
-    # Manual build, not autobuild: the C++23 `import std` experimental support and CPM.cmake
-    # dependency fetching are not reliable under CodeQL's generic autobuild heuristics. Uses the
-    # same ninja-gcc preset as linux-gcc16-build.yml, rather than a hand-written configure line
-    # that resembles it, so CodeQL's compiled surface cannot drift from the rest of CI as CMake
-    # options change.
-    - name: Configure and build
-      run: |
-        # CodeQL sets LD_PRELOAD to the `${LIB}_${PLATFORM}_trace.so` form, whose ld.so tokens this
-        # container's dynamic linker does not expand: it reports "cannot be preloaded ... ignored"
-        # and then every compiler invocation runs untraced. The job still passed, because an empty
-        # database analyses cleanly - 397 compiled translation units were producing a 7.76 KiB
-        # source archive and 20 KiB of relations. Pointing LD_PRELOAD at the concrete 64-bit tracer
-        # the same environment already exports is what makes the extraction real.
-        export LD_PRELOAD="${SEMMLE_PRELOAD_libtrace64:-$LD_PRELOAD}"
-        cmake --preset ninja-gcc
-        cmake --build --preset ninja-gcc
-
-    # A CodeQL run that extracted nothing reports success, which is the worst of both worlds: a
-    # green check and no analysis. Nothing upstream fails on it, so the check has to be here, and
-    # it has to be a count rather than a warning scan - the tracer's own failure was already
-    # printed as an ERROR line in a passing job for months.
-    - name: Verify the tracer actually saw the code
-      run: |
-        archive="${RUNNER_TEMP}/codeql_databases/cpp/src"
-        extracted=$(find "$archive" \( -name '*.cpp' -o -name '*.cppm' -o -name '*.hpp' \) 2>/dev/null | wc -l)
-        echo "CodeQL extracted ${extracted} C++ source files"
-        # The tree holds over a thousand; a working extraction reaches the hundreds, and a broken
-        # one lands in single digits. 200 separates those without tracking the exact figure.
-        if [ "${extracted}" -lt 200 ]; then
-          echo "::error::CodeQL extracted only ${extracted} source files - the build tracer is not attached, so the analysis below would be vacuous"
-          exit 1
-        fi
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         category: "/language:cpp"
+
+    # A CodeQL run that extracted nothing reports success, which is the worst of both worlds: a
+    # green check and no analysis. Nothing upstream fails on it - that is exactly how the empty
+    # database went unnoticed - so the check has to be here, and it has to be a count. The
+    # tracer's own failure was already printed as an ERROR line in a passing job.
+    - name: Verify the database is not empty
+      run: |
+        db="${RUNNER_TEMP}/codeql_databases/cpp"
+        if [ -f "${db}/src.zip" ]; then
+          extracted=$(unzip -l "${db}/src.zip" | grep -cE '\.(cpp|cppm|hpp|h)$' || true)
+        else
+          extracted=$(find "${db}/src" \( -name '*.cpp' -o -name '*.cppm' -o -name '*.hpp' \) 2>/dev/null | wc -l)
+        fi
+        echo "CodeQL extracted ${extracted} C++ source files"
+        # The tree holds over a thousand; a working extraction reaches the hundreds, and the
+        # broken one landed on two. 200 separates those without pinning the exact figure.
+        if [ "${extracted}" -lt 200 ]; then
+          echo "::error::CodeQL extracted only ${extracted} source files - the analysis above was vacuous"
+          exit 1
+        fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,10 +72,17 @@ jobs:
         else
           extracted=$(find "${db}/src" \( -name '*.cpp' -o -name '*.cppm' -o -name '*.hpp' \) 2>/dev/null | wc -l)
         fi
-        echo "CodeQL extracted ${extracted} C++ source files"
-        # The tree holds over a thousand; a working extraction reaches the hundreds, and the
-        # broken one landed on two. 200 separates those without pinning the exact figure.
-        if [ "${extracted}" -lt 200 ]; then
-          echo "::error::CodeQL extracted only ${extracted} source files - the analysis above was vacuous"
+        # Measured against what the repository actually holds rather than a number written down
+        # here, which would need editing every time the tree grows and would rot silently in the
+        # meantime. The first version of this guard hard-coded 200 and failed a *working* run that
+        # extracted 153 of 139 tracked files.
+        tracked=$(git ls-files | grep -cE '\.(cpp|cppm|hpp|h)$')
+        floor=$(( tracked * 80 / 100 ))
+        echo "CodeQL extracted ${extracted} C++ source files; the tree tracks ${tracked}"
+        # Whole files missing is the failure this catches - a tracer that attached to nothing left
+        # two. Some slack, because generated and excluded sources make the two counts differ
+        # legitimately in both directions.
+        if [ "${extracted}" -lt "${floor}" ]; then
+          echo "::error::CodeQL extracted ${extracted} source files against ${tracked} tracked - the analysis above was vacuous"
           exit 1
         fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ target_sources(MduXCore
             include/mdux/ml/Runtime.cppm
             include/mdux/draw/Draw.cppm
             include/mdux/font/Schema.cppm
+            include/mdux/text/Draw.cppm
             include/mdux/text/Schema.cppm
             include/mdux/text/Raster.cppm
     PRIVATE
@@ -206,6 +207,7 @@ target_sources(MduXCore
         src/ml/Runtime.cpp
         src/draw/Draw.cpp
         src/font/Schema.cpp
+        src/text/Draw.cpp
         src/text/Schema.cpp
         src/text/Raster.cpp
         src/governance/Governance.cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,11 @@ We use **Doxygen** syntax for code documentation. Follow these guidelines:
   - Use compact notation `/** @brief Description */` for simple one-line descriptions.
   - Use full format with `@param`, `@return`, `@note` for complex methods.
   - Include usage examples with `@code` blocks when helpful.
+- **`///` line comments carry no `@brief`.** The tag belongs to `/** */` blocks. A `///` comment
+  *is* the brief — Doxygen already treats it as one, and prefixing it adds a word that says only
+  "this is a comment". The tree is consistent on this: 485 `///` comments, none with `@brief`.
+  Reviewers and review bots ask for it regularly; the answer is no, and this line is here so the
+  question has somewhere to be answered once.
 - **Template parameters:** Document with `@tparam` when non-obvious.
 - **Private members:** Generally no documentation needed unless complex.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ are ordinary `PRIVATE` sources.
 | `mdux.text.schema` | `include/mdux/text/Schema.cppm` | `src/text/Schema.cpp` |
 | `mdux.text.raster` | `include/mdux/text/Raster.cppm` | `src/text/Raster.cpp` |
 | `mdux.font.schema` | `include/mdux/font/Schema.cppm` | `src/font/Schema.cpp` |
+| `mdux.text.draw` | `include/mdux/text/Draw.cppm` | `src/text/Draw.cpp` |
 | `mdux.draw` | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
 | `mdux.ml.schema` | `include/mdux/ml/Schema.cppm` | header-only |
 | `mdux.ml.kernels` | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
@@ -211,7 +212,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | S1–S4 landed (`mdux.text.schema`, `mdux.tools.truetype`, `mdux.text.raster`, atlas packer + font baker with the first committed font package). S5 (`mdux.font.schema` + restricted charset, #161) landed; S6 open |
+| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | Complete. S1–S4 landed (`mdux.text.schema`, `mdux.tools.truetype`, `mdux.text.raster`, atlas packer + font baker with the first committed font package), S5 the package type and restricted charset (`mdux.font.schema`, #161), S6 the coverage draw path and pixel tests (`mdux.text.draw`, #162) |
 | `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | the replacement for the retired HTML/CSS path |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,7 +212,6 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| Font and text pipeline | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) | Complete. S1–S4 landed (`mdux.text.schema`, `mdux.tools.truetype`, `mdux.text.raster`, atlas packer + font baker with the first committed font package), S5 the package type and restricted charset (`mdux.font.schema`, #161), S6 the coverage draw path and pixel tests (`mdux.text.draw`, #162) |
 | `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | the replacement for the retired HTML/CSS path |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ An epic opens when every epic it depends on has closed. Three waves have shipped
 closed with #14 and has not been tagged yet. Wave 5 is open now: #15's blockers were
 #12 and #14, both closed. #19 spans waves by design; its S3–S6 follow #15.
 
-```
+```text
 Wave 1 · shipped v0.2.0     #7 (done)   #11 (open · #116, #117)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,8 +7,9 @@ MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-d
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
 backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draws its first
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
-what the build actually produces. Track C's authoring story is what remains: #14 opens
-Wave 4 with the font and text pipeline.
+what the build actually produces. Track C's authoring story is what remains: #14 closed
+Wave 4 with the font and text pipeline, and #15 opens Wave 5 with the compiler that
+generates the screens it draws.
 
 | Metric | Count |
 |---|---|
@@ -34,7 +35,7 @@ this table was first written; the two that remain are the documentation rebuild 
 | Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time. | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Corpus closed (#8); README not. Five standards on real clause structure with per-clause indexes and JSON Schemas. The documentation architecture — README honesty, ADR re-baselining — is #10 and has not started. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
 | Copyright | Closed (#7). Reproduced text removed from the tree and from history, with `mdux-docs-lint` in CI to keep it out. | Reproducing normative text is forbidden outright; original prose only. |
-| Tests | Closed. 434 tests on `develop`, on SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification and rendered truth (`pixel`). | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
+| Tests | Closed. 434 tests on `develop`, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification and rendered truth (`pixel`). | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
 | Packaging | Closed (#11). Install/export restored; MSVC, GCC and Clang presets, with MSVC and GCC 16 both green in CI. | Workspace builds `--locked` on Linux and in containers. |
 
 ## Dependency order
@@ -42,16 +43,16 @@ this table was first written; the two that remain are the documentation rebuild 
 ### Six waves
 
 An epic opens when every epic it depends on has closed. Three waves have shipped
-(v0.2.0, v0.3.0, v0.4.0), one epic per wave closing the dependency it held. Wave 4 is
-open now: #14's blockers were #12 and #13, both closed. #19 spans waves by design; its
-S3–S6 follow #15.
+(v0.2.0, v0.3.0, v0.4.0), one epic per wave closing the dependency it held. Wave 4
+closed with #14 and has not been tagged yet. Wave 5 is open now: #15's blockers were
+#12 and #14, both closed. #19 spans waves by design; its S3–S6 follow #15.
 
 ```
 Wave 1 · shipped v0.2.0     #7 (done)   #11 (open · #116, #117)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
-Wave 4 · open now           #14
-Wave 5                      #15
+Wave 4 · closed, untagged   #14 (done)
+Wave 5 · open now           #15
 Wave 6                      #16  #17
 ```
 
@@ -213,7 +214,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **Blocked #12, #14**
+#### #15 — `.medui` compiler & build integration · **Ready · opens Wave 5**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -337,5 +338,5 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 ---
 
 _Verified against `develop @ d1329da` · 4 August 2026_
-_13 epics · 7 delivered · Waves 1–3 shipped · Wave 4 open · #11 enforcement open_
+_13 epics · 8 delivered · Waves 1–3 shipped · Wave 4 closed, untagged · Wave 5 open · #11 enforcement open_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ this table was first written; the two that remain are the documentation rebuild 
 | Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time. | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Corpus closed (#8); README not. Five standards on real clause structure with per-clause indexes and JSON Schemas. The documentation architecture — README honesty, ADR re-baselining — is #10 and has not started. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
 | Copyright | Closed (#7). Reproduced text removed from the tree and from history, with `mdux-docs-lint` in CI to keep it out. | Reproducing normative text is forbidden outright; original prose only. |
-| Tests | Closed. 360 tests on `develop`, on SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification and rendered truth (`pixel`). | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
+| Tests | Closed. 434 tests on `develop`, on SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification and rendered truth (`pixel`). | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
 | Packaging | Closed (#11). Install/export restored; MSVC, GCC and Clang presets, with MSVC and GCC 16 both green in CI. | Workspace builds `--locked` on Linux and in containers. |
 
 ## Dependency order
@@ -198,20 +198,20 @@ pipeline, four modes; buffers sized once from a compiler-computed budget and nev
 
 _Blocks #14, #16_
 
-#### #14 — Font & text pipeline · **Ready · opens Wave 4**
+#### #14 — Font & text pipeline · **Closed**
 
 Static text bakes to positioned glyph runs per locale. Dynamic text gets a restricted
 charset table — and the compiler rejects any format that could escape it, which turns
 "no shaping on device" from a slogan into a compile error.
 
-- S1 Text schema and baker
-- S2 Hand-parsed TrueType (`glyf` only)
-- S3 Rasteriser with coverage AA
-- S4 Atlas packer and font baker
-- S5 Metrics and the tabular-figure assertion
-- S6 Coverage draw path and text pixel tests
+- S1 Text schema and baker — `mdux.text.schema`, `mdux-textbake`
+- S2 Hand-parsed TrueType (`glyf` only) — `mdux.tools.truetype`, host-only
+- S3 Rasteriser with coverage AA — `mdux.text.raster`, integer-only
+- S4 Atlas packer and font baker — the first committed font package
+- S5 Metrics and the tabular-figure assertion — `mdux.font.schema`
+- S6 Coverage draw path and text pixel tests — `mdux.text.draw`, rendered under lavapipe
 
-_Blocks #15_
+_Unblocks #15_
 
 #### #15 — `.medui` compiler & build integration · **Blocked #12, #14**
 

--- a/include/mdux/draw/Draw.cppm
+++ b/include/mdux/draw/Draw.cppm
@@ -59,6 +59,23 @@ enum class DrawMode : std::uint32_t {
  * Positions are in pixels with a top-left origin; the vertex shader converts them once from a
  * push constant, so nothing here depends on the surface the frame will be drawn to.
  */
+/**
+ * @brief Normalised texture coordinates, in [0, 1].
+ *
+ * Distinct from `core::Rect` because that is integer pixels and the shader samples with
+ * normalised floats - an integer rectangle can express only 0 and 1, so a glyph's atlas slot
+ * cannot be written as one. Keeping the two types apart means a caller who reaches for the wrong
+ * one gets a compile error rather than a quad sampling far outside the sheet.
+ */
+struct UvRect {
+    float u0{0.0F};
+    float v0{0.0F};
+    float u1{0.0F};
+    float v1{0.0F};
+
+    constexpr bool operator==(const UvRect&) const = default;
+};
+
 struct UiVertex {
     float x{0.0F};              ///< offset 0
     float y{0.0F};              ///< offset 4
@@ -161,6 +178,20 @@ public:
         const DrawBudget& budget) noexcept;
 
     /// Records an axis-aligned rectangle in `mode`, sampling `uv` when the mode uses the atlas.
+    ///
+    /// `uv` is in **normalised** texture coordinates, because the fragment shader samples with
+    /// `texture(uAtlas, fragUv)` on a `sampler2D`. See `UvRect` for why this overload exists
+    /// alongside the `core::Rect` one.
+    [[nodiscard]] mdux::core::ResultVoid<DrawError> addRect(const mdux::core::Rect& rect,
+                                                            mdux::core::ColorRgba8 color,
+                                                            DrawMode mode,
+                                                            const UvRect& uv) noexcept;
+
+    /// Records an axis-aligned rectangle in `mode`, sampling `uv` when the mode uses the atlas.
+    ///
+    /// Retained for callers whose uv is already whole - a full-sheet quad, or the unit rect. It
+    /// converts to `UvRect` unchanged, so it cannot express a fractional coordinate: a glyph's
+    /// slot has to go through `mdux.text.draw`, which normalises it against the atlas extent.
     [[nodiscard]] mdux::core::ResultVoid<DrawError> addRect(const mdux::core::Rect& rect,
                                                             mdux::core::ColorRgba8 color,
                                                             DrawMode mode,

--- a/include/mdux/draw/Draw.cppm
+++ b/include/mdux/draw/Draw.cppm
@@ -136,6 +136,7 @@ enum class DrawError : std::uint8_t {
     IndexBudgetExceeded,
     CommandBudgetExceeded,
     DegenerateRect,          ///< zero or negative width or height
+    WrongList,               ///< a rollback marker names a position in a different list, or none
 };
 
 [[nodiscard]] std::string_view describe(DrawError error) noexcept;
@@ -210,11 +211,23 @@ public:
     /**
      * @brief A position in the list, for undoing a composite record that fails partway.
      *
-     * Opaque on purpose: it is the counters, but a caller reading them would be reading state the
-     * list does not otherwise expose. Cheap to copy and holds no reference to the list, so taking
-     * one costs nothing and a stale one is a programming error rather than a dangling pointer.
+     * Opaque, and only its own list can read it. The counters were public in the first version of
+     * this, which meant a caller could assemble one by hand or hand back a marker from a different
+     * list - and `rollback()` writes through `commandCount`, so a marker claiming more commands
+     * than the storage holds is an out-of-bounds write rather than a wrong picture. Carrying the
+     * owning list and keeping the fields private makes both mistakes unspellable.
+     *
+     * Copyable and cheap. The owner is compared, never dereferenced, so a marker outliving its
+     * list is a mismatch rather than a dangling read.
      */
-    struct Marker {
+    class Marker {
+    public:
+        Marker() noexcept = default;
+
+    private:
+        friend class DrawList;
+
+        const DrawList* owner{nullptr};
         std::uint32_t vertexCount{0};
         std::uint32_t indexCount{0};
         std::uint32_t commandCount{0};
@@ -238,12 +251,13 @@ public:
      * rather than starting a new command, so a rolled-back list would otherwise keep a command
      * claiming indices that are no longer there.
      *
-     * Passing a marker from a different list, or one taken after the position it names was already
-     * rolled back past, is a programming error. The counters only ever move backwards here, so the
-     * worst case is a list shorter than the caller expected rather than one reading past its
-     * storage.
+     * A marker from another list, or a default-constructed one, is refused - it names a position
+     * in something else. So is one whose counters exceed this list's, which can only mean the list
+     * was already rolled back past it. Both return `WrongList`; neither can move a counter forward
+     * or write outside the storage, which is the property that matters, since `rollback()` writes
+     * through the command count.
      */
-    void rollback(const Marker& marker) noexcept;
+    [[nodiscard]] mdux::core::ResultVoid<DrawError> rollback(const Marker& marker) noexcept;
 
     [[nodiscard]] std::span<const UiVertex> vertices() const noexcept {
         return vertices_.subspan(0, vertexCount_);

--- a/include/mdux/draw/Draw.cppm
+++ b/include/mdux/draw/Draw.cppm
@@ -207,6 +207,44 @@ public:
     /// Empties the list without touching the storage or the budget.
     void reset() noexcept;
 
+    /**
+     * @brief A position in the list, for undoing a composite record that fails partway.
+     *
+     * Opaque on purpose: it is the counters, but a caller reading them would be reading state the
+     * list does not otherwise expose. Cheap to copy and holds no reference to the list, so taking
+     * one costs nothing and a stale one is a programming error rather than a dangling pointer.
+     */
+    struct Marker {
+        std::uint32_t vertexCount{0};
+        std::uint32_t indexCount{0};
+        std::uint32_t commandCount{0};
+        std::uint32_t lastCommandIndexCount{0};
+        mdux::core::Rect clip{};
+    };
+
+    /// The list's current position, for a later `rollback()`.
+    [[nodiscard]] Marker mark() const noexcept;
+
+    /**
+     * @brief Discards everything recorded since `marker`, restoring the clip that was in force.
+     *
+     * For the caller that records several primitives as one unit and must not leave half of it in
+     * the frame - a glyph run whose fourth record names a glyph the package does not have should
+     * draw no glyphs, not three. `reset()` cannot do this: it empties the whole list, including
+     * whatever was recorded before the unit began.
+     *
+     * Restoring `commandCount` alone is not enough, which is why the marker carries a fourth
+     * number: `addRect()` extends the last command's `indexCount` when the clip has not changed
+     * rather than starting a new command, so a rolled-back list would otherwise keep a command
+     * claiming indices that are no longer there.
+     *
+     * Passing a marker from a different list, or one taken after the position it names was already
+     * rolled back past, is a programming error. The counters only ever move backwards here, so the
+     * worst case is a list shorter than the caller expected rather than one reading past its
+     * storage.
+     */
+    void rollback(const Marker& marker) noexcept;
+
     [[nodiscard]] std::span<const UiVertex> vertices() const noexcept {
         return vertices_.subspan(0, vertexCount_);
     }

--- a/include/mdux/render/VulkanRenderer.cppm
+++ b/include/mdux/render/VulkanRenderer.cppm
@@ -119,6 +119,7 @@ enum class RenderError : std::uint8_t {
     CommandBufferAllocationFailed,
     AtlasUploadFailed,
     AtlasExtentMismatch,      ///< the coverage byte count is not width * height, or an extent is zero
+    SampledRgbaWithCoverageAtlas,  ///< the frame samples RGBA from a renderer holding an R8 sheet
     NullCommandBuffer,
     FrameExceedsBudget,       ///< the DrawList is larger than the renderer was built for
 
@@ -173,6 +174,17 @@ public:
      *                sidecar `mdux-textbake` commits
      * @param width   sheet width in pixels; must be non-zero and match `atlas.size()`
      * @param height  sheet height in pixels
+     *
+     * ## This renderer can then draw text and solids, but not images
+     *
+     * The atlas is `VK_FORMAT_R8_UNORM`, and there is one of them. `DrawMode::SampledRgba` reads
+     * the same image expecting four channels, so it would sample red-only and return
+     * `(coverage, 0, 0, 1)` - a plausible picture in the wrong colours, which is the kind of
+     * failure nobody notices in review.
+     *
+     * So `record()` refuses a list containing any `SampledRgba` vertex on a coverage renderer,
+     * with `SampledRgbaWithCoverageAtlas`. Mixing baked text and images in one frame needs two
+     * atlas bindings, which is #17's problem rather than something to leave as a trap here.
      */
     [[nodiscard]] static mdux::core::Result<UiRenderer, RenderError> createWithCoverageAtlas(
         const VulkanRenderContext& context, const mdux::shader::PackageView& package,
@@ -239,6 +251,9 @@ private:
     VkDeviceMemory atlasMemory_{VK_NULL_HANDLE};
     VkImageView atlasView_{VK_NULL_HANDLE};
     VkSampler atlasSampler_{VK_NULL_HANDLE};
+    /// True when the atlas is an R8 coverage sheet, so `record()` can refuse a frame that samples
+    /// it as RGBA. Cheaper to carry than to query, and the answer never changes after create().
+    bool atlasIsCoverageOnly_{false};
     VkDescriptorPool descriptorPool_{VK_NULL_HANDLE};
     VkDescriptorSet descriptorSet_{VK_NULL_HANDLE};
     void* vertexMapped_{nullptr};

--- a/include/mdux/render/VulkanRenderer.cppm
+++ b/include/mdux/render/VulkanRenderer.cppm
@@ -118,6 +118,7 @@ enum class RenderError : std::uint8_t {
     CommandPoolCreationFailed,    ///< the one-shot pool used to upload the default atlas
     CommandBufferAllocationFailed,
     AtlasUploadFailed,
+    AtlasExtentMismatch,      ///< the coverage byte count is not width * height, or an extent is zero
     NullCommandBuffer,
     FrameExceedsBudget,       ///< the DrawList is larger than the renderer was built for
 
@@ -155,7 +156,40 @@ public:
         const VulkanRenderContext& context, const mdux::shader::PackageView& package,
         const mdux::draw::DrawBudget& budget) noexcept;
 
+    /**
+     * @brief Creates a renderer whose atlas is a baked R8 coverage sheet rather than the default.
+     *
+     * Replaces the atlas' *contents*, not the mechanism: #13 already created the image, sampler
+     * and descriptor, and this overload uploads different bytes into the same arrangement. There
+     * is no second binding, no second pipeline and no branch at record time - the shader's
+     * `CoverageR8` mode was always reading whatever this image held.
+     *
+     * Taken at construction rather than as a later `setAtlas()` because the descriptor is written
+     * once during `create()`. A renderer that could swap atlases mid-life would need either a
+     * descriptor rewrite between frames or a second set, and neither is worth carrying for a font
+     * that is chosen at build time.
+     *
+     * @param atlas   `width * height` bytes of coverage, row-major, top row first - exactly the
+     *                sidecar `mdux-textbake` commits
+     * @param width   sheet width in pixels; must be non-zero and match `atlas.size()`
+     * @param height  sheet height in pixels
+     */
+    [[nodiscard]] static mdux::core::Result<UiRenderer, RenderError> createWithCoverageAtlas(
+        const VulkanRenderContext& context, const mdux::shader::PackageView& package,
+        const mdux::draw::DrawBudget& budget, std::span<const std::byte> atlas,
+        std::uint32_t width, std::uint32_t height) noexcept;
+
     ~UiRenderer();
+
+private:
+    /// The shared body of both create() overloads. They differ only in the atlas they upload, so
+    /// the pipeline, buffers, sampler and descriptor arrangement are built once here.
+    [[nodiscard]] static mdux::core::Result<UiRenderer, RenderError> createInternal(
+        const VulkanRenderContext& context, const mdux::shader::PackageView& package,
+        const mdux::draw::DrawBudget& budget, VkFormat atlasFormat, std::uint32_t atlasWidth,
+        std::uint32_t atlasHeight, std::span<const std::byte> atlasPixels) noexcept;
+
+public:
 
     UiRenderer(const UiRenderer&) = delete;
     UiRenderer& operator=(const UiRenderer&) = delete;

--- a/include/mdux/text/Draw.cppm
+++ b/include/mdux/text/Draw.cppm
@@ -1,0 +1,138 @@
+/**
+ * @file Draw.cppm
+ * @brief Governed-zone coverage draw path: baked glyph runs into `CoverageR8` rectangles.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * Part of MduXCore. This is the last step of the text pipeline and the one that runs on a device:
+ * it takes a run the baker positioned and turns it into rectangles the renderer draws.
+ *
+ * ## Why this is replay, not layout
+ *
+ * ADR-010 forbids on-device shaping, layout and font-table parsing. Nothing here does any of
+ * those. A run record already carries the glyph and the position the baker computed; this module
+ * looks each glyph up in the package's table and emits a rectangle at the coordinates it was
+ * given. There is no pen advancing by a computed width, no code-point-to-glyph mapping, and no
+ * decision about where anything goes - every such decision was made at build time and is in the
+ * bytes.
+ *
+ * The distinction is worth stating because "draws text" sounds like the thing the ADR forbids.
+ * The check is whether a different input could produce a different *layout*: it cannot, because
+ * positions are inputs rather than outputs.
+ *
+ * ## The v1 run record
+ *
+ * Six bytes, little-endian, as `mdux.text.schema` documents and deliberately does not interpret:
+ *
+ * | offset | type            | meaning                                              |
+ * |--------|-----------------|------------------------------------------------------|
+ * | 0      | `std::uint16_t` | index into the font package's glyph table            |
+ * | 2      | `std::int16_t`  | x, in pixels, in the run's coordinate frame          |
+ * | 4      | `std::int16_t`  | y, in pixels, the glyph's baseline                   |
+ *
+ * The index is into the *package's* glyph table, not the font's `glyf` table. Those differ - the
+ * package holds only the baked charset - and confusing them draws the wrong character, so the
+ * record's field is validated against `FontPackage::glyphs.size()` rather than against anything
+ * the font would recognise.
+ *
+ * Little-endian is stated rather than assumed: the sidecar is committed bytes compared across
+ * toolchains, so the decode cannot inherit the host's byte order.
+ *
+ * ## Texture coordinates, and the reason this helper exists at all
+ *
+ * `DrawList::addRect()` takes its `uv` as a `core::Rect`, which is integer, and copies those
+ * integers straight into the vertex's `float u`/`v`. The fragment shader samples with
+ * `texture(uAtlas, fragUv)` - a `sampler2D`, so **normalised** coordinates. An integer rectangle
+ * can therefore only express 0 and 1: a real slot such as (13, 46, 11x12) would arrive as
+ * `u = 13.0` and sample far outside the sheet.
+ *
+ * So normalising a texel slot against the atlas extent is exactly what this module is for, and
+ * `addGlyphRect()` is the only supported way to record a `CoverageR8` rectangle. Calling
+ * `addRect()` with `DrawMode::CoverageR8` directly is not an error the type system can catch, but
+ * it is one this module exists to make unnecessary.
+ */
+module;
+
+export module mdux.text.draw;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.font.schema;
+
+export namespace mdux::text::draw {
+
+/// Bytes per v1 run record. Mirrors `mdux.text.schema`'s `recordSize`, restated here because this
+/// is the module that gives the number meaning - the schema only checks that the sidecar divides
+/// by it.
+inline constexpr std::size_t recordSize = 6;
+
+enum class DrawTextError : std::uint8_t {
+    PartialRecord,        ///< the run's byte length is not a multiple of `recordSize`
+    GlyphIndexOutOfRange, ///< a record names a glyph the package does not contain
+    EmptyAtlas,           ///< the package's atlas has zero extent, so no uv can be normalised
+    ListRejected,         ///< `DrawList` refused a rectangle - budget, clip or degenerate extent
+};
+
+[[nodiscard]] std::string_view describe(DrawTextError error) noexcept;
+
+/// One decoded record: which glyph, and where the baker put it.
+struct GlyphPlacement {
+    std::uint16_t glyphIndex{0};
+    mdux::core::Px x{0};
+    mdux::core::Px y{0};  ///< the baseline, not the bitmap's top edge
+};
+
+/**
+ * @brief Decodes one v1 run record.
+ *
+ * Exposed separately from `recordRun()` so the byte-order contract can be tested directly rather
+ * than only through a rendered frame - a decode that silently swapped its int16 fields would
+ * otherwise show up as a glyph in the wrong place, which is a much harder failure to read.
+ */
+[[nodiscard]] mdux::core::Result<GlyphPlacement, DrawTextError> decodeRecord(std::span<const std::byte> record) noexcept;
+
+/**
+ * @brief Records one baked glyph run into `list` as `CoverageR8` rectangles.
+ *
+ * @param list    the destination; rectangles are appended in record order
+ * @param package the font package the run was baked against
+ * @param records the run's bytes, a whole number of `recordSize` records
+ * @param origin  added to every record's position, so a run can be placed without re-baking it
+ * @param color   the text colour; coverage modulates its alpha, never its rgb
+ *
+ * Blank glyphs - the space, and anything else with no coverage - are skipped rather than recorded
+ * as empty rectangles: `DrawList::addRect()` refuses a degenerate extent, and a space is not an
+ * error. The advance it carries has already been applied by the baker, so skipping it changes
+ * nothing about where the following glyphs land.
+ *
+ * Fails without recording anything further on the first bad record, so a partially decoded run
+ * does not reach a frame.
+ */
+[[nodiscard]] mdux::core::ResultVoid<DrawTextError> recordRun(mdux::draw::DrawList& list,
+                                                              const mdux::font::FontPackage& package,
+                                                              std::span<const std::byte> records,
+                                                              mdux::core::Px originX,
+                                                              mdux::core::Px originY,
+                                                              mdux::core::ColorRgba8 color) noexcept;
+
+/**
+ * @brief Records one glyph, normalising its atlas slot against the sheet extent.
+ *
+ * The rectangle is placed with the glyph's baked origin applied: `bitmapOriginX` from the pen and
+ * `bitmapOriginY` *above* the baseline, which is why `y` in a record is the baseline rather than
+ * the top edge. Getting that inversion wrong renders text that looks right in isolation and sits
+ * at the wrong height next to anything else.
+ */
+[[nodiscard]] mdux::core::ResultVoid<DrawTextError> addGlyphRect(mdux::draw::DrawList& list,
+                                                                 const mdux::font::FontPackage& package,
+                                                                 const mdux::font::GlyphRecord& glyph,
+                                                                 mdux::core::Px penX,
+                                                                 mdux::core::Px baselineY,
+                                                                 mdux::core::ColorRgba8 color) noexcept;
+
+}  // namespace mdux::text::draw

--- a/include/mdux/text/Draw.cppm
+++ b/include/mdux/text/Draw.cppm
@@ -73,6 +73,7 @@ inline constexpr std::size_t recordSize = 6;
 
 enum class DrawTextError : std::uint8_t {
     PartialRecord,        ///< the run's byte length is not a multiple of `recordSize`
+    RecordSizeWrong,      ///< a span handed to `decodeRecord()` is not exactly one record
     GlyphIndexOutOfRange, ///< a record names a glyph the package does not contain
     EmptyAtlas,           ///< the package's atlas has zero extent, so no uv can be normalised
     ListRejected,         ///< `DrawList` refused a rectangle - budget, clip or degenerate extent
@@ -82,7 +83,14 @@ enum class DrawTextError : std::uint8_t {
 
 /// One decoded record: which glyph, and where the baker put it.
 struct GlyphPlacement {
-    std::uint16_t glyphIndex{0};
+    /// Index into `FontPackage::glyphs`.
+    ///
+    /// Deliberately *not* called `glyphIndex`, because `font::GlyphRecord::glyphIndex` already
+    /// means something else - the font's own glyph ID, from the `glyf` table. The two are
+    /// different numbers for the same glyph, since a package holds only the baked charset, and
+    /// code handling both types would otherwise have two fields with one name and no hint that
+    /// swapping them draws the wrong character.
+    std::uint16_t packageIndex{0};
     mdux::core::Px x{0};
     mdux::core::Px y{0};  ///< the baseline, not the bitmap's top edge
 };
@@ -93,6 +101,10 @@ struct GlyphPlacement {
  * Exposed separately from `recordRun()` so the byte-order contract can be tested directly rather
  * than only through a rendered frame - a decode that silently swapped its int16 fields would
  * otherwise show up as a glyph in the wrong place, which is a much harder failure to read.
+ *
+ * `record` must be exactly `recordSize` bytes. A longer span is refused rather than decoded and
+ * truncated: handing this the whole run instead of one record is the obvious misuse, and it would
+ * otherwise return the first glyph and look like it worked.
  */
 [[nodiscard]] mdux::core::Result<GlyphPlacement, DrawTextError> decodeRecord(std::span<const std::byte> record) noexcept;
 
@@ -102,7 +114,8 @@ struct GlyphPlacement {
  * @param list    the destination; rectangles are appended in record order
  * @param package the font package the run was baked against
  * @param records the run's bytes, a whole number of `recordSize` records
- * @param origin  added to every record's position, so a run can be placed without re-baking it
+ * @param originX added to every record's x, so a run can be placed without re-baking it
+ * @param originY added to every record's y, likewise
  * @param color   the text colour; coverage modulates its alpha, never its rgb
  *
  * Blank glyphs - the space, and anything else with no coverage - are skipped rather than recorded
@@ -110,8 +123,9 @@ struct GlyphPlacement {
  * error. The advance it carries has already been applied by the baker, so skipping it changes
  * nothing about where the following glyphs land.
  *
- * Fails without recording anything further on the first bad record, so a partially decoded run
- * does not reach a frame.
+ * All-or-nothing. On the first bad record the list is rolled back to where it was on entry, so a
+ * run that fails halfway leaves no rectangles behind and a fragment of a word cannot reach a
+ * frame. Anything the caller recorded *before* calling this is untouched.
  */
 [[nodiscard]] mdux::core::ResultVoid<DrawTextError> recordRun(mdux::draw::DrawList& list,
                                                               const mdux::font::FontPackage& package,

--- a/src/draw/Draw.cpp
+++ b/src/draw/Draw.cpp
@@ -46,6 +46,8 @@ std::string_view describe(DrawError error) noexcept {
         return "command budget exceeded";
     case DrawError::DegenerateRect:
         return "rectangle has zero or negative width or height";
+    case DrawError::WrongList:
+        return "a rollback marker names a position in a different list, or in none";
     }
     return "unknown draw error";
 }
@@ -81,17 +83,34 @@ void DrawList::reset() noexcept {
 }
 
 DrawList::Marker DrawList::mark() const noexcept {
-    return Marker{.vertexCount = vertexCount_,
-                  .indexCount = indexCount_,
-                  .commandCount = commandCount_,
-                  // The last command's index count, because addRect() extends it in place when the
-                  // clip has not changed. Restoring commandCount_ alone would leave that command
-                  // claiming indices the rollback took away.
-                  .lastCommandIndexCount = commandCount_ == 0 ? 0U : commands_[commandCount_ - 1].indexCount,
-                  .clip = clip_};
+    Marker marker;
+    marker.owner = this;
+    marker.vertexCount = vertexCount_;
+    marker.indexCount = indexCount_;
+    marker.commandCount = commandCount_;
+    // The last command's index count, because addRect() extends it in place when the clip has not
+    // changed. Restoring commandCount_ alone would leave that command claiming indices the
+    // rollback took away.
+    marker.lastCommandIndexCount = commandCount_ == 0 ? 0U : commands_[commandCount_ - 1].indexCount;
+    marker.clip = clip_;
+    return marker;
 }
 
-void DrawList::rollback(const Marker& marker) noexcept {
+ResultVoid<DrawError> DrawList::rollback(const Marker& marker) noexcept {
+    // Compared, never dereferenced: a marker that outlived its list is a mismatch here rather than
+    // a read through a dangling pointer.
+    if (marker.owner != this) {
+        return err(DrawError::WrongList);
+    }
+    // Backwards only. Every counter this restores indexes storage the list validated at create(),
+    // so a marker naming a larger position could put commandCount_ past the span and make the
+    // write below out of bounds. Refusing is cheap; the alternative is trusting a number that came
+    // from outside this call.
+    if (marker.vertexCount > vertexCount_ || marker.indexCount > indexCount_ ||
+        marker.commandCount > commandCount_) {
+        return err(DrawError::WrongList);
+    }
+
     vertexCount_ = marker.vertexCount;
     indexCount_ = marker.indexCount;
     commandCount_ = marker.commandCount;
@@ -102,6 +121,7 @@ void DrawList::rollback(const Marker& marker) noexcept {
     // The storage is not cleared. Nothing reads past the counters - vertices(), indices() and
     // commands() all subspan by them - so zeroing would be work no observer can tell apart from
     // not doing it, on the failure path of a frame that is about to be discarded anyway.
+    return {};
 }
 
 void DrawList::setClip(const mdux::core::Rect& clip) noexcept {

--- a/src/draw/Draw.cpp
+++ b/src/draw/Draw.cpp
@@ -80,6 +80,30 @@ void DrawList::reset() noexcept {
     clip_ = {};
 }
 
+DrawList::Marker DrawList::mark() const noexcept {
+    return Marker{.vertexCount = vertexCount_,
+                  .indexCount = indexCount_,
+                  .commandCount = commandCount_,
+                  // The last command's index count, because addRect() extends it in place when the
+                  // clip has not changed. Restoring commandCount_ alone would leave that command
+                  // claiming indices the rollback took away.
+                  .lastCommandIndexCount = commandCount_ == 0 ? 0U : commands_[commandCount_ - 1].indexCount,
+                  .clip = clip_};
+}
+
+void DrawList::rollback(const Marker& marker) noexcept {
+    vertexCount_ = marker.vertexCount;
+    indexCount_ = marker.indexCount;
+    commandCount_ = marker.commandCount;
+    if (commandCount_ > 0) {
+        commands_[commandCount_ - 1].indexCount = marker.lastCommandIndexCount;
+    }
+    clip_ = marker.clip;
+    // The storage is not cleared. Nothing reads past the counters - vertices(), indices() and
+    // commands() all subspan by them - so zeroing would be work no observer can tell apart from
+    // not doing it, on the failure path of a frame that is about to be discarded anyway.
+}
+
 void DrawList::setClip(const mdux::core::Rect& clip) noexcept {
     // Recorded rather than applied: the next primitive notices the change and starts a command.
     // Doing it here would emit an empty command for a clip nothing was drawn under.

--- a/src/draw/Draw.cpp
+++ b/src/draw/Draw.cpp
@@ -96,6 +96,17 @@ ResultVoid<DrawError> DrawList::addSolidRect(const mdux::core::Rect& rect,
 
 ResultVoid<DrawError> DrawList::addRect(const mdux::core::Rect& rect, mdux::core::ColorRgba8 color,
                                         DrawMode mode, const mdux::core::Rect& uv) noexcept {
+    // Widening only - the integer overload cannot express a fractional coordinate, which is
+    // exactly why glyphs go through mdux.text.draw instead.
+    return addRect(rect, color, mode,
+                   UvRect{.u0 = static_cast<float>(uv.x),
+                          .v0 = static_cast<float>(uv.y),
+                          .u1 = static_cast<float>(uv.right()),
+                          .v1 = static_cast<float>(uv.bottom())});
+}
+
+ResultVoid<DrawError> DrawList::addRect(const mdux::core::Rect& rect, mdux::core::ColorRgba8 color,
+                                        DrawMode mode, const UvRect& uv) noexcept {
     if (rect.width <= 0 || rect.height <= 0) {
         return err(DrawError::DegenerateRect);
     }
@@ -123,10 +134,10 @@ ResultVoid<DrawError> DrawList::addRect(const mdux::core::Rect& rect, mdux::core
     const auto top = static_cast<float>(rect.y);
     const auto right = static_cast<float>(rect.right());
     const auto bottom = static_cast<float>(rect.bottom());
-    const auto u0 = static_cast<float>(uv.x);
-    const auto v0 = static_cast<float>(uv.y);
-    const auto u1 = static_cast<float>(uv.right());
-    const auto v1 = static_cast<float>(uv.bottom());
+    const auto u0 = uv.u0;
+    const auto v0 = uv.v0;
+    const auto u1 = uv.u1;
+    const auto v1 = uv.v1;
     const std::uint32_t packed = packColor(color);
     const auto modeValue = static_cast<std::uint32_t>(mode);
 

--- a/src/render/VulkanRenderer.cpp
+++ b/src/render/VulkanRenderer.cpp
@@ -389,7 +389,10 @@ std::string_view describe(RenderError error) noexcept {
     case RenderError::CommandBufferAllocationFailed:
         return "vkAllocateCommandBuffers failed for the atlas upload";
     case RenderError::AtlasUploadFailed:      return "uploading the atlas failed";
-    case RenderError::AtlasExtentMismatch:   return "the coverage atlas' byte count does not match its extent";
+    case RenderError::AtlasExtentMismatch:
+        return "the coverage atlas has a zero extent, or its byte count is not width * height";
+    case RenderError::SampledRgbaWithCoverageAtlas:
+        return "the frame samples an RGBA atlas, but this renderer holds an R8 coverage sheet";
     case RenderError::NullCommandBuffer:      return "command buffer is null";
     case RenderError::FrameExceedsBudget:
         return "draw list is larger than the renderer's budget";
@@ -456,6 +459,11 @@ UiRenderer& UiRenderer::operator=(UiRenderer&& other) noexcept {
     pushStages_ = std::exchange(other.pushStages_, 0);
     pushOffset_ = std::exchange(other.pushOffset_, 0);
     pushSize_ = std::exchange(other.pushSize_, 0);
+    // Left out of this list on the first attempt, and the guard then silently never fired: create()
+    // returns by value, so the flag was set on a renderer that was immediately moved from. Exactly
+    // what the note above describes, which is why the test that exercises the guard is what caught
+    // it rather than review.
+    atlasIsCoverageOnly_ = std::exchange(other.atlasIsCoverageOnly_, false);
     return *this;
 }
 
@@ -667,6 +675,9 @@ Result<UiRenderer, RenderError> UiRenderer::createInternal(const VulkanRenderCon
     renderer.device_ = context.device;
     renderer.budget_ = budget;
     renderer.viewport_ = context.viewport;
+    // Derived from the format rather than passed as a flag, so the two cannot disagree: whatever
+    // image this renderer ends up holding is what record() judges a frame against.
+    renderer.atlasIsCoverageOnly_ = (atlasFormat == VK_FORMAT_R8_UNORM);
     renderer.atlasBinding_ = atlasBinding;
     renderer.pushStages_ = pushStages;
     renderer.pushOffset_ = pushOffset;
@@ -997,6 +1008,21 @@ ResultVoid<RenderError> UiRenderer::record(VkCommandBuffer commandBuffer,
         list.indices().size() > budget_.maxIndices ||
         list.commands().size() > budget_.maxCommands) {
         return err(RenderError::FrameExceedsBudget);
+    }
+    if (atlasIsCoverageOnly_) {
+        // An R8 image sampled as RGBA returns (coverage, 0, 0, 1): a picture in the wrong colours
+        // rather than a black frame or a crash, so it survives review. Refused here instead.
+        //
+        // The scan is per frame because the mode is per vertex, and there is nowhere earlier to
+        // put it - the list is rebuilt every frame. It is a pass over the same vertices the memcpy
+        // below already touches, so it costs the frame nothing measurable, and it buys a refusal
+        // in place of a screenshot nobody questions.
+        const auto samplesRgba = [](const draw::UiVertex& vertex) noexcept {
+            return vertex.mode == static_cast<std::uint32_t>(draw::DrawMode::SampledRgba);
+        };
+        if (std::ranges::any_of(list.vertices(), samplesRgba)) {
+            return err(RenderError::SampledRgbaWithCoverageAtlas);
+        }
     }
 
     if (!list.empty()) {

--- a/src/render/VulkanRenderer.cpp
+++ b/src/render/VulkanRenderer.cpp
@@ -147,8 +147,15 @@ struct DefaultAtlas {
     VkImageView view{VK_NULL_HANDLE};
 };
 
-[[nodiscard]] Result<DefaultAtlas, RenderError> createDefaultAtlas(
-    const VulkanRenderContext& context) noexcept {
+/// Builds the sampled image, in whichever format and extent the caller needs.
+///
+/// One function for both the 1x1 white default and a baked R8 coverage sheet, because they differ
+/// only in format, extent and the bytes staged into them - the image, memory, view, staging
+/// buffer, layout transitions and one-shot command buffer are identical. Two copies of that
+/// sequence would be two places for a barrier to go wrong.
+[[nodiscard]] Result<DefaultAtlas, RenderError> createAtlasImage(const VulkanRenderContext& context, VkFormat format,
+                                                                 std::uint32_t width, std::uint32_t height,
+                                                                 std::span<const std::byte> pixels) noexcept {
     DefaultAtlas atlas;
 
     const VkImageCreateInfo imageInfo{
@@ -156,8 +163,8 @@ struct DefaultAtlas {
         .pNext = nullptr,
         .flags = 0,
         .imageType = VK_IMAGE_TYPE_2D,
-        .format = VK_FORMAT_R8G8B8A8_UNORM,
-        .extent = {1, 1, 1},
+        .format = format,
+        .extent = {width, height, 1},
         .mipLevels = 1,
         .arrayLayers = 1,
         .samples = VK_SAMPLE_COUNT_1_BIT,
@@ -190,16 +197,15 @@ struct DefaultAtlas {
         return err(RenderError::MemoryAllocationFailed);
     }
 
-    // Four bytes through a staging buffer and a one-shot command buffer. Everything created here
+    // The pixels through a staging buffer and a one-shot command buffer. Everything created here
     // is destroyed before returning: the atlas outlives this function, the machinery does not.
-    auto staging = createMappedBuffer(context, 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+    auto staging = createMappedBuffer(context, pixels.size(), VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     if (!staging.has_value()) {
         vkFreeMemory(context.device, atlas.memory, nullptr);
         vkDestroyImage(context.device, atlas.image, nullptr);
         return err(staging.error());
     }
-    constexpr std::array<std::uint8_t, 4> white{255, 255, 255, 255};
-    std::memcpy(staging->mapped, white.data(), white.size());
+    std::memcpy(staging->mapped, pixels.data(), pixels.size());
 
     const VkCommandPoolCreateInfo poolInfo{.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
                                            .pNext = nullptr,
@@ -256,7 +262,7 @@ struct DefaultAtlas {
                                      .bufferImageHeight = 0,
                                      .imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
                                      .imageOffset = {0, 0, 0},
-                                     .imageExtent = {1, 1, 1}};
+                                     .imageExtent = {width, height, 1}};
         vkCmdCopyBufferToImage(commands, staging->buffer, atlas.image,
                                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
 
@@ -311,7 +317,7 @@ struct DefaultAtlas {
         .flags = 0,
         .image = atlas.image,
         .viewType = VK_IMAGE_VIEW_TYPE_2D,
-        .format = VK_FORMAT_R8G8B8A8_UNORM,
+        .format = format,
         .components = {},
         .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}};
     if (vkCreateImageView(context.device, &viewInfo, nullptr, &atlas.view) != VK_SUCCESS) {
@@ -382,7 +388,8 @@ std::string_view describe(RenderError error) noexcept {
         return "vkCreateCommandPool failed for the atlas upload";
     case RenderError::CommandBufferAllocationFailed:
         return "vkAllocateCommandBuffers failed for the atlas upload";
-    case RenderError::AtlasUploadFailed:      return "uploading the default atlas failed";
+    case RenderError::AtlasUploadFailed:      return "uploading the atlas failed";
+    case RenderError::AtlasExtentMismatch:   return "the coverage atlas' byte count does not match its extent";
     case RenderError::NullCommandBuffer:      return "command buffer is null";
     case RenderError::FrameExceedsBudget:
         return "draw list is larger than the renderer's budget";
@@ -535,6 +542,34 @@ void UiRenderer::destroy() noexcept {
 Result<UiRenderer, RenderError> UiRenderer::create(const VulkanRenderContext& context,
                                                    const shader::PackageView& package,
                                                    const draw::DrawBudget& budget) noexcept {
+    // The 1x1 white default. White is the neutral value: it is the identity for the sampled-RGBA
+    // path and full coverage for the R8 one, so a renderer with no atlas yet behaves correctly
+    // rather than approximately.
+    static constexpr std::array<std::byte, 4> white{std::byte{255}, std::byte{255}, std::byte{255}, std::byte{255}};
+    return createInternal(context, package, budget, VK_FORMAT_R8G8B8A8_UNORM, 1, 1, white);
+}
+
+Result<UiRenderer, RenderError> UiRenderer::createWithCoverageAtlas(const VulkanRenderContext& context,
+                                                                    const shader::PackageView& package,
+                                                                    const draw::DrawBudget& budget,
+                                                                    std::span<const std::byte> atlas,
+                                                                    std::uint32_t width,
+                                                                    std::uint32_t height) noexcept {
+    // Checked here rather than trusted: a sheet whose byte count disagrees with its extent would
+    // stage the wrong number of bytes and read uninitialised memory into a texture, which renders
+    // as plausible noise rather than failing.
+    if (width == 0 || height == 0
+        || atlas.size() != static_cast<std::size_t>(width) * static_cast<std::size_t>(height)) {
+        return err(RenderError::AtlasExtentMismatch);
+    }
+    return createInternal(context, package, budget, VK_FORMAT_R8_UNORM, width, height, atlas);
+}
+
+Result<UiRenderer, RenderError> UiRenderer::createInternal(const VulkanRenderContext& context,
+                                                           const shader::PackageView& package,
+                                                           const draw::DrawBudget& budget, VkFormat atlasFormat,
+                                                           std::uint32_t atlasWidth, std::uint32_t atlasHeight,
+                                                           std::span<const std::byte> atlasPixels) noexcept {
     // Context and budget first: both are cheap to check and neither needs a device call, so a
     // caller's mistake is reported before anything is created.
     if (context.device == VK_NULL_HANDLE) {
@@ -861,7 +896,7 @@ Result<UiRenderer, RenderError> UiRenderer::create(const VulkanRenderContext& co
 
     // The default atlas, and the descriptor set that binds it. Without these a draw is undefined
     // behaviour whatever mode its vertices carry, because the pipeline layout declares a sampler.
-    auto atlas = createDefaultAtlas(context);
+    auto atlas = createAtlasImage(context, atlasFormat, atlasWidth, atlasHeight, atlasPixels);
     if (!atlas.has_value()) {
         return err(atlas.error());
     }

--- a/src/text/Draw.cpp
+++ b/src/text/Draw.cpp
@@ -1,0 +1,131 @@
+/**
+ * @file Draw.cpp
+ * @brief Implementation of the governed-zone coverage draw path.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * See Draw.cppm for why replaying a baked run is not the layout ADR-010 forbids, and for the
+ * record layout this file decodes.
+ */
+module;
+
+module mdux.text.draw;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.font.schema;
+
+namespace mdux::text::draw {
+
+using mdux::core::err;
+using mdux::core::Result;
+using mdux::core::ResultVoid;
+
+std::string_view describe(DrawTextError error) noexcept {
+    switch (error) {
+        case DrawTextError::PartialRecord:
+            return "the run's byte length is not a whole number of records";
+        case DrawTextError::GlyphIndexOutOfRange:
+            return "a record names a glyph index the font package does not contain";
+        case DrawTextError::EmptyAtlas:
+            return "the font package's atlas has zero extent, so no texture coordinate exists";
+        case DrawTextError::ListRejected:
+            return "the draw list refused a rectangle (budget, clip, or degenerate extent)";
+    }
+    return "unknown text draw error";
+}
+
+Result<GlyphPlacement, DrawTextError> decodeRecord(std::span<const std::byte> record) noexcept {
+    if (record.size() < recordSize) {
+        return err(DrawTextError::PartialRecord);
+    }
+    // Little-endian, spelled out rather than memcpy'd over the struct: the sidecar is committed
+    // bytes compared across toolchains, so the decode must not inherit the host's byte order or
+    // its struct padding. Two toolchains disagreeing here would move glyphs, not fail.
+    const auto byteAt = [record](std::size_t index) noexcept {
+        return static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(record[index]));
+    };
+    const auto glyphIndex = static_cast<std::uint16_t>(byteAt(0) | (byteAt(1) << 8));
+    const auto rawX       = static_cast<std::uint16_t>(byteAt(2) | (byteAt(3) << 8));
+    const auto rawY       = static_cast<std::uint16_t>(byteAt(4) | (byteAt(5) << 8));
+    return GlyphPlacement{.glyphIndex = glyphIndex,
+                          // bit_cast rather than a cast chain: x and y are signed, and a glyph
+                          // left of the run's origin is ordinary rather than exceptional.
+                          .x = static_cast<mdux::core::Px>(std::bit_cast<std::int16_t>(rawX)),
+                          .y = static_cast<mdux::core::Px>(std::bit_cast<std::int16_t>(rawY))};
+}
+
+ResultVoid<DrawTextError> addGlyphRect(mdux::draw::DrawList& list, const mdux::font::FontPackage& package,
+                                       const mdux::font::GlyphRecord& glyph, mdux::core::Px penX,
+                                       mdux::core::Px baselineY, mdux::core::ColorRgba8 color) noexcept {
+    if (package.atlas.width == 0 || package.atlas.height == 0) {
+        return err(DrawTextError::EmptyAtlas);
+    }
+    if (glyph.isBlank()) {
+        // A space. Not an error, and not a rectangle: addRect() refuses a degenerate extent, and
+        // the advance the baker already applied means skipping it moves nothing.
+        return {};
+    }
+
+    // Place the bitmap against the pen. `bitmapOriginY` is measured *up* from the baseline, and
+    // the draw path's y axis points down - so it is subtracted. Getting that inversion wrong
+    // renders text that looks correct in isolation and sits at the wrong height beside anything
+    // else, which is why it is one line with a comment rather than folded into the expression.
+    const mdux::core::Rect rect{.x      = penX + glyph.bitmapOriginX,
+                                .y      = baselineY - glyph.bitmapOriginY,
+                                .width  = static_cast<mdux::core::Px>(glyph.width),
+                                .height = static_cast<mdux::core::Px>(glyph.height)};
+
+    // Texel slot to normalised coordinates. The division is what the integer `addRect` overload
+    // cannot express; see Draw.cppm.
+    const auto sheetWidth  = static_cast<float>(package.atlas.width);
+    const auto sheetHeight = static_cast<float>(package.atlas.height);
+    const mdux::draw::UvRect uv{.u0 = static_cast<float>(glyph.x) / sheetWidth,
+                                .v0 = static_cast<float>(glyph.y) / sheetHeight,
+                                .u1 = static_cast<float>(glyph.x + glyph.width) / sheetWidth,
+                                .v1 = static_cast<float>(glyph.y + glyph.height) / sheetHeight};
+
+    if (auto added = list.addRect(rect, color, mdux::draw::DrawMode::CoverageR8, uv); !added.has_value()) {
+        // The list's own error is not forwarded: a budget overflow and a degenerate extent are
+        // both "this rectangle was not recorded" to a caller drawing text, and the list's code is
+        // already the actionable one for whoever sized the budget.
+        return err(DrawTextError::ListRejected);
+    }
+    return {};
+}
+
+ResultVoid<DrawTextError> recordRun(mdux::draw::DrawList& list, const mdux::font::FontPackage& package,
+                                    std::span<const std::byte> records, mdux::core::Px originX,
+                                    mdux::core::Px originY, mdux::core::ColorRgba8 color) noexcept {
+    if (records.size() % recordSize != 0) {
+        // Checked before anything is recorded. A run that is one byte short would otherwise draw
+        // every glyph but the last and look merely truncated, which is the failure mode
+        // `mdux.text.schema` refuses to let reach a device in the first place.
+        return err(DrawTextError::PartialRecord);
+    }
+
+    for (std::size_t offset = 0; offset < records.size(); offset += recordSize) {
+        auto placement = decodeRecord(records.subspan(offset, recordSize));
+        if (!placement.has_value()) {
+            return err(placement.error());
+        }
+        if (placement->glyphIndex >= package.glyphs.size()) {
+            // An index into the *package's* table, not the font's. The two differ - the package
+            // holds only the baked charset - and a record built against a different package would
+            // otherwise draw a plausible wrong character rather than failing.
+            return err(DrawTextError::GlyphIndexOutOfRange);
+        }
+        const mdux::font::GlyphRecord& glyph = package.glyphs[placement->glyphIndex];
+        if (auto added = addGlyphRect(list, package, glyph, originX + placement->x, originY + placement->y, color);
+            !added.has_value()) {
+            return err(added.error());
+        }
+    }
+    return {};
+}
+
+}  // namespace mdux::text::draw

--- a/src/text/Draw.cpp
+++ b/src/text/Draw.cpp
@@ -29,6 +29,8 @@ std::string_view describe(DrawTextError error) noexcept {
     switch (error) {
         case DrawTextError::PartialRecord:
             return "the run's byte length is not a whole number of records";
+        case DrawTextError::RecordSizeWrong:
+            return "a single-record span is not exactly recordSize bytes";
         case DrawTextError::GlyphIndexOutOfRange:
             return "a record names a glyph index the font package does not contain";
         case DrawTextError::EmptyAtlas:
@@ -40,8 +42,12 @@ std::string_view describe(DrawTextError error) noexcept {
 }
 
 Result<GlyphPlacement, DrawTextError> decodeRecord(std::span<const std::byte> record) noexcept {
-    if (record.size() < recordSize) {
-        return err(DrawTextError::PartialRecord);
+    if (record.size() != recordSize) {
+        // Exactly one record, not "at least one". Accepting a longer span would silently decode
+        // the first record of a whole run and discard the rest, which is a plausible-looking
+        // wrong answer rather than a failure - and passing the run instead of a record is the
+        // most likely way to misuse this.
+        return err(DrawTextError::RecordSizeWrong);
     }
     // Little-endian, spelled out rather than memcpy'd over the struct: the sidecar is committed
     // bytes compared across toolchains, so the decode must not inherit the host's byte order or
@@ -52,7 +58,7 @@ Result<GlyphPlacement, DrawTextError> decodeRecord(std::span<const std::byte> re
     const auto glyphIndex = static_cast<std::uint16_t>(byteAt(0) | (byteAt(1) << 8));
     const auto rawX       = static_cast<std::uint16_t>(byteAt(2) | (byteAt(3) << 8));
     const auto rawY       = static_cast<std::uint16_t>(byteAt(4) | (byteAt(5) << 8));
-    return GlyphPlacement{.glyphIndex = glyphIndex,
+    return GlyphPlacement{.packageIndex = glyphIndex,
                           // bit_cast rather than a cast chain: x and y are signed, and a glyph
                           // left of the run's origin is ordinary rather than exceptional.
                           .x = static_cast<mdux::core::Px>(std::bit_cast<std::int16_t>(rawX)),
@@ -108,21 +114,32 @@ ResultVoid<DrawTextError> recordRun(mdux::draw::DrawList& list, const mdux::font
         return err(DrawTextError::PartialRecord);
     }
 
+    // The run is all-or-nothing. The length check above catches a truncated sidecar before any
+    // rectangle exists, but `GlyphIndexOutOfRange`, `EmptyAtlas` and `ListRejected` can all fire
+    // on the fourth record of four - and a run that drew three glyphs and then failed would put a
+    // fragment of a word on screen if the caller kept the list. Marking here and rolling back
+    // makes "does not reach a frame" true of the list itself rather than a caller obligation.
+    const auto start = list.mark();
+    const auto abort = [&list, start](DrawTextError error) {
+        list.rollback(start);
+        return err(error);
+    };
+
     for (std::size_t offset = 0; offset < records.size(); offset += recordSize) {
         auto placement = decodeRecord(records.subspan(offset, recordSize));
         if (!placement.has_value()) {
-            return err(placement.error());
+            return abort(placement.error());
         }
-        if (placement->glyphIndex >= package.glyphs.size()) {
+        if (placement->packageIndex >= package.glyphs.size()) {
             // An index into the *package's* table, not the font's. The two differ - the package
             // holds only the baked charset - and a record built against a different package would
             // otherwise draw a plausible wrong character rather than failing.
-            return err(DrawTextError::GlyphIndexOutOfRange);
+            return abort(DrawTextError::GlyphIndexOutOfRange);
         }
-        const mdux::font::GlyphRecord& glyph = package.glyphs[placement->glyphIndex];
+        const mdux::font::GlyphRecord& glyph = package.glyphs[placement->packageIndex];
         if (auto added = addGlyphRect(list, package, glyph, originX + placement->x, originY + placement->y, color);
             !added.has_value()) {
-            return err(added.error());
+            return abort(added.error());
         }
     }
     return {};

--- a/src/text/Draw.cpp
+++ b/src/text/Draw.cpp
@@ -121,7 +121,11 @@ ResultVoid<DrawTextError> recordRun(mdux::draw::DrawList& list, const mdux::font
     // makes "does not reach a frame" true of the list itself rather than a caller obligation.
     const auto start = list.mark();
     const auto abort = [&list, start](DrawTextError error) {
-        list.rollback(start);
+        // The marker came from this list one statement ago, so the only way this refuses is a bug
+        // in `rollback()` itself. Discarded rather than reported, because the caller is already
+        // being told the run failed and `DrawTextError` has no truthful code for "and the undo
+        // also failed" that would not read as a second, unrelated fault.
+        static_cast<void>(list.rollback(start));
         return err(error);
     };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -261,6 +261,7 @@ add_executable(offscreen_tests
     render/OffscreenTestMain.cpp
     render/OffscreenTests.cpp
     render/PixelTests.cpp
+    render/TextPixelTests.cpp
 )
 
 target_sources(offscreen_tests
@@ -587,6 +588,7 @@ add_executable(text_spec
     text/TextSpecMain.cpp
     text/SchemaTests.cpp
     text/RasterTests.cpp
+    text/DrawTests.cpp
 )
 
 target_link_libraries(text_spec PRIVATE MduX::Core speclab::speclab)

--- a/tests/framework/RunRecords.hpp
+++ b/tests/framework/RunRecords.hpp
@@ -1,0 +1,46 @@
+/**
+ * @file RunRecords.hpp
+ * @brief The v1 glyph-run record encoder, shared by the governed and rendered text suites.
+ *
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * One encoder, because the six-byte layout is a format contract rather than a detail: the sidecar
+ * is committed bytes compared across toolchains, so a test that encoded it differently from the
+ * baker would agree with a decoder that was also wrong. `tests/text` and `tests/render` both need
+ * to build records and are separate targets - governed-only and Vulkan-linked - so the encoder
+ * lives here rather than in either.
+ *
+ * Written byte by byte in little-endian rather than memcpy'd from a struct, for the same reason
+ * `mdux.text.draw` decodes it that way: a struct copy would inherit the host's padding and byte
+ * order, and would then pass on both CI legs while meaning two different things.
+ */
+#pragma once
+
+namespace mdux::spec {
+
+/// Bytes per v1 record. Restated rather than imported so the test's idea of the layout is
+/// independent of the module under test - a decoder that changed `recordSize` should break these
+/// suites rather than move with them.
+inline constexpr std::size_t runRecordSize = 6;
+
+/// Appends one record: glyph index into the package's table, then x and y in pixels.
+inline void appendRunRecord(std::vector<std::byte>& out, std::uint16_t packageIndex, std::int16_t x,
+                            std::int16_t y) {
+    const auto ux = std::bit_cast<std::uint16_t>(x);
+    const auto uy = std::bit_cast<std::uint16_t>(y);
+    out.push_back(static_cast<std::byte>(packageIndex & 0xFFu));
+    out.push_back(static_cast<std::byte>((packageIndex >> 8) & 0xFFu));
+    out.push_back(static_cast<std::byte>(ux & 0xFFu));
+    out.push_back(static_cast<std::byte>((ux >> 8) & 0xFFu));
+    out.push_back(static_cast<std::byte>(uy & 0xFFu));
+    out.push_back(static_cast<std::byte>((uy >> 8) & 0xFFu));
+}
+
+/// One record on its own.
+[[nodiscard]] inline std::vector<std::byte> runRecord(std::uint16_t packageIndex, std::int16_t x, std::int16_t y) {
+    std::vector<std::byte> out;
+    appendRunRecord(out, packageIndex, x, y);
+    return out;
+}
+
+}  // namespace mdux::spec

--- a/tests/render/TextPixelTests.cpp
+++ b/tests/render/TextPixelTests.cpp
@@ -1,0 +1,310 @@
+/**
+ * @file TextPixelTests.cpp
+ * @brief Rendered-truth tests for the coverage draw path (issue #162).
+ *
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * The last link in the text pipeline, checked the only way that means anything: render it and look
+ * at the pixels.
+ *
+ * ## Why a synthetic atlas rather than the committed font
+ *
+ * The expectations here are *derived*, not recorded. The atlas is two 4x4 blocks - one at coverage
+ * 255, one at 128 - so every output pixel follows from the blend equation and can be written down
+ * by hand:
+ *
+ *   background is opaque black, text is opaque white, blending is src-alpha over one-minus-src-alpha
+ *   result = white * (1.0 * coverage) + black * (1 - coverage)
+ *          = 255 * (coverage / 255)
+ *
+ * so coverage 255 renders 255, coverage 128 renders 128, coverage 0 renders the background. The
+ * sampler is `VK_FILTER_NEAREST` and the quad is placed 1:1, so a pixel centre lands on a texel
+ * centre and no filtering blurs the step.
+ *
+ * Rendering DejaVu instead would be more end-to-end and much weaker as a test: the expectation
+ * would be a golden nobody can check by reading it, and #162 asks specifically that no golden be
+ * silently rewritten. A test whose expected values are derivable cannot be "fixed" by re-recording
+ * it, because the derivation would have to change too.
+ *
+ * The committed font is still exercised end to end - by `evidence.font.dejavu-ui`, which compares
+ * its bytes, and by `font_spec`, which parses it. What is missing from neither is a check that the
+ * *renderer* draws what the package describes, and that is what this file adds.
+ */
+
+#include <vulkan/vulkan.h>
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.font.schema;
+import mdux.render.offscreen;
+import mdux.render.vulkan;
+import mdux.shader.schema;
+import mdux.shader.generated.mdux_ui;
+import mdux.test;
+import mdux.text.draw;
+
+#include "../framework/MduXTest.hpp"
+#include "HeadlessDevice.hpp"
+#include "PixelExpectation.hpp"
+
+namespace {
+
+using namespace mdux::render;
+namespace core     = mdux::core;
+namespace draw     = mdux::draw;
+namespace font     = mdux::font;
+namespace textdraw = mdux::text::draw;
+using mdux::test::compare;
+using mdux::test::ExpectedImage;
+using mdux::test::sharedDevice;
+
+constexpr core::Extent2D surface{.width = 48, .height = 32};
+
+constexpr core::ColorRgba8 background{.r = 0, .g = 0, .b = 0, .a = 255};
+constexpr core::ColorRgba8 white{.r = 255, .g = 255, .b = 255, .a = 255};
+
+/// The colour a fully covered texel produces, and the colour a half-covered one does. Written as
+/// the blend result rather than as constants so the derivation stays visible.
+constexpr core::ColorRgba8 fullCoverage{.r = 255, .g = 255, .b = 255, .a = 255};
+constexpr core::ColorRgba8 halfCoverage{.r = 128, .g = 128, .b = 128, .a = 255};
+
+constexpr std::uint32_t atlasEdge  = 8;
+constexpr std::uint32_t blockSize  = 4;
+constexpr std::uint8_t  halfValue  = 128;
+
+/// An 8x8 R8 sheet holding two 4x4 blocks: solid at (0,0), half-coverage at (4,0). The rest is
+/// zero, so a quad that sampled the wrong slot would render background and fail loudly.
+[[nodiscard]] std::vector<std::byte> syntheticAtlas() {
+    std::vector<std::byte> sheet(static_cast<std::size_t>(atlasEdge) * atlasEdge, std::byte{0});
+    for (std::uint32_t y = 0; y < blockSize; ++y) {
+        for (std::uint32_t x = 0; x < blockSize; ++x) {
+            sheet[static_cast<std::size_t>(y) * atlasEdge + x]             = std::byte{255};
+            sheet[static_cast<std::size_t>(y) * atlasEdge + blockSize + x] = std::byte{halfValue};
+        }
+    }
+    return sheet;
+}
+
+/// A package describing that sheet. Passes `validate()` - which is the point of building it here
+/// rather than hand-writing JSON: the renderer is fed something the schema would accept.
+[[nodiscard]] font::FontPackage syntheticPackage() {
+    font::FontPackage package;
+    package.id         = "pixel-fixture";
+    package.unitsPerEm = 2048;
+    package.pixelSize  = 4;
+    package.locales    = {"en-US"};
+
+    package.atlas.path             = "atlas.bin";
+    package.atlas.width            = atlasEdge;
+    package.atlas.height           = atlasEdge;
+    package.atlas.byteLength       = static_cast<std::uint64_t>(atlasEdge) * atlasEdge;
+    package.atlas.sha256           = std::string(64, 'a');
+    package.atlas.occupancyPercent = 50;
+
+    // 'A' is the solid block, 'B' the half one. bitmapOriginY is the height, so each glyph sits
+    // with its bottom on the baseline - the ordinary case, and the one where an inverted origin
+    // would be most visible.
+    package.glyphs = {font::GlyphRecord{.codePoint       = U'A',
+                                        .glyphIndex      = 1,
+                                        .advanceWidth    = 1024,
+                                        .leftSideBearing = 0,
+                                        .x               = 0,
+                                        .y               = 0,
+                                        .width           = blockSize,
+                                        .height          = blockSize,
+                                        .bitmapOriginX   = 0,
+                                        .bitmapOriginY   = static_cast<std::int32_t>(blockSize)},
+                      font::GlyphRecord{.codePoint       = U'B',
+                                        .glyphIndex      = 2,
+                                        .advanceWidth    = 1024,
+                                        .leftSideBearing = 0,
+                                        .x               = blockSize,
+                                        .y               = 0,
+                                        .width           = blockSize,
+                                        .height          = blockSize,
+                                        .bitmapOriginX   = 0,
+                                        .bitmapOriginY   = static_cast<std::int32_t>(blockSize)}};
+    package.restrictedCharset = {font::CharsetRange{.first = U'A', .last = U'B'}};
+    return package;
+}
+
+/// Two v1 records: glyph 0 at the run origin, glyph 1 ten pixels along. Written byte by byte in
+/// little-endian rather than memcpy'd from a struct, because that is the format the sidecar
+/// commits and a struct copy would inherit the host's padding and byte order.
+[[nodiscard]] std::vector<std::byte> runRecords() {
+    const auto append = [](std::vector<std::byte>& out, std::uint16_t glyphIndex, std::int16_t x, std::int16_t y) {
+        const auto ux = std::bit_cast<std::uint16_t>(x);
+        const auto uy = std::bit_cast<std::uint16_t>(y);
+        out.push_back(static_cast<std::byte>(glyphIndex & 0xFFu));
+        out.push_back(static_cast<std::byte>((glyphIndex >> 8) & 0xFFu));
+        out.push_back(static_cast<std::byte>(ux & 0xFFu));
+        out.push_back(static_cast<std::byte>((ux >> 8) & 0xFFu));
+        out.push_back(static_cast<std::byte>(uy & 0xFFu));
+        out.push_back(static_cast<std::byte>((uy >> 8) & 0xFFu));
+    };
+    std::vector<std::byte> records;
+    append(records, 0, 0, 0);
+    append(records, 1, 10, 0);
+    return records;
+}
+
+// Where the run is placed, and therefore where the ink must land. Derived once so the expectation
+// and the assertion cannot drift apart.
+constexpr core::Px originX   = 8;
+constexpr core::Px baselineY = 12;
+constexpr core::Rect solidRect{.x = originX,
+                               .y = baselineY - static_cast<core::Px>(blockSize),
+                               .width  = static_cast<core::Px>(blockSize),
+                               .height = static_cast<core::Px>(blockSize)};
+constexpr core::Rect halfRect{.x = originX + 10,
+                              .y = baselineY - static_cast<core::Px>(blockSize),
+                              .width  = static_cast<core::Px>(blockSize),
+                              .height = static_cast<core::Px>(blockSize)};
+
+struct Frame {
+    std::array<draw::UiVertex, 32> vertices{};
+    std::array<draw::Index, 48>    indices{};
+    std::array<draw::DrawCommand, 4> commands{};
+
+    [[nodiscard]] static constexpr draw::DrawBudget budget() noexcept {
+        return draw::DrawBudget{.maxVertices = 32, .maxIndices = 48, .maxCommands = 4};
+    }
+};
+
+struct RecordContext {
+    UiRenderer*           renderer;
+    const draw::DrawList* list;
+};
+
+void recordFrame(VkCommandBuffer commandBuffer, void* context) {
+    auto* recording = static_cast<RecordContext*>(context);
+    static_cast<void>(recording->renderer->record(commandBuffer, *recording->list));
+}
+
+/// Renders one run and returns the frame, or nullopt when the device could not be set up. Shared
+/// by every case below so they differ only in what they draw and what they expect.
+[[nodiscard]] std::optional<std::vector<core::ColorRgba8>> renderRun(const font::FontPackage& package,
+                                                                     std::span<const std::byte> records,
+                                                                     core::Px penX, core::Px penY) {
+    const auto& gpu    = sharedDevice();
+    auto        target = OffscreenTarget::create(gpu.device(), gpu.physicalDevice(), surface, gpu.queueFamilyIndex());
+    if (!target.has_value()) {
+        return std::nullopt;
+    }
+
+    VulkanRenderContext context;
+    context.device           = gpu.device();
+    context.physicalDevice   = gpu.physicalDevice();
+    context.renderPass       = target->renderPass();
+    context.queue            = gpu.queue();
+    context.queueFamilyIndex = gpu.queueFamilyIndex();
+    context.viewport         = surface;
+
+    const auto sheet = syntheticAtlas();
+    auto       renderer =
+        UiRenderer::createWithCoverageAtlas(context, mdux::shader::generated::mdux_ui::package(), Frame::budget(),
+                                            sheet, atlasEdge, atlasEdge);
+    if (!renderer.has_value()) {
+        return std::nullopt;
+    }
+
+    Frame frame;
+    auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, Frame::budget());
+    if (!list.has_value()) {
+        return std::nullopt;
+    }
+    if (!textdraw::recordRun(*list, package, records, penX, penY, white).has_value()) {
+        return std::nullopt;
+    }
+
+    RecordContext recording{.renderer = &*renderer, .list = &*list};
+    auto          pixels = target->renderAndRead(gpu.queue(), background, recordFrame, &recording);
+    if (!pixels.has_value()) {
+        return std::nullopt;
+    }
+    // Copied, not returned as a span: the readback lives in `target`, which is local to this
+    // function. Returning the view would hand every caller a dangling one.
+    return std::vector<core::ColorRgba8>{pixels->begin(), pixels->end()};
+}
+
+}  // namespace
+
+TEST_CASE("A baked glyph run renders at its recorded bounds, with its recorded coverage", "pixel") {
+    const auto package = syntheticPackage();
+    REQUIRE(package.validate().has_value());  // the fixture is one the schema would accept
+
+    const auto records = runRecords();
+    const auto pixels  = renderRun(package, records, originX, baselineY);
+    REQUIRE(pixels.has_value());
+
+    ExpectedImage expected{surface, background};
+    expected.paint(solidRect, fullCoverage);
+    expected.paint(halfRect, halfCoverage);
+
+    const auto diff = compare(expected, *pixels);
+    CHECK_MESSAGE(diff.matched(), diff.message);
+}
+
+TEST_CASE("A run moved by one pixel no longer matches", "pixel") {
+    // The sensitivity claim #162 asks for, demonstrated rather than asserted. If this passed, the
+    // positive case above would be proving nothing about position.
+    const auto package = syntheticPackage();
+    const auto records = runRecords();
+    const auto pixels  = renderRun(package, records, originX + 1, baselineY);
+    REQUIRE(pixels.has_value());
+
+    ExpectedImage expected{surface, background};
+    expected.paint(solidRect, fullCoverage);
+    expected.paint(halfRect, halfCoverage);
+
+    const auto diff = compare(expected, *pixels);
+    CHECK(!diff.matched());
+    // #162 asks that a deliberate change fail "with coordinates and expected/actual values", so
+    // the message is asserted rather than assumed. The coordinate is derivable: shifting the run
+    // one pixel right vacates the solid rect's leftmost column, so (8, 8) - its top-left - is the
+    // first pixel that differs, expecting white and getting the background.
+    CHECK(diff.message.find("(8, 8)") != std::string::npos);
+    CHECK(diff.message.find("expected") != std::string::npos);
+    CHECK(diff.message.find("actual") != std::string::npos);
+}
+
+TEST_CASE("A run drawn from the wrong atlas slot no longer matches", "pixel") {
+    // Both glyphs pointed at the solid block: the half-coverage rectangle would render white.
+    // This is what catches a uv normalisation error, which is the arithmetic most likely to be
+    // wrong in the coverage path and the one that looks plausible when it is.
+    auto package             = syntheticPackage();
+    package.glyphs[1].x      = 0;  // 'B' now samples 'A''s slot
+
+    const auto records = runRecords();
+    const auto pixels  = renderRun(package, records, originX, baselineY);
+    REQUIRE(pixels.has_value());
+
+    ExpectedImage expected{surface, background};
+    expected.paint(solidRect, fullCoverage);
+    expected.paint(halfRect, halfCoverage);
+
+    const auto diff = compare(expected, *pixels);
+    CHECK(!diff.matched());
+    CHECK(diff.differing == static_cast<std::size_t>(blockSize) * blockSize);
+}
+
+TEST_CASE("A blank glyph occupies no pixels but does not fail the run", "pixel") {
+    // The space. It has an advance and no coverage, so it must be skipped rather than recorded as
+    // a degenerate rectangle - which DrawList would refuse, failing the whole run.
+    auto package = syntheticPackage();
+    package.glyphs[1].width  = 0;
+    package.glyphs[1].height = 0;
+
+    const auto records = runRecords();
+    const auto pixels  = renderRun(package, records, originX, baselineY);
+    REQUIRE(pixels.has_value());
+
+    ExpectedImage expected{surface, background};
+    expected.paint(solidRect, fullCoverage);  // only the solid glyph; the blank paints nothing
+
+    const auto diff = compare(expected, *pixels);
+    CHECK_MESSAGE(diff.matched(), diff.message);
+}

--- a/tests/render/TextPixelTests.cpp
+++ b/tests/render/TextPixelTests.cpp
@@ -47,6 +47,7 @@ import mdux.test;
 import mdux.text.draw;
 
 #include "../framework/MduXTest.hpp"
+#include "../framework/RunRecords.hpp"
 #include "HeadlessDevice.hpp"
 #include "PixelExpectation.hpp"
 
@@ -135,19 +136,9 @@ constexpr std::uint8_t  halfValue  = 128;
 /// little-endian rather than memcpy'd from a struct, because that is the format the sidecar
 /// commits and a struct copy would inherit the host's padding and byte order.
 [[nodiscard]] std::vector<std::byte> runRecords() {
-    const auto append = [](std::vector<std::byte>& out, std::uint16_t glyphIndex, std::int16_t x, std::int16_t y) {
-        const auto ux = std::bit_cast<std::uint16_t>(x);
-        const auto uy = std::bit_cast<std::uint16_t>(y);
-        out.push_back(static_cast<std::byte>(glyphIndex & 0xFFu));
-        out.push_back(static_cast<std::byte>((glyphIndex >> 8) & 0xFFu));
-        out.push_back(static_cast<std::byte>(ux & 0xFFu));
-        out.push_back(static_cast<std::byte>((ux >> 8) & 0xFFu));
-        out.push_back(static_cast<std::byte>(uy & 0xFFu));
-        out.push_back(static_cast<std::byte>((uy >> 8) & 0xFFu));
-    };
     std::vector<std::byte> records;
-    append(records, 0, 0, 0);
-    append(records, 1, 10, 0);
+    mdux::spec::appendRunRecord(records, 0, 0, 0);
+    mdux::spec::appendRunRecord(records, 1, 10, 0);
     return records;
 }
 
@@ -179,20 +170,47 @@ struct RecordContext {
     const draw::DrawList* list;
 };
 
+/// Like `RecordContext`, but keeps what `record()` returned. The callback runs inside
+/// `renderAndRead`, so a refusal has nowhere else to go - discarding it is what the ordinary
+/// `recordFrame` does, and is why a test wanting the error needs its own callback.
+struct Outcome {
+    UiRenderer*                            renderer;
+    const draw::DrawList*                  list;
+    mdux::core::ResultVoid<RenderError>    result;
+};
+
+void captureRecord(VkCommandBuffer commandBuffer, void* context) {
+    auto* outcome    = static_cast<Outcome*>(context);
+    outcome->result = outcome->renderer->record(commandBuffer, *outcome->list);
+}
+
 void recordFrame(VkCommandBuffer commandBuffer, void* context) {
     auto* recording = static_cast<RecordContext*>(context);
     static_cast<void>(recording->renderer->record(commandBuffer, *recording->list));
 }
 
-/// Renders one run and returns the frame, or nullopt when the device could not be set up. Shared
-/// by every case below so they differ only in what they draw and what they expect.
-[[nodiscard]] std::optional<std::vector<core::ColorRgba8>> renderRun(const font::FontPackage& package,
-                                                                     std::span<const std::byte> records,
-                                                                     core::Px penX, core::Px penY) {
+/// A rendered frame, or the step that stopped it from being one.
+///
+/// Not `optional`: five different failures reach this - target, renderer, list, run and readback -
+/// and collapsing them all to "no pixels" means a broken atlas upload and a rejected glyph run
+/// report the same thing. The binary already skips wholesale when there is no device, so a failure
+/// here is always a real one and deserves to say which.
+using RenderedRun = std::expected<std::vector<core::ColorRgba8>, std::string>;
+
+/// The failure text, or empty when there was none. REQUIRE_MESSAGE takes its message by value, so
+/// calling `.error()` directly at the assertion would read the error of a `RenderedRun` that holds
+/// pixels - undefined, and on the passing path.
+[[nodiscard]] std::string whyNot(const RenderedRun& run) {
+    return run.has_value() ? std::string{} : run.error();
+}
+
+/// Renders one run. Shared by every case below so they differ only in what they draw and expect.
+[[nodiscard]] RenderedRun renderRun(const font::FontPackage& package, std::span<const std::byte> records,
+                                    core::Px penX, core::Px penY) {
     const auto& gpu    = sharedDevice();
     auto        target = OffscreenTarget::create(gpu.device(), gpu.physicalDevice(), surface, gpu.queueFamilyIndex());
     if (!target.has_value()) {
-        return std::nullopt;
+        return std::unexpected(std::format("OffscreenTarget::create failed: {}", describe(target.error())));
     }
 
     VulkanRenderContext context;
@@ -208,22 +226,23 @@ void recordFrame(VkCommandBuffer commandBuffer, void* context) {
         UiRenderer::createWithCoverageAtlas(context, mdux::shader::generated::mdux_ui::package(), Frame::budget(),
                                             sheet, atlasEdge, atlasEdge);
     if (!renderer.has_value()) {
-        return std::nullopt;
+        return std::unexpected(
+            std::format("createWithCoverageAtlas failed: {}", describe(renderer.error())));
     }
 
     Frame frame;
     auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, Frame::budget());
     if (!list.has_value()) {
-        return std::nullopt;
+        return std::unexpected(std::format("DrawList::create failed: {}", draw::describe(list.error())));
     }
-    if (!textdraw::recordRun(*list, package, records, penX, penY, white).has_value()) {
-        return std::nullopt;
+    if (auto recorded = textdraw::recordRun(*list, package, records, penX, penY, white); !recorded.has_value()) {
+        return std::unexpected(std::format("recordRun failed: {}", textdraw::describe(recorded.error())));
     }
 
     RecordContext recording{.renderer = &*renderer, .list = &*list};
     auto          pixels = target->renderAndRead(gpu.queue(), background, recordFrame, &recording);
     if (!pixels.has_value()) {
-        return std::nullopt;
+        return std::unexpected(std::format("renderAndRead failed: {}", describe(pixels.error())));
     }
     // Copied, not returned as a span: the readback lives in `target`, which is local to this
     // function. Returning the view would hand every caller a dangling one.
@@ -238,7 +257,7 @@ TEST_CASE("A baked glyph run renders at its recorded bounds, with its recorded c
 
     const auto records = runRecords();
     const auto pixels  = renderRun(package, records, originX, baselineY);
-    REQUIRE(pixels.has_value());
+    REQUIRE_MESSAGE(pixels.has_value(), whyNot(pixels));
 
     ExpectedImage expected{surface, background};
     expected.paint(solidRect, fullCoverage);
@@ -254,7 +273,7 @@ TEST_CASE("A run moved by one pixel no longer matches", "pixel") {
     const auto package = syntheticPackage();
     const auto records = runRecords();
     const auto pixels  = renderRun(package, records, originX + 1, baselineY);
-    REQUIRE(pixels.has_value());
+    REQUIRE_MESSAGE(pixels.has_value(), whyNot(pixels));
 
     ExpectedImage expected{surface, background};
     expected.paint(solidRect, fullCoverage);
@@ -280,7 +299,7 @@ TEST_CASE("A run drawn from the wrong atlas slot no longer matches", "pixel") {
 
     const auto records = runRecords();
     const auto pixels  = renderRun(package, records, originX, baselineY);
-    REQUIRE(pixels.has_value());
+    REQUIRE_MESSAGE(pixels.has_value(), whyNot(pixels));
 
     ExpectedImage expected{surface, background};
     expected.paint(solidRect, fullCoverage);
@@ -300,11 +319,58 @@ TEST_CASE("A blank glyph occupies no pixels but does not fail the run", "pixel")
 
     const auto records = runRecords();
     const auto pixels  = renderRun(package, records, originX, baselineY);
-    REQUIRE(pixels.has_value());
+    REQUIRE_MESSAGE(pixels.has_value(), whyNot(pixels));
 
     ExpectedImage expected{surface, background};
     expected.paint(solidRect, fullCoverage);  // only the solid glyph; the blank paints nothing
 
     const auto diff = compare(expected, *pixels);
     CHECK_MESSAGE(diff.matched(), diff.message);
+}
+
+TEST_CASE("A coverage renderer refuses a frame that samples RGBA", "pixel") {
+    // An R8 image sampled as RGBA returns (coverage, 0, 0, 1) - a picture in the wrong colours,
+    // which survives review in a way a black frame or a crash would not. The refusal is what makes
+    // "this renderer draws text and solids, not images" checkable rather than a comment.
+    const auto& gpu = sharedDevice();
+    auto target = OffscreenTarget::create(gpu.device(), gpu.physicalDevice(), surface, gpu.queueFamilyIndex());
+    REQUIRE(target.has_value());
+
+    VulkanRenderContext context;
+    context.device           = gpu.device();
+    context.physicalDevice   = gpu.physicalDevice();
+    context.renderPass       = target->renderPass();
+    context.queue            = gpu.queue();
+    context.queueFamilyIndex = gpu.queueFamilyIndex();
+    context.viewport         = surface;
+
+    const auto sheet    = syntheticAtlas();
+    auto       renderer = UiRenderer::createWithCoverageAtlas(
+        context, mdux::shader::generated::mdux_ui::package(), Frame::budget(), sheet, atlasEdge, atlasEdge);
+    REQUIRE(renderer.has_value());
+
+    Frame frame;
+    auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, Frame::budget());
+    REQUIRE(list.has_value());
+
+    constexpr core::Rect rect{.x = 0, .y = 0, .width = 4, .height = 4};
+    constexpr draw::UvRect unit{.u0 = 0.0F, .v0 = 0.0F, .u1 = 1.0F, .v1 = 1.0F};
+    REQUIRE(list->addRect(rect, white, draw::DrawMode::SampledRgba, unit).has_value());
+
+    // Through the real recording path rather than a synthesised command buffer, so what is being
+    // checked is the call a frame actually makes. The refusal happens before any vkCmd, so the
+    // pass still completes - it just draws nothing.
+    Outcome outcome{.renderer = &*renderer, .list = &*list, .result = {}};
+    static_cast<void>(target->renderAndRead(gpu.queue(), background, captureRecord, &outcome));
+    REQUIRE(!outcome.result.has_value());
+    CHECK(outcome.result.error() == RenderError::SampledRgbaWithCoverageAtlas);
+
+    // And the same renderer still accepts an ordinary coverage frame, so what the guard rejects is
+    // the mode rather than the renderer.
+    const auto package = syntheticPackage();
+    list->reset();
+    REQUIRE(textdraw::recordRun(*list, package, runRecords(), originX, baselineY, white).has_value());
+    static_cast<void>(target->renderAndRead(gpu.queue(), background, captureRecord, &outcome));
+    CHECK_MESSAGE(outcome.result.has_value(),
+                  outcome.result.has_value() ? std::string{} : std::string{describe(outcome.result.error())});
 }

--- a/tests/render/TextPixelTests.cpp
+++ b/tests/render/TextPixelTests.cpp
@@ -360,8 +360,12 @@ TEST_CASE("A coverage renderer refuses a frame that samples RGBA", "pixel") {
     // Through the real recording path rather than a synthesised command buffer, so what is being
     // checked is the call a frame actually makes. The refusal happens before any vkCmd, so the
     // pass still completes - it just draws nothing.
-    Outcome outcome{.renderer = &*renderer, .list = &*list, .result = {}};
-    static_cast<void>(target->renderAndRead(gpu.queue(), background, captureRecord, &outcome));
+    Outcome    outcome{.renderer = &*renderer, .list = &*list, .result = {}};
+    const auto rejected = target->renderAndRead(gpu.queue(), background, captureRecord, &outcome);
+    // The pass itself must still succeed - record() refusing means the frame draws nothing, not
+    // that submission failed. Checking it is what stops a readback failure from passing this test
+    // for the wrong reason.
+    REQUIRE_MESSAGE(rejected.has_value(), rejected.has_value() ? std::string{} : std::string{describe(rejected.error())});
     REQUIRE(!outcome.result.has_value());
     CHECK(outcome.result.error() == RenderError::SampledRgbaWithCoverageAtlas);
 
@@ -370,7 +374,8 @@ TEST_CASE("A coverage renderer refuses a frame that samples RGBA", "pixel") {
     const auto package = syntheticPackage();
     list->reset();
     REQUIRE(textdraw::recordRun(*list, package, runRecords(), originX, baselineY, white).has_value());
-    static_cast<void>(target->renderAndRead(gpu.queue(), background, captureRecord, &outcome));
+    const auto accepted = target->renderAndRead(gpu.queue(), background, captureRecord, &outcome);
+    REQUIRE_MESSAGE(accepted.has_value(), accepted.has_value() ? std::string{} : std::string{describe(accepted.error())});
     CHECK_MESSAGE(outcome.result.has_value(),
                   outcome.result.has_value() ? std::string{} : std::string{describe(outcome.result.error())});
 }

--- a/tests/text/DrawTests.cpp
+++ b/tests/text/DrawTests.cpp
@@ -260,3 +260,64 @@ const mdux::spec::Register aFailedRunLeavesNothingBehind{
                   })
             .Execute();
     }};
+
+const mdux::spec::Register aMarkerBelongsToOneList{
+    "A rollback marker is refused by any list but its own",
+    "evidence-unit",
+    [] {
+        // rollback() writes through the marker's command count, so a marker naming more commands
+        // than the storage holds is an out-of-bounds write rather than a wrong picture. The type
+        // makes a forged marker unspellable - the fields are private - and this covers the two
+        // that are still spellable: one from another list, and a default-constructed one.
+        return speclab::Test("draw-marker-ownership")
+            .Given("two lists over separate storage", [] {})
+            .When("each is handed the other's marker", [] {})
+            .Then("both refuse, and neither moves",
+                  [] {
+                      mdux::spec::Checks         checks;
+                      constexpr core::ColorRgba8 white{.r = 255, .g = 255, .b = 255, .a = 255};
+                      constexpr core::Rect       rect{.x = 0, .y = 0, .width = 2, .height = 2};
+
+                      Buffers storageA;
+                      Buffers storageB;
+                      auto    listA = draw::DrawList::create(storageA.vertices, storageA.indices,
+                                                             storageA.commands, Buffers::budget());
+                      auto    listB = draw::DrawList::create(storageB.vertices, storageB.indices,
+                                                             storageB.commands, Buffers::budget());
+                      checks.expect(listA.has_value() && listB.has_value(), "both lists are created");
+                      if (!listA.has_value() || !listB.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      // A is empty when marked; B then records more than A ever will, so a marker
+                      // accepted across lists would be visible as a changed count.
+                      const auto markerA = listA->mark();
+                      checks.expect(listB->addSolidRect(rect, white).has_value(), "B records a rect");
+                      const auto beforeB = listB->vertices().size();
+
+                      auto foreign = listB->rollback(markerA);
+                      checks.expect(!foreign.has_value() && foreign.error() == draw::DrawError::WrongList,
+                                    "B refuses A's marker");
+                      checks.expect(listB->vertices().size() == beforeB,
+                                    std::format("and B is unmoved: {} vertices, was {}",
+                                                listB->vertices().size(), beforeB));
+
+                      // A default-constructed marker names no list at all.
+                      auto orphan = listB->rollback(draw::DrawList::Marker{});
+                      checks.expect(!orphan.has_value() && orphan.error() == draw::DrawError::WrongList,
+                                    "a marker that was never taken is refused");
+
+                      // And a marker from the right list, naming a position the list has already
+                      // gone back past, cannot drag a counter forward.
+                      const auto afterB = listB->mark();
+                      checks.expect(listB->rollback(afterB).has_value(), "its own current marker is accepted");
+                      listB->reset();
+                      auto stale = listB->rollback(afterB);
+                      checks.expect(!stale.has_value() && stale.error() == draw::DrawError::WrongList,
+                                    "a marker past the list's current position is refused");
+                      checks.expect(listB->vertices().empty(), "the reset list stays empty");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/text/DrawTests.cpp
+++ b/tests/text/DrawTests.cpp
@@ -1,0 +1,203 @@
+/**
+ * @file DrawTests.cpp
+ * @brief BDD scenarios for the governed coverage draw path (issue #162).
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-010 No on-device text shaping
+ *
+ * These run without a GPU, which is the point of the draw path being governed: the record decode
+ * and the uv arithmetic are checkable directly, so a failure names the wrong number rather than
+ * showing up as a glyph in the wrong place in a rendered frame. `TextPixelTests.cpp` covers what
+ * only a render can - that the numbers reach the screen.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.font.schema;
+import mdux.text.draw;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace core = mdux::core;
+namespace draw = mdux::draw;
+namespace font = mdux::font;
+namespace td   = mdux::text::draw;
+
+/// A package with one 4x4 glyph at slot (4, 0) of an 8x8 sheet, so the normalised coordinates are
+/// halves and quarters - values a reader can check without a calculator.
+[[nodiscard]] font::FontPackage packageWithOneGlyph() {
+    font::FontPackage package;
+    package.id         = "fixture";
+    package.unitsPerEm = 2048;
+    package.pixelSize  = 4;
+    package.locales    = {"en-US"};
+    package.atlas      = font::AtlasMetrics{.path             = "atlas.bin",
+                                            .width            = 8,
+                                            .height           = 8,
+                                            .byteLength       = 64,
+                                            .sha256           = std::string(64, 'a'),
+                                            .occupancyPercent = 25};
+    package.glyphs     = {font::GlyphRecord{.codePoint       = U'A',
+                                            .glyphIndex      = 1,
+                                            .advanceWidth    = 1024,
+                                            .leftSideBearing = 0,
+                                            .x               = 4,
+                                            .y               = 0,
+                                            .width           = 4,
+                                            .height          = 4,
+                                            .bitmapOriginX   = 1,
+                                            .bitmapOriginY   = 4}};
+    package.restrictedCharset = {font::CharsetRange{.first = U'A', .last = U'A'}};
+    return package;
+}
+
+struct Buffers {
+    std::array<draw::UiVertex, 16>   vertices{};
+    std::array<draw::Index, 24>      indices{};
+    std::array<draw::DrawCommand, 2> commands{};
+    [[nodiscard]] static constexpr draw::DrawBudget budget() noexcept {
+        return draw::DrawBudget{.maxVertices = 16, .maxIndices = 24, .maxCommands = 2};
+    }
+};
+
+[[nodiscard]] std::vector<std::byte> record(std::uint16_t glyphIndex, std::int16_t x, std::int16_t y) {
+    const auto ux = std::bit_cast<std::uint16_t>(x);
+    const auto uy = std::bit_cast<std::uint16_t>(y);
+    return {static_cast<std::byte>(glyphIndex & 0xFFu), static_cast<std::byte>((glyphIndex >> 8) & 0xFFu),
+            static_cast<std::byte>(ux & 0xFFu),         static_cast<std::byte>((ux >> 8) & 0xFFu),
+            static_cast<std::byte>(uy & 0xFFu),         static_cast<std::byte>((uy >> 8) & 0xFFu)};
+}
+
+}  // namespace
+
+const mdux::spec::Register recordsDecodeLittleEndian{
+    "A run record decodes little-endian, including negative positions",
+    "evidence-unit",
+    [] {
+        // The byte order is a contract, not an implementation detail: the sidecar is committed
+        // bytes compared across toolchains, so a decode that inherited the host's order would
+        // move glyphs on one leg and not the other. Negative x is ordinary - a glyph can sit left
+        // of its run's origin - and is the case a sign-extension mistake breaks.
+        return speclab::Test("text-draw-record-decode")
+            .Given("nothing", [] {})
+            .When("nothing", [] {})
+            .Then("each field is read from its own two bytes, with sign preserved",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         positive = record(0x0102, 300, -40);
+                      auto               decoded  = td::decodeRecord(positive);
+                      checks.expect(decoded.has_value(), "a whole record decodes");
+                      if (decoded.has_value()) {
+                          checks.expect(decoded->glyphIndex == 0x0102, "glyphIndex reads bytes 0-1");
+                          checks.expect(decoded->x == 300, "x reads bytes 2-3");
+                          checks.expect(decoded->y == -40,
+                                        std::format("y is sign-extended, got {}", decoded->y));
+                      }
+                      // A short buffer is a partial record, which the schema refuses to let reach
+                      // a device precisely because a partial read means something different
+                      // between two struct layouts.
+                      const std::array<std::byte, 5> truncated{};
+                      auto                           short_ = td::decodeRecord(truncated);
+                      checks.expect(!short_.has_value() && short_.error() == td::DrawTextError::PartialRecord,
+                                    "a five-byte record is refused");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register glyphRectIsPlacedAndNormalised{
+    "A glyph is placed against the baseline and its slot normalised against the sheet",
+    "evidence-unit",
+    [] {
+        // The arithmetic that a rendered frame can only show indirectly. The slot is (4,0) 4x4 on
+        // an 8x8 sheet, so u runs 0.5..1.0 and v runs 0.0..0.5 - and the rect sits at
+        // (pen + bitmapOriginX, baseline - bitmapOriginY), which is the inversion most likely to
+        // be written the wrong way round.
+        return speclab::Test("text-draw-glyph-rect")
+            .Given("nothing", [] {})
+            .When("nothing", [] {})
+            .Then("the vertices carry the derived position and normalised uv",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         package = packageWithOneGlyph();
+                      Buffers            buffers;
+                      auto list = draw::DrawList::create(buffers.vertices, buffers.indices, buffers.commands,
+                                                         Buffers::budget());
+                      checks.expect(list.has_value(), "the list is created");
+                      if (!list.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      constexpr core::ColorRgba8 white{.r = 255, .g = 255, .b = 255, .a = 255};
+                      auto added = td::addGlyphRect(*list, package, package.glyphs[0], 20, 30, white);
+                      checks.expect(added.has_value(), "the glyph is recorded");
+
+                      const auto vertices = list->vertices();
+                      checks.expect(vertices.size() == 4, "one quad");
+                      if (vertices.size() != 4) {
+                          checks.raise();
+                          return;
+                      }
+                      // Top-left corner: pen 20 + bitmapOriginX 1 = 21; baseline 30 - originY 4 = 26.
+                      checks.expect(vertices[0].x == 21.0F && vertices[0].y == 26.0F,
+                                    std::format("top-left at (21, 26), got ({}, {})", vertices[0].x, vertices[0].y));
+                      checks.expect(vertices[2].x == 25.0F && vertices[2].y == 30.0F,
+                                    "bottom-right is four pixels along and down, sitting on the baseline");
+                      checks.expect(vertices[0].u == 0.5F && vertices[0].v == 0.0F,
+                                    std::format("uv starts at (0.5, 0.0), got ({}, {})", vertices[0].u, vertices[0].v));
+                      checks.expect(vertices[2].u == 1.0F && vertices[2].v == 0.5F,
+                                    std::format("uv ends at (1.0, 0.5), got ({}, {})", vertices[2].u, vertices[2].v));
+                      checks.expect(vertices[0].mode == static_cast<std::uint32_t>(draw::DrawMode::CoverageR8),
+                                    "recorded in CoverageR8, not solid");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register runRejections{
+    "recordRun() refuses a malformed run without recording part of it",
+    "evidence-unit",
+    [] {
+        return speclab::Test("text-draw-run-rejections")
+            .Given("nothing", [] {})
+            .When("nothing", [] {})
+            .Then("a partial run and an out-of-range glyph index are both refused",
+                  [] {
+                      mdux::spec::Checks         checks;
+                      const auto                 package = packageWithOneGlyph();
+                      constexpr core::ColorRgba8 white{.r = 255, .g = 255, .b = 255, .a = 255};
+
+                      Buffers buffers;
+                      auto    list = draw::DrawList::create(buffers.vertices, buffers.indices, buffers.commands,
+                                                            Buffers::budget());
+                      checks.expect(list.has_value(), "the list is created");
+                      if (!list.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      // Seven bytes: one whole record and one byte of another. Refused before
+                      // anything is recorded, so a truncated run cannot draw its first glyph and
+                      // look merely short.
+                      std::vector<std::byte> partial = record(0, 0, 0);
+                      partial.push_back(std::byte{0});
+                      auto partialResult = td::recordRun(*list, package, partial, 0, 0, white);
+                      checks.expect(!partialResult.has_value()
+                                        && partialResult.error() == td::DrawTextError::PartialRecord,
+                                    "a partial run is refused");
+                      checks.expect(list->vertices().empty(), "and nothing was recorded before the refusal");
+
+                      // An index into the package's table, not the font's - a record built against
+                      // a different package would otherwise draw a plausible wrong character.
+                      auto stray = td::recordRun(*list, package, record(7, 0, 0), 0, 0, white);
+                      checks.expect(!stray.has_value() && stray.error() == td::DrawTextError::GlyphIndexOutOfRange,
+                                    "a glyph index past the package's table is refused");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/text/DrawTests.cpp
+++ b/tests/text/DrawTests.cpp
@@ -19,6 +19,7 @@ import mdux.draw;
 import mdux.font.schema;
 import mdux.text.draw;
 
+#include "../framework/RunRecords.hpp"
 #include "../framework/SpecLabBridge.hpp"
 
 namespace {
@@ -65,13 +66,7 @@ struct Buffers {
     }
 };
 
-[[nodiscard]] std::vector<std::byte> record(std::uint16_t glyphIndex, std::int16_t x, std::int16_t y) {
-    const auto ux = std::bit_cast<std::uint16_t>(x);
-    const auto uy = std::bit_cast<std::uint16_t>(y);
-    return {static_cast<std::byte>(glyphIndex & 0xFFu), static_cast<std::byte>((glyphIndex >> 8) & 0xFFu),
-            static_cast<std::byte>(ux & 0xFFu),         static_cast<std::byte>((ux >> 8) & 0xFFu),
-            static_cast<std::byte>(uy & 0xFFu),         static_cast<std::byte>((uy >> 8) & 0xFFu)};
-}
+using mdux::spec::runRecord;
 
 }  // namespace
 
@@ -89,11 +84,11 @@ const mdux::spec::Register recordsDecodeLittleEndian{
             .Then("each field is read from its own two bytes, with sign preserved",
                   [] {
                       mdux::spec::Checks checks;
-                      const auto         positive = record(0x0102, 300, -40);
+                      const auto         positive = runRecord(0x0102, 300, -40);
                       auto               decoded  = td::decodeRecord(positive);
                       checks.expect(decoded.has_value(), "a whole record decodes");
                       if (decoded.has_value()) {
-                          checks.expect(decoded->glyphIndex == 0x0102, "glyphIndex reads bytes 0-1");
+                          checks.expect(decoded->packageIndex == 0x0102, "packageIndex reads bytes 0-1");
                           checks.expect(decoded->x == 300, "x reads bytes 2-3");
                           checks.expect(decoded->y == -40,
                                         std::format("y is sign-extended, got {}", decoded->y));
@@ -103,8 +98,16 @@ const mdux::spec::Register recordsDecodeLittleEndian{
                       // between two struct layouts.
                       const std::array<std::byte, 5> truncated{};
                       auto                           short_ = td::decodeRecord(truncated);
-                      checks.expect(!short_.has_value() && short_.error() == td::DrawTextError::PartialRecord,
+                      checks.expect(!short_.has_value() && short_.error() == td::DrawTextError::RecordSizeWrong,
                                     "a five-byte record is refused");
+                      // And a whole run handed to the single-record decoder, which would otherwise
+                      // return the first glyph and look like it had worked.
+                      std::vector<std::byte> two = runRecord(1, 0, 0);
+                      const auto             second = runRecord(2, 0, 0);
+                      two.insert(two.end(), second.begin(), second.end());
+                      auto oversize = td::decodeRecord(two);
+                      checks.expect(!oversize.has_value() && oversize.error() == td::DrawTextError::RecordSizeWrong,
+                                    "a two-record span is refused rather than truncated");
                       checks.raise();
                   })
             .Execute();
@@ -184,7 +187,7 @@ const mdux::spec::Register runRejections{
                       // Seven bytes: one whole record and one byte of another. Refused before
                       // anything is recorded, so a truncated run cannot draw its first glyph and
                       // look merely short.
-                      std::vector<std::byte> partial = record(0, 0, 0);
+                      std::vector<std::byte> partial = runRecord(0, 0, 0);
                       partial.push_back(std::byte{0});
                       auto partialResult = td::recordRun(*list, package, partial, 0, 0, white);
                       checks.expect(!partialResult.has_value()
@@ -194,9 +197,65 @@ const mdux::spec::Register runRejections{
 
                       // An index into the package's table, not the font's - a record built against
                       // a different package would otherwise draw a plausible wrong character.
-                      auto stray = td::recordRun(*list, package, record(7, 0, 0), 0, 0, white);
+                      auto stray = td::recordRun(*list, package, runRecord(7, 0, 0), 0, 0, white);
                       checks.expect(!stray.has_value() && stray.error() == td::DrawTextError::GlyphIndexOutOfRange,
                                     "a glyph index past the package's table is refused");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aFailedRunLeavesNothingBehind{
+    "A run that fails on its second glyph records neither glyph",
+    "evidence-unit",
+    [] {
+        // The rejections above all fail before anything is recorded, so they would pass even if
+        // recordRun() left half a run in the list. This is the case that does not: a good record
+        // followed by a bad one. Without the rollback the list keeps one rectangle, and a fragment
+        // of a word reaches the frame - which the header promises it cannot.
+        return speclab::Test("text-draw-run-rollback")
+            .Given("a list with a rectangle already recorded by someone else", [] {})
+            .When("a two-glyph run fails on its second record", [] {})
+            .Then("the run leaves nothing, and the earlier rectangle survives",
+                  [] {
+                      mdux::spec::Checks         checks;
+                      const auto                 package = packageWithOneGlyph();
+                      constexpr core::ColorRgba8 white{.r = 255, .g = 255, .b = 255, .a = 255};
+
+                      Buffers buffers;
+                      auto    list = draw::DrawList::create(buffers.vertices, buffers.indices, buffers.commands,
+                                                            Buffers::budget());
+                      checks.expect(list.has_value(), "the list is created");
+                      if (!list.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      // Someone else's rectangle. Rolling back the run must not take this with it,
+                      // which is the difference between rollback() and reset().
+                      constexpr core::Rect earlier{.x = 0, .y = 0, .width = 2, .height = 2};
+                      checks.expect(list->addSolidRect(earlier, white).has_value(), "the earlier rect is recorded");
+                      const auto verticesBefore = list->vertices().size();
+                      const auto indicesBefore  = list->indices().size();
+                      const auto commandsBefore = list->commands().size();
+
+                      // Glyph 0 exists; glyph 9 does not. The first is recorded, then the run fails.
+                      std::vector<std::byte> run = runRecord(0, 0, 0);
+                      const auto             bad = runRecord(9, 8, 0);
+                      run.insert(run.end(), bad.begin(), bad.end());
+
+                      auto result = td::recordRun(*list, package, run, 0, 0, white);
+                      checks.expect(!result.has_value()
+                                        && result.error() == td::DrawTextError::GlyphIndexOutOfRange,
+                                    "the run is refused");
+                      checks.expect(list->vertices().size() == verticesBefore,
+                                    std::format("no vertices left behind: {} before, {} after", verticesBefore,
+                                                list->vertices().size()));
+                      checks.expect(list->indices().size() == indicesBefore, "no indices left behind");
+                      checks.expect(list->commands().size() == commandsBefore, "no commands left behind");
+                      // And the rollback stopped where it was told to, rather than emptying the list.
+                      checks.expect(verticesBefore == 4 && !list->empty(),
+                                    "the earlier rectangle is still there");
                       checks.raise();
                   })
             .Execute();


### PR DESCRIPTION
Closes #162. Last child of epic #14 — with this merged, the font and text pipeline is complete: a `.ttf` in `recipes/` becomes a committed package, and a baked run from that package reaches a frame.

## What this adds

**`mdux.text.draw`** (governed, `MduXCore`) — decodes the six-byte v1 run record and records each glyph as a `CoverageR8` rectangle.

It is replay, not layout. A record already carries the glyph and the position the baker computed; this module looks the glyph up in the package's table and emits a rectangle where it was told to. There is no pen advancing by a computed width, no code-point-to-glyph mapping, no fallback. The test for ADR-010 is whether a different input could produce a different *layout* — it cannot, because positions are inputs rather than outputs. Worth stating explicitly, because "draws text" sounds like the thing the ADR forbids.

**`UiRenderer::createWithCoverageAtlas()`** (adapter) — uploads a baked sheet in place of the built-in 2×2 default. The renderer previously had no way to replace its atlas contents at all, which is why this is here rather than in a later issue.

**`tests/render/TextPixelTests.cpp`** — four scenarios under lavapipe, `-L pixel`.

## The finding that made this module necessary

`DrawList::addRect()` takes its `uv` as a `core::Rect`, which is **integer**, and copies those integers straight into the vertex's `float u`/`v`. The fragment shader samples with `texture(uAtlas, fragUv)` — a `sampler2D`, so **normalised** coordinates.

An integer rectangle can therefore only ever express 0 and 1. A real atlas slot such as (13, 46, 11×12) would arrive as `u = 13.0` and sample far outside the sheet. Every glyph would have been wrong, and silently — a sampler clamps rather than fails.

So `mdux.draw` gains a `UvRect` (four floats) and an `addRect` overload taking it; the integer overload now delegates by widening, so nothing that exists changes behaviour. Normalising a texel slot against the sheet extent is exactly what `addGlyphRect()` is for, and it is the only supported way to record a `CoverageR8` rectangle.

## Why the pixel tests have no goldens

The atlas is synthetic: an 8×8 R8 sheet with a 4×4 block at coverage 255 beside a 4×4 block at coverage 128. That makes every expected pixel **derivable** from the blend equation — `255 * coverage/255` — rather than recorded from a run that happened to look right. A failing test names a wrong number instead of a changed image, and nobody is ever tempted to re-bless a golden.

Three of the four scenarios are negative, because a pixel test that only asserts the good case proves very little:

| scenario | what it would catch |
|---|---|
| a run renders at its recorded bounds with its recorded coverage | the happy path, including that 128 blends to 128 and not 255 |
| a run moved by one pixel no longer matches | a comparison too loose to see placement |
| a run drawn from the wrong atlas slot no longer matches | a uv error that lands *inside* the sheet |
| a blank glyph occupies no pixels but does not fail the run | the space — must draw nothing without being an error |

## Governed unit tests

`tests/text/DrawTests.cpp` covers the three things a rendered frame can only show indirectly, where a failure would otherwise appear as "a glyph is in the wrong place":

- **little-endian decode**, including a negative `x`. The byte order is a contract, not an implementation detail: the sidecar is committed bytes compared across toolchains, so a decode inheriting the host's order would move glyphs on one CI leg and not the other. A five-byte record is refused.
- **the baseline inversion** — `bitmapOriginY` is measured *up* from the baseline while the draw path's y axis points down. Getting this backwards renders text that looks correct in isolation and sits at the wrong height beside anything else.
- **the uv division** — slot (4,0) 4×4 on an 8×8 sheet gives u 0.5→1.0, v 0.0→0.5. Checkable by eye.

Plus the two refusals: a partial run records *nothing* before failing (a run one byte short would otherwise draw every glyph but the last and look merely truncated), and a glyph index past the package's table is refused rather than drawing a plausible wrong character. The index is into the *package's* glyph table, not the font's `glyf` table — those differ, since the package holds only the baked charset.

## Verification

- `434/434` tests pass — 33 → 36 in `text_spec`, 26 → 30 in `offscreen_tests`
- `mdux_verify_trust_zones: 2 governed target(s) clean of Vulkan/windowing dependencies` — `mdux.text.draw` is in `MduXCore` and imports `std` only
- labels intact: `evidence` 5, `determinism` 4, `pixel` 1, `noheap` 5, `regulatory` 4
- docs: `mdux.text.draw` recorded in `architecture.md`; `#14` marked closed in `roadmap.md` and the test count refreshed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added text rendering from baked glyph runs, including placement, coverage drawing, normalized texture coordinates, and validation.
  - Added coverage-based font atlas support and fractional UV rectangles.
  - Added draw-list rollback support for recovering from failed text rendering.

- **Bug Fixes**
  - Improved validation for malformed records, invalid glyphs, empty atlases, and mismatched atlas data.

- **Tests**
  - Added unit and pixel-rendering coverage for text rendering scenarios.

- **Documentation**
  - Updated architecture, roadmap, and contribution guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->