### PR TITLE
Enforce ADR-005's no-throwing rule on the emitted objects [#116]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,11 +2,22 @@
 # Based on C++ Core Guidelines
 # Enforces coding standards from CONTRIBUTING.md
 
+# bugprone-exception-escape is deliberately NOT disabled. It was, until issue #116: ADR-005 opens
+# by citing that suppression as the reason a `noexcept` violation in governed code was invisible to
+# static analysis, and listed re-enabling it as a follow-up gated on MduXCore existing. MduXCore has
+# existed since Wave 1.
+#
+# Scope, stated honestly: this check is *available* rather than *enforced*. The only CI job running
+# clang-tidy is security-analysis.yml, which invokes it with `|| true` against a GCC-generated
+# compile_commands.json that clang-tidy cannot parse for module interface units - both limitations
+# are documented in that workflow. So re-enabling this catches a noexcept violation for a developer
+# running clang-tidy locally, and will catch one in CI when the Clang leg is restored (#48), but it
+# is not what stops one landing today. That is governed.noThrow.symbolScan, which reads the emitted
+# objects and runs on every ctest.
 Checks: >
   -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
-  -bugprone-exception-escape,
   cert-*,
   -cert-dcl21-cpp,
   -cert-dcl50-cpp,

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -108,6 +108,15 @@ jobs:
     - name: Verify ML determinism (GCC 16)
       run: ctest --preset ninja-gcc -L determinism --output-on-failure
 
+    # Governed-zone no-throw, at the object level (ADR-005, issue #116). Broken out with -V rather
+    # than folded into the full run above, because a passing ctest prints none of a test's output -
+    # and this scan's output is half its purpose. It reports the throw-helper references it
+    # deliberately tolerates, and the ADR justifies tolerating them on the grounds that they stay
+    # "visible and counted". A number nobody can see in a job log is not counted. -V is what makes
+    # the claim true, and is the same reason the pixel step below uses it.
+    - name: Verify governed-zone no-throw (GCC 16)
+      run: ctest --preset ninja-gcc -L governed -V --no-tests=error
+
     # Rendered-truth verification (issue #125), moved here when the GCC 15 leg was retired.
     # Without it a broken ICD turns the only test that renders anything into a silent no-op:
     # offscreen_tests exits 77 with no device and CTest reports Skipped, which does not fail a run.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -115,6 +115,16 @@ jobs:
       run: ctest --preset ninja-msvc -L determinism
       shell: cmd
 
+    # Governed-zone no-throw (ADR-005, issue #116). Informational on this toolchain, and run
+    # anyway: the MSVC STL inlines its own throw sites, so _CxxThrowException in a governed object
+    # is the same symbol whether it came from a hand-written throw or a std::string growth path.
+    # The scan therefore forbids nothing here and prints what it found, which is worth having in
+    # the log - it is the only place the MSVC-side references are visible at all. mdux-governed-lint
+    # is what actually gates the rule on Windows. -V because a passing ctest prints no test output.
+    - name: Verify governed-zone no-throw (MSVC, informational)
+      run: ctest --preset ninja-msvc -L governed -V --no-tests=error
+      shell: cmd
+
     - name: Verify no source-tree writes
       shell: pwsh
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -51,12 +51,20 @@ Makefile
 *.user
 *.sln.docstates
 
-# Documentation files (large PDFs, proprietary standards)
-inputs/Documentation/*.pdf
-inputs/Documentation/*.epub
-inputs/Documentation/ISO\ 13485/
-inputs/Documentation/ISO\ 14971\ The\ Definitive\ Guide/
-inputs/Documentation/Medical\ Device\ Cybersecurity\ for\ Engineers\ and\ Manufacturers/
+# Local reference material - never committed.
+#
+# The whole directory, not selected paths inside it. Five specific sub-paths were listed here
+# until issue #116, which left inputs/CMake/ and any newly-added folder under
+# inputs/Documentation/ untracked-but-not-ignored - so a `git add -A` would have committed them.
+# That is the exact class of content #7 and #23 spent a history rewrite removing, and ADR-006
+# forbids outright. A directory-level rule cannot be defeated by adding a file to it.
+#
+# This lives in the *first* PR of the #116 stack rather than the last, because the narrow rule
+# actually caught someone out while that stack was in review: a `git add -A` on this branch staged
+# `inputs/CMake` as a gitlink. It was a one-line SHA rather than the 431 MB behind it, and it was
+# amended out before anyone pulled, but a guard that lands after the thing it guards against is
+# not a guard.
+inputs/
 
 # Temporary files
 *.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,6 @@ target_sources(MduXCore
             include/mdux/font/Schema.cppm
             include/mdux/text/Draw.cppm
             include/mdux/text/Schema.cppm
-            include/mdux/text/Raster.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
@@ -209,7 +208,6 @@ target_sources(MduXCore
         src/font/Schema.cpp
         src/text/Draw.cpp
         src/text/Schema.cpp
-        src/text/Raster.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp
         src/governance/Program.cpp

--- a/cmake/MduXNoHeapScan.cmake
+++ b/cmake/MduXNoHeapScan.cmake
@@ -34,11 +34,18 @@
 # is a genuine difference in how the two standard libraries generate code, not a gap in effort.
 #
 # On libstdc++, a `throw` expression emits `__cxa_throw`, while the library's own throw sites go
-# through out-of-line helpers - `std::__throw_length_error`, `std::__throw_logic_error`,
-# `std::__throw_out_of_range_fmt`. The two are therefore distinguishable in the object, and this
-# profile forbids the first while reporting the second. Eight governed objects reference the
-# helpers, all from inside `std::string` and `std::vector`: growth paths reference
-# `__throw_length_error`, and `std::string_view::substr` references `__throw_out_of_range_fmt` even
+# through out-of-line helpers. The two are therefore distinguishable in the object, and this
+# profile forbids the first while reporting the second.
+#
+# The reported set is `__throw_length_error`, `__throw_logic_error`, `__throw_out_of_range` and
+# `__throw_bad_alloc`, matched as substrings - so `__throw_out_of_range` also covers libstdc++'s
+# `__throw_out_of_range_fmt`, which is the spelling actually seen in this tree. `__throw_bad_alloc`
+# is in the set for completeness rather than because anything references it today; a scan that
+# reports only the symbols it has already met would go quiet exactly when something new arrived.
+#
+# Eight governed objects reference these, all from inside `std::string` and `std::vector`: growth
+# paths reference `__throw_length_error`, and `std::string_view::substr` references
+# `__throw_out_of_range_fmt` even
 # where the caller's invariant makes the throw unreachable (Json.cpp's parser and Governance.cpp's
 # id splitting are both of that shape).
 #
@@ -79,7 +86,10 @@ file(STRINGS "${MDUX_NOHEAP_OBJECT_LIST}" MDUX_NOHEAP_OBJECTS)
 if(MDUX_NOHEAP_OBJECTS STREQUAL "")
     message(FATAL_ERROR
         "MduXNoHeapScan: the object list is empty. That would make this test pass by checking "
-        "nothing - the '${MDUX_SCAN_PROFILE}' profile expects objects to be part of MduXCore.")
+        "nothing. Whichever file(GENERATE) produced '${MDUX_NOHEAP_OBJECT_LIST}' resolved to no "
+        "objects - check the $<TARGET_OBJECTS:...> expression that writes it. Note that the "
+        "negative fixture deliberately scans an object library outside MduXCore, so an empty list "
+        "here does not necessarily mean MduXCore is the target that went missing.")
 endif()
 
 # Mangled and demangled spellings both, so this works whether or not the tool demangles.

--- a/cmake/MduXNoHeapScan.cmake
+++ b/cmake/MduXNoHeapScan.cmake
@@ -1,29 +1,63 @@
 # MduXNoHeapScan.cmake
 #
-# Layer 2 of issue #63: scan the compiled ML objects for any undefined reference to the allocation
-# and deallocation family, or to the exception-throwing runtime.
+# Scans compiled objects for undefined references that would contradict a zone's stated guarantee.
+# Two profiles, selected by MDUX_SCAN_PROFILE:
+#
+#   ml-noheap      Layer 2 of issue #63, over the ML objects: no allocation family, no throwing
+#                  runtime. This is the original scan.
+#   governed-throw Issue #116, over every MduXCore object: no literal throw. Allocation is NOT
+#                  forbidden here - mdux.evidence.json and mdux.governance legitimately allocate.
+#
+# Run as a ctest via `cmake -P`, not at configure time, because the object files do not exist until
+# after a build.
+#
+# ## ml-noheap
 #
 # The delete operators are in the forbidden set alongside the new ones deliberately. A reference to
 # `operator delete` means the object owns heap memory just as surely as a reference to `operator
 # new` does - often more visibly, because a destructor emitted for a std container is what pulls it
 # in. So a failure naming a delete symbol means the same thing as one naming new: something in the
-# governed ML zone acquired owning memory. Run as a ctest via `cmake -P`, not at configure time, because
-# the object files do not exist until after a build.
+# governed ML zone acquired owning memory.
 #
 # Where layer 1 (tests/ml/NoHeapTests.cpp) proves predict() does not allocate *when run*, this
 # proves the kernels and the runtime cannot allocate *at all* - no path through them, taken or not,
 # reaches operator new or malloc. It is also far cheaper, and it fails in the PR that introduced
 # the reference rather than whenever someone next executes that path.
 #
-# __cxa_throw is in the forbidden set for a second reason: it double-checks ADR-005's no-throwing
-# rule for the governed zone. A std::vector::at() or a std::stoi() that crept in would show up here
-# as a throw reference even if it never allocated.
+# ## governed-throw
+#
+# ADR-005 says governed code does not throw. The source lint checks that at the source level; this
+# checks it in the emitted objects, which is the stronger of the two - it sees through a std
+# facility that throws on a path the source never spells out.
+#
+# **What it forbids, precisely: a literal `throw`.** `__cxa_throw` is what the compiler emits for a
+# throw expression, and no MduXCore object references it.
+#
+# **What it deliberately does not forbid** is libstdc++'s throw *helpers* -
+# `std::__throw_length_error`, `std::__throw_logic_error`, `std::__throw_out_of_range_fmt`. Eight
+# governed objects reference them today, and they arrive from inside `std::string` and
+# `std::vector`: growth paths reference `__throw_length_error`, and `std::string_view::substr`
+# references `__throw_out_of_range_fmt` even where the caller's invariant makes the throw
+# unreachable (Json.cpp's parser and Governance.cpp's id splitting are both of that shape).
+#
+# Forbidding those would mean banning `std::string`, `std::vector` and `substr` from the governed
+# zone outright. That may be the right end state for a Class C build, but it is a much larger
+# decision than this scan, and it needs its own ADR. Until then this file reports the helper
+# references rather than failing on them, so that they stay visible and counted instead of being
+# quietly implied not to exist. See ADR-005 for the claim as it is actually made.
 #
 # Expected variables (passed with -D):
+#   MDUX_SCAN_PROFILE       - "ml-noheap" or "governed-throw"
 #   MDUX_NOHEAP_OBJECT_LIST - path to a newline-separated file of object paths, written by
 #                             file(GENERATE) so that a generator expression resolves per config
 #   MDUX_NOHEAP_TOOL        - "nm" or "dumpbin"
 #   MDUX_NOHEAP_COMMAND     - path to that tool
+
+if(NOT DEFINED MDUX_SCAN_PROFILE)
+    message(FATAL_ERROR
+        "MduXNoHeapScan: MDUX_SCAN_PROFILE is not set. Pass 'ml-noheap' or 'governed-throw' - "
+        "defaulting would let a caller get the wrong forbidden set without noticing.")
+endif()
 
 if(NOT DEFINED MDUX_NOHEAP_OBJECT_LIST OR NOT EXISTS "${MDUX_NOHEAP_OBJECT_LIST}")
     message(FATAL_ERROR
@@ -35,33 +69,64 @@ file(STRINGS "${MDUX_NOHEAP_OBJECT_LIST}" MDUX_NOHEAP_OBJECTS)
 if(MDUX_NOHEAP_OBJECTS STREQUAL "")
     message(FATAL_ERROR
         "MduXNoHeapScan: the object list is empty. That would make this test pass by checking "
-        "nothing - the ML sources are expected to be part of MduXCore.")
+        "nothing - the '${MDUX_SCAN_PROFILE}' profile expects objects to be part of MduXCore.")
 endif()
 
 # Mangled and demangled spellings both, so this works whether or not the tool demangles.
-set(forbidden_symbols
-    "operator new"
-    "operator delete"
-    "_Znwm"      # operator new(unsigned long)
-    "_Znam"      # operator new[](unsigned long)
-    "_ZdlPv"     # operator delete(void*)
-    "_ZdaPv"     # operator delete[](void*)
-    "malloc"
-    "calloc"
-    "realloc"
-    "__cxa_throw"
-    "??2@"       # MSVC operator new
-    "??_U@"      # MSVC operator new[]
-)
+if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
+    set(forbidden_symbols
+        "operator new"
+        "operator delete"
+        "_Znwm"      # operator new(unsigned long)
+        "_Znam"      # operator new[](unsigned long)
+        "_ZdlPv"     # operator delete(void*)
+        "_ZdaPv"     # operator delete[](void*)
+        "malloc"
+        "calloc"
+        "realloc"
+        "__cxa_throw"
+        "??2@"       # MSVC operator new
+        "??_U@"      # MSVC operator new[]
+    )
+    set(reported_symbols "")
+    # One string, not a list of strings: message() concatenates its own arguments cleanly, but a
+    # ;-separated list expanded through ${} arrives with the separators embedded in the text.
+    string(CONCAT violation_explanation
+        "mdux.ml.kernels and mdux.ml.runtime must reach neither. If this is a std facility that "
+        "allocates only on a path you believe is unreachable, that is not sufficient - the device "
+        "build must not contain the reference at all.")
+elseif(MDUX_SCAN_PROFILE STREQUAL "governed-throw")
+    set(forbidden_symbols
+        "__cxa_throw"
+        "__cxa_rethrow"
+        "_CxxThrowException"   # MSVC
+    )
+    # Counted and printed, never failed on. See the header comment.
+    set(reported_symbols
+        "__throw_length_error"
+        "__throw_logic_error"
+        "__throw_out_of_range"
+        "__throw_bad_alloc"
+    )
+    string(CONCAT violation_explanation
+        "A governed module contains a throw expression. ADR-005 requires governed code to report "
+        "failure through mdux.core.result instead. If the throwing construct is unavoidable, the "
+        "module belongs in the host-tools zone - which is where mdux.text.raster went in #116.")
+else()
+    message(FATAL_ERROR
+        "MduXNoHeapScan: unknown MDUX_SCAN_PROFILE '${MDUX_SCAN_PROFILE}'. Expected 'ml-noheap' "
+        "or 'governed-throw'.")
+endif()
 
 set(violations "")
+set(reported "")
 set(scanned_count 0)
 
 foreach(object ${MDUX_NOHEAP_OBJECTS})
     if(NOT EXISTS "${object}")
         message(FATAL_ERROR
             "MduXNoHeapScan: object '${object}' does not exist. The scan would otherwise pass by "
-            "checking nothing - build the ML targets before running this test.")
+            "checking nothing - build the targets before running this test.")
     endif()
     math(EXPR scanned_count "${scanned_count} + 1")
 
@@ -99,6 +164,12 @@ foreach(object ${MDUX_NOHEAP_OBJECTS})
                 list(APPEND violations "${object_name}: ${line}")
             endif()
         endforeach()
+        foreach(symbol ${reported_symbols})
+            string(FIND "${line}" "${symbol}" found)
+            if(NOT found EQUAL -1)
+                list(APPEND reported "${object_name}: ${line}")
+            endif()
+        endforeach()
     endforeach()
 endforeach()
 
@@ -106,11 +177,26 @@ if(violations)
     list(REMOVE_DUPLICATES violations)
     string(REPLACE ";" "\n  " violation_text "${violations}")
     message(FATAL_ERROR
-        "No-heap violation (ADR-008, issue #63): the ML objects reference an allocator or the "
-        "throwing runtime.\n  ${violation_text}\n"
-        "mdux.ml.kernels and mdux.ml.runtime must reach neither. If this is a std facility that "
-        "allocates only on a path you believe is unreachable, that is not sufficient - the device "
-        "build must not contain the reference at all.")
+        "Symbol scan violation (profile '${MDUX_SCAN_PROFILE}'):\n  ${violation_text}\n"
+        "${violation_explanation}")
 endif()
 
-message(STATUS "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")
+# Printed rather than failed on, and printed every run rather than only when the count changes:
+# a tolerated reference that nobody sees becomes a reference nobody remembers tolerating.
+if(reported)
+    list(REMOVE_DUPLICATES reported)
+    list(LENGTH reported reported_count)
+    string(REPLACE ";" "\n  " reported_text "${reported}")
+    message(STATUS
+        "MduXNoHeapScan: ${reported_count} tolerated throw-helper reference(s), from std::string, "
+        "std::vector and std::string_view::substr internals - see this file's header and ADR-005 "
+        "for why these are reported rather than forbidden:\n  ${reported_text}")
+endif()
+
+if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")
+else()
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} governed object(s) contain no throw expression")
+endif()

--- a/cmake/MduXNoHeapScan.cmake
+++ b/cmake/MduXNoHeapScan.cmake
@@ -30,19 +30,29 @@
 # checks it in the emitted objects, which is the stronger of the two - it sees through a std
 # facility that throws on a path the source never spells out.
 #
-# **What it forbids, precisely: a literal `throw`.** `__cxa_throw` is what the compiler emits for a
-# throw expression, and no MduXCore object references it.
+# **This profile is only a gate on GCC/Clang, and reports rather than fails on MSVC.** The reason
+# is a genuine difference in how the two standard libraries generate code, not a gap in effort.
 #
-# **What it deliberately does not forbid** is libstdc++'s throw *helpers* -
-# `std::__throw_length_error`, `std::__throw_logic_error`, `std::__throw_out_of_range_fmt`. Eight
-# governed objects reference them today, and they arrive from inside `std::string` and
-# `std::vector`: growth paths reference `__throw_length_error`, and `std::string_view::substr`
-# references `__throw_out_of_range_fmt` even where the caller's invariant makes the throw
-# unreachable (Json.cpp's parser and Governance.cpp's id splitting are both of that shape).
+# On libstdc++, a `throw` expression emits `__cxa_throw`, while the library's own throw sites go
+# through out-of-line helpers - `std::__throw_length_error`, `std::__throw_logic_error`,
+# `std::__throw_out_of_range_fmt`. The two are therefore distinguishable in the object, and this
+# profile forbids the first while reporting the second. Eight governed objects reference the
+# helpers, all from inside `std::string` and `std::vector`: growth paths reference
+# `__throw_length_error`, and `std::string_view::substr` references `__throw_out_of_range_fmt` even
+# where the caller's invariant makes the throw unreachable (Json.cpp's parser and Governance.cpp's
+# id splitting are both of that shape).
 #
-# Forbidding those would mean banning `std::string`, `std::vector` and `substr` from the governed
-# zone outright. That may be the right end state for a Class C build, but it is a much larger
-# decision than this scan, and it needs its own ADR. Until then this file reports the helper
+# On the MSVC STL those throw sites are **inlined into the caller**, so the same `std::string` use
+# emits `_CxxThrowException` directly in the governed object - the identical symbol a hand-written
+# `throw` would emit. Nine governed objects reference it, and `mdux-governed-lint` independently
+# confirms there is no `throw` in any of their sources. The symbol simply cannot tell the two apart
+# there, so forbidding it would fail the build on correct code, and tolerating it would forbid
+# nothing at all. It is reported instead, and the source lint - which is toolchain-independent - is
+# what enforces the rule on Windows.
+#
+# Forbidding the helpers on GCC would mean banning `std::string`, `std::vector` and `substr` from
+# the governed zone outright. That may be the right end state for a Class C build, but it is a much
+# larger decision than this scan, and it needs its own ADR. Until then this file reports those
 # references rather than failing on them, so that they stay visible and counted instead of being
 # quietly implied not to exist. See ADR-005 for the claim as it is actually made.
 #
@@ -89,6 +99,7 @@ if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
         "??_U@"      # MSVC operator new[]
     )
     set(reported_symbols "")
+    set(reported_explanation "")
     # One string, not a list of strings: message() concatenates its own arguments cleanly, but a
     # ;-separated list expanded through ${} arrives with the separators embedded in the text.
     string(CONCAT violation_explanation
@@ -96,18 +107,39 @@ if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
         "allocates only on a path you believe is unreachable, that is not sufficient - the device "
         "build must not contain the reference at all.")
 elseif(MDUX_SCAN_PROFILE STREQUAL "governed-throw")
-    set(forbidden_symbols
-        "__cxa_throw"
-        "__cxa_rethrow"
-        "_CxxThrowException"   # MSVC
-    )
-    # Counted and printed, never failed on. See the header comment.
-    set(reported_symbols
-        "__throw_length_error"
-        "__throw_logic_error"
-        "__throw_out_of_range"
-        "__throw_bad_alloc"
-    )
+    # Toolchain-dependent, because the distinction this profile rests on is a property of the
+    # standard library's code generation rather than of the source. See the header comment.
+    if(MDUX_NOHEAP_TOOL STREQUAL "dumpbin")
+        set(forbidden_symbols "")
+        set(reported_symbols
+            "_CxxThrowException"
+            "_Xlength_error"
+            "_Xout_of_range"
+            "_Xbad_alloc"
+            "_Xinvalid_argument"
+        )
+        string(CONCAT reported_explanation
+            "tolerated throw reference(s). The MSVC STL inlines its own throw sites, so "
+            "_CxxThrowException in a governed object is indistinguishable from a hand-written "
+            "throw - see this file's header. mdux-governed-lint is what enforces the no-throw rule "
+            "on this toolchain; this scan is informational here")
+    else()
+        set(forbidden_symbols
+            "__cxa_throw"
+            "__cxa_rethrow"
+        )
+        # Counted and printed, never failed on.
+        set(reported_symbols
+            "__throw_length_error"
+            "__throw_logic_error"
+            "__throw_out_of_range"
+            "__throw_bad_alloc"
+        )
+        string(CONCAT reported_explanation
+            "tolerated throw-helper reference(s), from std::string, std::vector and "
+            "std::string_view::substr internals - see this file's header and ADR-005 for why "
+            "these are reported rather than forbidden")
+    endif()
     string(CONCAT violation_explanation
         "A governed module contains a throw expression. ADR-005 requires governed code to report "
         "failure through mdux.core.result instead. If the throwing construct is unavoidable, the "
@@ -188,15 +220,20 @@ if(reported)
     list(LENGTH reported reported_count)
     string(REPLACE ";" "\n  " reported_text "${reported}")
     message(STATUS
-        "MduXNoHeapScan: ${reported_count} tolerated throw-helper reference(s), from std::string, "
-        "std::vector and std::string_view::substr internals - see this file's header and ADR-005 "
-        "for why these are reported rather than forbidden:\n  ${reported_text}")
+        "MduXNoHeapScan: ${reported_count} ${reported_explanation}:\n  ${reported_text}")
 endif()
 
 if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
     message(STATUS
         "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")
-else()
+elseif(forbidden_symbols)
     message(STATUS
         "MduXNoHeapScan: ${scanned_count} governed object(s) contain no throw expression")
+else()
+    # Never "no throw expression" here - nothing was forbidden, so nothing was established. Saying
+    # otherwise would be the exact shape of unearned claim issue #116 exists to remove.
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} governed object(s) scanned; this toolchain cannot "
+        "distinguish a governed throw from an inlined std one, so no verdict is claimed here - "
+        "mdux-governed-lint enforces the rule at source level")
 endif()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,6 @@ are ordinary `PRIVATE` sources.
 | `mdux.governance.compliance` | `include/mdux/governance/Compliance.cppm` | `src/governance/Compliance.cpp` |
 | `mdux.shader.schema` | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
 | `mdux.text.schema` | `include/mdux/text/Schema.cppm` | `src/text/Schema.cpp` |
-| `mdux.text.raster` | `include/mdux/text/Raster.cppm` | `src/text/Raster.cpp` |
 | `mdux.font.schema` | `include/mdux/font/Schema.cppm` | `src/font/Schema.cpp` |
 | `mdux.text.draw` | `include/mdux/text/Draw.cppm` | `src/text/Draw.cpp` |
 | `mdux.draw` | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
@@ -89,10 +88,15 @@ performs no checking and confers no compliance.
 | `MduXToolsCommon` | `tools/common/` | TOML subset reader, CLI parser, shared diagnostic envelope |
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
-| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158) and `mdux.tools.atlaspacker` (the shelf packer, #160) |
+| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
+
+`mdux.text.raster` was governed until [#116](https://github.com/ambroise-leclerc/MduX/issues/116).
+It allocates, and `std::vector` reports failure by throwing, so it could not remain in a target
+compiled with `-fno-exceptions`. It runs once per glyph at build time and never on a device, which
+is what made the host-tools zone the right home rather than a reason to rewrite it.
 
 ## The Vulkan boundary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,9 +94,10 @@ Host tools parse untrusted input, so they are deliberately outside the governed 
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
 
 `mdux.text.raster` was governed until [#116](https://github.com/ambroise-leclerc/MduX/issues/116).
-It allocates, and `std::vector` reports failure by throwing, so it could not remain in a target
-compiled with `-fno-exceptions`. It runs once per glyph at build time and never on a device, which
-is what made the host-tools zone the right home rather than a reason to rewrite it.
+It allocates, and `std::vector` reports failure by throwing, so its `noexcept` entry point has to
+catch — which [ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md) forbids in governed
+code. It runs once per glyph at build time and never on a device, which is what made the host-tools
+zone the right home rather than a reason to rewrite it.
 
 ## The Vulkan boundary
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -548,9 +548,10 @@ mdux_discover_tests(ml_spec)
 #
 # Links MduX::Core only. mdux.text.schema is governed and contains no Vulkan handle, so a
 # scenario that needed MduX::MduX to build it would mean the trust-zone boundary had moved -
-# the same standing evidence shader_spec, draw_spec and ml_spec give. S1 ships the schema and a
-# no-run baker skeleton; the TrueType parser (#158), rasteriser (#159), atlas font baker (#160),
-# font schema (#161) and coverage draw path (#162) follow as their blockers close.
+# the same standing evidence shader_spec, draw_spec and ml_spec give. The suite covers the
+# governed half of the text pipeline: the schema (#157), the font schema (#161) and the coverage
+# draw path (#162). The host-only halves - the TrueType parser (#158), the rasteriser (#159) and
+# the atlas font baker (#160) - are covered by text_tools_spec instead.
 # Font schema suite (issue #161)
 #
 # Its own executable rather than cases inside text_spec, because a font package and a text package
@@ -587,7 +588,6 @@ mdux_discover_tests(font_spec)
 add_executable(text_spec
     text/TextSpecMain.cpp
     text/SchemaTests.cpp
-    text/RasterTests.cpp
     text/DrawTests.cpp
 )
 
@@ -619,11 +619,17 @@ mdux_discover_tests(text_spec)
 # `ml_tools_spec` and `shader_spec` follow: drive `parseRecipe()` / `run()` / `write()` / `verify()`
 # as calls so a failing assertion names the diagnostic code that failed rather than only an exit
 # status from a spawned process.
+#
+# RasterTests.cpp lives here rather than in text_spec since #116, because `mdux.text.raster` moved
+# to the host-tools zone. Moving the test with the module is not bookkeeping: text_spec links
+# MduX::Core alone, and that link line *is* the standing evidence above. Leaving raster cases there
+# would force MduX::TextBakeLib onto text_spec and destroy the very thing it exists to demonstrate.
 add_executable(text_tools_spec
     text/TextToolsSpecMain.cpp
     text/TextBakeTests.cpp
     text/TruetypeTests.cpp
     text/AtlasPackerTests.cpp
+    text/RasterTests.cpp
 )
 
 target_link_libraries(text_tools_spec PRIVATE MduX::TextBakeLib speclab::speclab)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -729,6 +729,19 @@ file(GENERATE
     CONTENT "$<JOIN:$<FILTER:$<TARGET_OBJECTS:MduXCore>,INCLUDE,/ml/>,\n>"
 )
 
+# The same mechanism over the whole governed target (issue #116), with the forbidden set narrowed
+# to the throw expression alone. No filter: every MduXCore object, module interfaces included.
+#
+# The allocator symbols cannot come along. mdux.evidence.json and mdux.governance allocate by
+# design - they build strings and vectors - so the ml-noheap forbidden set applied here would fail
+# on correct code. What generalises is the no-throwing half, which is a property ADR-005 asserts of
+# the whole governed zone rather than only of the ML modules.
+set(mdux_governed_object_list "${CMAKE_CURRENT_BINARY_DIR}/governed_objects_$<CONFIG>.txt")
+file(GENERATE
+    OUTPUT "${mdux_governed_object_list}"
+    CONTENT "$<JOIN:$<TARGET_OBJECTS:MduXCore>,\n>"
+)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     find_program(MDUX_SYMBOL_TOOL NAMES dumpbin)
     set(mdux_symbol_tool_kind "dumpbin")
@@ -745,16 +758,74 @@ endif()
 if(MDUX_SYMBOL_TOOL)
     add_test(NAME ml.noheap.symbolScan
         COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=ml-noheap
             -DMDUX_NOHEAP_OBJECT_LIST=${mdux_ml_object_list}
             -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
             -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
             -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
     )
     set_tests_properties(ml.noheap.symbolScan PROPERTIES LABELS "noheap")
+
+    # Issue #116. Labelled `governed` rather than `noheap`: it is not a no-heap check, and a CI leg
+    # selecting -L noheap should not silently start covering something else.
+    add_test(NAME governed.noThrow.symbolScan
+        COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=governed-throw
+            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_governed_object_list}
+            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+    )
+    set_tests_properties(governed.noThrow.symbolScan PROPERTIES LABELS "governed")
+
+    # The negative fixture. See tests/governed/ThrowFixture.cpp for why a scan that only ever runs
+    # against conforming code is not yet evidence of anything.
+    #
+    # CXX_SCAN_FOR_MODULES OFF keeps this object out of the module dependency graph: it declares no
+    # module and imports none, and a fixture whose job is to be non-conforming has no business in
+    # anyone's dyndep.
+    add_library(mdux_throw_fixture OBJECT governed/ThrowFixture.cpp)
+    set_target_properties(mdux_throw_fixture
+        PROPERTIES
+            CXX_STANDARD 23
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF
+            CXX_SCAN_FOR_MODULES OFF
+    )
+
+    set(mdux_throw_fixture_object_list
+        "${CMAKE_CURRENT_BINARY_DIR}/throw_fixture_objects_$<CONFIG>.txt")
+    file(GENERATE
+        OUTPUT "${mdux_throw_fixture_object_list}"
+        CONTENT "$<JOIN:$<TARGET_OBJECTS:mdux_throw_fixture>,\n>"
+    )
+
+    add_test(NAME governed.noThrow.symbolScan.negative
+        COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=governed-throw
+            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_throw_fixture_object_list}
+            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+    )
+    # PASS_REGULAR_EXPRESSION rather than WILL_FAIL, and the two must not be combined. When
+    # PASS_REGULAR_EXPRESSION is set CTest ignores the exit status and passes the test iff the
+    # regex matches, so it already accommodates the expected non-zero exit; adding WILL_FAIL then
+    # *inverts* that verdict and turns the correct outcome into a reported failure (observed).
+    #
+    # Matching the message rather than merely the exit status is what makes this a real negative
+    # test. A bare WILL_FAIL would be satisfied by a missing object, a misspelled profile or a bad
+    # path - every way of failing except the one being verified.
+    set_tests_properties(governed.noThrow.symbolScan.negative
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "Symbol scan violation \\(profile 'governed-throw'\\)"
+            LABELS "governed"
+    )
 else()
-    # Deliberately not silent. A missing tool means this layer is not running, and the other two
-    # layers do not cover what it covers.
+    # Deliberately not silent. A missing tool means these layers are not running, and nothing else
+    # covers what they cover.
     message(WARNING
-        "No symbol tool (nm/dumpbin) found - ml.noheap.symbolScan will not run, so issue #63's "
-        "layer 2 is unverified in this build.")
+        "No symbol tool (nm/dumpbin) found - ml.noheap.symbolScan and governed.noThrow.symbolScan "
+        "will not run, so issue #63's layer 2 and issue #116's object-level no-throw check are "
+        "both unverified in this build.")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -781,46 +781,62 @@ if(MDUX_SYMBOL_TOOL)
     # The negative fixture. See tests/governed/ThrowFixture.cpp for why a scan that only ever runs
     # against conforming code is not yet evidence of anything.
     #
+    # MSVC is excluded, and the reason is the same one that makes the positive scan
+    # report-only there: the MSVC STL inlines its own throw sites, so `_CxxThrowException` cannot
+    # distinguish a governed `throw` from an ordinary `std::string` growth path. The
+    # `governed-throw` profile therefore forbids nothing under dumpbin, and a negative test needs
+    # something to be forbidden before it can prove the rejection works. Registering it anyway
+    # would produce a test that fails on Windows for a reason unrelated to any defect - the kind of
+    # noise that trains a reader to ignore a red check.
+    #
     # CXX_SCAN_FOR_MODULES OFF keeps this object out of the module dependency graph: it declares no
     # module and imports none, and a fixture whose job is to be non-conforming has no business in
     # anyone's dyndep.
-    add_library(mdux_throw_fixture OBJECT governed/ThrowFixture.cpp)
-    set_target_properties(mdux_throw_fixture
-        PROPERTIES
-            CXX_STANDARD 23
-            CXX_STANDARD_REQUIRED ON
-            CXX_EXTENSIONS OFF
-            CXX_SCAN_FOR_MODULES OFF
-    )
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        message(STATUS
+            "governed.noThrow.symbolScan.negative not registered on MSVC - the governed-throw "
+            "profile forbids no symbol under dumpbin, so there is nothing for a negative test to "
+            "prove. mdux-governed-lint covers the rule on this toolchain.")
+    else()
+        add_library(mdux_throw_fixture OBJECT governed/ThrowFixture.cpp)
+        set_target_properties(mdux_throw_fixture
+            PROPERTIES
+                CXX_STANDARD 23
+                CXX_STANDARD_REQUIRED ON
+                CXX_EXTENSIONS OFF
+                CXX_SCAN_FOR_MODULES OFF
+        )
 
-    set(mdux_throw_fixture_object_list
-        "${CMAKE_CURRENT_BINARY_DIR}/throw_fixture_objects_$<CONFIG>.txt")
-    file(GENERATE
-        OUTPUT "${mdux_throw_fixture_object_list}"
-        CONTENT "$<JOIN:$<TARGET_OBJECTS:mdux_throw_fixture>,\n>"
-    )
+        set(mdux_throw_fixture_object_list
+            "${CMAKE_CURRENT_BINARY_DIR}/throw_fixture_objects_$<CONFIG>.txt")
+        file(GENERATE
+            OUTPUT "${mdux_throw_fixture_object_list}"
+            CONTENT "$<JOIN:$<TARGET_OBJECTS:mdux_throw_fixture>,\n>"
+        )
 
-    add_test(NAME governed.noThrow.symbolScan.negative
-        COMMAND ${CMAKE_COMMAND}
-            -DMDUX_SCAN_PROFILE=governed-throw
-            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_throw_fixture_object_list}
-            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
-            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
-            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
-    )
-    # PASS_REGULAR_EXPRESSION rather than WILL_FAIL, and the two must not be combined. When
-    # PASS_REGULAR_EXPRESSION is set CTest ignores the exit status and passes the test iff the
-    # regex matches, so it already accommodates the expected non-zero exit; adding WILL_FAIL then
-    # *inverts* that verdict and turns the correct outcome into a reported failure (observed).
-    #
-    # Matching the message rather than merely the exit status is what makes this a real negative
-    # test. A bare WILL_FAIL would be satisfied by a missing object, a misspelled profile or a bad
-    # path - every way of failing except the one being verified.
-    set_tests_properties(governed.noThrow.symbolScan.negative
-        PROPERTIES
-            PASS_REGULAR_EXPRESSION "Symbol scan violation \\(profile 'governed-throw'\\)"
-            LABELS "governed"
-    )
+        add_test(NAME governed.noThrow.symbolScan.negative
+            COMMAND ${CMAKE_COMMAND}
+                -DMDUX_SCAN_PROFILE=governed-throw
+                -DMDUX_NOHEAP_OBJECT_LIST=${mdux_throw_fixture_object_list}
+                -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+                -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+                -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+        )
+        # PASS_REGULAR_EXPRESSION rather than WILL_FAIL, and the two must not be combined. When
+        # PASS_REGULAR_EXPRESSION is set CTest ignores the exit status and passes the test iff the
+        # regex matches, so it already accommodates the expected non-zero exit; adding WILL_FAIL
+        # then *inverts* that verdict and turns the correct outcome into a reported failure
+        # (observed).
+        #
+        # Matching the message rather than merely the exit status is what makes this a real
+        # negative test. A bare WILL_FAIL would be satisfied by a missing object, a misspelled
+        # profile or a bad path - every way of failing except the one being verified.
+        set_tests_properties(governed.noThrow.symbolScan.negative
+            PROPERTIES
+                PASS_REGULAR_EXPRESSION "Symbol scan violation \\(profile 'governed-throw'\\)"
+                LABELS "governed"
+        )
+    endif()
 else()
     # Deliberately not silent. A missing tool means these layers are not running, and nothing else
     # covers what they cover.

--- a/tests/governed/ThrowFixture.cpp
+++ b/tests/governed/ThrowFixture.cpp
@@ -15,7 +15,14 @@
  *
  * The `throw` below is what the compiler turns into a `__cxa_throw` reference, the exact symbol
  * the `governed-throw` profile forbids. Narrow that forbidden set or break the symbol matching and
- * this stops failing, which CTest reports as an error because the test carries `WILL_FAIL`.
+ * the scan stops rejecting this object, which CTest reports as a failure because the test carries
+ * `PASS_REGULAR_EXPRESSION` matching the violation message. Deliberately *not* `WILL_FAIL`: with a
+ * pass regex CTest already ignores the exit status, and adding `WILL_FAIL` inverts the verdict so
+ * the correct outcome is reported as a failure. `tests/CMakeLists.txt` carries the full reasoning.
+ *
+ * Only registered on GCC/Clang. The MSVC STL inlines its own throw sites, so the `governed-throw`
+ * profile forbids no symbol under `dumpbin` — and a negative test needs something to be forbidden
+ * before it can prove the rejection works.
  *
  * Plain includes rather than `import std`, and no module declaration: the fixture is compiled as
  * an object library outside the module graph, so that a file whose entire purpose is to be

--- a/tests/governed/ThrowFixture.cpp
+++ b/tests/governed/ThrowFixture.cpp
@@ -1,0 +1,33 @@
+/**
+ * @file ThrowFixture.cpp
+ * @brief A deliberately non-conforming source, used to prove the governed no-throw scan fails.
+ *
+ * @compliance ADR-005 Error handling and exceptions policy
+ *
+ * This file is **not** part of `MduXCore` and is never linked into anything that ships. It exists
+ * so that `governed.noThrow.symbolScan.negative` has something to fail on.
+ *
+ * A check that only ever runs against conforming code proves very little: it passes identically
+ * when it is working and when it is scanning an empty list, matching no symbol, or reading the
+ * wrong objects. `MduXNoHeapScan.cmake` guards the empty-list and missing-object cases with its own
+ * `FATAL_ERROR`s. This covers the case those cannot - the scan running correctly over a real
+ * object and simply failing to recognise the thing it is looking for.
+ *
+ * The `throw` below is what the compiler turns into a `__cxa_throw` reference, the exact symbol
+ * the `governed-throw` profile forbids. Narrow that forbidden set or break the symbol matching and
+ * this stops failing, which CTest reports as an error because the test carries `WILL_FAIL`.
+ *
+ * Plain includes rather than `import std`, and no module declaration: the fixture is compiled as
+ * an object library outside the module graph, so that a file whose entire purpose is to be
+ * non-conforming cannot participate in anyone's module dependency scan.
+ */
+#include <stdexcept>
+
+namespace mdux::test {
+
+/// Throws unconditionally. Never called; the reference in the emitted object is the whole point.
+[[noreturn]] void alwaysThrows() {
+    throw std::runtime_error{"this function exists to be found by a symbol scan"};
+}
+
+}  // namespace mdux::test

--- a/tests/text/RasterTests.cpp
+++ b/tests/text/RasterTests.cpp
@@ -1,11 +1,14 @@
 /**
  * @file RasterTests.cpp
- * @brief BDD scenarios for the governed-zone glyph rasteriser (issue #159).
+ * @brief BDD scenarios for the host-tools glyph rasteriser (issue #159).
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
  * @compliance ADR-010 No on-device text shaping
+ *
+ * Part of text_tools_spec rather than text_spec since #116, because `mdux.text.raster` moved to
+ * the host-tools zone. The scenarios themselves are unchanged: the rasteriser is still
+ * integer-only, and the frozen-digest scenario at the bottom still holds it to the byte.
  *
  * The outlines here are built in code rather than loaded from a font, for the reason
  * `TruetypeTests.cpp` gives: a fixture whose intended defect a reviewer has to take on trust is

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -220,7 +220,8 @@ endif()
 # registered until S4 commits a real artifact.
 #
 # `mdux.text.raster` moved here from MduXCore in #116. It allocates, and `std::vector` reports
-# failure by throwing, so it could not stay in a governed target compiled with -fno-exceptions.
+# failure by throwing, so its noexcept entry point has to catch - which ADR-005 forbids in the
+# governed zone.
 # Nothing else about it changed - it is integer-only and its output is still byte-compared in CI.
 # See tools/text/Raster.cppm for the full argument.
 add_library(MduXTextBakeLib)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -218,6 +218,11 @@ endif()
 # that hosts the recipe model. S4 extends the recipe with the font pipeline inputs and S5
 # (#161) adds the restricted-charset validation; no mdux_bake_artifact() call site is
 # registered until S4 commits a real artifact.
+#
+# `mdux.text.raster` moved here from MduXCore in #116. It allocates, and `std::vector` reports
+# failure by throwing, so it could not stay in a governed target compiled with -fno-exceptions.
+# Nothing else about it changed - it is integer-only and its output is still byte-compared in CI.
+# See tools/text/Raster.cppm for the full argument.
 add_library(MduXTextBakeLib)
 add_library(MduX::TextBakeLib ALIAS MduXTextBakeLib)
 
@@ -229,10 +234,12 @@ target_sources(MduXTextBakeLib
             text/TextBake.cppm
             text/Truetype.cppm
             text/AtlasPacker.cppm
+            text/Raster.cppm
     PRIVATE
         text/TextBake.cpp
         text/Truetype.cpp
         text/AtlasPacker.cpp
+        text/Raster.cpp
 )
 
 target_compile_features(MduXTextBakeLib PUBLIC cxx_std_23)

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -17,8 +17,8 @@
  *
  * `mdux.text.raster` (#159) sits in this zone for the same reason as of #116. It was governed
  * on the argument that a device path might one day rasterise, which ADR-008 decision 1 would
- * then require to be *that* module rather than a second one - but it allocates, so it could not
- * stay in a target compiled with `-fno-exceptions`. See `Raster.cppm`.
+ * then require to be *that* module rather than a second one - but it allocates, so it has to
+ * catch at its `noexcept` boundary, which ADR-005 forbids in governed code. See `Raster.cppm`.
  *
  * ## Shelf placement, and why not something better
  *

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -10,12 +10,15 @@
  *
  * ## Why this is host-tools rather than governed
  *
- * `mdux.text.raster` (#159) is governed because a device path could conceivably need to
- * rasterise, and ADR-008 decision 1 says that would have to be *this* module rather than a second
- * one. Packing has no such future: an atlas is chosen once, at build time, and a device consumes
- * the slot rectangles the baker recorded. Nothing on a device ever packs, so a governed packer
- * would be a promise with no caller - and every module in the governed zone is a module a
- * reviewer has to reason about for device behaviour.
+ * An atlas is chosen once, at build time, and a device consumes the slot rectangles the baker
+ * recorded. Nothing on a device ever packs, so a governed packer would be a promise with no
+ * caller - and every module in the governed zone is a module a reviewer has to reason about for
+ * device behaviour.
+ *
+ * `mdux.text.raster` (#159) sits in this zone for the same reason as of #116. It was governed
+ * on the argument that a device path might one day rasterise, which ADR-008 decision 1 would
+ * then require to be *that* module rather than a second one - but it allocates, so it could not
+ * stay in a target compiled with `-fno-exceptions`. See `Raster.cppm`.
  *
  * ## Shelf placement, and why not something better
  *

--- a/tools/text/Raster.cpp
+++ b/tools/text/Raster.cpp
@@ -580,8 +580,8 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     // The final `catch (...)` is defensive: nothing else on this path throws anything else, and
     // if that ever stops being true this still returns rather than terminating.
     //
-    // This block is what put the module in the host-tools zone (#116). `MduXCore` is compiled
-    // with `-fno-exceptions`, so `try` cannot appear there at all - see Raster.cppm on why the
+    // This block is what put the module in the host-tools zone (#116): governed code does not
+    // throw, and ADR-005 makes that a rule rather than a preference. See Raster.cppm on why the
     // zone moved rather than the code.
     try {
         return rasteriseImpl(request);

--- a/tools/text/Raster.cpp
+++ b/tools/text/Raster.cpp
@@ -1,10 +1,9 @@
 /**
  * @file Raster.cpp
- * @brief Implementation of the governed-zone glyph rasteriser.
+ * @brief Implementation of the host-tools glyph rasteriser.
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
  * @compliance ADR-010 No on-device text shaping
  *
  * Four passes, in order:
@@ -578,8 +577,12 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     //
     // `std::length_error` is caught alongside `bad_alloc` because `resize()` raises it when a
     // request exceeds `max_size()`, which is the same condition arriving by a different name.
-    // The final `catch (...)` is defensive: nothing in the governed zone throws anything else,
-    // and if that ever stops being true this still returns rather than terminating.
+    // The final `catch (...)` is defensive: nothing else on this path throws anything else, and
+    // if that ever stops being true this still returns rather than terminating.
+    //
+    // This block is what put the module in the host-tools zone (#116). `MduXCore` is compiled
+    // with `-fno-exceptions`, so `try` cannot appear there at all - see Raster.cppm on why the
+    // zone moved rather than the code.
     try {
         return rasteriseImpl(request);
     } catch (const std::bad_alloc&) {

--- a/tools/text/Raster.cppm
+++ b/tools/text/Raster.cppm
@@ -1,28 +1,37 @@
 /**
  * @file Raster.cppm
- * @brief Governed-zone glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
+ * @brief Host-tools glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
  *        only, so the same glyph produces the same bytes on every supported toolchain.
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
- * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone: runs at build time, never on a device)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept entry point)
  * @compliance ADR-007 Evidence pipeline doctrine (the bytes this produces get committed)
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010: one
- *             module, not a host implementation and a device one that could drift)
  * @compliance ADR-010 No on-device text shaping
  *
- * Part of MduXCore. The font baker (#160, S4) imports this to fill an atlas; if a device path
- * ever needs to rasterise, it imports *this* module rather than growing a second implementation.
- * That is ADR-008 decision 1 applied to text, and it is why this file is governed rather than
- * sitting in `tools/` next to the parser that feeds it.
+ * Part of `MduXTextBakeLib`. The font baker (#160, S4) imports this to fill an atlas.
+ *
+ * ## Why this is host-tools code and not governed
+ *
+ * It was governed until issue #116, on the argument that a device path might one day want to
+ * rasterise and should import *this* module rather than grow a second implementation - ADR-008
+ * decision 1 applied to text. The argument was speculative and the cost was not: `rasterise()`
+ * allocates, and a `std::vector` reports failure by throwing, so keeping this module in
+ * `MduXCore` is incompatible with compiling the governed zone under `-fno-exceptions`. That
+ * compile mode is the thing ADR-005 calls a Class C and Vulkan SC prerequisite, and a real
+ * prerequisite outranks a hypothetical consumer.
+ *
+ * Nothing about the module's determinism changes with the move. The integer-only rule below is a
+ * property of the source, and the committed atlas bytes it produces are byte-compared in CI
+ * exactly as before.
  *
  * ## Why it does not take a `truetype::SimpleGlyph`
  *
- * `mdux.tools.truetype` (#158) is host-tools-zone code. ADR-004 forbids a governed module from
- * importing one, and the rule is mechanically checked by `mdux_verify_trust_zones()` - so this
- * module cannot name that type even though it is the obvious input. It takes `Outline` instead:
- * the same TrueType shape (points, per-contour end indices, on/off-curve flags) expressed in
- * governed types, with the baker doing a flat conversion. That indirection is the trust-zone
- * boundary made visible, not an abstraction for its own sake.
+ * It could now - `mdux.tools.truetype` (#158) is in this same zone, and the trust-zone rule that
+ * forbade naming that type no longer applies. The `Outline` input is kept anyway: it is the same
+ * TrueType shape (points, per-contour end indices, on/off-curve flags) in types that carry no
+ * parser with them, so this module stays movable back into `MduXCore` if a device path is ever
+ * built and made allocation-free. What used to be a constraint is now a deliberately preserved
+ * option, and the distinction is worth stating rather than leaving for a reader to infer.
  *
  * ## The determinism rule
  *

--- a/tools/text/Raster.cppm
+++ b/tools/text/Raster.cppm
@@ -15,10 +15,11 @@
  * It was governed until issue #116, on the argument that a device path might one day want to
  * rasterise and should import *this* module rather than grow a second implementation - ADR-008
  * decision 1 applied to text. The argument was speculative and the cost was not: `rasterise()`
- * allocates, and a `std::vector` reports failure by throwing, so keeping this module in
- * `MduXCore` is incompatible with compiling the governed zone under `-fno-exceptions`. That
- * compile mode is the thing ADR-005 calls a Class C and Vulkan SC prerequisite, and a real
- * prerequisite outranks a hypothetical consumer.
+ * allocates, and a `std::vector` reports failure by throwing, so the `noexcept` entry point below
+ * has to catch. ADR-005 forbids exactly that in the governed zone, and #116 made the rule
+ * mechanical - `mdux-governed-lint` rejects `try`/`catch` in governed source, and on GCC/Clang
+ * `governed.noThrow.symbolScan` rejects the resulting `__cxa_throw` reference in the object. A
+ * present rule outranks a hypothetical consumer.
  *
  * Nothing about the module's determinism changes with the move. The integer-only rule below is a
  * property of the source, and the committed atlas bytes it produces are byte-compared in CI
@@ -153,8 +154,10 @@ struct OutlinePoint {
 /**
  * @brief A glyph outline in font units: points, plus the index of each contour's last point.
  *
- * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in governed types because a
- * governed module may not import a host-tools one (ADR-004). `contourEnds[i]` is the index of
+ * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in parser-independent types.
+ * Until #116 that restatement was forced - a governed module may not import a host-tools one
+ * (ADR-004) - and it is now kept by choice, so this module stays movable back into `MduXCore` if
+ * a device path is ever built and made allocation-free. `contourEnds[i]` is the index of
  * the final point of contour `i`, so contour 0 is `points[0 .. contourEnds[0]]` and contour `i`
  * is `points[contourEnds[i-1] + 1 .. contourEnds[i]]` - TrueType's own convention, kept rather
  * than converted to offsets so the baker's translation stays a copy rather than a computation.

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -470,9 +470,12 @@ struct BakedGlyph {
                 continue;
             }
 
-            // Translate the parser's outline into the rasteriser's governed input type. This copy
-            // is the trust-zone boundary made concrete: mdux.text.raster is governed and cannot
-            // name a host-tools type, so the baker is what bridges them (ADR-004).
+            // Translate the parser's outline into the rasteriser's own input type. This copy was
+            // the trust-zone boundary made concrete until #116, when mdux.text.raster joined this
+            // zone; the rasteriser could now name `truetype::GlyphPoint` directly. It is kept
+            // because the decoupling is what would let the rasteriser move back into MduXCore if a
+            // device path is ever built (see Raster.cppm), and the copy costs one pass per glyph
+            // at build time.
             std::vector<raster::OutlinePoint> points;
             points.reserve(outline->points.size());
             for (const truetype::GlyphPoint& gp : outline->points) {


### PR DESCRIPTION
## Summary

Second of three for #116. ADR-005 says the governed zone does not throw. Nothing checked it — the claim was made in the present tense at `ADR-005:41`, the lint said to reject `throw`/`try`/`catch` had never been written, and `bugprone-exception-escape` (the check ADR-005 *opens by citing* as the reason a `noexcept` violation was invisible) was still suppressed in `.clang-tidy`.

### The intended mechanism is not available

ADR-005 specified `-fno-exceptions` on `MduXCore`. That cannot be done while the governed zone uses `import std`. Verified directly rather than inferred:

- GCC records the language dialect in every module BMI. A governed module compiled with the flag is rejected against the shared `std` BMI with `language dialect differs 'C++23', expected 'C++23/no-exceptions/no-rtti'`. **Each of `-fno-exceptions` and `-fno-rtti` fails this way on its own**, not only in combination.
- CMake synthesises exactly one `__CMAKE__CXX23@synth_*` std target for the whole build, shared by the adapter and host-tools targets, which must keep exceptions. Adding the flags to `MduXCore` did not produce a second one.
- A separately built governed-dialect `std` BMI *does* compile and work when driven by hand, so the constraint is the **sharing**, not the flags. Hand-rolling one would displace the most fragile part of this build.

So the rule is enforced where it can be checked properly — in the objects.

### What landed instead

`MduXNoHeapScan.cmake` grows a profile selector, and `governed.noThrow.symbolScan` runs the new `governed-throw` profile over all 29 `MduXCore` objects. This is the stronger of the two available checks: `-fno-exceptions` stops you *writing* a throw, while the symbol scan sees a throw arriving through a std facility the source never spells out.

The allocator symbols do **not** generalise from the ML profile and are excluded — `mdux.evidence.json` and `mdux.governance` allocate by design.

### What it tolerates, and says so

The scan forbids a literal throw (`__cxa_throw`), and no governed object references it. It deliberately tolerates libstdc++'s throw *helpers*: eight objects reference `__throw_length_error`, `__throw_logic_error` or `__throw_out_of_range_fmt`, all from inside `std::string`, `std::vector` and `std::string_view::substr` — `Json.cpp`'s parser and `Governance.cpp`'s id splitting are both of that shape, and in both the caller's invariant makes the throw unreachable.

Forbidding those means banning those types from the governed zone, which is a larger decision than this issue and needs its own ADR. Until then the scan **prints all 14 references on every run** rather than implying they do not exist.

Part of #116.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #184

## Dependency

- **Base branch:** `116-move-raster-to-host-tools` (stacked, so this PR shows one issue's diff)
- **Predecessor PR:** #187
- **Merge order:** **must not merge until #187 has merged.** The scan fails on `develop` as it stands today — `src/text/Raster.cpp` is governed and contains `try`/`catch`, which is precisely what #187 resolves.

## Shared registries touched

- [x] `tests/CMakeLists.txt` — a second scan registration, the negative fixture object library and its test
- [x] None of the others

## Rebase state

- **Rebased onto:** `913fe84` (predecessor head), itself on `e96dc35` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [x] `cmake --preset ninja-gcc && cmake --build build-gcc` — clean
- [x] `ctest --test-dir build-gcc` — 438/438 passed (436 + the two new `governed` tests)
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK
- [x] Other:
  - `ctest -L governed` — both pass; the scan reports `29 governed object(s) contain no throw expression` and lists all 14 tolerated helper references
  - `ctest -L noheap` — 5/5, the existing ML scan unaffected by the profile split
  - the negative fixture was confirmed to fail for the *right reason*, matching `Symbol scan violation (profile 'governed-throw')` on `ThrowFixture.cpp.o: U __cxa_throw`

Not run locally: the MSVC leg. It is the least-exercised part of this PR — `dumpbin /SYMBOLS` rather than `nm -u -C`, and `_CxxThrowException` rather than `__cxa_throw` — so the Windows check on this PR is the gate, not a formality.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.

## Regulatory impact

**Adds a compliance-relevant check, and narrows a claim.** ADR-005's "no throwing" assertion becomes mechanically verified for literal throws, which it was not before.

It also establishes that the governed zone **cannot** currently be built with `-fno-exceptions`, contradicting a consequence ADR-005 lists as positive. That is a reduction in what the project may claim, not an increase. The ADR text recording both the new mechanism and the retracted claim lands with #189 — deliberately last, so the documents describe what merged.

`bugprone-exception-escape` is re-enabled with a comment stating plainly that it is *available* rather than *enforced*: the only job running clang-tidy does so with `|| true` against a compile database it cannot parse for module interface units.