### PR TITLE
ci: run ASan and UBSan over the test suite (#179)

### DIFF
--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -124,6 +124,10 @@ jobs:
         # covered by .gitignore's `*.log` - so the "Verify no source-tree writes" step below could
         # not see it, and, more to the point, could not see any other .log a build step wrote
         # either. Keeping this file outside the tree keeps that check honest.
+        # Same reason as the sanitizer leg: `run:` gets `bash -e`, not `bash -eo pipefail`, so the
+        # `| tee` below would otherwise report tee's status and let a failing pixel run pass. This
+        # predates #179 and was found while reviewing the copy of this step made for it.
+        set -o pipefail
         PIXEL_LOG="$RUNNER_TEMP/pixel.log"
         # -V rather than --output-on-failure: a passing run must still print, because two of the
         # things this step verifies are only visible in the output of tests that succeeded.

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -111,7 +111,9 @@ jobs:
       run: |
         export DISPLAY=:99
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        ctest --test-dir build-asan -E offscreen_tests --output-on-failure
+        # --no-tests=error: a filter that matched nothing would otherwise be a pass. The whole
+        # point of this job is that it ran.
+        ctest --test-dir build-asan -E offscreen_tests --output-on-failure --no-tests=error
 
     # offscreen_tests runs against lavapipe, and the Vulkan ICD leaks 512 bytes once, on a thread
     # it starts itself, through pthread_once - a stack with no MduX frame in it at all. That is the
@@ -129,4 +131,15 @@ jobs:
       run: |
         export DISPLAY=:99
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        ctest --test-dir build-asan -R offscreen_tests --output-on-failure
+        # offscreen_tests exits 77 with no loader, no ICD or no device, and tests/CMakeLists.txt
+        # sets SKIP_RETURN_CODE 77 so CTest reports that as Skipped - which does not fail a run.
+        # Without the check below, a runner that lost its ICD would turn the sanitized half of the
+        # render path into a silent no-op and this job would stay green, which is the same shape as
+        # the CodeQL database that analysed two files. linux-gcc16-build.yml guards its pixel step
+        # the same way and for the same reason.
+        LOG="$RUNNER_TEMP/asan-pixel.log"
+        ctest --test-dir build-asan -R offscreen_tests --output-on-failure --no-tests=error 2>&1 | tee "$LOG"
+        if grep -q "Skipped" "$LOG"; then
+          echo "::error::offscreen_tests was skipped - no Vulkan device, so nothing in the render path was sanitized"
+          exit 1
+        fi

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,132 @@
+name: Sanitizers
+
+# AddressSanitizer and UndefinedBehaviorSanitizer over the test suite (issue #179).
+#
+# This exists because a green ordinary build proves less than it looks like it does here. ASan
+# found a heap-use-after-free in TruetypeTests.cpp during #171 - a test parsing from a temporary
+# while `tt::Font` held non-owning spans - and found a second one of exactly the same shape in
+# SchemaTests.cpp the first time this workflow was written. Both suites had been passing for
+# months. The tree is full of hand-rolled binary parsing over spans, which is the code where that
+# bug lives, so the instrumented run is not a formality.
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    # Matches the PR's *base*, not its head - see linux-gcc16-build.yml for why the list reads
+    # this way and what `[0-9]+-*` is.
+    branches: [ main, develop, '[0-9]+-*', 'feat/**' ]
+  schedule:
+    # Catches a regression that lands through a path with no PR, and keeps the job from rotting
+    # unnoticed between changes that happen to touch it.
+    - cron: '0 5 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sanitize:
+    name: ASan + UBSan (GCC 16)
+    runs-on: ubuntu-latest
+    container: gcc:16
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # No step here performs an authenticated Git operation, so the checkout token has no
+      # reason to survive into .git/config where any later build or test step could read it
+      # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
+      with:
+        persist-credentials: false
+
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get install -y \
+          cmake \
+          ninja-build \
+          pkg-config \
+          libvulkan-dev \
+          vulkan-tools \
+          vulkan-utility-libraries-dev \
+          spirv-tools \
+          mesa-vulkan-drivers \
+          vulkan-validationlayers \
+          libglfw3-dev \
+          libwayland-dev \
+          wayland-protocols \
+          wayland-utils \
+          libwayland-egl1 \
+          libxrandr-dev \
+          libxinerama-dev \
+          libxcursor-dev \
+          libxi-dev \
+          xvfb \
+          wget \
+          gnupg
+
+    - name: Install latest CMake
+      run: |
+        # Download to RUNNER_TEMP, not the checkout root, matching linux-gcc16-build.yml.
+        CMAKE_VERSION="4.1.1"
+        CMAKE_ARCHIVE="${RUNNER_TEMP}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz"
+        # Pinned SHA-256 from Kitware's own cmake-4.1.1-SHA-256.txt manifest. `sha256sum -c` exits
+        # non-zero on a mismatch and `set -e` is on by default in a `run:` block, so extraction
+        # cannot proceed past a substituted download.
+        CMAKE_SHA256="5a6c61cb62b38e153148a2c8d4af7b3d387f0c8c32b6dbceb5eb4af113efd65a"
+        wget -O "$CMAKE_ARCHIVE" https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz
+        echo "${CMAKE_SHA256}  ${CMAKE_ARCHIVE}" | sha256sum -c -
+        tar -xzf "$CMAKE_ARCHIVE" -C /opt/
+        ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/cmake /usr/bin/cmake
+        ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/ctest /usr/bin/ctest
+        cmake --version
+
+    # Not through a preset: the sanitizer build is deliberately not one of the configurations
+    # CMakePresets.json describes, because it is not a configuration anything ships. Debug, since
+    # ASan's reports are unreadable without frame pointers and line numbers, and examples off
+    # because nothing here runs them.
+    #
+    # `enable_sanitizers()` in cmake/Sanitizers.cmake already carries these options; this job is
+    # the first thing to switch them on. It also adds -fno-sanitize-recover=all, so a UBSan
+    # violation aborts instead of printing into a passing log.
+    - name: Configure with ASan and UBSan
+      run: |
+        cmake -S . -B build-asan -G Ninja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DMDUX_BUILD_TESTS=ON \
+          -DMDUX_BUILD_EXAMPLES=OFF \
+          -DENABLE_SANITIZER_ADDRESS=ON \
+          -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON
+
+    - name: Build
+      run: cmake --build build-asan
+
+    # Everything except the one suite that talks to a GPU driver. Leak detection is on here, which
+    # is the half that catches an owner dropped on the floor.
+    - name: Run tests under ASan and UBSan
+      env:
+        ASAN_OPTIONS: detect_leaks=1
+        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      run: |
+        export DISPLAY=:99
+        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        ctest --test-dir build-asan -E offscreen_tests --output-on-failure
+
+    # offscreen_tests runs against lavapipe, and the Vulkan ICD leaks 512 bytes once, on a thread
+    # it starts itself, through pthread_once - a stack with no MduX frame in it at all. That is the
+    # driver's allocation to free, not this project's, and it is not suppressible by name because
+    # the frames resolve to `<unknown module>`.
+    #
+    # So leak detection is off for this suite only. Every other ASan check - use-after-free,
+    # buffer overflow, use-after-scope - stays on, and those are the ones that matter for code
+    # that renders through spans into mapped memory. A suite skipped entirely would be the worse
+    # trade.
+    - name: Run rendered-truth tests under ASan, without leak detection
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      run: |
+        export DISPLAY=:99
+        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        ctest --test-dir build-asan -R offscreen_tests --output-on-failure

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -137,6 +137,10 @@ jobs:
         # render path into a silent no-op and this job would stay green, which is the same shape as
         # the CodeQL database that analysed two files. linux-gcc16-build.yml guards its pixel step
         # the same way and for the same reason.
+        # A `run:` block gets `bash -e`, which is not `bash -eo pipefail`: without this line the
+        # pipeline below reports tee's status, so a failing ctest would pass the step. Demonstrated
+        # rather than assumed - `false | tee /dev/null` exits 0 under `bash -e` and 1 with pipefail.
+        set -o pipefail
         LOG="$RUNNER_TEMP/asan-pixel.log"
         ctest --test-dir build-asan -R offscreen_tests --output-on-failure --no-tests=error 2>&1 | tee "$LOG"
         if grep -q "Skipped" "$LOG"; then

--- a/cmake/MduXDeterminism.cmake
+++ b/cmake/MduXDeterminism.cmake
@@ -85,7 +85,15 @@ function(mdux_enforce_fp_determinism TGT)
             # "No heap" must not quietly become "enormous stack", which on a device is the same bug
             # wearing a different hat. Re-checked by issue #63; the flag belongs with the other
             # determinism flags.
-            -Wframe-larger-than=4096
+            #
+            # Suspended under AddressSanitizer, which surrounds every stack object with redzones
+            # and so inflates frames far past this limit for reasons that have nothing to do with
+            # the source. Measured: src/font/Schema.cpp goes from within budget to 7648 bytes,
+            # src/governance/Compliance.cpp to 5040. Leaving the flag on would mean the sanitizer
+            # build could never compile, and raising the number for everyone would retire a real
+            # guard to accommodate a build that is not the one shipped. The limit still applies to
+            # every ordinary build, which is where a genuine stack regression would appear.
+            $<$<NOT:$<BOOL:${ENABLE_SANITIZER_ADDRESS}>>:-Wframe-larger-than=4096>
         )
 
         # x87 excess precision, hazard 3. Only 32-bit x86 has the 80-bit-register problem; on

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -59,7 +59,11 @@ function(enable_sanitizers project_name)
        "${LIST_OF_SANITIZERS}"
        STREQUAL
        "")
-      target_compile_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+      # -fno-sanitize-recover: UndefinedBehaviorSanitizer's default is to print and carry on, which
+      # in CI means a job that reports the violation and then passes. Nobody reads a green log, so
+      # a recoverable sanitizer finding is a finding nobody sees. Aborting turns it into a failure.
+      target_compile_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS}
+                                                       -fno-sanitize-recover=all)
       target_link_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
     endif()
   endif()

--- a/tests/shader/SchemaTests.cpp
+++ b/tests/shader/SchemaTests.cpp
@@ -917,6 +917,12 @@ const mdux::spec::Register parseRunsValidate{
 const mdux::spec::Register findLocatesModule{
     "find() locates a module by id and reports a miss", "evidence-unit", [] {
         struct State {
+            // The package is *owned* here, not rebuilt in each step. `find()` returns a pointer
+            // into `package.modules`, so a package that lived only for the Given step would leave
+            // both members dangling and the Then step reading freed memory - which is precisely
+            // what it did until AddressSanitizer was pointed at this suite (#179). The test passed
+            // throughout, because the freed bytes still happened to hold the right stage.
+            ShaderPackage       package{};
             const ShaderModule* found{nullptr};
             const ShaderModule* miss{nullptr};
         };
@@ -924,9 +930,9 @@ const mdux::spec::Register findLocatesModule{
 
         return speclab::Test("shader-find-locates-module")
             .Given("the reference package", [state] {
-                const ShaderPackage package = validPackage();
-                state->found = package.find("ui.vert");
-                state->miss = package.find("ui.frag");
+                state->package = validPackage();
+                state->found = state->package.find("ui.vert");
+                state->miss = state->package.find("ui.frag");
             })
             .When("a known and an unknown id are looked up", [] {})
             .Then("the known id is found and the unknown is a miss",


### PR DESCRIPTION
Closes #179.

`cmake/Sanitizers.cmake` has exposed `ENABLE_SANITIZER_ADDRESS` and friends for a long time, and nothing in `.github/workflows/` has ever set one. The machinery was there; nobody had pulled the lever.

## It found a use-after-free on the first run

Not a hypothetical. `tests/shader/SchemaTests.cpp` built a `ShaderPackage` as a local in its `Given` step and kept the pointers `find()` returned into `package.modules`:

```cpp
.Given("the reference package", [state] {
    const ShaderPackage package = validPackage();   // dies at the closing brace
    state->found = package.find("ui.vert");         // pointer into package.modules
    state->miss  = package.find("ui.frag");
})
```

The `Then` step then dereferences `state->found->stage`. The suite had been green throughout, because the freed bytes still happened to hold the right stage value.

```text
ERROR: AddressSanitizer: heap-use-after-free on address 0x76b5b03e0060
READ of size 1 at 0x76b5b03e0060 thread T0
    #0 tests/shader/SchemaTests.cpp:940
freed by thread T0 here:
    #7 mdux::shader::ShaderPackage::~ShaderPackage() include/mdux/shader/Schema.cppm:170
    #8 tests/shader/SchemaTests.cpp:930
```

Same shape as the #171 finding — a view outliving what it views — in a different suite, found the same way. The package is now owned by the shared state.

That is also the acceptance criterion #179 asked for ("a deliberately reintroduced use-after-free fails it"), satisfied by a real one rather than a planted one.

## Two build-level changes were needed

**`-Wframe-larger-than=4096` is suspended under ASan.** The sanitizer wraps every stack object in redzones, which inflated `src/font/Schema.cpp` to 7648 bytes and `src/governance/Compliance.cpp` to 5040 — for reasons that have nothing to do with the source. Left on, the sanitizer build simply cannot compile. Raising the number for everyone would have retired a real guard to accommodate a build nobody ships, so it is scoped with a generator expression instead; ordinary builds keep it, and that is where a genuine stack regression would appear. Verified: 62 occurrences of the flag remain in the ordinary `build.ninja`.

**`-fno-sanitize-recover=all`.** UBSan's default is to print and continue. In CI that is a job that reports a violation and then goes green, which is a finding nobody reads.

## The one exclusion, and why it is not "skip the hard suite"

`offscreen_tests` runs against lavapipe. The Vulkan ICD leaks 512 bytes once, on a thread it starts itself, via `pthread_once`:

```text
Direct leak of 512 byte(s) in 1 object(s) allocated from:
    #0 realloc
    #1 <unknown module>
    #3 __pthread_once_slow
    #7 asan_thread_start
```

No MduX frame anywhere in it, and the frames resolve to `<unknown module>`, so it cannot be suppressed by name either. Leak detection is therefore off **for that suite only**. Use-after-free, buffer overflow and use-after-scope stay on — those are precisely the checks that matter for code rendering through spans into mapped memory, and dropping the suite entirely would have been the worse trade.

## Verification

| | |
|---|---|
| under ASan + UBSan, leaks on | 435/435 |
| `offscreen_tests` under ASan, leaks off | 31/31 |
| ordinary build, unchanged | 436/436 |

Runs on PRs to the usual branch set, on push to `main`/`develop`, weekly, and on demand. On PRs because that is the point at which this bug class is cheapest to fix — both instances found so far were introduced by a passing PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated sanitizer coverage for memory errors and undefined behavior.
  - Added scheduled and on-demand validation for general functionality and Vulkan rendering.
  - Rendering checks now fail when the graphics path is not exercised.
  - Improved shader package test stability and pointer-lifetime validation.
  - Corrected test reporting so rendering failures cannot be masked.

- **Bug Fixes**
  - Sanitizer-detected issues now stop validation immediately.
  - Preserved frame-size checks for standard builds while supporting sanitizer-enabled validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->