### PR TITLE
docs: require @file, and add it to the 56 files that lacked it (#180)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,19 @@ We follow the **C++ Core Guidelines** to ensure conformance with modern C++23 ge
 
 We use **Doxygen** syntax for code documentation. Follow these guidelines:
 
-- **File-level documentation:** Use `@brief` only, no `@file` or `@author` tags.
+- **File-level documentation:** open the block with `@file <basename>`, then `@brief`. Still no
+  `@author` tags.
+
+  `@file` is what makes Doxygen attach the block to the *file*. Without it the block is not
+  ignored — it silently becomes the documentation of whatever comes next. Measured on
+  `tests/framework/RunRecords.hpp` with Doxygen 1.15: with the tag, the file page carries "The v1
+  glyph-run record encoder, shared by…"; without it, the file page's brief is empty and that
+  sentence turns up as the documentation for `namespace mdux::spec`. Wrong documentation, with no
+  warning, rather than missing documentation.
+
+  This rule previously said the opposite. It was never what the tree did — 82 files used `@file`
+  against 56 that did not — and review bots cite this document, so the contradiction kept
+  resurfacing on unrelated pull requests. #180 settled it in favour of the half that works.
 - **Class documentation:** Include `@brief` with detailed description and usage examples.
 - **Method documentation:**
   - Use compact notation `/** @brief Description */` for simple one-line descriptions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,18 @@ We follow the **C++ Core Guidelines** to ensure conformance with modern C++23 ge
 
 We use **Doxygen** syntax for code documentation. Follow these guidelines:
 
-- **File-level documentation:** open the block with `@file <basename>`, then `@brief`. Still no
-  `@author` tags.
+- **File-level documentation:** open the block with `@file`, naming the file **with its
+  extension and no path**, then `@brief`. Still no `@author` tags.
+
+  ```cpp
+  /**
+   * @file VulkanRenderer.cppm
+   * @brief One sentence on what this file is.
+   */
+  ```
+
+  The extension matters: `Draw.cppm` and `Draw.cpp` are different files with the same stem, and
+  this tree has several such pairs.
 
   `@file` is what makes Doxygen attach the block to the *file*. Without it the block is not
   ignored — it silently becomes the documentation of whatever comes next. Measured on

--- a/examples/SimpleMedicalUiExample.cpp
+++ b/examples/SimpleMedicalUiExample.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file SimpleMedicalUiExample.cpp
  * @brief What MduX builds a frame out of, with no Vulkan device and no window.
  *
  * @compliance IEC 62304 Class B - Medical Device Example

--- a/examples/VulkanSCTriangleExample.cpp
+++ b/examples/VulkanSCTriangleExample.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file VulkanSCTriangleExample.cpp
  * @brief Vulkan SC Pattern Demo - Triangle with Static Memory Management
  *
  * IMPORTANT: This is NOT true Vulkan SC. It demonstrates Vulkan SC patterns

--- a/include/mdux/draw/Draw.cppm
+++ b/include/mdux/draw/Draw.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file Draw.cppm
  * @brief Governed-zone fixed-budget draw types: what a frame is, before Vulkan sees it.
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)

--- a/include/mdux/mdux.cppm
+++ b/include/mdux/mdux.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file mdux.cppm
  * @brief MduX facade: version, compliance metadata and Vulkan capability reporting.
  *
  * What is left here after issue #127 retired the HTML/CSS runtime path. `MedicalUiRenderer`,

--- a/include/mdux/render/Offscreen.cppm
+++ b/include/mdux/render/Offscreen.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file Offscreen.cppm
  * @brief Adapter-zone headless render target: a fixed-size colour image, no window, no swapchain.
  *
  * @compliance ADR-004 Trust zones in C++ (adapter zone: may name Vulkan, never named by MduXCore)

--- a/include/mdux/render/VulkanRenderer.cppm
+++ b/include/mdux/render/VulkanRenderer.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file VulkanRenderer.cppm
  * @brief Adapter-zone fixed-budget Vulkan renderer: where a governed DrawList becomes commands.
  *
  * @compliance ADR-004 Trust zones in C++ (adapter zone: may name Vulkan, never named by MduXCore)

--- a/include/mdux/shader/Schema.cppm
+++ b/include/mdux/shader/Schema.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file Schema.cppm
  * @brief Governed-zone shader package types: the canonical shape of every shader `package.json`.
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)

--- a/include/mdux/text/Schema.cppm
+++ b/include/mdux/text/Schema.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file Schema.cppm
  * @brief Governed-zone text package types: the canonical shape of every baked `package.json`
  *        produced by the text pipeline, and the runtime view generated code exposes.
  *

--- a/src/draw/Draw.cpp
+++ b/src/draw/Draw.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file Draw.cpp
  * @brief Implementation of the governed fixed-budget draw types.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/src/mdux.cpp
+++ b/src/mdux.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file mdux.cpp
  * @brief MduX C++23 Module Implementation - Medical Device User eXperience Library
  * 
  * Pure Vulkan complement library implementation for medical device UI.

--- a/src/render/Offscreen.cpp
+++ b/src/render/Offscreen.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file Offscreen.cpp
  * @brief Implementation of the adapter-zone headless render target.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/src/render/VulkanRenderer.cpp
+++ b/src/render/VulkanRenderer.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file VulkanRenderer.cpp
  * @brief Implementation of the adapter-zone fixed-budget renderer.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/src/shader/Schema.cpp
+++ b/src/shader/Schema.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file Schema.cpp
  * @brief Implementation of the governed shader package types.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/src/text/Schema.cpp
+++ b/src/text/Schema.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file Schema.cpp
  * @brief Implementation of the governed text package types.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/tests/ComplianceTestMain.cpp
+++ b/tests/ComplianceTestMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file ComplianceTestMain.cpp
  * @brief Main entry point for MduX compliance tests (MduXTest framework)
  */
 

--- a/tests/TestCompliance.cpp
+++ b/tests/TestCompliance.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file TestCompliance.cpp
  * @brief Compliance-related tests for MduX library
  */
 

--- a/tests/TestMain.cpp
+++ b/tests/TestMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file TestMain.cpp
  * @brief Main entry point for MduX unit tests (MduXTest framework)
  */
 

--- a/tests/TestRegulatoryCompliance.cpp
+++ b/tests/TestRegulatoryCompliance.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file TestRegulatoryCompliance.cpp
  * @brief Regulatory compliance tests for MduX library
  */
 

--- a/tests/TestVersion.cpp
+++ b/tests/TestVersion.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file TestVersion.cpp
  * @brief Version-related tests for MduX library
  */
 

--- a/tests/draw/DrawSpecMain.cpp
+++ b/tests/draw/DrawSpecMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file DrawSpecMain.cpp
  * @brief Entry point for the mdux.draw SpecLab BDD executable.
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone)

--- a/tests/evidence/EvidenceTestMain.cpp
+++ b/tests/evidence/EvidenceTestMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file EvidenceTestMain.cpp
  * @brief Entry point for the evidence-kernel test executable (MduXTest framework).
  *
  * @compliance ADR-007 Evidence pipeline doctrine

--- a/tests/font/FontSpecMain.cpp
+++ b/tests/font/FontSpecMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file FontSpecMain.cpp
  * @brief Entry point for the mdux.font.schema SpecLab BDD executable.
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone)

--- a/tests/framework/SpecLabBridge.hpp
+++ b/tests/framework/SpecLabBridge.hpp
@@ -1,4 +1,5 @@
 /**
+ * @file SpecLabBridge.hpp
  * @brief Runs SpecLab scenarios under the test-discovery contract the rest of this suite uses.
  *
  * ## Why a bridge exists at all

--- a/tests/ml/MlSpecMain.cpp
+++ b/tests/ml/MlSpecMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file MlSpecMain.cpp
  * @brief Entry point for the mdux.ml SpecLab BDD executable.
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone)

--- a/tests/ml/MlToolsSpecMain.cpp
+++ b/tests/ml/MlToolsSpecMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file MlToolsSpecMain.cpp
  * @brief Entry point for the ML host-tools SpecLab executable (issue #60).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)

--- a/tests/ml/NoHeapSpecMain.cpp
+++ b/tests/ml/NoHeapSpecMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file NoHeapSpecMain.cpp
  * @brief Entry point for the no-heap SpecLab executable (issue #63).
  *
  * @compliance ADR-008 Zero-SOUP ML inference

--- a/tests/render/HeadlessDevice.hpp
+++ b/tests/render/HeadlessDevice.hpp
@@ -1,4 +1,5 @@
 /**
+ * @file HeadlessDevice.hpp
  * @brief A Vulkan instance, device and queue created with no surface and no window.
  *
  * Test scaffolding, not library code: MduX never creates a device, because the application owns

--- a/tests/render/OffscreenTestMain.cpp
+++ b/tests/render/OffscreenTestMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file OffscreenTestMain.cpp
  * @brief Entry point for the offscreen rendering suite, which needs a real Vulkan device.
  *
  * @compliance ADR-004 Trust zones in C++ (adapter zone)

--- a/tests/render/OffscreenTests.cpp
+++ b/tests/render/OffscreenTests.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file OffscreenTests.cpp
  * @brief Tests for the headless offscreen target: creation, clearing, rendering, readback.
  *
  * This is the first suite in the repository that puts anything on a GPU. What it proves is

--- a/tests/render/PixelExpectation.hpp
+++ b/tests/render/PixelExpectation.hpp
@@ -1,4 +1,5 @@
 /**
+ * @file PixelExpectation.hpp
  * @brief Compares a rendered frame against an expectation, and says exactly where it differs.
  *
  * ## The expectation is code, not a committed image

--- a/tests/render/PixelTests.cpp
+++ b/tests/render/PixelTests.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file PixelTests.cpp
  * @brief The project's first pixel test: a rendered frame compared against an expectation,
  *        every pixel, with actionable output when it differs.
  *

--- a/tests/render/RenderTestMain.cpp
+++ b/tests/render/RenderTestMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file RenderTestMain.cpp
  * @brief Entry point for the adapter-zone renderer test executable (MduXTest framework).
  *
  * @compliance ADR-004 Trust zones in C++ (adapter zone)

--- a/tests/render/VulkanRendererTests.cpp
+++ b/tests/render/VulkanRendererTests.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file VulkanRendererTests.cpp
  * @brief Tests for mdux.render.vulkan that need no Vulkan device.
  *
  * ## What this file can and cannot cover, stated plainly

--- a/tests/shader/GeneratedConsumers.hpp
+++ b/tests/shader/GeneratedConsumers.hpp
@@ -1,4 +1,5 @@
 /**
+ * @file GeneratedConsumers.hpp
  * @brief Declares the two ways of reaching the same generated shader package.
  *
  * The point of #121's two outputs is that they describe identical bytes and an identical contract.

--- a/tests/shader/GeneratedHeaderConsumer.cpp
+++ b/tests/shader/GeneratedHeaderConsumer.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file GeneratedHeaderConsumer.cpp
  * @brief Reaches the generated shader package through its header form.
  *
  * The other half of #121's acceptance. The header exists for a translation unit that cannot

--- a/tests/shader/GeneratedModuleConsumer.cpp
+++ b/tests/shader/GeneratedModuleConsumer.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file GeneratedModuleConsumer.cpp
  * @brief Reaches the generated shader package through its module interface.
  *
  * This translation unit existing and compiling *is* half of #121's acceptance: the generated

--- a/tests/shader/ShaderSpecMain.cpp
+++ b/tests/shader/ShaderSpecMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file ShaderSpecMain.cpp
  * @brief Entry point for the shader schema and baker SpecLab BDD executable.
  *
  * @compliance ADR-004 Trust zones in C++ (governed + host-tools zones)

--- a/tests/shader/SpirvFixtures.hpp
+++ b/tests/shader/SpirvFixtures.hpp
@@ -1,4 +1,5 @@
 /**
+ * @file SpirvFixtures.hpp
  * @brief A SPIR-V assembler for tests, shared by the reflector and baker suites.
  *
  * Modules are built word by word rather than loaded from committed `.spv` files. That costs this

--- a/tests/spec/BridgeSpec.cpp
+++ b/tests/spec/BridgeSpec.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file BridgeSpec.cpp
  * @brief Proves the SpecLab integration itself, before any suite is written against it.
  *
  * This file exists because the bridge has more moving parts than the tests it will carry: a

--- a/tests/text/TextSpecMain.cpp
+++ b/tests/text/TextSpecMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file TextSpecMain.cpp
  * @brief Entry point for the mdux.text.schema SpecLab BDD executable.
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone)

--- a/tests/tools/ToolsSpecMain.cpp
+++ b/tests/tools/ToolsSpecMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file ToolsSpecMain.cpp
  * @brief Entry point for the host-tools SpecLab BDD executable.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tests/tools/ToolsTestMain.cpp
+++ b/tests/tools/ToolsTestMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file ToolsTestMain.cpp
  * @brief Entry point for the host-tools test executable (MduXTest framework).
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/ml/MlBakeMain.cpp
+++ b/tools/ml/MlBakeMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file MlBakeMain.cpp
  * @brief `mdux-mlbake` entry point.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/shader/Emit.cpp
+++ b/tools/shader/Emit.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file Emit.cpp
  * @brief Implementation of the shader package C++ emitter.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/tools/shader/Emit.cppm
+++ b/tools/shader/Emit.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file Emit.cppm
  * @brief Turns a committed shader package into C++ the renderer can hold as `constexpr` data.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/shader/ShaderBake.cpp
+++ b/tools/shader/ShaderBake.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file ShaderBake.cpp
  * @brief Implementation of the shader baker's recipe model and bake/verify core.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/tools/shader/ShaderBake.cppm
+++ b/tools/shader/ShaderBake.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file ShaderBake.cppm
  * @brief The shader baker's recipe model and bake/verify core, separated from `main()`.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/shader/ShaderBakeMain.cpp
+++ b/tools/shader/ShaderBakeMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file ShaderBakeMain.cpp
  * @brief `mdux-shaderbake` entry point.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/shader/ShaderEmitMain.cpp
+++ b/tools/shader/ShaderEmitMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file ShaderEmitMain.cpp
  * @brief `mdux-shaderemit` entry point.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/shader/Spirv.cpp
+++ b/tools/shader/Spirv.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file Spirv.cpp
  * @brief Implementation of the host-only SPIR-V reflector.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/tools/shader/Spirv.cppm
+++ b/tools/shader/Spirv.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file Spirv.cppm
  * @brief Host-only SPIR-V reflection: enough of the binary format to state a shader's contract.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone: never linked into MduXCore or MduX)

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file TextBake.cpp
  * @brief Implementation of the text baker's recipe model and bake/verify core.
  *
  * @compliance ADR-004 Trust zones in C++

--- a/tools/text/TextBake.cppm
+++ b/tools/text/TextBake.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file TextBake.cppm
  * @brief The text baker's recipe model and bake/verify core, separated from `main()`.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/text/TextBakeMain.cpp
+++ b/tools/text/TextBakeMain.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file TextBakeMain.cpp
  * @brief `mdux-textbake` entry point.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/text/Truetype.cpp
+++ b/tools/text/Truetype.cpp
@@ -1,4 +1,5 @@
 /**
+ * @file Truetype.cpp
  * @brief Implementation of the host-only TrueType (glyf) parser.
  *
  * @compliance ADR-004 Trust zones in C++ (host-tools zone)

--- a/tools/text/Truetype.cppm
+++ b/tools/text/Truetype.cppm
@@ -1,4 +1,5 @@
 /**
+ * @file Truetype.cppm
  * @brief Host-only TrueType parser, glyf only: walks the offset table, head/maxp/loca and one
  *        glyf record at a time, deliberately not linking freetype or any other font SOUP.
  *


### PR DESCRIPTION
Closes #180.

`CONTRIBUTING.md` said file-level blocks should use "`@brief` only, no `@file`". The tree said otherwise — **82** files carried the tag against **56** that did not — and since review bots cite `CONTRIBUTING.md` as authoritative, the contradiction kept surfacing on unrelated PRs.

## Why the rule was the wrong half to keep

Removing `@file` does not relocate documentation. It **misattributes** it. Measured on a real file from this tree with Doxygen 1.15:

| | file compound brief | where the sentence goes |
|---|---|---|
| with `@file` | "The v1 glyph-run record encoder, shared by…" | `RunRecords_8hpp.xml` |
| without `@file` | **EMPTY** | `namespacemdux_1_1spec.xml` |

So `namespace mdux::spec` ends up documented as *"The v1 glyph-run record encoder, shared by the governed and rendered text suites."* Doxygen emits no warning — it just attaches the block to the next entity it finds. That is wrong documentation rather than missing documentation, which is the worse of the two failure modes, and `@file` is the tag Doxygen provides precisely to prevent it.

For `.cppm` module interfaces the block lands on the module compound instead, which is defensible. For plain headers and `.cpp` files it lands on a namespace, which is not.

## The change

- `CONTRIBUTING.md` now requires `@file <basename>` first, then `@brief`, with the measurement above as the stated reason so it is not re-litigated. `@author` stays prohibited — that half of the rule is about attribution churn and is unrelated.
- One line inserted into each of the 56 files. **All 56 already had a leading `/** */` block**, so nothing here writes or invents documentation; it tags what was already there. 56 files changed, 56 insertions, 0 deletions.

## Verification

- Every tracked `.cpp`/`.cppm`/`.hpp`/`.h` file now carries the tag — the missing count is 0.
- Confirmed the tag does what it is for: `include/mdux/draw/Draw.cppm` now reports "Governed-zone fixed-budget draw types: what a frame is, before Vulkan sees it" on its **file** page, where before the change that page had no brief at all.
- 436 tests pass.

Reviewer note: the diff is 56 identical one-line insertions, so it reads faster from `git show --stat` than file by file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized file-level Doxygen comments by requiring an `@file` annotation with each filename and extension before `@brief`.
  * Added file-identification annotations across source, module, example, test, tool, and header documentation.
  * Updated contribution guidelines to reflect the revised documentation standard.

* **Behavior**
  * No functional behavior, public declarations, or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->