### PR TITLE
Move mdux.text.raster to the host-tools zone [#116]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,12 +51,20 @@ Makefile
 *.user
 *.sln.docstates
 
-# Documentation files (large PDFs, proprietary standards)
-inputs/Documentation/*.pdf
-inputs/Documentation/*.epub
-inputs/Documentation/ISO\ 13485/
-inputs/Documentation/ISO\ 14971\ The\ Definitive\ Guide/
-inputs/Documentation/Medical\ Device\ Cybersecurity\ for\ Engineers\ and\ Manufacturers/
+# Local reference material - never committed.
+#
+# The whole directory, not selected paths inside it. Five specific sub-paths were listed here
+# until issue #116, which left inputs/CMake/ and any newly-added folder under
+# inputs/Documentation/ untracked-but-not-ignored - so a `git add -A` would have committed them.
+# That is the exact class of content #7 and #23 spent a history rewrite removing, and ADR-006
+# forbids outright. A directory-level rule cannot be defeated by adding a file to it.
+#
+# This lives in the *first* PR of the #116 stack rather than the last, because the narrow rule
+# actually caught someone out while that stack was in review: a `git add -A` on this branch staged
+# `inputs/CMake` as a gitlink. It was a one-line SHA rather than the 431 MB behind it, and it was
+# amended out before anyone pulled, but a guard that lands after the thing it guards against is
+# not a guard.
+inputs/
 
 # Temporary files
 *.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,6 @@ target_sources(MduXCore
             include/mdux/font/Schema.cppm
             include/mdux/text/Draw.cppm
             include/mdux/text/Schema.cppm
-            include/mdux/text/Raster.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
@@ -209,7 +208,6 @@ target_sources(MduXCore
         src/font/Schema.cpp
         src/text/Draw.cpp
         src/text/Schema.cpp
-        src/text/Raster.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp
         src/governance/Program.cpp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,6 @@ are ordinary `PRIVATE` sources.
 | `mdux.governance.compliance` | `include/mdux/governance/Compliance.cppm` | `src/governance/Compliance.cpp` |
 | `mdux.shader.schema` | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
 | `mdux.text.schema` | `include/mdux/text/Schema.cppm` | `src/text/Schema.cpp` |
-| `mdux.text.raster` | `include/mdux/text/Raster.cppm` | `src/text/Raster.cpp` |
 | `mdux.font.schema` | `include/mdux/font/Schema.cppm` | `src/font/Schema.cpp` |
 | `mdux.text.draw` | `include/mdux/text/Draw.cppm` | `src/text/Draw.cpp` |
 | `mdux.draw` | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
@@ -89,10 +88,15 @@ performs no checking and confers no compliance.
 | `MduXToolsCommon` | `tools/common/` | TOML subset reader, CLI parser, shared diagnostic envelope |
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
-| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158) and `mdux.tools.atlaspacker` (the shelf packer, #160) |
+| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
+
+`mdux.text.raster` was governed until [#116](https://github.com/ambroise-leclerc/MduX/issues/116).
+It allocates, and `std::vector` reports failure by throwing, so it could not remain in a target
+compiled with `-fno-exceptions`. It runs once per glyph at build time and never on a device, which
+is what made the host-tools zone the right home rather than a reason to rewrite it.
 
 ## The Vulkan boundary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,9 +94,10 @@ Host tools parse untrusted input, so they are deliberately outside the governed 
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
 
 `mdux.text.raster` was governed until [#116](https://github.com/ambroise-leclerc/MduX/issues/116).
-It allocates, and `std::vector` reports failure by throwing, so it could not remain in a target
-compiled with `-fno-exceptions`. It runs once per glyph at build time and never on a device, which
-is what made the host-tools zone the right home rather than a reason to rewrite it.
+It allocates, and `std::vector` reports failure by throwing, so its `noexcept` entry point has to
+catch — which [ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md) forbids in governed
+code. It runs once per glyph at build time and never on a device, which is what made the host-tools
+zone the right home rather than a reason to rewrite it.
 
 ## The Vulkan boundary
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -548,9 +548,10 @@ mdux_discover_tests(ml_spec)
 #
 # Links MduX::Core only. mdux.text.schema is governed and contains no Vulkan handle, so a
 # scenario that needed MduX::MduX to build it would mean the trust-zone boundary had moved -
-# the same standing evidence shader_spec, draw_spec and ml_spec give. S1 ships the schema and a
-# no-run baker skeleton; the TrueType parser (#158), rasteriser (#159), atlas font baker (#160),
-# font schema (#161) and coverage draw path (#162) follow as their blockers close.
+# the same standing evidence shader_spec, draw_spec and ml_spec give. The suite covers the
+# governed half of the text pipeline: the schema (#157), the font schema (#161) and the coverage
+# draw path (#162). The host-only halves - the TrueType parser (#158), the rasteriser (#159) and
+# the atlas font baker (#160) - are covered by text_tools_spec instead.
 # Font schema suite (issue #161)
 #
 # Its own executable rather than cases inside text_spec, because a font package and a text package
@@ -587,7 +588,6 @@ mdux_discover_tests(font_spec)
 add_executable(text_spec
     text/TextSpecMain.cpp
     text/SchemaTests.cpp
-    text/RasterTests.cpp
     text/DrawTests.cpp
 )
 
@@ -619,11 +619,17 @@ mdux_discover_tests(text_spec)
 # `ml_tools_spec` and `shader_spec` follow: drive `parseRecipe()` / `run()` / `write()` / `verify()`
 # as calls so a failing assertion names the diagnostic code that failed rather than only an exit
 # status from a spawned process.
+#
+# RasterTests.cpp lives here rather than in text_spec since #116, because `mdux.text.raster` moved
+# to the host-tools zone. Moving the test with the module is not bookkeeping: text_spec links
+# MduX::Core alone, and that link line *is* the standing evidence above. Leaving raster cases there
+# would force MduX::TextBakeLib onto text_spec and destroy the very thing it exists to demonstrate.
 add_executable(text_tools_spec
     text/TextToolsSpecMain.cpp
     text/TextBakeTests.cpp
     text/TruetypeTests.cpp
     text/AtlasPackerTests.cpp
+    text/RasterTests.cpp
 )
 
 target_link_libraries(text_tools_spec PRIVATE MduX::TextBakeLib speclab::speclab)

--- a/tests/text/RasterTests.cpp
+++ b/tests/text/RasterTests.cpp
@@ -1,11 +1,14 @@
 /**
  * @file RasterTests.cpp
- * @brief BDD scenarios for the governed-zone glyph rasteriser (issue #159).
+ * @brief BDD scenarios for the host-tools glyph rasteriser (issue #159).
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
  * @compliance ADR-010 No on-device text shaping
+ *
+ * Part of text_tools_spec rather than text_spec since #116, because `mdux.text.raster` moved to
+ * the host-tools zone. The scenarios themselves are unchanged: the rasteriser is still
+ * integer-only, and the frozen-digest scenario at the bottom still holds it to the byte.
  *
  * The outlines here are built in code rather than loaded from a font, for the reason
  * `TruetypeTests.cpp` gives: a fixture whose intended defect a reviewer has to take on trust is

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -220,7 +220,8 @@ endif()
 # registered until S4 commits a real artifact.
 #
 # `mdux.text.raster` moved here from MduXCore in #116. It allocates, and `std::vector` reports
-# failure by throwing, so it could not stay in a governed target compiled with -fno-exceptions.
+# failure by throwing, so its noexcept entry point has to catch - which ADR-005 forbids in the
+# governed zone.
 # Nothing else about it changed - it is integer-only and its output is still byte-compared in CI.
 # See tools/text/Raster.cppm for the full argument.
 add_library(MduXTextBakeLib)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -218,6 +218,11 @@ endif()
 # that hosts the recipe model. S4 extends the recipe with the font pipeline inputs and S5
 # (#161) adds the restricted-charset validation; no mdux_bake_artifact() call site is
 # registered until S4 commits a real artifact.
+#
+# `mdux.text.raster` moved here from MduXCore in #116. It allocates, and `std::vector` reports
+# failure by throwing, so it could not stay in a governed target compiled with -fno-exceptions.
+# Nothing else about it changed - it is integer-only and its output is still byte-compared in CI.
+# See tools/text/Raster.cppm for the full argument.
 add_library(MduXTextBakeLib)
 add_library(MduX::TextBakeLib ALIAS MduXTextBakeLib)
 
@@ -229,10 +234,12 @@ target_sources(MduXTextBakeLib
             text/TextBake.cppm
             text/Truetype.cppm
             text/AtlasPacker.cppm
+            text/Raster.cppm
     PRIVATE
         text/TextBake.cpp
         text/Truetype.cpp
         text/AtlasPacker.cpp
+        text/Raster.cpp
 )
 
 target_compile_features(MduXTextBakeLib PUBLIC cxx_std_23)

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -17,8 +17,8 @@
  *
  * `mdux.text.raster` (#159) sits in this zone for the same reason as of #116. It was governed
  * on the argument that a device path might one day rasterise, which ADR-008 decision 1 would
- * then require to be *that* module rather than a second one - but it allocates, so it could not
- * stay in a target compiled with `-fno-exceptions`. See `Raster.cppm`.
+ * then require to be *that* module rather than a second one - but it allocates, so it has to
+ * catch at its `noexcept` boundary, which ADR-005 forbids in governed code. See `Raster.cppm`.
  *
  * ## Shelf placement, and why not something better
  *

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -10,12 +10,15 @@
  *
  * ## Why this is host-tools rather than governed
  *
- * `mdux.text.raster` (#159) is governed because a device path could conceivably need to
- * rasterise, and ADR-008 decision 1 says that would have to be *this* module rather than a second
- * one. Packing has no such future: an atlas is chosen once, at build time, and a device consumes
- * the slot rectangles the baker recorded. Nothing on a device ever packs, so a governed packer
- * would be a promise with no caller - and every module in the governed zone is a module a
- * reviewer has to reason about for device behaviour.
+ * An atlas is chosen once, at build time, and a device consumes the slot rectangles the baker
+ * recorded. Nothing on a device ever packs, so a governed packer would be a promise with no
+ * caller - and every module in the governed zone is a module a reviewer has to reason about for
+ * device behaviour.
+ *
+ * `mdux.text.raster` (#159) sits in this zone for the same reason as of #116. It was governed
+ * on the argument that a device path might one day rasterise, which ADR-008 decision 1 would
+ * then require to be *that* module rather than a second one - but it allocates, so it could not
+ * stay in a target compiled with `-fno-exceptions`. See `Raster.cppm`.
  *
  * ## Shelf placement, and why not something better
  *

--- a/tools/text/Raster.cpp
+++ b/tools/text/Raster.cpp
@@ -580,8 +580,8 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     // The final `catch (...)` is defensive: nothing else on this path throws anything else, and
     // if that ever stops being true this still returns rather than terminating.
     //
-    // This block is what put the module in the host-tools zone (#116). `MduXCore` is compiled
-    // with `-fno-exceptions`, so `try` cannot appear there at all - see Raster.cppm on why the
+    // This block is what put the module in the host-tools zone (#116): governed code does not
+    // throw, and ADR-005 makes that a rule rather than a preference. See Raster.cppm on why the
     // zone moved rather than the code.
     try {
         return rasteriseImpl(request);

--- a/tools/text/Raster.cpp
+++ b/tools/text/Raster.cpp
@@ -1,10 +1,9 @@
 /**
  * @file Raster.cpp
- * @brief Implementation of the governed-zone glyph rasteriser.
+ * @brief Implementation of the host-tools glyph rasteriser.
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
  * @compliance ADR-010 No on-device text shaping
  *
  * Four passes, in order:
@@ -578,8 +577,12 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     //
     // `std::length_error` is caught alongside `bad_alloc` because `resize()` raises it when a
     // request exceeds `max_size()`, which is the same condition arriving by a different name.
-    // The final `catch (...)` is defensive: nothing in the governed zone throws anything else,
-    // and if that ever stops being true this still returns rather than terminating.
+    // The final `catch (...)` is defensive: nothing else on this path throws anything else, and
+    // if that ever stops being true this still returns rather than terminating.
+    //
+    // This block is what put the module in the host-tools zone (#116). `MduXCore` is compiled
+    // with `-fno-exceptions`, so `try` cannot appear there at all - see Raster.cppm on why the
+    // zone moved rather than the code.
     try {
         return rasteriseImpl(request);
     } catch (const std::bad_alloc&) {

--- a/tools/text/Raster.cppm
+++ b/tools/text/Raster.cppm
@@ -1,28 +1,37 @@
 /**
  * @file Raster.cppm
- * @brief Governed-zone glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
+ * @brief Host-tools glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
  *        only, so the same glyph produces the same bytes on every supported toolchain.
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
- * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone: runs at build time, never on a device)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept entry point)
  * @compliance ADR-007 Evidence pipeline doctrine (the bytes this produces get committed)
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010: one
- *             module, not a host implementation and a device one that could drift)
  * @compliance ADR-010 No on-device text shaping
  *
- * Part of MduXCore. The font baker (#160, S4) imports this to fill an atlas; if a device path
- * ever needs to rasterise, it imports *this* module rather than growing a second implementation.
- * That is ADR-008 decision 1 applied to text, and it is why this file is governed rather than
- * sitting in `tools/` next to the parser that feeds it.
+ * Part of `MduXTextBakeLib`. The font baker (#160, S4) imports this to fill an atlas.
+ *
+ * ## Why this is host-tools code and not governed
+ *
+ * It was governed until issue #116, on the argument that a device path might one day want to
+ * rasterise and should import *this* module rather than grow a second implementation - ADR-008
+ * decision 1 applied to text. The argument was speculative and the cost was not: `rasterise()`
+ * allocates, and a `std::vector` reports failure by throwing, so keeping this module in
+ * `MduXCore` is incompatible with compiling the governed zone under `-fno-exceptions`. That
+ * compile mode is the thing ADR-005 calls a Class C and Vulkan SC prerequisite, and a real
+ * prerequisite outranks a hypothetical consumer.
+ *
+ * Nothing about the module's determinism changes with the move. The integer-only rule below is a
+ * property of the source, and the committed atlas bytes it produces are byte-compared in CI
+ * exactly as before.
  *
  * ## Why it does not take a `truetype::SimpleGlyph`
  *
- * `mdux.tools.truetype` (#158) is host-tools-zone code. ADR-004 forbids a governed module from
- * importing one, and the rule is mechanically checked by `mdux_verify_trust_zones()` - so this
- * module cannot name that type even though it is the obvious input. It takes `Outline` instead:
- * the same TrueType shape (points, per-contour end indices, on/off-curve flags) expressed in
- * governed types, with the baker doing a flat conversion. That indirection is the trust-zone
- * boundary made visible, not an abstraction for its own sake.
+ * It could now - `mdux.tools.truetype` (#158) is in this same zone, and the trust-zone rule that
+ * forbade naming that type no longer applies. The `Outline` input is kept anyway: it is the same
+ * TrueType shape (points, per-contour end indices, on/off-curve flags) in types that carry no
+ * parser with them, so this module stays movable back into `MduXCore` if a device path is ever
+ * built and made allocation-free. What used to be a constraint is now a deliberately preserved
+ * option, and the distinction is worth stating rather than leaving for a reader to infer.
  *
  * ## The determinism rule
  *

--- a/tools/text/Raster.cppm
+++ b/tools/text/Raster.cppm
@@ -15,10 +15,11 @@
  * It was governed until issue #116, on the argument that a device path might one day want to
  * rasterise and should import *this* module rather than grow a second implementation - ADR-008
  * decision 1 applied to text. The argument was speculative and the cost was not: `rasterise()`
- * allocates, and a `std::vector` reports failure by throwing, so keeping this module in
- * `MduXCore` is incompatible with compiling the governed zone under `-fno-exceptions`. That
- * compile mode is the thing ADR-005 calls a Class C and Vulkan SC prerequisite, and a real
- * prerequisite outranks a hypothetical consumer.
+ * allocates, and a `std::vector` reports failure by throwing, so the `noexcept` entry point below
+ * has to catch. ADR-005 forbids exactly that in the governed zone, and #116 made the rule
+ * mechanical - `mdux-governed-lint` rejects `try`/`catch` in governed source, and on GCC/Clang
+ * `governed.noThrow.symbolScan` rejects the resulting `__cxa_throw` reference in the object. A
+ * present rule outranks a hypothetical consumer.
  *
  * Nothing about the module's determinism changes with the move. The integer-only rule below is a
  * property of the source, and the committed atlas bytes it produces are byte-compared in CI
@@ -153,8 +154,10 @@ struct OutlinePoint {
 /**
  * @brief A glyph outline in font units: points, plus the index of each contour's last point.
  *
- * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in governed types because a
- * governed module may not import a host-tools one (ADR-004). `contourEnds[i]` is the index of
+ * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in parser-independent types.
+ * Until #116 that restatement was forced - a governed module may not import a host-tools one
+ * (ADR-004) - and it is now kept by choice, so this module stays movable back into `MduXCore` if
+ * a device path is ever built and made allocation-free. `contourEnds[i]` is the index of
  * the final point of contour `i`, so contour 0 is `points[0 .. contourEnds[0]]` and contour `i`
  * is `points[contourEnds[i-1] + 1 .. contourEnds[i]]` - TrueType's own convention, kept rather
  * than converted to offsets so the baker's translation stays a copy rather than a computation.

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -470,9 +470,12 @@ struct BakedGlyph {
                 continue;
             }
 
-            // Translate the parser's outline into the rasteriser's governed input type. This copy
-            // is the trust-zone boundary made concrete: mdux.text.raster is governed and cannot
-            // name a host-tools type, so the baker is what bridges them (ADR-004).
+            // Translate the parser's outline into the rasteriser's own input type. This copy was
+            // the trust-zone boundary made concrete until #116, when mdux.text.raster joined this
+            // zone; the rasteriser could now name `truetype::GlyphPoint` directly. It is kept
+            // because the decoupling is what would let the rasteriser move back into MduXCore if a
+            // device path is ever built (see Raster.cppm), and the copy costs one pass per glyph
+            // at build time.
             std::vector<raster::OutlinePoint> points;
             points.reserve(outline->points.size());
             for (const truetype::GlyphPoint& gp : outline->points) {


### PR DESCRIPTION
## Summary

First of three for #116. The rasteriser was governed on a speculative argument: a device path might one day need to rasterise, and ADR-008 decision 1 would then require it to be *this* module rather than a second one. The argument was hypothetical; the cost was not.

`rasterise()` allocates, and `std::vector` reports failure by throwing, so `Raster.cpp` carries a `try`/`catch` at its `noexcept` boundary to turn an out-of-memory condition into a diagnostic instead of `std::terminate`. That block is well-reasoned and **stays exactly as written** — but it is incompatible with the governed zone's no-throwing rule, which the next PR in this chain starts enforcing. A real constraint outranks a hypothetical consumer, so the zone moves rather than the code.

The module runs once per glyph at build time and never on a device, which its own header comment already said. Its only consumers are `mdux-textbake` and its tests.

- `include/mdux/text/Raster.cppm` → `tools/text/Raster.cppm`
- `src/text/Raster.cpp` → `tools/text/Raster.cpp`
- registered on `MduXTextBakeLib`, dropped from `MduXCore`
- `RasterTests.cpp` moves from `text_spec` to `text_tools_spec`
- the stale "raster is governed" rationales in `AtlasPacker.cppm` and `TextBake.cpp` are corrected rather than left to mislead

The test move is not bookkeeping. `text_spec` links `MduX::Core` alone, and `tests/CMakeLists.txt` states that this link line **is** its standing evidence that governed text code reaches nothing but `std`. Leaving raster cases there would force `MduX::TextBakeLib` onto the target and destroy the very thing it demonstrates.

The module name `mdux.text.raster` is unchanged, so no `import` statement anywhere moves.

### Breaking change

This removes `mdux.text.raster` from the **installed surface** — `MduXTextBakeLib` is not in the install/export set — which affects any 0.5.0 consumer that imported it. A build-time baker has no business in a device consumer's include tree, so the removal is intended. `InstallTreeConsumer` passes, confirming nothing that remains depends on it.

Part of #116.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #184

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now. It is the predecessor of #188 and #189; both must wait on it.

## Shared registries touched

- [x] `CMakeLists.txt` (root) — `MduXCore` loses two sources
- [x] `FILE_SET CXX_MODULES` lists — `Raster.cppm` moves between targets
- [x] `tools/CMakeLists.txt` — `MduXTextBakeLib` gains both files
- [x] `tests/CMakeLists.txt` — `RasterTests.cpp` moves suite

## Rebase state

- **Rebased onto:** `e96dc35` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

Clean configure and build from an empty build directory, GCC 16.1.0 / CMake 4.2.3 / Ninja.

- [x] `cmake --preset ninja-gcc && cmake --build build-gcc` — clean; `mdux_verify_trust_zones()` passes at configure
- [x] `ctest --test-dir build-gcc` — 436/436 passed, the same count as before the move
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (78 files, 0 findings)
- [x] Other:
  - `ctest -R "text_spec|text_tools_spec"` — raster cases now run under `text_tools_spec` (44 cases, was 41); `text_spec` is down to 26 and still links `MduX::Core` alone
  - `InstallTreeConsumer` — passed (7.32s)
  - installed to a scratch prefix and confirmed `mdux.text.raster` is absent from the install tree, and `Schema.cppm`/`Draw.cppm` are still present
  - `evidence` label — 5/5, so the committed `generated/font/dejavu-ui/` atlas still byte-compares with the rasteriser in its new home
  - `mdux-evidence-lint` — OK (38 files)

Not run locally: the MSVC leg. CI covers it.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.

## Regulatory impact

**Trust-zone boundary change**, so ADR-004 applies. A module moves from the governed zone to host tools; the governed zone shrinks, which is the safe direction. No governed module imports the moved one — verified by grep across `include/` and `src/` — and `mdux_verify_trust_zones()` passes.

The determinism properties are unchanged: the rasteriser is integer-only, and its committed output is still byte-compared in CI on both toolchain legs. The ADR-004 text recording this placement rule lands with #189, so that the ADR describes what merged rather than what was intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved text glyph rasterization into the host-only text baking workflow.
  * Included rasterization with atlas generation instead of the core runtime.
  * Clarified that rasterization and atlas packing occur at build time, while devices consume generated atlas data.

* **Documentation**
  * Updated architecture, trust-boundary, and text pipeline documentation to reflect the revised component classification.

* **Tests**
  * Reclassified rasterization tests under the text tools test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->