### PR TITLE
Encode the stack-safe PR and post-merge policy [#117]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,6 +61,16 @@ locally, CI covers it" is an acceptable answer and a more useful one than a wron
 
 - [ ] I understand that the `develop` workflow must be green after this merges before the next
       dependent PR may merge.
+- **Post-merge `develop` run:** <!-- workflow URL or run ID once this has merged, or "no successor" -->
+- [ ] That run is green. *(Tick after merging this PR and before merging its successor. "No
+      successor" above means there is nothing to gate, and this box may be left unticked.)*
+
+<!--
+The first box records that the author knows the rule; the second records that the rule was
+followed. They are not redundant - a successor could otherwise merge against an unverified
+integration while the template looked complete, which is the gap this section exists to close.
+-->
+
 
 ## Regulatory impact
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,14 @@
+<!--
+Every section is required. Where a field does not apply, write "none" or "not stacked" rather
+than deleting the heading — a missing heading reads as an oversight, an explicit "none" reads as
+an answer. See CONTRIBUTING.md § "Stacked delivery" for what the dependency fields are for.
+-->
+
 ## Summary
 
 Describe the change and why it is needed.
+
+Closes #
 
 ## Invitation and contributor agreement
 
@@ -9,7 +17,55 @@ Describe the change and why it is needed.
 
 Invitation / CLA issue: #
 
+## Dependency
+
+- **Base branch:** <!-- `develop`, or the predecessor branch this is stacked on -->
+- **Predecessor PR:** <!-- #NNN, or "not stacked" -->
+- **Merge order:** <!-- "mergeable now", or "must not merge until #NNN has merged" -->
+
+<!--
+A stacked PR targets its predecessor rather than `develop`, so a reviewer sees one issue's diff
+instead of the cumulative one. It must not merge until its predecessor has.
+-->
+
+## Shared registries touched
+
+Tick every registry this PR edits. These are the files two branches collide in, and where Wave 2
+lost wiring during conflict resolution:
+
+- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
+- [ ] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
+- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
+- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
+- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
+- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
+- [ ] Committed artifacts under `generated/`
+- [ ] None of the above
+
+## Rebase state
+
+- **Rebased onto:** <!-- the `develop` SHA this branch sits on, or the predecessor's head SHA -->
+- **Conflicts resolved as a union:** <!-- yes / no conflicts. If a conflict was resolved by taking one side, say which and why. -->
+
 ## Verification
 
-List the checks performed and their results.
+List the checks performed and their results. Do not tick anything you did not run — "not run
+locally, CI covers it" is an acceptable answer and a more useful one than a wrong tick.
 
+- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc`
+- [ ] `ctest --test-dir build-gcc` — <!-- N/N passed -->
+- [ ] `python3 tools/docs-lint/mdux_docs_lint.py`
+- [ ] Other: <!-- sanitizers, evidence re-bake, install consumer, MSVC leg -->
+
+## Post-merge gate
+
+- [ ] I understand that the `develop` workflow must be green after this merges before the next
+      dependent PR may merge.
+
+## Regulatory impact
+
+<!--
+Required by AGENTS.md § 8. If this change can affect safety behaviour, risk controls, compliance
+metadata, traceability, or any claim about a standard, say so and name the artifacts updated.
+"None — <reason>" is a complete answer for changes that carry no such impact.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,10 +287,13 @@ has to apply while working are:
 - **Wait for the post-merge `develop` run**, not just the PR check, before merging the next
   dependent PR. The PR check proves the branch builds; only the `develop` run proves the
   integration does.
-- **Resolve every shared-registry conflict as a union.** The root `CMakeLists.txt`, the
-  `FILE_SET CXX_MODULES` lists, `tools/CMakeLists.txt`, `tests/CMakeLists.txt`, the schemas and
-  the generated indexes are the files where taking one side deletes the other side's work while
-  leaving a build that still compiles and tests that still pass.
+- **Resolve a shared-registry conflict as a union by default.** The root `CMakeLists.txt`, the
+  `FILE_SET CXX_MODULES` lists, `tools/CMakeLists.txt`, `tests/CMakeLists.txt`, the schemas, the
+  generated indexes and the committed artifacts under `generated/` are the files where taking one
+  side deletes the other side's work while leaving a build that still compiles and tests that
+  still pass. If a conflict genuinely has to be resolved by taking one side, say in the PR
+  description which side you took and why — an undocumented one-sided resolution is the Wave 2
+  failure, a documented one is a decision.
 - **Land canonical types and schemas before their consumers.** Import what the predecessor
   defined; do not restate it on a parallel branch.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,32 @@ easiest to miss on review. So:
 `push:` triggers stay limited to `main` and `develop` deliberately: an open PR already covers its
 own branch, and adding work branches there would run every workflow twice per commit.
 
+### Stacked delivery
+
+Branch naming above is what keeps CI *attached* to a stack. This is what keeps a stack *correct*.
+The full policy is in [`CONTRIBUTING.md`](CONTRIBUTING.md) § "Stacked delivery"; the rules an agent
+has to apply while working are:
+
+- **Declare the base.** A PR states whether it targets `develop` or a predecessor branch, and
+  which PR that predecessor is. `.github/pull_request_template.md` has the fields.
+- **Never merge a successor before its predecessor.** After the predecessor merges, rebase onto
+  current `develop` and re-request review of the final diff against `develop` — not against the
+  predecessor.
+- **Wait for the post-merge `develop` run**, not just the PR check, before merging the next
+  dependent PR. The PR check proves the branch builds; only the `develop` run proves the
+  integration does.
+- **Resolve every shared-registry conflict as a union.** The root `CMakeLists.txt`, the
+  `FILE_SET CXX_MODULES` lists, `tools/CMakeLists.txt`, `tests/CMakeLists.txt`, the schemas and
+  the generated indexes are the files where taking one side deletes the other side's work while
+  leaving a build that still compiles and tests that still pass.
+- **Land canonical types and schemas before their consumers.** Import what the predecessor
+  defined; do not restate it on a parallel branch.
+
+This is not general good practice written down for its own sake. Wave 2's stacked PRs lost CMake,
+module and test wiring during conflict resolution, and allowed two incompatible governance models
+to coexist until integration found them — repaired by #104 and reconciled by #105. Each rule above
+is one of the things that would have caught that earlier.
+
 ### Conventions
 
 - Follow the naming, formatting, and documentation conventions in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,56 @@ Please run these tools on your code before submitting a pull request.
 - Ensure your branch is up to date with `develop` before submitting.
 - All code must pass CI checks and tests before merging.
 - Request a review from at least one maintainer.
+- Fill in [`.github/pull_request_template.md`](.github/pull_request_template.md) completely. Its
+  fields are the policy below, in the place where it is cheapest to apply.
+
+## Stacked delivery
+
+An epic is delivered as a chain of pull requests, each on its own issue branch, each targeting its
+predecessor rather than `develop` so a reviewer sees one issue's diff instead of the cumulative
+one. The branch-naming rule that keeps CI attached to such a chain is in
+[`AGENTS.md`](AGENTS.md) § 6; the rules below govern the *order* things merge in.
+
+They exist because of a specific failure. During Wave 2, stacked pull requests lost CMake, module
+and test wiring while their conflicts were being resolved, and two incompatible governance models
+coexisted on separate branches until integration discovered them — which took a repair PR (#104)
+and a reconciliation (#105) to undo. Every rule here is one of the things that would have caught
+it earlier.
+
+### Merge order
+
+- **A successor cannot merge before its predecessor.** Not "should not" — a stacked PR whose base
+  has not merged is proposing a diff against a branch that may still change under it.
+- After the predecessor merges, **rebase the successor onto current `develop`** and re-request
+  review of its final diff against `develop`. The diff a reviewer approved against the predecessor
+  is not the diff that will land.
+- **Required PR CI must be green, and then the resulting `develop` workflow must be green,**
+  before the next dependent PR merges. A green PR check proves the branch builds; only the
+  post-merge `develop` run proves the *integration* does.
+
+### Conflicts
+
+- **Resolve a conflict in a shared registry as an explicit union, not a choice.** The registries
+  that matter are listed in the PR template: the root `CMakeLists.txt`, `FILE_SET CXX_MODULES`
+  lists, `tools/CMakeLists.txt`, `tests/CMakeLists.txt`, schemas, generated indexes and
+  `generated/` artifacts. Taking one side of a conflict in a source list silently deletes the other
+  side's target, which still compiles and still passes every test that was not the deleted one.
+- If a conflict genuinely has to be resolved by taking one side, say so in the PR description and
+  say why.
+
+### Ordering within a chain
+
+- **Canonical shared types and schemas land before their exports and consumers.** A successor
+  imports the type its predecessor defined; it does not restate it. Two branches each defining
+  their own version of "the same" type is how Wave 2 ended up with two governance models, and
+  neither branch's CI could see the problem.
+
+### Emergency merges
+
+A merge that bypasses the gates above — a local merge, an API push, an administrative override —
+requires a comment on the issue or PR naming **the exact head SHA that was incorporated** and
+**the post-merge CI run that covered it**. An undocumented bypass leaves no way to tell later
+which code was actually reviewed.
 
 ## Additional Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,9 @@ it earlier.
   is not the diff that will land.
 - **Required PR CI must be green, and then the resulting `develop` workflow must be green,**
   before the next dependent PR merges. A green PR check proves the branch builds; only the
-  post-merge `develop` run proves the *integration* does.
+  post-merge `develop` run proves the *integration* does. **Record that run** — its URL or id — in
+  the successor's "Post-merge gate" section, so the gate leaves evidence rather than only an
+  intention. A checkbox saying the author understood the rule is not a record that it was followed.
 
 ### Conflicts
 


### PR DESCRIPTION
## Summary

Wave 2's stacked pull requests lost CMake, module and test wiring while their conflicts were being resolved, and let two incompatible governance models coexist on separate branches until integration found them — repaired by #104 and reconciled by #105. Nothing in the repository recorded what should have happened instead, so the same shape of failure was available to the next wave.

Wave 5 (#15) is a twelve-child epic whose children are inherently stacked: diagnostics, then the parser, then semantics, then the emitters, then the CMake integration, then the runtime. It is exactly the shape that failed before, which is why this lands ahead of it rather than after.

Extends `.github/pull_request_template.md`, which until now asked only for a summary, the CLA acknowledgement and a list of checks. It gains the fields the policy needs applied where applying them is cheapest: base and predecessor, the shared registries touched, the rebase SHA, and an acknowledgement of the post-merge gate. The invitation and CLA section is untouched.

The policy itself goes in `CONTRIBUTING.md` as a new "Stacked delivery" section; `AGENTS.md` § 6 gets the working subset next to the branch-naming rule it completes — naming keeps CI attached to a stack, this keeps the stack correct.

The verification section deliberately invites "not run locally, CI covers it" as an answer. A wrong tick is worse than an honest gap, and `AGENTS.md` § 6 already forbids claiming a command passed that was not run.

Closes #117.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #184

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now. Independent of the #116 chain, and worth merging first since it is the policy the rest of that chain follows.

## Shared registries touched

- [x] None of the above

## Rebase state

- **Rebased onto:** `e96dc35` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

Documentation only; no code paths change.

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run, no build inputs changed
- [ ] `ctest --test-dir build-gcc` — not run, no build inputs changed
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (78 files checked, 0 findings), which covers the new internal links from `CONTRIBUTING.md` and `AGENTS.md`
- [x] Other: `python3 -m unittest discover -s tools/docs-lint -p "test_*.py"` — OK

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.

## Regulatory impact

None — repository delivery process only. No safety behaviour, risk control, compliance metadata or traceability artifact changes, and no claim about a standard is added or altered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with clearer requirements for stacked pull requests, merge sequencing, rebasing, conflict resolution, CI checks, and emergency merges.
  * Added guidance for ordering shared types and schemas before dependent changes.
  * Expanded the pull request template with stacked-dependency, shared-registry, rebase, conflict-status, verification, post-merge gating, and regulatory-impact fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->