### PR TITLE
Add mdux-governed-lint and reconcile ADR-004/005 with what runs [#116]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,11 +2,22 @@
 # Based on C++ Core Guidelines
 # Enforces coding standards from CONTRIBUTING.md
 
+# bugprone-exception-escape is deliberately NOT disabled. It was, until issue #116: ADR-005 opens
+# by citing that suppression as the reason a `noexcept` violation in governed code was invisible to
+# static analysis, and listed re-enabling it as a follow-up gated on MduXCore existing. MduXCore has
+# existed since Wave 1.
+#
+# Scope, stated honestly: this check is *available* rather than *enforced*. The only CI job running
+# clang-tidy is security-analysis.yml, which invokes it with `|| true` against a GCC-generated
+# compile_commands.json that clang-tidy cannot parse for module interface units - both limitations
+# are documented in that workflow. So re-enabling this catches a noexcept violation for a developer
+# running clang-tidy locally, and will catch one in CI when the Clang leg is restored (#48), but it
+# is not what stops one landing today. That is governed.noThrow.symbolScan, which reads the emitted
+# objects and runs on every ctest.
 Checks: >
   -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
-  -bugprone-exception-escape,
   cert-*,
   -cert-dcl21-cpp,
   -cert-dcl50-cpp,

--- a/.github/workflows/governed-lint.yml
+++ b/.github/workflows/governed-lint.yml
@@ -1,0 +1,47 @@
+name: Governed Source Lint
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    # Matches the PR's *base*, not its head: a base branch missing from this list means that PR
+    # reports no checks at all, silently - which is worse than reporting failures. `[0-9]+-*` is
+    # the scheme GitHub's "create a branch for this issue" button generates (issue number, dash,
+    # slugified title) and this project's standard - see AGENTS.md "Branch naming". It is also
+    # what gets a stacked PR checked, i.e. one targeting its predecessor rather than develop so a
+    # reviewer sees one issue's diff instead of the cumulative one. `feat/**` predates the
+    # convention and is kept for branches already in flight.
+    branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
+
+permissions:
+  contents: read
+
+jobs:
+  governed-lint:
+    name: Governed Source Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # No step here performs an authenticated Git operation, so the checkout token has no
+      # reason to survive into .git/config where any later build or test step could read it
+      # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
+      with:
+        persist-credentials: false
+
+    # ADR-005's governed-zone source rules (issue #116): no throw/try/catch, no throwing
+    # `.value()`, no raw allocation, no filesystem/console/clock/randomness, no unsafe cast, no
+    # std::fma. Needs no C++ toolchain - the lint parses MduXCore's source list out of
+    # CMakeLists.txt rather than configuring the project - so it runs as its own fast job.
+    #
+    # This is one of two layers. The other, governed.noThrow.symbolScan, reads the emitted objects
+    # and therefore needs a build; it runs inside the toolchain legs as a ctest. Neither subsumes
+    # the other: this sees a std::filesystem call that never throws, and the scan sees a throw
+    # arriving through a std facility the source never spells out.
+    - name: Run mdux-governed-lint
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: |
+        python3 -m unittest discover -s tools/governed-lint -p "test_*.py"
+        python3 tools/governed-lint/mdux_governed_lint.py

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -108,6 +108,15 @@ jobs:
     - name: Verify ML determinism (GCC 16)
       run: ctest --preset ninja-gcc -L determinism --output-on-failure
 
+    # Governed-zone no-throw, at the object level (ADR-005, issue #116). Broken out with -V rather
+    # than folded into the full run above, because a passing ctest prints none of a test's output -
+    # and this scan's output is half its purpose. It reports the throw-helper references it
+    # deliberately tolerates, and the ADR justifies tolerating them on the grounds that they stay
+    # "visible and counted". A number nobody can see in a job log is not counted. -V is what makes
+    # the claim true, and is the same reason the pixel step below uses it.
+    - name: Verify governed-zone no-throw (GCC 16)
+      run: ctest --preset ninja-gcc -L governed -V --no-tests=error
+
     # Rendered-truth verification (issue #125), moved here when the GCC 15 leg was retired.
     # Without it a broken ICD turns the only test that renders anything into a silent no-op:
     # offscreen_tests exits 77 with no device and CTest reports Skipped, which does not fail a run.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -115,6 +115,16 @@ jobs:
       run: ctest --preset ninja-msvc -L determinism
       shell: cmd
 
+    # Governed-zone no-throw (ADR-005, issue #116). Informational on this toolchain, and run
+    # anyway: the MSVC STL inlines its own throw sites, so _CxxThrowException in a governed object
+    # is the same symbol whether it came from a hand-written throw or a std::string growth path.
+    # The scan therefore forbids nothing here and prints what it found, which is worth having in
+    # the log - it is the only place the MSVC-side references are visible at all. mdux-governed-lint
+    # is what actually gates the rule on Windows. -V because a passing ctest prints no test output.
+    - name: Verify governed-zone no-throw (MSVC, informational)
+      run: ctest --preset ninja-msvc -L governed -V --no-tests=error
+      shell: cmd
+
     - name: Verify no source-tree writes
       shell: pwsh
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -51,12 +51,20 @@ Makefile
 *.user
 *.sln.docstates
 
-# Documentation files (large PDFs, proprietary standards)
-inputs/Documentation/*.pdf
-inputs/Documentation/*.epub
-inputs/Documentation/ISO\ 13485/
-inputs/Documentation/ISO\ 14971\ The\ Definitive\ Guide/
-inputs/Documentation/Medical\ Device\ Cybersecurity\ for\ Engineers\ and\ Manufacturers/
+# Local reference material - never committed.
+#
+# The whole directory, not selected paths inside it. Five specific sub-paths were listed here
+# until issue #116, which left inputs/CMake/ and any newly-added folder under
+# inputs/Documentation/ untracked-but-not-ignored - so a `git add -A` would have committed them.
+# That is the exact class of content #7 and #23 spent a history rewrite removing, and ADR-006
+# forbids outright. A directory-level rule cannot be defeated by adding a file to it.
+#
+# This lives in the *first* PR of the #116 stack rather than the last, because the narrow rule
+# actually caught someone out while that stack was in review: a `git add -A` on this branch staged
+# `inputs/CMake` as a gitlink. It was a one-line SHA rather than the 431 MB behind it, and it was
+# amended out before anyone pulled, but a guard that lands after the thing it guards against is
+# not a guard.
+inputs/
 
 # Temporary files
 *.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,6 @@ target_sources(MduXCore
             include/mdux/font/Schema.cppm
             include/mdux/text/Draw.cppm
             include/mdux/text/Schema.cppm
-            include/mdux/text/Raster.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
@@ -209,7 +208,6 @@ target_sources(MduXCore
         src/font/Schema.cpp
         src/text/Draw.cpp
         src/text/Schema.cpp
-        src/text/Raster.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp
         src/governance/Program.cpp

--- a/cmake/MduXNoHeapScan.cmake
+++ b/cmake/MduXNoHeapScan.cmake
@@ -34,11 +34,18 @@
 # is a genuine difference in how the two standard libraries generate code, not a gap in effort.
 #
 # On libstdc++, a `throw` expression emits `__cxa_throw`, while the library's own throw sites go
-# through out-of-line helpers - `std::__throw_length_error`, `std::__throw_logic_error`,
-# `std::__throw_out_of_range_fmt`. The two are therefore distinguishable in the object, and this
-# profile forbids the first while reporting the second. Eight governed objects reference the
-# helpers, all from inside `std::string` and `std::vector`: growth paths reference
-# `__throw_length_error`, and `std::string_view::substr` references `__throw_out_of_range_fmt` even
+# through out-of-line helpers. The two are therefore distinguishable in the object, and this
+# profile forbids the first while reporting the second.
+#
+# The reported set is `__throw_length_error`, `__throw_logic_error`, `__throw_out_of_range` and
+# `__throw_bad_alloc`, matched as substrings - so `__throw_out_of_range` also covers libstdc++'s
+# `__throw_out_of_range_fmt`, which is the spelling actually seen in this tree. `__throw_bad_alloc`
+# is in the set for completeness rather than because anything references it today; a scan that
+# reports only the symbols it has already met would go quiet exactly when something new arrived.
+#
+# Eight governed objects reference these, all from inside `std::string` and `std::vector`: growth
+# paths reference `__throw_length_error`, and `std::string_view::substr` references
+# `__throw_out_of_range_fmt` even
 # where the caller's invariant makes the throw unreachable (Json.cpp's parser and Governance.cpp's
 # id splitting are both of that shape).
 #
@@ -79,7 +86,10 @@ file(STRINGS "${MDUX_NOHEAP_OBJECT_LIST}" MDUX_NOHEAP_OBJECTS)
 if(MDUX_NOHEAP_OBJECTS STREQUAL "")
     message(FATAL_ERROR
         "MduXNoHeapScan: the object list is empty. That would make this test pass by checking "
-        "nothing - the '${MDUX_SCAN_PROFILE}' profile expects objects to be part of MduXCore.")
+        "nothing. Whichever file(GENERATE) produced '${MDUX_NOHEAP_OBJECT_LIST}' resolved to no "
+        "objects - check the $<TARGET_OBJECTS:...> expression that writes it. Note that the "
+        "negative fixture deliberately scans an object library outside MduXCore, so an empty list "
+        "here does not necessarily mean MduXCore is the target that went missing.")
 endif()
 
 # Mangled and demangled spellings both, so this works whether or not the tool demangles.

--- a/cmake/MduXNoHeapScan.cmake
+++ b/cmake/MduXNoHeapScan.cmake
@@ -1,29 +1,63 @@
 # MduXNoHeapScan.cmake
 #
-# Layer 2 of issue #63: scan the compiled ML objects for any undefined reference to the allocation
-# and deallocation family, or to the exception-throwing runtime.
+# Scans compiled objects for undefined references that would contradict a zone's stated guarantee.
+# Two profiles, selected by MDUX_SCAN_PROFILE:
+#
+#   ml-noheap      Layer 2 of issue #63, over the ML objects: no allocation family, no throwing
+#                  runtime. This is the original scan.
+#   governed-throw Issue #116, over every MduXCore object: no literal throw. Allocation is NOT
+#                  forbidden here - mdux.evidence.json and mdux.governance legitimately allocate.
+#
+# Run as a ctest via `cmake -P`, not at configure time, because the object files do not exist until
+# after a build.
+#
+# ## ml-noheap
 #
 # The delete operators are in the forbidden set alongside the new ones deliberately. A reference to
 # `operator delete` means the object owns heap memory just as surely as a reference to `operator
 # new` does - often more visibly, because a destructor emitted for a std container is what pulls it
 # in. So a failure naming a delete symbol means the same thing as one naming new: something in the
-# governed ML zone acquired owning memory. Run as a ctest via `cmake -P`, not at configure time, because
-# the object files do not exist until after a build.
+# governed ML zone acquired owning memory.
 #
 # Where layer 1 (tests/ml/NoHeapTests.cpp) proves predict() does not allocate *when run*, this
 # proves the kernels and the runtime cannot allocate *at all* - no path through them, taken or not,
 # reaches operator new or malloc. It is also far cheaper, and it fails in the PR that introduced
 # the reference rather than whenever someone next executes that path.
 #
-# __cxa_throw is in the forbidden set for a second reason: it double-checks ADR-005's no-throwing
-# rule for the governed zone. A std::vector::at() or a std::stoi() that crept in would show up here
-# as a throw reference even if it never allocated.
+# ## governed-throw
+#
+# ADR-005 says governed code does not throw. The source lint checks that at the source level; this
+# checks it in the emitted objects, which is the stronger of the two - it sees through a std
+# facility that throws on a path the source never spells out.
+#
+# **What it forbids, precisely: a literal `throw`.** `__cxa_throw` is what the compiler emits for a
+# throw expression, and no MduXCore object references it.
+#
+# **What it deliberately does not forbid** is libstdc++'s throw *helpers* -
+# `std::__throw_length_error`, `std::__throw_logic_error`, `std::__throw_out_of_range_fmt`. Eight
+# governed objects reference them today, and they arrive from inside `std::string` and
+# `std::vector`: growth paths reference `__throw_length_error`, and `std::string_view::substr`
+# references `__throw_out_of_range_fmt` even where the caller's invariant makes the throw
+# unreachable (Json.cpp's parser and Governance.cpp's id splitting are both of that shape).
+#
+# Forbidding those would mean banning `std::string`, `std::vector` and `substr` from the governed
+# zone outright. That may be the right end state for a Class C build, but it is a much larger
+# decision than this scan, and it needs its own ADR. Until then this file reports the helper
+# references rather than failing on them, so that they stay visible and counted instead of being
+# quietly implied not to exist. See ADR-005 for the claim as it is actually made.
 #
 # Expected variables (passed with -D):
+#   MDUX_SCAN_PROFILE       - "ml-noheap" or "governed-throw"
 #   MDUX_NOHEAP_OBJECT_LIST - path to a newline-separated file of object paths, written by
 #                             file(GENERATE) so that a generator expression resolves per config
 #   MDUX_NOHEAP_TOOL        - "nm" or "dumpbin"
 #   MDUX_NOHEAP_COMMAND     - path to that tool
+
+if(NOT DEFINED MDUX_SCAN_PROFILE)
+    message(FATAL_ERROR
+        "MduXNoHeapScan: MDUX_SCAN_PROFILE is not set. Pass 'ml-noheap' or 'governed-throw' - "
+        "defaulting would let a caller get the wrong forbidden set without noticing.")
+endif()
 
 if(NOT DEFINED MDUX_NOHEAP_OBJECT_LIST OR NOT EXISTS "${MDUX_NOHEAP_OBJECT_LIST}")
     message(FATAL_ERROR
@@ -35,33 +69,64 @@ file(STRINGS "${MDUX_NOHEAP_OBJECT_LIST}" MDUX_NOHEAP_OBJECTS)
 if(MDUX_NOHEAP_OBJECTS STREQUAL "")
     message(FATAL_ERROR
         "MduXNoHeapScan: the object list is empty. That would make this test pass by checking "
-        "nothing - the ML sources are expected to be part of MduXCore.")
+        "nothing - the '${MDUX_SCAN_PROFILE}' profile expects objects to be part of MduXCore.")
 endif()
 
 # Mangled and demangled spellings both, so this works whether or not the tool demangles.
-set(forbidden_symbols
-    "operator new"
-    "operator delete"
-    "_Znwm"      # operator new(unsigned long)
-    "_Znam"      # operator new[](unsigned long)
-    "_ZdlPv"     # operator delete(void*)
-    "_ZdaPv"     # operator delete[](void*)
-    "malloc"
-    "calloc"
-    "realloc"
-    "__cxa_throw"
-    "??2@"       # MSVC operator new
-    "??_U@"      # MSVC operator new[]
-)
+if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
+    set(forbidden_symbols
+        "operator new"
+        "operator delete"
+        "_Znwm"      # operator new(unsigned long)
+        "_Znam"      # operator new[](unsigned long)
+        "_ZdlPv"     # operator delete(void*)
+        "_ZdaPv"     # operator delete[](void*)
+        "malloc"
+        "calloc"
+        "realloc"
+        "__cxa_throw"
+        "??2@"       # MSVC operator new
+        "??_U@"      # MSVC operator new[]
+    )
+    set(reported_symbols "")
+    # One string, not a list of strings: message() concatenates its own arguments cleanly, but a
+    # ;-separated list expanded through ${} arrives with the separators embedded in the text.
+    string(CONCAT violation_explanation
+        "mdux.ml.kernels and mdux.ml.runtime must reach neither. If this is a std facility that "
+        "allocates only on a path you believe is unreachable, that is not sufficient - the device "
+        "build must not contain the reference at all.")
+elseif(MDUX_SCAN_PROFILE STREQUAL "governed-throw")
+    set(forbidden_symbols
+        "__cxa_throw"
+        "__cxa_rethrow"
+        "_CxxThrowException"   # MSVC
+    )
+    # Counted and printed, never failed on. See the header comment.
+    set(reported_symbols
+        "__throw_length_error"
+        "__throw_logic_error"
+        "__throw_out_of_range"
+        "__throw_bad_alloc"
+    )
+    string(CONCAT violation_explanation
+        "A governed module contains a throw expression. ADR-005 requires governed code to report "
+        "failure through mdux.core.result instead. If the throwing construct is unavoidable, the "
+        "module belongs in the host-tools zone - which is where mdux.text.raster went in #116.")
+else()
+    message(FATAL_ERROR
+        "MduXNoHeapScan: unknown MDUX_SCAN_PROFILE '${MDUX_SCAN_PROFILE}'. Expected 'ml-noheap' "
+        "or 'governed-throw'.")
+endif()
 
 set(violations "")
+set(reported "")
 set(scanned_count 0)
 
 foreach(object ${MDUX_NOHEAP_OBJECTS})
     if(NOT EXISTS "${object}")
         message(FATAL_ERROR
             "MduXNoHeapScan: object '${object}' does not exist. The scan would otherwise pass by "
-            "checking nothing - build the ML targets before running this test.")
+            "checking nothing - build the targets before running this test.")
     endif()
     math(EXPR scanned_count "${scanned_count} + 1")
 
@@ -99,6 +164,12 @@ foreach(object ${MDUX_NOHEAP_OBJECTS})
                 list(APPEND violations "${object_name}: ${line}")
             endif()
         endforeach()
+        foreach(symbol ${reported_symbols})
+            string(FIND "${line}" "${symbol}" found)
+            if(NOT found EQUAL -1)
+                list(APPEND reported "${object_name}: ${line}")
+            endif()
+        endforeach()
     endforeach()
 endforeach()
 
@@ -106,11 +177,26 @@ if(violations)
     list(REMOVE_DUPLICATES violations)
     string(REPLACE ";" "\n  " violation_text "${violations}")
     message(FATAL_ERROR
-        "No-heap violation (ADR-008, issue #63): the ML objects reference an allocator or the "
-        "throwing runtime.\n  ${violation_text}\n"
-        "mdux.ml.kernels and mdux.ml.runtime must reach neither. If this is a std facility that "
-        "allocates only on a path you believe is unreachable, that is not sufficient - the device "
-        "build must not contain the reference at all.")
+        "Symbol scan violation (profile '${MDUX_SCAN_PROFILE}'):\n  ${violation_text}\n"
+        "${violation_explanation}")
 endif()
 
-message(STATUS "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")
+# Printed rather than failed on, and printed every run rather than only when the count changes:
+# a tolerated reference that nobody sees becomes a reference nobody remembers tolerating.
+if(reported)
+    list(REMOVE_DUPLICATES reported)
+    list(LENGTH reported reported_count)
+    string(REPLACE ";" "\n  " reported_text "${reported}")
+    message(STATUS
+        "MduXNoHeapScan: ${reported_count} tolerated throw-helper reference(s), from std::string, "
+        "std::vector and std::string_view::substr internals - see this file's header and ADR-005 "
+        "for why these are reported rather than forbidden:\n  ${reported_text}")
+endif()
+
+if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")
+else()
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} governed object(s) contain no throw expression")
+endif()

--- a/cmake/MduXNoHeapScan.cmake
+++ b/cmake/MduXNoHeapScan.cmake
@@ -30,19 +30,29 @@
 # checks it in the emitted objects, which is the stronger of the two - it sees through a std
 # facility that throws on a path the source never spells out.
 #
-# **What it forbids, precisely: a literal `throw`.** `__cxa_throw` is what the compiler emits for a
-# throw expression, and no MduXCore object references it.
+# **This profile is only a gate on GCC/Clang, and reports rather than fails on MSVC.** The reason
+# is a genuine difference in how the two standard libraries generate code, not a gap in effort.
 #
-# **What it deliberately does not forbid** is libstdc++'s throw *helpers* -
-# `std::__throw_length_error`, `std::__throw_logic_error`, `std::__throw_out_of_range_fmt`. Eight
-# governed objects reference them today, and they arrive from inside `std::string` and
-# `std::vector`: growth paths reference `__throw_length_error`, and `std::string_view::substr`
-# references `__throw_out_of_range_fmt` even where the caller's invariant makes the throw
-# unreachable (Json.cpp's parser and Governance.cpp's id splitting are both of that shape).
+# On libstdc++, a `throw` expression emits `__cxa_throw`, while the library's own throw sites go
+# through out-of-line helpers - `std::__throw_length_error`, `std::__throw_logic_error`,
+# `std::__throw_out_of_range_fmt`. The two are therefore distinguishable in the object, and this
+# profile forbids the first while reporting the second. Eight governed objects reference the
+# helpers, all from inside `std::string` and `std::vector`: growth paths reference
+# `__throw_length_error`, and `std::string_view::substr` references `__throw_out_of_range_fmt` even
+# where the caller's invariant makes the throw unreachable (Json.cpp's parser and Governance.cpp's
+# id splitting are both of that shape).
 #
-# Forbidding those would mean banning `std::string`, `std::vector` and `substr` from the governed
-# zone outright. That may be the right end state for a Class C build, but it is a much larger
-# decision than this scan, and it needs its own ADR. Until then this file reports the helper
+# On the MSVC STL those throw sites are **inlined into the caller**, so the same `std::string` use
+# emits `_CxxThrowException` directly in the governed object - the identical symbol a hand-written
+# `throw` would emit. Nine governed objects reference it, and `mdux-governed-lint` independently
+# confirms there is no `throw` in any of their sources. The symbol simply cannot tell the two apart
+# there, so forbidding it would fail the build on correct code, and tolerating it would forbid
+# nothing at all. It is reported instead, and the source lint - which is toolchain-independent - is
+# what enforces the rule on Windows.
+#
+# Forbidding the helpers on GCC would mean banning `std::string`, `std::vector` and `substr` from
+# the governed zone outright. That may be the right end state for a Class C build, but it is a much
+# larger decision than this scan, and it needs its own ADR. Until then this file reports those
 # references rather than failing on them, so that they stay visible and counted instead of being
 # quietly implied not to exist. See ADR-005 for the claim as it is actually made.
 #
@@ -89,6 +99,7 @@ if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
         "??_U@"      # MSVC operator new[]
     )
     set(reported_symbols "")
+    set(reported_explanation "")
     # One string, not a list of strings: message() concatenates its own arguments cleanly, but a
     # ;-separated list expanded through ${} arrives with the separators embedded in the text.
     string(CONCAT violation_explanation
@@ -96,18 +107,39 @@ if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
         "allocates only on a path you believe is unreachable, that is not sufficient - the device "
         "build must not contain the reference at all.")
 elseif(MDUX_SCAN_PROFILE STREQUAL "governed-throw")
-    set(forbidden_symbols
-        "__cxa_throw"
-        "__cxa_rethrow"
-        "_CxxThrowException"   # MSVC
-    )
-    # Counted and printed, never failed on. See the header comment.
-    set(reported_symbols
-        "__throw_length_error"
-        "__throw_logic_error"
-        "__throw_out_of_range"
-        "__throw_bad_alloc"
-    )
+    # Toolchain-dependent, because the distinction this profile rests on is a property of the
+    # standard library's code generation rather than of the source. See the header comment.
+    if(MDUX_NOHEAP_TOOL STREQUAL "dumpbin")
+        set(forbidden_symbols "")
+        set(reported_symbols
+            "_CxxThrowException"
+            "_Xlength_error"
+            "_Xout_of_range"
+            "_Xbad_alloc"
+            "_Xinvalid_argument"
+        )
+        string(CONCAT reported_explanation
+            "tolerated throw reference(s). The MSVC STL inlines its own throw sites, so "
+            "_CxxThrowException in a governed object is indistinguishable from a hand-written "
+            "throw - see this file's header. mdux-governed-lint is what enforces the no-throw rule "
+            "on this toolchain; this scan is informational here")
+    else()
+        set(forbidden_symbols
+            "__cxa_throw"
+            "__cxa_rethrow"
+        )
+        # Counted and printed, never failed on.
+        set(reported_symbols
+            "__throw_length_error"
+            "__throw_logic_error"
+            "__throw_out_of_range"
+            "__throw_bad_alloc"
+        )
+        string(CONCAT reported_explanation
+            "tolerated throw-helper reference(s), from std::string, std::vector and "
+            "std::string_view::substr internals - see this file's header and ADR-005 for why "
+            "these are reported rather than forbidden")
+    endif()
     string(CONCAT violation_explanation
         "A governed module contains a throw expression. ADR-005 requires governed code to report "
         "failure through mdux.core.result instead. If the throwing construct is unavoidable, the "
@@ -188,15 +220,20 @@ if(reported)
     list(LENGTH reported reported_count)
     string(REPLACE ";" "\n  " reported_text "${reported}")
     message(STATUS
-        "MduXNoHeapScan: ${reported_count} tolerated throw-helper reference(s), from std::string, "
-        "std::vector and std::string_view::substr internals - see this file's header and ADR-005 "
-        "for why these are reported rather than forbidden:\n  ${reported_text}")
+        "MduXNoHeapScan: ${reported_count} ${reported_explanation}:\n  ${reported_text}")
 endif()
 
 if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
     message(STATUS
         "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")
-else()
+elseif(forbidden_symbols)
     message(STATUS
         "MduXNoHeapScan: ${scanned_count} governed object(s) contain no throw expression")
+else()
+    # Never "no throw expression" here - nothing was forbidden, so nothing was established. Saying
+    # otherwise would be the exact shape of unearned claim issue #116 exists to remove.
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} governed object(s) scanned; this toolchain cannot "
+        "distinguish a governed throw from an inlined std one, so no verdict is claimed here - "
+        "mdux-governed-lint enforces the rule at source level")
 endif()

--- a/docs/adr/ADR-004-trust-zones-in-cpp.md
+++ b/docs/adr/ADR-004-trust-zones-in-cpp.md
@@ -186,11 +186,11 @@ context:
 
 > Governed targets have no declared platform or graphics dependencies; their sources are checked
 > to reject direct inclusion of platform, graphics, and OS headers, are checked by an enforced
-> static-analysis profile, contain no throw expression in either their source or their emitted
-> objects, and are covered by determinism tests. This is **not** a claim that governed modules
-> cannot contain undefined behaviour, that compiler system headers are physically inaccessible,
-> that governed code cannot reach a throwing standard-library helper, or that governed targets can
-> be built with `-fno-exceptions`.
+> static-analysis profile, contain no throw expression — verified at source level on every
+> toolchain and additionally in the emitted objects on GCC/Clang — and are covered by determinism
+> tests. This is **not** a claim that governed modules cannot contain undefined behaviour, that
+> compiler system headers are physically inaccessible, that governed code cannot reach a throwing
+> standard-library helper, or that governed targets can be built with `-fno-exceptions`.
 
 Each clause of that paragraph names a mechanism that runs in CI, and each exclusion names something
 that was checked and found not to hold — see ADR-005's "What is enforced" for the throw-related

--- a/docs/adr/ADR-004-trust-zones-in-cpp.md
+++ b/docs/adr/ADR-004-trust-zones-in-cpp.md
@@ -62,12 +62,22 @@ existing precedent):
    accidental use of SDK-private headers that are reachable only through those targets. It does
    **not** make system-installed headers unreachable: a compiler may still find Vulkan, platform,
    or OS headers in its default search paths.
-2. **A mandatory CI banned-include lint** over governed directories rejects direct inclusion of
-   Vulkan, GLFW, platform, and OS headers. The same lint bans `reinterpret_cast`, `const_cast`,
-   `new `, `malloc`, `<random>`, `std::chrono::*_clock::now`, `std::fma`, `getenv`,
-   `std::filesystem`, and decimal float format specifiers (`%f`, `%g`, `%e`) in evidence-writing
-   code. This check, rather than include-directory isolation alone, enforces the source-level header
-   boundary on machines where those SDKs are installed.
+2. **`mdux-governed-lint`** (`tools/governed-lint/`, CI job `Governed Source Lint`, issue #116)
+   rejects direct inclusion of Vulkan, GLFW, platform and OS headers (GOV009), plus
+   `reinterpret_cast`, `const_cast`, raw `new`/`delete`/`malloc`, `<random>`,
+   `std::chrono::*_clock`, `std::fma`, `getenv`, `std::filesystem`, console streams, `throw`,
+   `try`/`catch` and throwing `.value()`. This check, rather than include-directory isolation
+   alone, enforces the source-level header boundary on machines where those SDKs are installed.
+
+   It scans exactly the sources `CMakeLists.txt` lists for `MduXCore`, parsed out of that block, so
+   a module is enrolled by being registered rather than by a second list someone maintains — and
+   generated code, which lives in the build tree, is excluded by construction. Matching runs on the
+   source with comments and string literals removed, so documentation may discuss the constructs it
+   bans. A line ending `mdux-governed-lint:allow` is a per-line, reviewed exception; there are two
+   in the tree, both the weights-blob `reinterpret_cast` in `src/ml/Runtime.cpp`.
+
+   Decimal float format specifiers in evidence-writing code are `mdux-evidence-lint`'s rule, not
+   this one — ADR-007 owns that boundary.
 3. **Configure-time link-graph assertion.** `cmake/MduXTrustZones.cmake` provides
    `mdux_declare_governed(<target>)`, recording the target in a global property, and
    `mdux_verify_trust_zones()`, called once at the end of the top-level `CMakeLists.txt`, which
@@ -88,8 +98,11 @@ existing precedent):
 
 - Nothing stops a governed module from writing undefined behavior inside its own translation unit.
   There is no `unsafe` keyword and no borrow checker to forbid.
-- `import std;` gives governed code `std::vector`, threads, and file/network I/O. Only the grep
-  lint (item 2) and code review keep those out of a module that should not need them.
+- `import std;` gives governed code `std::vector`, threads, and file/network I/O. Only
+  `mdux-governed-lint` (item 2) and code review keep those out of a module that should not need
+  them. `import std` also has a second cost, found in #116: it makes `-fno-exceptions` unavailable
+  to the governed zone, because GCC records the dialect in each module BMI and CMake synthesises
+  one shared `std` target for the whole build. See ADR-005, "What is enforced".
 - clang-tidy's analysis of C++23 module interface units is immature as of this writing. Run it in
   the Clang CI leg only (once issue #48 re-enables that leg); treat its results as advisory on
   Windows/MSVC.
@@ -122,7 +135,24 @@ evidence, draw-list, and ML modules to it as they land. `mdux.vulkansc.memory` a
 `mdux.vulkansc.objects` remain in the adapter zone — they take `VkDevice` in their public APIs by
 design and are not candidates for `MduXCore`.
 
-## Consequences
+### What allocation means for zone placement (issue #116)
+
+A module that allocates cannot be governed if its allocation failure has to be reported rather than
+terminate the process, because `std::vector` reports that failure by throwing.
+
+`mdux.text.raster` was governed on the argument that a device path might one day need to rasterise,
+which ADR-008 decision 1 would then require to be *that* module rather than a second one. It moved
+to the host-tools zone in #116. It allocates — the coverage accumulator alone can ask for 256 MiB —
+and `rasterise()`'s `noexcept` entry point therefore catches `std::bad_alloc` to turn an
+out-of-memory condition into a diagnostic instead of `std::terminate`. That is correct code, and it
+is not governed code.
+
+The general rule this establishes: **a speculative future device consumer does not justify governed
+placement against a present constraint.** The rasteriser runs once per glyph at build time, its
+only callers are `mdux-textbake` and its tests, and nothing on a device has ever called it. Where a
+module genuinely must be governed *and* must allocate, the pattern is `mdux.ml.runtime`'s — take
+caller-supplied scratch storage and never allocate at all, verified by
+`ml.noheap.symbolScan`.
 
 ### Positive
 - Target usage requirements cannot accidentally propagate native SDK dependencies into governed
@@ -156,9 +186,15 @@ context:
 
 > Governed targets have no declared platform or graphics dependencies; their sources are checked
 > to reject direct inclusion of platform, graphics, and OS headers, are checked by an enforced
-> static-analysis profile, and are covered by determinism tests. This is **not** a claim that
-> governed modules cannot contain undefined behaviour or that compiler system headers are
-> physically inaccessible.
+> static-analysis profile, contain no throw expression in either their source or their emitted
+> objects, and are covered by determinism tests. This is **not** a claim that governed modules
+> cannot contain undefined behaviour, that compiler system headers are physically inaccessible,
+> that governed code cannot reach a throwing standard-library helper, or that governed targets can
+> be built with `-fno-exceptions`.
+
+Each clause of that paragraph names a mechanism that runs in CI, and each exclusion names something
+that was checked and found not to hold — see ADR-005's "What is enforced" for the throw-related
+half. Nothing in it is aspirational.
 
 ## References
 - [TrustSC ADR-005: Pure-Rust project boundary and dependency policy](https://github.com/ambroise-leclerc/TrustSC/blob/main/docs/adr/ADR-005-pure-rust-project-boundary-and-dependency-policy.md)
@@ -169,4 +205,7 @@ context:
 ## Approval
 - **Decision Date**: 2026-07-26
 - **Approved By**: Project maintainer
-- **Review Date**: at the next parity-programme epic boundary (issue #12 landing)
+- **Amended**: 2026-08-11 (issue #116) — item 2's banned-include lint exists now and is named;
+  added the allocation-and-zone-placement rule that moved `mdux.text.raster` to host tools; the
+  claim paragraph gained its no-throw clause and its `-fno-exceptions` exclusion.
+- **Review Date**: at the next parity-programme epic boundary (issue #15 landing)

--- a/docs/adr/ADR-005-error-handling-and-exceptions-policy.md
+++ b/docs/adr/ADR-005-error-handling-and-exceptions-policy.md
@@ -95,21 +95,23 @@ Two consequences worth stating plainly:
 
 ### The layers that do run
 
-| Layer | Reads | Where |
-|---|---|---|
-| `mdux-governed-lint` | the source | `tools/governed-lint/`, CI job `Governed Source Lint` |
-| `governed.noThrow.symbolScan` | the emitted objects | `cmake/MduXNoHeapScan.cmake`, a ctest |
-| `bugprone-exception-escape` | the AST | `.clang-tidy` |
+| Layer | Reads | Where | Gates on |
+|---|---|---|---|
+| `mdux-governed-lint` | the source | `tools/governed-lint/`, CI job `Governed Source Lint` | every toolchain |
+| `governed.noThrow.symbolScan` | the emitted objects | `cmake/MduXNoHeapScan.cmake`, a ctest | GCC/Clang; reports only on MSVC |
+| `bugprone-exception-escape` | the AST | `.clang-tidy` | nothing yet — see below |
+
+Only the first is a gate everywhere. That is the honest reading of the table, and the reason the
+source lint rather than the symbol scan is what the no-throw claim rests on.
 
 **`mdux-governed-lint`** rejects `throw`, `try`/`catch`, throwing `.value()`, raw allocation,
 filesystem and console facilities, clocks and randomness, unsafe casts, and `std::fma`. It scans
 exactly the sources `CMakeLists.txt` lists for `MduXCore`, parsed out of that block rather than
 globbed, and matches on the source with comments and string literals removed.
 
-**`governed.noThrow.symbolScan`** is the stronger of the two, and the reason the flags are not
-missed as much as they might be: it sees a throw arriving through a std facility the source never
-spells out, which `-fno-exceptions` would only have caught by refusing to compile the facility.
-It forbids `__cxa_throw` across all 29 governed objects, and none references it.
+**`governed.noThrow.symbolScan`** sees a throw arriving through a std facility the source never
+spells out, which `-fno-exceptions` would only have caught by refusing to compile the facility. It
+forbids `__cxa_throw` across all 29 governed objects, and none references it.
 
 It **tolerates**, and prints on every run, libstdc++'s throw *helpers*: `__throw_length_error`,
 `__throw_logic_error` and `__throw_out_of_range_fmt`, 14 references across eight objects. They
@@ -119,6 +121,19 @@ invariant makes the throw unreachable. Forbidding them means banning those types
 zone outright, which may be the right end state for a Class C build but is a larger decision than
 #116 and needs its own ADR.
 
+**This layer is a gate on GCC/Clang only, and is informational on MSVC.** The distinction it rests
+on — a literal `throw` emits one symbol, the library's own throw sites emit another — is a property
+of libstdc++'s code generation, not a portable one. The MSVC STL inlines its throw sites, so an
+ordinary `std::string` growth path emits `_CxxThrowException` directly into the governed object,
+the identical symbol a hand-written `throw` would emit. Nine governed objects reference it while
+`mdux-governed-lint` confirms none of their sources contains a `throw`.
+
+Forbidding that symbol would fail the build on correct code; tolerating it would forbid nothing. So
+under `dumpbin` the profile forbids nothing, reports what it finds, and its closing message states
+that no verdict is claimed. The rule is still enforced on Windows — by the source lint, which is
+toolchain-independent. What is GCC-specific is only the object-level corroboration, and the
+negative fixture is not registered on MSVC for the same reason.
+
 **`bugprone-exception-escape`** is re-enabled, as this ADR's original follow-up asked, but it is
 *available* rather than *enforced*: the only CI job running clang-tidy invokes it with `|| true`
 against a GCC-generated compile database it cannot parse for module interface units. It becomes a
@@ -126,10 +141,15 @@ real gate when the Clang leg is restored (issue #48).
 
 ### What is therefore claimed
 
-Governed code contains no throw expression, and no source-level construct from the banned list;
-both are checked mechanically on every pull request. Governed code **can still reach libstdc++'s
-throwing helpers** through ordinary `std::string` and `std::vector` use, and `MduXCore` **cannot
-currently be compiled with `-fno-exceptions`**. Anything stronger than that is not established.
+Governed code contains no throw expression and no source-level construct from the banned list,
+checked mechanically on every pull request and on every toolchain by `mdux-governed-lint`. On
+GCC/Clang that is independently corroborated in the emitted objects.
+
+Three things are **not** established. Governed code can still reach the standard library's throwing
+helpers through ordinary `std::string` and `std::vector` use. The object-level check does not gate
+on MSVC, so the no-throw property is single-sourced to the source lint there. And `MduXCore` cannot
+currently be compiled with `-fno-exceptions` on any toolchain. Anything stronger than the paragraph
+above is not established.
 
 **`MedicalUiRenderer`'s throwing constructor was grandfathered**, not retrofitted — it lived in the
 adapter zone and was scheduled for deletion with the HTML/CSS UI path rather than for a

--- a/docs/adr/ADR-005-error-handling-and-exceptions-policy.md
+++ b/docs/adr/ADR-005-error-handling-and-exceptions-policy.md
@@ -13,8 +13,9 @@ MduX ↔ TrustSC parity programme requires:
   `src/mdux.cpp` was trimmed from 575 lines to 85 in the same change, so any line number here
   would now point at something unrelated. Git history is the reference for what it looked like.
 - `include/mdux/vulkansc/MemoryPoolManager.cppm:100` documents throwing behavior.
-- `.clang-tidy:9` **disables** `bugprone-exception-escape` — the check that would otherwise flag an
-  exception escaping a `noexcept` boundary.
+- `.clang-tidy` **disabled** `bugprone-exception-escape` — the check that would otherwise flag an
+  exception escaping a `noexcept` boundary. Re-enabled by issue #116; see "What is enforced" below
+  for what that is and is not worth.
 
 Separately, ADR-004 introduces a governed zone (`MduXCore`) whose whole purpose is to be usable in
 contexts a Vulkan-linked adapter target is not — including Class C / Vulkan SC deployments that
@@ -38,22 +39,23 @@ regardless of how clean its exception hierarchy is.
 
 | Zone | Rule |
 |---|---|
-| Governed (`MduXCore`) | `std::expected` and `noexcept` throughout. No throwing. |
+| Governed (`MduXCore`) | `std::expected` and `noexcept` throughout. No throwing — see "What is enforced" for the two layers that check this and the one thing they do not cover. |
 | Adapter (`MduX`) | Exceptions permitted at construction boundaries only, never across a `noexcept` render/predict path. |
 | Host tools (`tools/`) | Exceptions freely — they are never shipped, and their code is not qualified. |
 
 **Why `std::expected` and not exceptions, for the governed zone specifically:** Class C and Vulkan
-SC deployments routinely build with `-fno-exceptions`. The non-throwing operations on
+SC deployments routinely build with `-fno-exceptions`. That the governed zone cannot *currently* be
+built that way (see "What is enforced") does not weaken this reasoning — it is what keeps the
+option open, since an exception-based API would foreclose it permanently rather than temporarily.
+The non-throwing operations on
 `std::expected` do not require exception handling, and it is available on MSVC 19.33+, GCC 12+, and
 Clang 16+ — all comfortably below this project's enforced floor of MSVC 19.40 / GCC 15 / Clang 20
 (ADR-003), so adopting it costs nothing in toolchain reach. Throwing observers such as `.value()`
 remain prohibited in governed code.
 
-**Make it a build error, not a review comment.** Compile `MduXCore` (or, at minimum, any future
-`src/ml/` target — see issue #18) with `-fno-exceptions -fno-rtti` / `/EHs-c- /GR-` in its own
-object library. The governed-zone source lint also rejects `throw`, `try`, and `catch`; on MSVC,
-the exception-disabled diagnostics are promoted to errors. A stray throwing construct therefore
-fails the build rather than merely triggering a warning that a busy reviewer can miss.
+**Make it a build error, not a review comment.** A stray throwing construct fails CI rather than
+merely triggering a warning a busy reviewer can miss. What does the failing is described in "What
+is enforced" below, and it is not what this ADR originally specified.
 
 **Error types carry evidence.** A governed-zone error is a struct, not a bare enum, whenever the
 failure has diagnostic content worth keeping — e.g. the planned `MlError` (issue #18) records the
@@ -61,9 +63,73 @@ diverging layer index, golden-vector index, element index, and both the expected
 patterns. That struct is the audit record if a device fails closed in the field; a bare error code
 would discard exactly the information an incident report needs.
 
-**Re-enable `bugprone-exception-escape`** in the governed zone's `.clang-tidy` (see ADR-004) once
-`MduXCore` exists, so a `noexcept` violation is caught by static analysis rather than only at
-runtime or at link time.
+## What is enforced
+
+Added by issue #116, which found this ADR asserting in the present tense a lint that had never been
+written. The list below is exhaustive, and each entry names the file that does the work so a reader
+can check the claim rather than take it.
+
+### The constraint that shaped this
+
+**`import std` and `-fno-exceptions` are mutually exclusive on GCC 16.** This ADR originally
+specified compiling `MduXCore` with `-fno-exceptions -fno-rtti` / `/EHs-c- /GR-`. That is not
+available while the governed zone uses `import std`:
+
+- GCC records the language dialect in every module BMI. A governed module compiled with either flag
+  is rejected against the shared `std` BMI with `language dialect differs 'C++23', expected
+  'C++23/no-exceptions/no-rtti'`. Each flag fails this way on its own, not only in combination.
+- CMake synthesises exactly one `__CMAKE__CXX23` std target for the whole build, shared by the
+  adapter and host-tools targets, which must keep exceptions. There is no per-target std dialect.
+
+A separately built governed-dialect `std` BMI does work when driven by hand, so the constraint is
+the *sharing*, not the flags. Hand-rolling one would displace the most fragile part of this build,
+and was judged not worth it against the alternatives below.
+
+Two consequences worth stating plainly:
+
+1. The "usable in `-fno-exceptions` builds" claim under Consequences is **not currently true**, and
+   is not achievable by any project consuming `MduXCore` through `import std`. It is retained below
+   as the motivation for the `std::expected` API, which it still is, and marked as unmet.
+2. Revisiting this needs either a per-target std dialect from CMake, or the governed zone giving up
+   `import std`. Neither is scheduled.
+
+### The layers that do run
+
+| Layer | Reads | Where |
+|---|---|---|
+| `mdux-governed-lint` | the source | `tools/governed-lint/`, CI job `Governed Source Lint` |
+| `governed.noThrow.symbolScan` | the emitted objects | `cmake/MduXNoHeapScan.cmake`, a ctest |
+| `bugprone-exception-escape` | the AST | `.clang-tidy` |
+
+**`mdux-governed-lint`** rejects `throw`, `try`/`catch`, throwing `.value()`, raw allocation,
+filesystem and console facilities, clocks and randomness, unsafe casts, and `std::fma`. It scans
+exactly the sources `CMakeLists.txt` lists for `MduXCore`, parsed out of that block rather than
+globbed, and matches on the source with comments and string literals removed.
+
+**`governed.noThrow.symbolScan`** is the stronger of the two, and the reason the flags are not
+missed as much as they might be: it sees a throw arriving through a std facility the source never
+spells out, which `-fno-exceptions` would only have caught by refusing to compile the facility.
+It forbids `__cxa_throw` across all 29 governed objects, and none references it.
+
+It **tolerates**, and prints on every run, libstdc++'s throw *helpers*: `__throw_length_error`,
+`__throw_logic_error` and `__throw_out_of_range_fmt`, 14 references across eight objects. They
+arrive from inside `std::string`, `std::vector` and `std::string_view::substr` — `Json.cpp`'s
+parser and `Governance.cpp`'s id splitting are both of that shape, and in both the caller's
+invariant makes the throw unreachable. Forbidding them means banning those types from the governed
+zone outright, which may be the right end state for a Class C build but is a larger decision than
+#116 and needs its own ADR.
+
+**`bugprone-exception-escape`** is re-enabled, as this ADR's original follow-up asked, but it is
+*available* rather than *enforced*: the only CI job running clang-tidy invokes it with `|| true`
+against a GCC-generated compile database it cannot parse for module interface units. It becomes a
+real gate when the Clang leg is restored (issue #48).
+
+### What is therefore claimed
+
+Governed code contains no throw expression, and no source-level construct from the banned list;
+both are checked mechanically on every pull request. Governed code **can still reach libstdc++'s
+throwing helpers** through ordinary `std::string` and `std::vector` use, and `MduXCore` **cannot
+currently be compiled with `-fno-exceptions`**. Anything stronger than that is not established.
 
 **`MedicalUiRenderer`'s throwing constructor was grandfathered**, not retrofitted — it lived in the
 adapter zone and was scheduled for deletion with the HTML/CSS UI path rather than for a
@@ -97,12 +163,16 @@ call-site brevity; that is a naming convenience, not a reimplementation.
 ## Consequences
 
 ### Positive
-- The governed zone becomes usable in `-fno-exceptions` builds, which is a prerequisite for taking
-  any Vulkan SC / Class C deployment claim seriously rather than as aspiration.
+- **Unmet.** The governed zone was to become usable in `-fno-exceptions` builds, a prerequisite for
+  taking any Vulkan SC / Class C deployment claim seriously rather than as aspiration. `import std`
+  blocks it — see "The constraint that shaped this". The `std::expected` API is still the right
+  shape for that goal, and is what makes it reachable if the constraint ever lifts, but the goal is
+  not reached today.
 - Structured error types double as incident-evidence records, which is directly useful for the
   fail-closed patterns already planned for `.medui` compilation and ML inference.
-- The exception-disabled object library turns throwing constructs into build failures, closing the
-  gap left by `.clang-tidy:9` currently disabling the one check that would otherwise catch this.
+- A throwing construct fails CI — through `mdux-governed-lint` at the source level and
+  `governed.noThrow.symbolScan` at the object level, rather than through the exception-disabled
+  object library this ADR first proposed.
 
 ### Negative
 - Two error-handling idioms coexist in the codebase: the host-tools zone throws (the TOML parser
@@ -113,13 +183,22 @@ call-site brevity; that is a naming convenience, not a reimplementation.
   happy-path case — an accepted cost given the deployment constraint that motivates this decision.
 
 ### Risks and Mitigations
-- **A future governed-zone PR quietly adds a `throw`.** *Mitigation*: the exception-disabled object
-  library makes this a compile failure, not a style question.
+- **A future governed-zone PR quietly adds a `throw`.** *Mitigation*: `mdux-governed-lint` rejects
+  the construct and `governed.noThrow.symbolScan` rejects the resulting `__cxa_throw` reference.
+  Two independent layers, both required to pass, neither able to see everything the other does.
 - **`std::expected` gets used inconsistently** (some call sites check it, others `.value()` it and
-  risk termination when the expected is empty). *Mitigation*: the governed-zone CI lint rejects
-  `.value()`; callers must branch on `has_value()`/`operator bool` and then use non-throwing
-  accessors. The re-enabled `bugprone-exception-escape` check remains defense in depth for other
-  exception paths.
+  risk termination when the expected is empty). *Mitigation*: `mdux-governed-lint` rejects
+  `.value()` (GOV003); callers must branch on `has_value()`/`operator bool` and then use
+  non-throwing accessors.
+- **A governed module reaches a throwing std facility on a path that is actually taken.** The
+  tolerated `__throw_*` helper references are believed unreachable because of caller invariants,
+  and that belief is not mechanically checked. *Mitigation*: none today, stated rather than
+  papered over. The scan prints all 14 references on every run so they stay counted, and the ADR
+  that decides whether to ban `std::string` and `std::vector` from the governed zone is the
+  place to resolve it.
+- **A module is added to `MduXCore` and the lint does not notice.** *Mitigation*: the lint derives
+  its file list from the `target_sources(MduXCore ...)` block, so registering the module is what
+  enrols it. There is no second list to forget.
 
 ## References
 - [TrustSC ADR-001 through ADR-003](https://github.com/ambroise-leclerc/TrustSC/tree/main/docs/adr) (the text/font pipeline's fail-closed self-test pattern this policy is modeled on)
@@ -129,4 +208,9 @@ call-site brevity; that is a naming convenience, not a reimplementation.
 ## Approval
 - **Decision Date**: 2026-07-26
 - **Approved By**: Project maintainer
-- **Review Date**: when `MduXCore` first ships a public API (issue #11, S7)
+- **Amended**: 2026-08-11 (issue #116) — added "What is enforced", recording that `import std`
+  blocks the `-fno-exceptions` build this ADR specified, and replacing the never-written
+  exception-disabled object library with the two layers that do run.
+- **Review Date**: when either CMake gains a per-target `import std` dialect or the governed zone
+  stops using `import std`, whichever comes first — both would reopen the `-fno-exceptions`
+  question this ADR had to leave unmet.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,6 @@ are ordinary `PRIVATE` sources.
 | `mdux.governance.compliance` | `include/mdux/governance/Compliance.cppm` | `src/governance/Compliance.cpp` |
 | `mdux.shader.schema` | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
 | `mdux.text.schema` | `include/mdux/text/Schema.cppm` | `src/text/Schema.cpp` |
-| `mdux.text.raster` | `include/mdux/text/Raster.cppm` | `src/text/Raster.cpp` |
 | `mdux.font.schema` | `include/mdux/font/Schema.cppm` | `src/font/Schema.cpp` |
 | `mdux.text.draw` | `include/mdux/text/Draw.cppm` | `src/text/Draw.cpp` |
 | `mdux.draw` | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
@@ -89,10 +88,15 @@ performs no checking and confers no compliance.
 | `MduXToolsCommon` | `tools/common/` | TOML subset reader, CLI parser, shared diagnostic envelope |
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
-| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158) and `mdux.tools.atlaspacker` (the shelf packer, #160) |
+| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
+
+`mdux.text.raster` was governed until [#116](https://github.com/ambroise-leclerc/MduX/issues/116).
+It allocates, and `std::vector` reports failure by throwing, so it could not remain in a target
+compiled with `-fno-exceptions`. It runs once per glyph at build time and never on a device, which
+is what made the host-tools zone the right home rather than a reason to rewrite it.
 
 ## The Vulkan boundary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,7 +191,7 @@ Labels select the evidence-bearing suites:
 | `evidence-unit` | unit tests of the evidence modules themselves |
 | `determinism` | the ML kernels produce the frozen bit patterns |
 | `noheap` | `predict()` performs no allocation |
-| `governed` | no governed object contains a throw expression ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)) |
+| `governed` | no governed object contains a throw expression — a gate on GCC/Clang, informational on MSVC ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)) |
 | `pixel` | rendered output matches expectations, under lavapipe |
 | `regulatory` | corpus indexes and schemas are current |
 
@@ -200,10 +200,16 @@ must not produce the same CI signal. `governed` is separate from `noheap` for th
 run `cmake/MduXNoHeapScan.cmake`, but over different objects with different forbidden sets, and a
 CI leg selecting one should not silently start covering the other.
 
-`governed` includes a negative test. `governed.noThrow.symbolScan.negative` scans a deliberately
-non-conforming object (`tests/governed/ThrowFixture.cpp`) and passes only when the scan rejects it
-with the expected message — because a check that has only ever run against conforming code passes
-identically when it is working and when it is looking for the wrong thing.
+`governed` includes a negative test on GCC/Clang. `governed.noThrow.symbolScan.negative` scans a
+deliberately non-conforming object (`tests/governed/ThrowFixture.cpp`) and passes only when the scan
+rejects it with the expected message — because a check that has only ever run against conforming
+code passes identically when it is working and when it is looking for the wrong thing.
+
+Neither test gates on MSVC, and the reason is worth knowing: the MSVC STL inlines its own throw
+sites, so `_CxxThrowException` in a governed object is the same symbol whether it came from a
+hand-written `throw` or from a `std::string` growth path. The scan reports there instead of
+failing, and [`mdux-governed-lint`](../tools/governed-lint/) — which reads source and is
+toolchain-independent — is what enforces the rule on Windows.
 
 ## Install and export
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,8 +32,17 @@ It is a *link-graph* property, checked mechanically.
 
 **What it is not:** it is not `#![forbid(unsafe_code)]`. It does not prove the absence of undefined
 behaviour, and no combination of C++ tooling here does. Governed modules are compiled without access
-to platform, graphics or OS headers, are covered by determinism and no-heap tests, and are held to
-an enforced warning set — that is the whole of the claim.
+to platform, graphics or OS headers, are checked at the source level by
+[`mdux-governed-lint`](../tools/governed-lint/) and at the object level by
+`governed.noThrow.symbolScan`, are covered by determinism and no-heap tests, and are held to an
+enforced warning set — that is the whole of the claim.
+
+Two things that claim deliberately does not include. Governed code can still reach libstdc++'s
+throwing helpers through ordinary `std::string` and `std::vector` use — 14 such references exist and
+the scan prints them on every run rather than implying otherwise. And `MduXCore` cannot be built
+with `-fno-exceptions`: `import std` and that flag are mutually exclusive on GCC, because the std
+BMI records its dialect and CMake synthesises one shared std target. Both are recorded in
+[ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md), "What is enforced".
 
 ## Modules
 
@@ -182,11 +191,19 @@ Labels select the evidence-bearing suites:
 | `evidence-unit` | unit tests of the evidence modules themselves |
 | `determinism` | the ML kernels produce the frozen bit patterns |
 | `noheap` | `predict()` performs no allocation |
+| `governed` | no governed object contains a throw expression ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)) |
 | `pixel` | rendered output matches expectations, under lavapipe |
 | `regulatory` | corpus indexes and schemas are current |
 
 The `evidence` / `evidence-unit` split is deliberate: a broken SHA-256 test and a drifted artifact
-must not produce the same CI signal.
+must not produce the same CI signal. `governed` is separate from `noheap` for the same reason: both
+run `cmake/MduXNoHeapScan.cmake`, but over different objects with different forbidden sets, and a
+CI leg selecting one should not silently start covering the other.
+
+`governed` includes a negative test. `governed.noThrow.symbolScan.negative` scans a deliberately
+non-conforming object (`tests/governed/ThrowFixture.cpp`) and passes only when the scan rejects it
+with the expected message — because a check that has only ever run against conforming code passes
+identically when it is working and when it is looking for the wrong thing.
 
 ## Install and export
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,9 +94,10 @@ Host tools parse untrusted input, so they are deliberately outside the governed 
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
 
 `mdux.text.raster` was governed until [#116](https://github.com/ambroise-leclerc/MduX/issues/116).
-It allocates, and `std::vector` reports failure by throwing, so it could not remain in a target
-compiled with `-fno-exceptions`. It runs once per glyph at build time and never on a device, which
-is what made the host-tools zone the right home rather than a reason to rewrite it.
+It allocates, and `std::vector` reports failure by throwing, so its `noexcept` entry point has to
+catch — which [ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md) forbids in governed
+code. It runs once per glyph at build time and never on a device, which is what made the host-tools
+zone the right home rather than a reason to rewrite it.
 
 ## The Vulkan boundary
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 4 August 2026
-> Verified against `develop @ d1329da` · 4 August 2026
+> Backlog · ambroise-leclerc/MduX · updated 11 August 2026
+> Verified against `v0.5.0` · 11 August 2026
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
@@ -14,9 +14,9 @@ generates the screens it draws.
 | Metric | Count |
 |---|---|
 | Epics | 13 |
-| Delivered | 7 |
-| Remaining | 6 |
-| Waves shipped | 3 |
+| Delivered | 9 |
+| Remaining | 4 |
+| Waves shipped | 4 |
 
 ## The thesis
 
@@ -32,10 +32,10 @@ the whole of Track C.
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Five artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
-| Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time. | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
+| Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time, `mdux-governed-lint` rejects the banned construct at source level, and `governed.noThrow.symbolScan` rejects it in the emitted objects (#116). | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Closed (#8, #10). Five standards on real clause structure with per-clause indexes and JSON Schemas, plus the documentation architecture — README derived from real targets, a contiguous ADR index, and a CI lint for internal links and retired paths. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
 | Copyright | Closed (#7). Reproduced text removed from the tree and from history, with `mdux-docs-lint` in CI to keep it out. | Reproducing normative text is forbidden outright; original prose only. |
-| Tests | Closed. 436 tests on `develop`, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
+| Tests | Closed. 438 tests on `develop`, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification, governed-zone no-throw (`governed`, #116, with a negative fixture) and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
 | Packaging | Closed (#11). Install/export restored; MSVC, GCC and Clang presets, with MSVC and GCC 16 both green in CI. | Workspace builds `--locked` on Linux and in containers. |
 
 ## Dependency order
@@ -44,10 +44,12 @@ the whole of Track C.
 
 An epic opens when every epic it depends on has closed. Four waves have shipped
 (v0.2.0, v0.3.0, v0.4.0, v0.5.0), one epic per wave closing the dependency it held.
-Wave 5 is open now: #15's blockers were #12 and #14, both closed. #19 spans waves by design; its S3–S6 follow #15.
+Wave 5 is open now: #15's blockers were #12 and #14, both closed. #11 closed ahead of it with
+`#116` and `#117`, so no enforcement gap carries into the largest epic of the programme.
+#19 spans waves by design; its S3–S6 follow #15.
 
 ```text
-Wave 1 · shipped v0.2.0     #7 (done)   #11 (open · #116, #117)  #19 (S4–S6 open)
+Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
@@ -136,16 +138,27 @@ _All nine closed in PR #154. `#65` also closes the S1 child of #19_
 
 ### Track B · Load-bearing foundations
 
-#### #11 — Foundations & trust-zone skeleton · **Open · Wave 2 enforcement gaps**
+#### #11 — Foundations & trust-zone skeleton · **Done**
 
 A new `MduXCore` that never receives Vulkan's include directories — so
-`#include <vulkan/vulkan.h>` in governed code is a compile error on every platform. Plus
+`#include <vulkan/vulkan.h>` in governed code is rejected on every platform. Plus
 the prerequisites that produce no demo and block everything.
 
 The foundations shipped in Wave 1: `MduXCore` split, link-graph verification, the test
 framework, presets, install/export, and `#48` (GCC 16 CI green; the Clang CI leg stays
-disabled, an honesty scope pinned in ADR-007). The epic stays open for the two enforcement
-gaps that postdate v0.2.0 and were folded back in.
+disabled, an honesty scope pinned in ADR-007). The two enforcement gaps that postdate
+v0.2.0 closed before Wave 5 opened, which closes the epic.
+
+`#116` found the gap it was written for to be live rather than theoretical. ADR-005
+asserted in the present tense a governed-source lint that had never been written, and
+`src/text/Raster.cpp` — governed, shipped in v0.5.0 — contained `try` and three `catch`
+clauses. The intended fix, `-fno-exceptions` on `MduXCore`, turned out to be unavailable:
+GCC records the language dialect in every module BMI and CMake synthesises one shared
+`std` target, so `import std` and `-fno-exceptions` are mutually exclusive. Enforcement
+landed instead as `mdux-governed-lint` over the source and `governed.noThrow.symbolScan`
+over the emitted objects; the rasteriser moved to the host-tools zone; and ADR-004 and
+ADR-005 were rewritten to describe only mechanisms CI runs, including what they still
+cannot claim.
 
 - #40 ADR: trust zones in C++
 - #41 ADR: error handling and exceptions
@@ -159,7 +172,8 @@ gaps that postdate v0.2.0 and were folded back in.
 - #116 S10 — Enforce governed-zone source and exception policy
 - #117 S11 — Stack-safe PR integration and post-merge policy
 
-_Remaining: `#116`, `#117`. Downstream epics are no longer blocked_
+_All eleven closed. `#117`'s PR template and merge-ordering policy land ahead of Wave 5,
+which is the most stacked epic of the programme_
 
 #### #12 — Evidence kernel · **Done v0.3.0**
 
@@ -336,6 +350,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Verified at `v0.5.0` · 9 August 2026_
-_13 epics · 8 delivered · Waves 1–4 shipped · Wave 5 open · #11 enforcement open_
+_Verified at `v0.5.0` · 11 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 open · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -175,6 +175,13 @@ cannot claim.
 _All eleven closed. `#117`'s PR template and merge-ordering policy land ahead of Wave 5,
 which is the most stacked epic of the programme_
 
+> **Closure depends on two independent merges**, and this line exists so that a reader can check
+> rather than assume: `#116` closes with PR #189 (the last of a three-PR stack behind #188 and
+> #187), and `#117` closes with PR #186, which targets `develop` on its own. Neither gates the
+> other in GitHub. If you are reading this and #186 is still open, the "Done" above is ahead of
+> the tree — which is precisely the kind of unearned status `#116` existed to remove, so say so
+> rather than working around it.
+
 #### #12 — Evidence kernel · **Done v0.3.0**
 
 Host-only bakers produce committed artifacts; CI re-derives them and asserts byte-identity.

--- a/src/ml/Runtime.cpp
+++ b/src/ml/Runtime.cpp
@@ -89,7 +89,7 @@ mdux::core::Result<Classifier1D, MlError> Classifier1D::create(const ModelPackag
     //
     // Note the golden self-test below independently covers a *wrong* interpretation of these
     // bytes: if the weights were being read incorrectly, no golden vector would reproduce.
-    const auto blobAddress = reinterpret_cast<std::uintptr_t>(weights.data());
+    const auto blobAddress = reinterpret_cast<std::uintptr_t>(weights.data());  // mdux-governed-lint:allow
     if (!weights.empty() && blobAddress % alignof(float) != 0) {
         return err(MlError{.code = MlError::Code::WeightsUnaligned});
     }
@@ -107,7 +107,7 @@ mdux::core::Result<Classifier1D, MlError> Classifier1D::create(const ModelPackag
     classifier.outputLength_ = package.outputLength;
 
     // Resolve every tensor to a float span once, here, rather than per predict() call.
-    const float* base = weights.empty() ? nullptr : reinterpret_cast<const float*>(weights.data());
+    const float* base = weights.empty() ? nullptr : reinterpret_cast<const float*>(weights.data());  // mdux-governed-lint:allow
     for (std::size_t i = 0; i < package.layers.size(); ++i) {
         const LayerDesc& layer = package.layers[i];
         LayerTensors tensors;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -548,9 +548,10 @@ mdux_discover_tests(ml_spec)
 #
 # Links MduX::Core only. mdux.text.schema is governed and contains no Vulkan handle, so a
 # scenario that needed MduX::MduX to build it would mean the trust-zone boundary had moved -
-# the same standing evidence shader_spec, draw_spec and ml_spec give. S1 ships the schema and a
-# no-run baker skeleton; the TrueType parser (#158), rasteriser (#159), atlas font baker (#160),
-# font schema (#161) and coverage draw path (#162) follow as their blockers close.
+# the same standing evidence shader_spec, draw_spec and ml_spec give. The suite covers the
+# governed half of the text pipeline: the schema (#157), the font schema (#161) and the coverage
+# draw path (#162). The host-only halves - the TrueType parser (#158), the rasteriser (#159) and
+# the atlas font baker (#160) - are covered by text_tools_spec instead.
 # Font schema suite (issue #161)
 #
 # Its own executable rather than cases inside text_spec, because a font package and a text package
@@ -587,7 +588,6 @@ mdux_discover_tests(font_spec)
 add_executable(text_spec
     text/TextSpecMain.cpp
     text/SchemaTests.cpp
-    text/RasterTests.cpp
     text/DrawTests.cpp
 )
 
@@ -619,11 +619,17 @@ mdux_discover_tests(text_spec)
 # `ml_tools_spec` and `shader_spec` follow: drive `parseRecipe()` / `run()` / `write()` / `verify()`
 # as calls so a failing assertion names the diagnostic code that failed rather than only an exit
 # status from a spawned process.
+#
+# RasterTests.cpp lives here rather than in text_spec since #116, because `mdux.text.raster` moved
+# to the host-tools zone. Moving the test with the module is not bookkeeping: text_spec links
+# MduX::Core alone, and that link line *is* the standing evidence above. Leaving raster cases there
+# would force MduX::TextBakeLib onto text_spec and destroy the very thing it exists to demonstrate.
 add_executable(text_tools_spec
     text/TextToolsSpecMain.cpp
     text/TextBakeTests.cpp
     text/TruetypeTests.cpp
     text/AtlasPackerTests.cpp
+    text/RasterTests.cpp
 )
 
 target_link_libraries(text_tools_spec PRIVATE MduX::TextBakeLib speclab::speclab)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -729,6 +729,19 @@ file(GENERATE
     CONTENT "$<JOIN:$<FILTER:$<TARGET_OBJECTS:MduXCore>,INCLUDE,/ml/>,\n>"
 )
 
+# The same mechanism over the whole governed target (issue #116), with the forbidden set narrowed
+# to the throw expression alone. No filter: every MduXCore object, module interfaces included.
+#
+# The allocator symbols cannot come along. mdux.evidence.json and mdux.governance allocate by
+# design - they build strings and vectors - so the ml-noheap forbidden set applied here would fail
+# on correct code. What generalises is the no-throwing half, which is a property ADR-005 asserts of
+# the whole governed zone rather than only of the ML modules.
+set(mdux_governed_object_list "${CMAKE_CURRENT_BINARY_DIR}/governed_objects_$<CONFIG>.txt")
+file(GENERATE
+    OUTPUT "${mdux_governed_object_list}"
+    CONTENT "$<JOIN:$<TARGET_OBJECTS:MduXCore>,\n>"
+)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     find_program(MDUX_SYMBOL_TOOL NAMES dumpbin)
     set(mdux_symbol_tool_kind "dumpbin")
@@ -745,16 +758,74 @@ endif()
 if(MDUX_SYMBOL_TOOL)
     add_test(NAME ml.noheap.symbolScan
         COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=ml-noheap
             -DMDUX_NOHEAP_OBJECT_LIST=${mdux_ml_object_list}
             -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
             -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
             -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
     )
     set_tests_properties(ml.noheap.symbolScan PROPERTIES LABELS "noheap")
+
+    # Issue #116. Labelled `governed` rather than `noheap`: it is not a no-heap check, and a CI leg
+    # selecting -L noheap should not silently start covering something else.
+    add_test(NAME governed.noThrow.symbolScan
+        COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=governed-throw
+            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_governed_object_list}
+            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+    )
+    set_tests_properties(governed.noThrow.symbolScan PROPERTIES LABELS "governed")
+
+    # The negative fixture. See tests/governed/ThrowFixture.cpp for why a scan that only ever runs
+    # against conforming code is not yet evidence of anything.
+    #
+    # CXX_SCAN_FOR_MODULES OFF keeps this object out of the module dependency graph: it declares no
+    # module and imports none, and a fixture whose job is to be non-conforming has no business in
+    # anyone's dyndep.
+    add_library(mdux_throw_fixture OBJECT governed/ThrowFixture.cpp)
+    set_target_properties(mdux_throw_fixture
+        PROPERTIES
+            CXX_STANDARD 23
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF
+            CXX_SCAN_FOR_MODULES OFF
+    )
+
+    set(mdux_throw_fixture_object_list
+        "${CMAKE_CURRENT_BINARY_DIR}/throw_fixture_objects_$<CONFIG>.txt")
+    file(GENERATE
+        OUTPUT "${mdux_throw_fixture_object_list}"
+        CONTENT "$<JOIN:$<TARGET_OBJECTS:mdux_throw_fixture>,\n>"
+    )
+
+    add_test(NAME governed.noThrow.symbolScan.negative
+        COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=governed-throw
+            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_throw_fixture_object_list}
+            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+    )
+    # PASS_REGULAR_EXPRESSION rather than WILL_FAIL, and the two must not be combined. When
+    # PASS_REGULAR_EXPRESSION is set CTest ignores the exit status and passes the test iff the
+    # regex matches, so it already accommodates the expected non-zero exit; adding WILL_FAIL then
+    # *inverts* that verdict and turns the correct outcome into a reported failure (observed).
+    #
+    # Matching the message rather than merely the exit status is what makes this a real negative
+    # test. A bare WILL_FAIL would be satisfied by a missing object, a misspelled profile or a bad
+    # path - every way of failing except the one being verified.
+    set_tests_properties(governed.noThrow.symbolScan.negative
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "Symbol scan violation \\(profile 'governed-throw'\\)"
+            LABELS "governed"
+    )
 else()
-    # Deliberately not silent. A missing tool means this layer is not running, and the other two
-    # layers do not cover what it covers.
+    # Deliberately not silent. A missing tool means these layers are not running, and nothing else
+    # covers what they cover.
     message(WARNING
-        "No symbol tool (nm/dumpbin) found - ml.noheap.symbolScan will not run, so issue #63's "
-        "layer 2 is unverified in this build.")
+        "No symbol tool (nm/dumpbin) found - ml.noheap.symbolScan and governed.noThrow.symbolScan "
+        "will not run, so issue #63's layer 2 and issue #116's object-level no-throw check are "
+        "both unverified in this build.")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -781,46 +781,62 @@ if(MDUX_SYMBOL_TOOL)
     # The negative fixture. See tests/governed/ThrowFixture.cpp for why a scan that only ever runs
     # against conforming code is not yet evidence of anything.
     #
+    # MSVC is excluded, and the reason is the same one that makes the positive scan
+    # report-only there: the MSVC STL inlines its own throw sites, so `_CxxThrowException` cannot
+    # distinguish a governed `throw` from an ordinary `std::string` growth path. The
+    # `governed-throw` profile therefore forbids nothing under dumpbin, and a negative test needs
+    # something to be forbidden before it can prove the rejection works. Registering it anyway
+    # would produce a test that fails on Windows for a reason unrelated to any defect - the kind of
+    # noise that trains a reader to ignore a red check.
+    #
     # CXX_SCAN_FOR_MODULES OFF keeps this object out of the module dependency graph: it declares no
     # module and imports none, and a fixture whose job is to be non-conforming has no business in
     # anyone's dyndep.
-    add_library(mdux_throw_fixture OBJECT governed/ThrowFixture.cpp)
-    set_target_properties(mdux_throw_fixture
-        PROPERTIES
-            CXX_STANDARD 23
-            CXX_STANDARD_REQUIRED ON
-            CXX_EXTENSIONS OFF
-            CXX_SCAN_FOR_MODULES OFF
-    )
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        message(STATUS
+            "governed.noThrow.symbolScan.negative not registered on MSVC - the governed-throw "
+            "profile forbids no symbol under dumpbin, so there is nothing for a negative test to "
+            "prove. mdux-governed-lint covers the rule on this toolchain.")
+    else()
+        add_library(mdux_throw_fixture OBJECT governed/ThrowFixture.cpp)
+        set_target_properties(mdux_throw_fixture
+            PROPERTIES
+                CXX_STANDARD 23
+                CXX_STANDARD_REQUIRED ON
+                CXX_EXTENSIONS OFF
+                CXX_SCAN_FOR_MODULES OFF
+        )
 
-    set(mdux_throw_fixture_object_list
-        "${CMAKE_CURRENT_BINARY_DIR}/throw_fixture_objects_$<CONFIG>.txt")
-    file(GENERATE
-        OUTPUT "${mdux_throw_fixture_object_list}"
-        CONTENT "$<JOIN:$<TARGET_OBJECTS:mdux_throw_fixture>,\n>"
-    )
+        set(mdux_throw_fixture_object_list
+            "${CMAKE_CURRENT_BINARY_DIR}/throw_fixture_objects_$<CONFIG>.txt")
+        file(GENERATE
+            OUTPUT "${mdux_throw_fixture_object_list}"
+            CONTENT "$<JOIN:$<TARGET_OBJECTS:mdux_throw_fixture>,\n>"
+        )
 
-    add_test(NAME governed.noThrow.symbolScan.negative
-        COMMAND ${CMAKE_COMMAND}
-            -DMDUX_SCAN_PROFILE=governed-throw
-            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_throw_fixture_object_list}
-            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
-            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
-            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
-    )
-    # PASS_REGULAR_EXPRESSION rather than WILL_FAIL, and the two must not be combined. When
-    # PASS_REGULAR_EXPRESSION is set CTest ignores the exit status and passes the test iff the
-    # regex matches, so it already accommodates the expected non-zero exit; adding WILL_FAIL then
-    # *inverts* that verdict and turns the correct outcome into a reported failure (observed).
-    #
-    # Matching the message rather than merely the exit status is what makes this a real negative
-    # test. A bare WILL_FAIL would be satisfied by a missing object, a misspelled profile or a bad
-    # path - every way of failing except the one being verified.
-    set_tests_properties(governed.noThrow.symbolScan.negative
-        PROPERTIES
-            PASS_REGULAR_EXPRESSION "Symbol scan violation \\(profile 'governed-throw'\\)"
-            LABELS "governed"
-    )
+        add_test(NAME governed.noThrow.symbolScan.negative
+            COMMAND ${CMAKE_COMMAND}
+                -DMDUX_SCAN_PROFILE=governed-throw
+                -DMDUX_NOHEAP_OBJECT_LIST=${mdux_throw_fixture_object_list}
+                -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+                -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+                -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+        )
+        # PASS_REGULAR_EXPRESSION rather than WILL_FAIL, and the two must not be combined. When
+        # PASS_REGULAR_EXPRESSION is set CTest ignores the exit status and passes the test iff the
+        # regex matches, so it already accommodates the expected non-zero exit; adding WILL_FAIL
+        # then *inverts* that verdict and turns the correct outcome into a reported failure
+        # (observed).
+        #
+        # Matching the message rather than merely the exit status is what makes this a real
+        # negative test. A bare WILL_FAIL would be satisfied by a missing object, a misspelled
+        # profile or a bad path - every way of failing except the one being verified.
+        set_tests_properties(governed.noThrow.symbolScan.negative
+            PROPERTIES
+                PASS_REGULAR_EXPRESSION "Symbol scan violation \\(profile 'governed-throw'\\)"
+                LABELS "governed"
+        )
+    endif()
 else()
     # Deliberately not silent. A missing tool means these layers are not running, and nothing else
     # covers what they cover.

--- a/tests/governed/ThrowFixture.cpp
+++ b/tests/governed/ThrowFixture.cpp
@@ -15,7 +15,14 @@
  *
  * The `throw` below is what the compiler turns into a `__cxa_throw` reference, the exact symbol
  * the `governed-throw` profile forbids. Narrow that forbidden set or break the symbol matching and
- * this stops failing, which CTest reports as an error because the test carries `WILL_FAIL`.
+ * the scan stops rejecting this object, which CTest reports as a failure because the test carries
+ * `PASS_REGULAR_EXPRESSION` matching the violation message. Deliberately *not* `WILL_FAIL`: with a
+ * pass regex CTest already ignores the exit status, and adding `WILL_FAIL` inverts the verdict so
+ * the correct outcome is reported as a failure. `tests/CMakeLists.txt` carries the full reasoning.
+ *
+ * Only registered on GCC/Clang. The MSVC STL inlines its own throw sites, so the `governed-throw`
+ * profile forbids no symbol under `dumpbin` — and a negative test needs something to be forbidden
+ * before it can prove the rejection works.
  *
  * Plain includes rather than `import std`, and no module declaration: the fixture is compiled as
  * an object library outside the module graph, so that a file whose entire purpose is to be

--- a/tests/governed/ThrowFixture.cpp
+++ b/tests/governed/ThrowFixture.cpp
@@ -1,0 +1,33 @@
+/**
+ * @file ThrowFixture.cpp
+ * @brief A deliberately non-conforming source, used to prove the governed no-throw scan fails.
+ *
+ * @compliance ADR-005 Error handling and exceptions policy
+ *
+ * This file is **not** part of `MduXCore` and is never linked into anything that ships. It exists
+ * so that `governed.noThrow.symbolScan.negative` has something to fail on.
+ *
+ * A check that only ever runs against conforming code proves very little: it passes identically
+ * when it is working and when it is scanning an empty list, matching no symbol, or reading the
+ * wrong objects. `MduXNoHeapScan.cmake` guards the empty-list and missing-object cases with its own
+ * `FATAL_ERROR`s. This covers the case those cannot - the scan running correctly over a real
+ * object and simply failing to recognise the thing it is looking for.
+ *
+ * The `throw` below is what the compiler turns into a `__cxa_throw` reference, the exact symbol
+ * the `governed-throw` profile forbids. Narrow that forbidden set or break the symbol matching and
+ * this stops failing, which CTest reports as an error because the test carries `WILL_FAIL`.
+ *
+ * Plain includes rather than `import std`, and no module declaration: the fixture is compiled as
+ * an object library outside the module graph, so that a file whose entire purpose is to be
+ * non-conforming cannot participate in anyone's module dependency scan.
+ */
+#include <stdexcept>
+
+namespace mdux::test {
+
+/// Throws unconditionally. Never called; the reference in the emitted object is the whole point.
+[[noreturn]] void alwaysThrows() {
+    throw std::runtime_error{"this function exists to be found by a symbol scan"};
+}
+
+}  // namespace mdux::test

--- a/tests/text/RasterTests.cpp
+++ b/tests/text/RasterTests.cpp
@@ -1,11 +1,14 @@
 /**
  * @file RasterTests.cpp
- * @brief BDD scenarios for the governed-zone glyph rasteriser (issue #159).
+ * @brief BDD scenarios for the host-tools glyph rasteriser (issue #159).
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
  * @compliance ADR-010 No on-device text shaping
+ *
+ * Part of text_tools_spec rather than text_spec since #116, because `mdux.text.raster` moved to
+ * the host-tools zone. The scenarios themselves are unchanged: the rasteriser is still
+ * integer-only, and the frozen-digest scenario at the bottom still holds it to the byte.
  *
  * The outlines here are built in code rather than loaded from a font, for the reason
  * `TruetypeTests.cpp` gives: a fixture whose intended defect a reviewer has to take on trust is

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -220,7 +220,8 @@ endif()
 # registered until S4 commits a real artifact.
 #
 # `mdux.text.raster` moved here from MduXCore in #116. It allocates, and `std::vector` reports
-# failure by throwing, so it could not stay in a governed target compiled with -fno-exceptions.
+# failure by throwing, so its noexcept entry point has to catch - which ADR-005 forbids in the
+# governed zone.
 # Nothing else about it changed - it is integer-only and its output is still byte-compared in CI.
 # See tools/text/Raster.cppm for the full argument.
 add_library(MduXTextBakeLib)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -218,6 +218,11 @@ endif()
 # that hosts the recipe model. S4 extends the recipe with the font pipeline inputs and S5
 # (#161) adds the restricted-charset validation; no mdux_bake_artifact() call site is
 # registered until S4 commits a real artifact.
+#
+# `mdux.text.raster` moved here from MduXCore in #116. It allocates, and `std::vector` reports
+# failure by throwing, so it could not stay in a governed target compiled with -fno-exceptions.
+# Nothing else about it changed - it is integer-only and its output is still byte-compared in CI.
+# See tools/text/Raster.cppm for the full argument.
 add_library(MduXTextBakeLib)
 add_library(MduX::TextBakeLib ALIAS MduXTextBakeLib)
 
@@ -229,10 +234,12 @@ target_sources(MduXTextBakeLib
             text/TextBake.cppm
             text/Truetype.cppm
             text/AtlasPacker.cppm
+            text/Raster.cppm
     PRIVATE
         text/TextBake.cpp
         text/Truetype.cpp
         text/AtlasPacker.cpp
+        text/Raster.cpp
 )
 
 target_compile_features(MduXTextBakeLib PUBLIC cxx_std_23)

--- a/tools/governed-lint/mdux_governed_lint.py
+++ b/tools/governed-lint/mdux_governed_lint.py
@@ -29,6 +29,10 @@ So the rule is enforced at two levels instead, and this is the source-level one:
 Neither subsumes the other. The scan is blind to a `std::filesystem` call that never throws; this
 is blind to a throw inside a header it does not read.
 
+GOV009 additionally closes the gap ADR-004 item 1 names explicitly: denying `MduXCore` Vulkan's
+include *directories* does not make a system-installed `<vulkan/vulkan.h>` unreachable, because the
+compiler still finds it in a default search path. Only a source-level check does.
+
 ## What it scans
 
 **Exactly the sources `CMakeLists.txt` lists for `MduXCore`**, parsed out of the
@@ -173,6 +177,21 @@ RULES = (
             "Prefer std::bit_cast, std::as_bytes or a span conversion. Where the cast is genuinely "
             f"the mechanism - reading a caller-supplied blob - end the line with {SUPPRESS_MARKER} "
             "so the exception is reviewed rather than silent."
+        ),
+    ),
+    Rule(
+        code="GOV009",
+        pattern=re.compile(
+            r"#\s*include\s*<\s*(?:vulkan/|GLFW/|windows\.h|winsock|unistd\.h|sys/|fcntl\.h"
+            r"|pthread\.h|dlfcn\.h|X11/|wayland-)",
+            re.IGNORECASE,
+        ),
+        message="platform, graphics or OS header in governed code",
+        fix_hint=(
+            "ADR-004 item 1 keeps these off the include path that MduXCore is *given*, but a "
+            "system-installed header is still findable in the compiler's default search paths - "
+            "which is the gap this rule closes. Governed code takes handles and bytes from its "
+            "caller; the adapter zone is where a platform header belongs."
         ),
     ),
     Rule(

--- a/tools/governed-lint/mdux_governed_lint.py
+++ b/tools/governed-lint/mdux_governed_lint.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""mdux-governed-lint: enforces ADR-005's governed-zone source rules.
+
+Host-only tool (see ADR-004's trust-zone model) - never built into MduXCore or MduX, no
+third-party dependencies, standard library only, so it runs anywhere Python 3.9+ runs without
+a build.
+
+## Why this exists
+
+ADR-005 states that governed code does not throw, and ADR-004 that it reaches no platform,
+filesystem, time or randomness facility. Until issue #116 nothing checked either claim. The ADR
+described a lint "the governed-zone source lint also rejects `throw`, `try`, and `catch`" that had
+never been written, which is the worst shape a compliance claim can take: asserted in the present
+tense, believed by readers, enforced by nothing.
+
+The intended mechanism was compiling MduXCore with `-fno-exceptions -fno-rtti`. That is not
+available while the governed zone uses `import std`: GCC records the language dialect in every
+module BMI, and CMake synthesises one shared `std` target for the whole build, so a governed module
+built with those flags cannot read the same `std` BMI the adapter and host-tools targets read. See
+ADR-005's constraint section.
+
+So the rule is enforced at two levels instead, and this is the source-level one:
+
+- **this lint** reads the source and rejects the construct;
+- **`governed.noThrow.symbolScan`** (cmake/MduXNoHeapScan.cmake) reads the emitted objects and
+  rejects the symbol, catching a throw that arrives through a std facility the source never
+  spells out.
+
+Neither subsumes the other. The scan is blind to a `std::filesystem` call that never throws; this
+is blind to a throw inside a header it does not read.
+
+## What it scans
+
+**Exactly the sources `CMakeLists.txt` lists for `MduXCore`**, parsed out of the
+`target_sources(MduXCore ...)` block rather than globbed. Three reasons, all of them things a glob
+gets wrong:
+
+1. `include/mdux/**` also holds the *adapter* modules (`render/`, `vulkansc/`), which are permitted
+   exceptions and would be reported as violations.
+2. Generated shader C arrays land in `<binary>/mdux_generated/`, outside the source tree - a
+   requirement in #116 is that they are not scanned as hand-authored governed source. Deriving from
+   the source list excludes them by construction rather than by an exclusion pattern someone has to
+   remember to maintain.
+3. A module added to MduXCore is covered the moment it is registered, with no second edit here.
+   That matters most for #15, which adds several.
+
+If the block cannot be parsed, this exits non-zero rather than scanning nothing. A lint that
+silently checks an empty list reports success identically to one that is working.
+
+## How it matches
+
+On the source **with comments and string literals removed**, not on raw lines. The governed tree is
+heavily commented and those comments discuss the very constructs banned here - `Kernels.cppm` says
+"Never `std::fma`", `Draw.cpp` says "a new command is needed", `Runtime.cppm` says "throw away
+exactly the information the incident report needs". Every one of those is prose, and a line-based
+matcher reports all of them. Stripping first is what makes the rule enforceable without forcing
+authors to reword documentation to appease a regex.
+
+Removal preserves line numbers, so a finding still points at the right line.
+
+## Escape hatch
+
+A line ending with `mdux-governed-lint:allow` is exempt. Intended for the genuinely unavoidable
+case - `src/ml/Runtime.cpp` reinterprets a caller-supplied byte span as floats, which is the entire
+mechanism ADR-008 chose for weights - and reviewed rather than routine. It is deliberately per-line
+and visible in the diff.
+
+Usage:
+    python3 tools/governed-lint/mdux_governed_lint.py [--format text|json] [paths...]
+
+Exit status 0 if no findings, 1 otherwise. With no paths, scans MduXCore's declared sources.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SUPPRESS_MARKER = "mdux-governed-lint:allow"
+
+# The block in CMakeLists.txt that declares what the governed target is made of.
+GOVERNED_TARGET = "MduXCore"
+
+SOURCE_LINE_RE = re.compile(r"^\s*((?:include|src|tools|tests)/[^\s()]+\.(?:cppm|cpp))\s*$")
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One banned construct.
+
+    `code` is stable once published: an agent keys off it, and a reworded `message` must not break
+    that. See docs/governance/schemas/diagnostic.schema.json.
+    """
+
+    code: str
+    pattern: re.Pattern
+    message: str
+    fix_hint: str
+
+
+RULES = (
+    Rule(
+        code="GOV001",
+        pattern=re.compile(r"\bthrow\b"),
+        message="`throw` in governed code",
+        fix_hint=(
+            "Return a mdux::core::Result error instead (ADR-005). If the throwing construct is "
+            "unavoidable, the module belongs in the host-tools zone - that is where "
+            "mdux.text.raster went in #116."
+        ),
+    ),
+    Rule(
+        code="GOV002",
+        pattern=re.compile(r"\b(?:try|catch)\b"),
+        message="`try`/`catch` in governed code",
+        fix_hint=(
+            "Governed code has nothing to catch, because governed code does not throw (ADR-005). "
+            "A module that needs to catch belongs in the host-tools zone."
+        ),
+    ),
+    Rule(
+        code="GOV003",
+        pattern=re.compile(r"\.value\(\)"),
+        message="`.value()` on a Result/expected, which throws when the value is absent",
+        fix_hint=(
+            "Branch on has_value() or operator bool, then use operator* or operator->, which do "
+            "not throw. ADR-005's risk register names this construct specifically."
+        ),
+    ),
+    Rule(
+        code="GOV004",
+        pattern=re.compile(r"\bnew\s+[A-Za-z_:]|\bdelete\s|\b(?:m|c|re)alloc\s*\(|\bfree\s*\("),
+        message="raw owning allocation in governed code",
+        fix_hint=(
+            "Governed code uses caller-supplied storage or std containers, never a raw new/delete "
+            "or the C allocator family. See ADR-004; mdux.ml.runtime's no-heap predict() is the "
+            "pattern to follow for a hot path."
+        ),
+    ),
+    Rule(
+        code="GOV005",
+        pattern=re.compile(
+            r"std::filesystem|\bstd::(?:i|o)fstream\b|\bstd::(?:cout|cerr|cin|clog)\b"
+            r"|\bstd::getenv\b|\bgetenv\s*\(|\bstd::system\s*\(|\bstd::(?:f|s)?printf\s*\("
+        ),
+        message="platform, filesystem or console facility in governed code",
+        fix_hint=(
+            "Governed code performs no I/O: it is meant to run on a device with no filesystem and "
+            "no console (ADR-004, ADR-008 decision 2). Move the I/O to a host tool and pass the "
+            "bytes in."
+        ),
+    ),
+    Rule(
+        code="GOV006",
+        pattern=re.compile(
+            r"std::chrono::(?:system_clock|steady_clock|high_resolution_clock)"
+            r"|std::random_device|std::mt19937|\bstd::s?rand\s*\(|\bstd::time\s*\("
+        ),
+        message="clock or randomness in governed code, which makes output non-reproducible",
+        fix_hint=(
+            "A governed result must be a pure function of its inputs, or the evidence pipeline's "
+            "byte-identity guarantee (ADR-007) does not hold. Pass a timestamp or seed in as data."
+        ),
+    ),
+    Rule(
+        code="GOV007",
+        pattern=re.compile(r"\b(?:reinterpret_cast|const_cast)\b"),
+        message="unsafe cast in governed code",
+        fix_hint=(
+            "Prefer std::bit_cast, std::as_bytes or a span conversion. Where the cast is genuinely "
+            f"the mechanism - reading a caller-supplied blob - end the line with {SUPPRESS_MARKER} "
+            "so the exception is reviewed rather than silent."
+        ),
+    ),
+    Rule(
+        code="GOV008",
+        pattern=re.compile(r"\bstd::fmaf?\b"),
+        message="std::fma in governed code",
+        fix_hint=(
+            "std::fma rounds once where the scalar multiply-then-add sequence rounds twice, so it "
+            "changes results against the golden vectors. Write the multiply and the add "
+            "separately. See mdux.ml.kernels' header and ADR-008."
+        ),
+    ),
+)
+
+
+@dataclass
+class Finding:
+    """One finding in the shared envelope - docs/governance/schemas/diagnostic.schema.json.
+
+    Deliberately the same field names and severity vocabulary as `mdux::tools::cli::Diagnostic`
+    (tools/common/Cli.cppm), mdux-docs-lint and mdux-evidence-lint, so an agent parses one schema
+    for the whole repository. `line` and `column` are both 1-based, with 0 meaning "no precise
+    position on this axis". This lint reports both: stripping preserves offsets, so the column a
+    match lands on is the column in the original file.
+    """
+
+    path: str
+    line: int
+    code: str
+    severity: str
+    message: str
+    fix_hint: str = ""
+    column: int = 0
+
+    def to_json(self) -> dict:
+        return {
+            "file": self.path,
+            "line": self.line,
+            "column": self.column,
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "fixHint": self.fix_hint,
+        }
+
+
+def strip_comments_and_literals(text: str) -> str:
+    """Blanks out comments and string/character literals, preserving length and line breaks.
+
+    Every removed character becomes a space, and newlines inside a removed run are kept, so an
+    offset into the result is an offset into the original: line and column numbers survive.
+
+    This is the inverse of mdux-evidence-lint's `extract_string_literals`, which keeps the literals
+    and discards the code. Both exist because the two lints ask opposite questions - a format
+    specifier can only be in a literal, and a `throw` can only be outside one.
+    """
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        two = text[i : i + 2]
+
+        if two == "//":
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+
+        if two == "/*":
+            end = text.find("*/", i + 2)
+            end = n if end == -1 else end + 2
+            for c in text[i:end]:
+                out.append("\n" if c == "\n" else " ")
+            i = end
+            continue
+
+        # Raw string literal: R"delim(body)delim", no escape processing inside.
+        if text[i] == "R" and text[i + 1 : i + 2] == '"':
+            open_paren = text.find("(", i + 2)
+            if open_paren != -1:
+                terminator = ")" + text[i + 2 : open_paren] + '"'
+                end = text.find(terminator, open_paren + 1)
+                if end != -1:
+                    end += len(terminator)
+                    for c in text[i:end]:
+                        out.append("\n" if c == "\n" else " ")
+                    i = end
+                    continue
+
+        if text[i] in ('"', "'"):
+            quote = text[i]
+            start = i
+            i += 1
+            while i < n:
+                if text[i] == "\\" and i + 1 < n:
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    i += 1
+                    break
+                if text[i] == "\n":  # unterminated; let the compiler complain about it
+                    break
+                i += 1
+            for c in text[start:i]:
+                out.append("\n" if c == "\n" else " ")
+            continue
+
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+
+def governed_sources(root: Path) -> list[Path]:
+    """The files CMakeLists.txt lists for MduXCore, in declaration order.
+
+    Raises ValueError if the block cannot be found or yields nothing - see the module docstring on
+    why this fails rather than returning an empty list.
+    """
+    cmakelists = root / "CMakeLists.txt"
+    try:
+        text = cmakelists.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"could not read {cmakelists}: {exc}") from exc
+
+    marker = f"target_sources({GOVERNED_TARGET}"
+    start = text.find(marker)
+    if start == -1:
+        raise ValueError(
+            f"no `{marker}` block in CMakeLists.txt. The governed source list is derived from "
+            "that block; if the target was renamed, update GOVERNED_TARGET in this file."
+        )
+
+    # Scan from the opening paren itself, not from the end of the marker: starting past it leaves
+    # depth at 0, so the block's own closing paren takes it to -1, the `depth == 0` test never
+    # fires, and the "block" runs to end of file - swallowing the *adapter* target's source list
+    # and reporting its permitted exceptions as governed violations. Observed while writing this.
+    open_paren = text.index("(", start)
+    depth = 0
+    end = start
+    for index in range(open_paren, len(text)):
+        if text[index] == "(":
+            depth += 1
+        elif text[index] == ")":
+            depth -= 1
+            if depth == 0:
+                end = index
+                break
+    else:
+        raise ValueError(f"unterminated `{marker}` block in CMakeLists.txt")
+
+    block = strip_cmake_comments(text[start:end])
+    paths = []
+    for line in block.splitlines():
+        match = SOURCE_LINE_RE.match(line)
+        if match:
+            paths.append(root / match.group(1))
+
+    if not paths:
+        raise ValueError(
+            f"the `{marker}` block parsed to zero sources. Refusing to report success on an "
+            "empty scan."
+        )
+    return paths
+
+
+def strip_cmake_comments(text: str) -> str:
+    """Drops `#` comments from a CMake fragment. No literals to worry about in a source list."""
+    return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+
+
+def check_file(path: Path, root: Path, findings: list[Finding]) -> None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        findings.append(
+            Finding(
+                path=str(path.relative_to(root)),
+                line=0,
+                code="GOV000",
+                severity="error",
+                message=f"could not read file: {exc}",
+            )
+        )
+        return
+
+    relative = str(path.relative_to(root))
+    code_only = strip_comments_and_literals(text)
+    original_lines = text.splitlines()
+
+    # Offset of the first character of each 1-based line, for turning a match position into a
+    # line and column without scanning the whole prefix per match.
+    line_starts = [0]
+    for index, character in enumerate(code_only):
+        if character == "\n":
+            line_starts.append(index + 1)
+
+    def position_of(offset: int) -> tuple[int, int]:
+        low, high = 0, len(line_starts) - 1
+        while low < high:
+            mid = (low + high + 1) // 2
+            if line_starts[mid] <= offset:
+                low = mid
+            else:
+                high = mid - 1
+        return low + 1, offset - line_starts[low] + 1
+
+    for rule in RULES:
+        for match in rule.pattern.finditer(code_only):
+            line, column = position_of(match.start())
+            original = original_lines[line - 1] if line <= len(original_lines) else ""
+            if original.rstrip().endswith(SUPPRESS_MARKER):
+                continue
+            findings.append(
+                Finding(
+                    path=relative,
+                    line=line,
+                    column=column,
+                    code=rule.code,
+                    severity="error",
+                    message=f"{rule.message}: {match.group(0)!r}",
+                    fix_hint=rule.fix_hint,
+                )
+            )
+
+    findings.sort(key=lambda f: (f.path, f.line, f.column, f.code))
+
+
+def find_repository_root() -> Path:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / ".git").exists():
+            return candidate
+    return here.parents[2]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Enforce ADR-005's governed-zone source rules over MduXCore's sources."
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Files to scan. Defaults to MduXCore's declared sources.",
+    )
+    args = parser.parse_args(argv)
+
+    root = find_repository_root()
+    if args.paths:
+        sources = [p if p.is_absolute() else (Path.cwd() / p) for p in args.paths]
+    else:
+        try:
+            sources = governed_sources(root)
+        except ValueError as exc:
+            print(f"mdux-governed-lint: {exc}", file=sys.stderr)
+            return 1
+
+    missing = [s for s in sources if not s.is_file()]
+    if missing:
+        for path in missing:
+            print(f"mdux-governed-lint: declared source not found: {path}", file=sys.stderr)
+        return 1
+
+    findings: list[Finding] = []
+    for source in sources:
+        check_file(source, root, findings)
+
+    if args.format == "json":
+        # The shared envelope: docs/governance/schemas/diagnostic.schema.json.
+        print(
+            json.dumps(
+                {
+                    "tool": "mdux-governed-lint",
+                    "filesChecked": len(sources),
+                    "findings": [f.to_json() for f in findings],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for finding in findings:
+            print(
+                f"{finding.path}:{finding.line}:{finding.column}: {finding.severity}: "
+                f"[{finding.code}] {finding.message}"
+            )
+            if finding.fix_hint:
+                print(f"    fix: {finding.fix_hint}")
+        if findings:
+            print(f"mdux-governed-lint: {len(findings)} finding(s) in {len(sources)} file(s)")
+        else:
+            print(f"mdux-governed-lint: OK ({len(sources)} files checked, 0 findings)")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/governed-lint/mdux_governed_lint.py
+++ b/tools/governed-lint/mdux_governed_lint.py
@@ -78,6 +78,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -136,7 +137,12 @@ RULES = (
     ),
     Rule(
         code="GOV004",
-        pattern=re.compile(r"\bnew\s+[A-Za-z_:]|\bdelete\s|\b(?:m|c|re)alloc\s*\(|\bfree\s*\("),
+        # `delete` needs the `[` alternative: `\bdelete\s` requires trailing whitespace, so the
+        # very common `delete[] p` spelling slipped through while `delete [] p` was caught.
+        pattern=re.compile(
+            r"\bnew\s+[A-Za-z_:(]|\bdelete\s*(?:\[\s*\]|\s)"
+            r"|\b(?:m|c|re)alloc\s*\(|\bfree\s*\("
+        ),
         message="raw owning allocation in governed code",
         fix_hint=(
             "Governed code uses caller-supplied storage or std containers, never a raw new/delete "
@@ -146,9 +152,15 @@ RULES = (
     ),
     Rule(
         code="GOV005",
+        # The printf family is matched with an optional `std::`, because the C spellings are
+        # equally reachable through `import std` and a bare `system("...")` is the one that
+        # matters most. `snprintf`/`vsnprintf` are included: they write to a buffer rather than a
+        # stream, but they are still the C formatting machinery this zone has no use for, and
+        # ADR-007 has its own reasons to keep float formatting out of anything evidence-adjacent.
         pattern=re.compile(
             r"std::filesystem|\bstd::(?:i|o)fstream\b|\bstd::(?:cout|cerr|cin|clog)\b"
-            r"|\bstd::getenv\b|\bgetenv\s*\(|\bstd::system\s*\(|\bstd::(?:f|s)?printf\s*\("
+            r"|\b(?:std::)?getenv\s*\(|\b(?:std::)?system\s*\("
+            r"|\b(?:std::)?v?(?:f|s|sn)?printf\s*\("
         ),
         message="platform, filesystem or console facility in governed code",
         fix_hint=(
@@ -181,9 +193,20 @@ RULES = (
     ),
     Rule(
         code="GOV009",
+        # A blocklist, and therefore not exhaustive - stated plainly here because the alternative
+        # is a reader assuming otherwise. An allowlist of std headers would be the airtight shape,
+        # but governed code reaches std through `import std` and carries almost no #include at all
+        # (one, `<cstddef>`, at the time of writing), so an allowlist would be a large mechanism
+        # guarding a nearly empty surface. The names below are the ones actually reachable on the
+        # platforms this project builds on; add to them when a new one becomes reachable.
+        #
+        # The real backstop is not this rule: it is ADR-004 item 3's link-graph assertion, which
+        # fails at configure time if a governed target ever acquires a dependency that would make
+        # such a header resolvable through target usage requirements.
         pattern=re.compile(
             r"#\s*include\s*<\s*(?:vulkan/|GLFW/|windows\.h|winsock|unistd\.h|sys/|fcntl\.h"
-            r"|pthread\.h|dlfcn\.h|X11/|wayland-)",
+            r"|pthread\.h|dlfcn\.h|X11/|wayland-|linux/|termios\.h|io\.h|direct\.h|process\.h"
+            r"|signal\.h|poll\.h|netinet/|arpa/|sched\.h|mmintrin\.h|immintrin\.h)",
             re.IGNORECASE,
         ),
         message="platform, graphics or OS header in governed code",
@@ -191,7 +214,8 @@ RULES = (
             "ADR-004 item 1 keeps these off the include path that MduXCore is *given*, but a "
             "system-installed header is still findable in the compiler's default search paths - "
             "which is the gap this rule closes. Governed code takes handles and bytes from its "
-            "caller; the adapter zone is where a platform header belongs."
+            "caller; the adapter zone is where a platform header belongs. This list is a "
+            "blocklist: if you have reached a platform header it does not name, add it."
         ),
     ),
     Rule(
@@ -362,13 +386,33 @@ def strip_cmake_comments(text: str) -> str:
     return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
 
 
+def display_path(path: Path, root: Path) -> str:
+    """The path as a finding should name it: repository-relative where possible.
+
+    `Path.relative_to` raises for anything outside `root`, which made the documented `[paths...]`
+    interface traceback on any file elsewhere on the filesystem - reported in review, reproduced
+    with a file under /tmp. A lint that crashes instead of reporting is not usable in the editor
+    integrations that interface exists for, so `os.path.relpath` handles the outside case and falls
+    back to the absolute path when even that is not expressible (a different drive on Windows).
+    """
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        try:
+            return os.path.relpath(path, root)
+        except ValueError:
+            return str(path)
+
+
 def check_file(path: Path, root: Path, findings: list[Finding]) -> None:
+    relative = display_path(path, root)
+
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         findings.append(
             Finding(
-                path=str(path.relative_to(root)),
+                path=relative,
                 line=0,
                 code="GOV000",
                 severity="error",
@@ -376,8 +420,6 @@ def check_file(path: Path, root: Path, findings: list[Finding]) -> None:
             )
         )
         return
-
-    relative = str(path.relative_to(root))
     code_only = strip_comments_and_literals(text)
     original_lines = text.splitlines()
 
@@ -442,6 +484,11 @@ def main(argv: list[str]) -> int:
 
     root = find_repository_root()
     if args.paths:
+        # Relative arguments resolve against the working directory, not the repository root.
+        # That is what every other command-line tool does, and what mdux-evidence-lint already
+        # does, so `mdux_governed_lint.py Draw.cpp` from inside src/draw/ means the file the shell
+        # would have completed. Findings are still *reported* repository-relative - see
+        # display_path(), which also keeps a path outside the repository from crashing the run.
         sources = [p if p.is_absolute() else (Path.cwd() / p) for p in args.paths]
     else:
         try:

--- a/tools/governed-lint/test_mdux_governed_lint.py
+++ b/tools/governed-lint/test_mdux_governed_lint.py
@@ -119,6 +119,19 @@ class Rules(unittest.TestCase):
     def test_fma(self):
         self.assertEqual(codes_for("acc = std::fma(a, b, acc);\n"), ["GOV008"])
 
+    def test_banned_platform_headers(self):
+        self.assertEqual(codes_for("#include <vulkan/vulkan.h>\n"), ["GOV009"])
+        self.assertEqual(codes_for("#include <GLFW/glfw3.h>\n"), ["GOV009"])
+        self.assertEqual(codes_for("#include <windows.h>\n"), ["GOV009"])
+        self.assertEqual(codes_for("#include <sys/mman.h>\n"), ["GOV009"])
+        # Spacing variants a real file might use.
+        self.assertEqual(codes_for("#  include  < vulkan/vulkan.h >\n"), ["GOV009"])
+
+    def test_permitted_std_headers(self):
+        # src/draw/Draw.cppm:39 does exactly this, in a global module fragment.
+        self.assertEqual(codes_for("#include <cstddef>\n"), [])
+        self.assertEqual(codes_for("#include <stdexcept>\n"), [])
+
     def test_suppression_marker(self):
         source = "auto* p = reinterpret_cast<int*>(q);  // mdux-governed-lint:allow\n"
         self.assertEqual(codes_for(source), [])

--- a/tools/governed-lint/test_mdux_governed_lint.py
+++ b/tools/governed-lint/test_mdux_governed_lint.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Unit tests for mdux-governed-lint.
+
+Run with `python3 -m unittest discover -s tools/governed-lint -p "test_*.py"`, the same way
+tools/docs-lint and tools/evidence-lint are run in CI.
+
+The tests that matter most here are the *negative* ones - the cases where the lint must not fire.
+A source lint over a heavily-commented tree earns its keep by being quiet about prose, and the
+governed tree discusses every construct this file bans. A lint that reports those is a lint an
+author learns to route around by rewording documentation, which is worse than no lint at all.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import mdux_governed_lint as lint
+
+
+def findings_for(source: str) -> list[lint.Finding]:
+    """Runs the rules over a source string, without touching the filesystem."""
+    findings: list[lint.Finding] = []
+    code_only = lint.strip_comments_and_literals(source)
+    original_lines = source.splitlines()
+
+    line_starts = [0]
+    for index, character in enumerate(code_only):
+        if character == "\n":
+            line_starts.append(index + 1)
+
+    for rule in lint.RULES:
+        for match in rule.pattern.finditer(code_only):
+            line = sum(1 for start in line_starts if start <= match.start())
+            original = original_lines[line - 1] if line <= len(original_lines) else ""
+            if original.rstrip().endswith(lint.SUPPRESS_MARKER):
+                continue
+            findings.append(
+                lint.Finding(
+                    path="<test>",
+                    line=line,
+                    code=rule.code,
+                    severity="error",
+                    message=rule.message,
+                )
+            )
+    return findings
+
+
+def codes_for(source: str) -> list[str]:
+    return sorted(f.code for f in findings_for(source))
+
+
+class StripCommentsAndLiterals(unittest.TestCase):
+    def test_preserves_line_numbers(self):
+        source = 'int a;\n// throw\nint b;\n"throw"\nint c;\n'
+        stripped = lint.strip_comments_and_literals(source)
+        self.assertEqual(source.count("\n"), stripped.count("\n"))
+
+    def test_preserves_offsets(self):
+        source = 'x = "abc"; y = 1;\n'
+        stripped = lint.strip_comments_and_literals(source)
+        self.assertEqual(len(source), len(stripped))
+        self.assertEqual(stripped.index("y"), source.index("y"))
+
+    def test_blanks_line_comment(self):
+        self.assertNotIn("throw", lint.strip_comments_and_literals("int a; // throw here\n"))
+
+    def test_blanks_block_comment_spanning_lines(self):
+        source = "/*\n * throw\n */\nint a;\n"
+        stripped = lint.strip_comments_and_literals(source)
+        self.assertNotIn("throw", stripped)
+        self.assertIn("int a;", stripped)
+
+    def test_blanks_string_literal(self):
+        self.assertNotIn("throw", lint.strip_comments_and_literals('auto s = "throw";\n'))
+
+    def test_blanks_raw_string_literal(self):
+        source = 'auto s = R"json({"throw": 1})json";\n'
+        self.assertNotIn("throw", lint.strip_comments_and_literals(source))
+
+    def test_keeps_code_outside_literals(self):
+        self.assertIn("throw", lint.strip_comments_and_literals('throw Err{"msg"};\n'))
+
+    def test_escaped_quote_does_not_end_the_literal(self):
+        # The literal runs to the *second* unescaped quote; `throw` is inside it throughout.
+        source = 'auto s = "a\\" throw b";\nint after;\n'
+        stripped = lint.strip_comments_and_literals(source)
+        self.assertNotIn("throw", stripped)
+        self.assertIn("int after;", stripped)
+
+
+class Rules(unittest.TestCase):
+    def test_throw(self):
+        self.assertEqual(codes_for("throw Error{};\n"), ["GOV001"])
+
+    def test_try_and_catch(self):
+        self.assertEqual(codes_for("try { f(); } catch (...) {}\n"), ["GOV002", "GOV002"])
+
+    def test_value_accessor(self):
+        self.assertEqual(codes_for("auto x = result.value();\n"), ["GOV003"])
+
+    def test_raw_allocation(self):
+        self.assertEqual(codes_for("auto* p = new Widget{};\n"), ["GOV004"])
+        self.assertEqual(codes_for("delete p;\n"), ["GOV004"])
+        self.assertEqual(codes_for("void* p = malloc(4);\n"), ["GOV004"])
+
+    def test_filesystem_and_console(self):
+        self.assertEqual(codes_for("std::filesystem::path p;\n"), ["GOV005"])
+        self.assertEqual(codes_for("std::cout << x;\n"), ["GOV005"])
+
+    def test_clock_and_randomness(self):
+        self.assertEqual(codes_for("auto t = std::chrono::system_clock::now();\n"), ["GOV006"])
+        self.assertEqual(codes_for("std::random_device rd;\n"), ["GOV006"])
+
+    def test_unsafe_casts(self):
+        self.assertEqual(codes_for("auto* p = reinterpret_cast<int*>(q);\n"), ["GOV007"])
+        self.assertEqual(codes_for("auto* p = const_cast<int*>(q);\n"), ["GOV007"])
+
+    def test_fma(self):
+        self.assertEqual(codes_for("acc = std::fma(a, b, acc);\n"), ["GOV008"])
+
+    def test_suppression_marker(self):
+        source = "auto* p = reinterpret_cast<int*>(q);  // mdux-governed-lint:allow\n"
+        self.assertEqual(codes_for(source), [])
+
+
+class NotFindings(unittest.TestCase):
+    """Constructs that must stay quiet. Each quotes a real line from the governed tree.
+
+    The `/**` and `*/` around the block-comment cases are not decoration. A comment *interior*
+    passed on its own is, correctly, code - which is what these fixtures asserted on the first
+    attempt, and they failed for exactly that reason. The delimiters are what makes the fixture
+    the thing it claims to quote.
+    """
+
+    def test_prose_about_throwing(self):
+        # include/mdux/ml/Runtime.cppm:46
+        source = "/**\n * throw away exactly the information the incident report needs\n */\n"
+        self.assertEqual(codes_for(source), [])
+
+    def test_prose_about_fma(self):
+        # include/mdux/ml/Kernels.cppm:28
+        source = (
+            "/**\n"
+            " * - **Never `std::fma`.** It rounds once where the scalar sequence rounds twice.\n"
+            " */\n"
+        )
+        self.assertEqual(codes_for(source), [])
+
+    def test_prose_about_a_new_command(self):
+        # src/draw/Draw.cpp:168
+        source = "    // A new command is needed when nothing has been recorded yet\n"
+        self.assertEqual(codes_for(source), [])
+
+    def test_prose_about_catching(self):
+        # include/mdux/text/Draw.cppm:54
+        source = "/**\n * is not an error the type system can catch, but\n */\n"
+        self.assertEqual(codes_for(source), [])
+
+    def test_has_value_is_not_value(self):
+        self.assertEqual(codes_for("if (result.has_value()) { }\n"), [])
+
+    def test_identifier_containing_new(self):
+        self.assertEqual(codes_for("auto renewed = compute();\n"), [])
+
+    def test_string_mentioning_a_banned_construct(self):
+        self.assertEqual(codes_for('report("cannot throw here");\n'), [])
+
+
+class GovernedSourceList(unittest.TestCase):
+    def test_parses_the_real_cmakelists(self):
+        root = lint.find_repository_root()
+        sources = lint.governed_sources(root)
+        self.assertTrue(sources)
+        for path in sources:
+            self.assertTrue(path.is_file(), f"{path} does not exist")
+
+    def test_excludes_the_adapter_target(self):
+        """The block scan must stop at MduXCore's closing paren.
+
+        It did not, in the first version of this file: the scan started one character past the
+        opening paren, so depth never returned to zero and the "block" ran to end of file,
+        swallowing MduX's source list. The adapter is permitted to throw, so the lint reported
+        every one of DeviceObjectManager.cpp's throws as a governed violation.
+        """
+        root = lint.find_repository_root()
+        names = {str(p.relative_to(root)) for p in lint.governed_sources(root)}
+        self.assertNotIn("src/vulkansc/DeviceObjectManager.cpp", names)
+        self.assertNotIn("src/render/Offscreen.cpp", names)
+        self.assertIn("src/ml/Runtime.cpp", names)
+
+    def test_excludes_generated_sources(self):
+        """#116 requires that generated shader C arrays are not scanned as governed source.
+
+        They are emitted into the build tree, so nothing under the repository's source list can
+        name one - this asserts that property rather than trusting it.
+        """
+        root = lint.find_repository_root()
+        for path in lint.governed_sources(root):
+            self.assertNotIn("mdux_generated", str(path))
+
+    def test_rejects_a_cmakelists_without_the_block(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "CMakeLists.txt").write_text("project(Nothing)\n", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                lint.governed_sources(Path(tmp))
+
+
+class TreeIsClean(unittest.TestCase):
+    def test_no_findings_on_the_governed_tree(self):
+        """The lint passes on `develop`. Kept as a test so a violation fails here too, not only
+        in the CI job - a contributor running the unit tests locally should see it."""
+        root = lint.find_repository_root()
+        findings: list[lint.Finding] = []
+        for source in lint.governed_sources(root):
+            lint.check_file(source, root, findings)
+        self.assertEqual(
+            [],
+            [f"{f.path}:{f.line}: [{f.code}] {f.message}" for f in findings],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/governed-lint/test_mdux_governed_lint.py
+++ b/tools/governed-lint/test_mdux_governed_lint.py
@@ -104,6 +104,18 @@ class Rules(unittest.TestCase):
         self.assertEqual(codes_for("delete p;\n"), ["GOV004"])
         self.assertEqual(codes_for("void* p = malloc(4);\n"), ["GOV004"])
 
+    def test_array_delete_spellings(self):
+        """`delete[] p` slipped through until review: `\\bdelete\\s` needs trailing whitespace."""
+        self.assertEqual(codes_for("delete[] p;\n"), ["GOV004"])
+        self.assertEqual(codes_for("delete [] p;\n"), ["GOV004"])
+        self.assertEqual(codes_for("auto* p = new int[4];\n"), ["GOV004"])
+
+    def test_c_formatting_and_system(self):
+        self.assertEqual(codes_for('std::snprintf(b, n, "x");\n'), ["GOV005"])
+        self.assertEqual(codes_for('snprintf(b, n, "x");\n'), ["GOV005"])
+        self.assertEqual(codes_for('system("rm -rf /");\n'), ["GOV005"])
+        self.assertEqual(codes_for("getenv(\"HOME\");\n"), ["GOV005"])
+
     def test_filesystem_and_console(self):
         self.assertEqual(codes_for("std::filesystem::path p;\n"), ["GOV005"])
         self.assertEqual(codes_for("std::cout << x;\n"), ["GOV005"])
@@ -211,6 +223,29 @@ class GovernedSourceList(unittest.TestCase):
         root = lint.find_repository_root()
         for path in lint.governed_sources(root):
             self.assertNotIn("mdux_generated", str(path))
+
+    def test_display_path_handles_a_file_outside_the_repository(self):
+        """The documented [paths...] interface must not traceback.
+
+        `Path.relative_to` raises for anything outside the root, which crashed the tool for any
+        file elsewhere on the filesystem - reported in review and reproduced with a file under
+        /tmp. Editor integrations are the reason that interface exists, and they pass absolute
+        paths.
+        """
+        root = lint.find_repository_root()
+        outside = Path("/tmp/definitely-not-in-the-repo.cpp")
+        self.assertIsInstance(lint.display_path(outside, root), str)
+
+    def test_check_file_reports_rather_than_crashes_outside_the_repository(self):
+        import tempfile
+
+        root = lint.find_repository_root()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Outside.cpp"
+            path.write_text("void f() { throw 1; }\n", encoding="utf-8")
+            findings: list[lint.Finding] = []
+            lint.check_file(path, root, findings)
+            self.assertEqual(["GOV001"], [f.code for f in findings])
 
     def test_rejects_a_cmakelists_without_the_block(self):
         import tempfile

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -17,8 +17,8 @@
  *
  * `mdux.text.raster` (#159) sits in this zone for the same reason as of #116. It was governed
  * on the argument that a device path might one day rasterise, which ADR-008 decision 1 would
- * then require to be *that* module rather than a second one - but it allocates, so it could not
- * stay in a target compiled with `-fno-exceptions`. See `Raster.cppm`.
+ * then require to be *that* module rather than a second one - but it allocates, so it has to
+ * catch at its `noexcept` boundary, which ADR-005 forbids in governed code. See `Raster.cppm`.
  *
  * ## Shelf placement, and why not something better
  *

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -10,12 +10,15 @@
  *
  * ## Why this is host-tools rather than governed
  *
- * `mdux.text.raster` (#159) is governed because a device path could conceivably need to
- * rasterise, and ADR-008 decision 1 says that would have to be *this* module rather than a second
- * one. Packing has no such future: an atlas is chosen once, at build time, and a device consumes
- * the slot rectangles the baker recorded. Nothing on a device ever packs, so a governed packer
- * would be a promise with no caller - and every module in the governed zone is a module a
- * reviewer has to reason about for device behaviour.
+ * An atlas is chosen once, at build time, and a device consumes the slot rectangles the baker
+ * recorded. Nothing on a device ever packs, so a governed packer would be a promise with no
+ * caller - and every module in the governed zone is a module a reviewer has to reason about for
+ * device behaviour.
+ *
+ * `mdux.text.raster` (#159) sits in this zone for the same reason as of #116. It was governed
+ * on the argument that a device path might one day rasterise, which ADR-008 decision 1 would
+ * then require to be *that* module rather than a second one - but it allocates, so it could not
+ * stay in a target compiled with `-fno-exceptions`. See `Raster.cppm`.
  *
  * ## Shelf placement, and why not something better
  *

--- a/tools/text/Raster.cpp
+++ b/tools/text/Raster.cpp
@@ -580,8 +580,8 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     // The final `catch (...)` is defensive: nothing else on this path throws anything else, and
     // if that ever stops being true this still returns rather than terminating.
     //
-    // This block is what put the module in the host-tools zone (#116). `MduXCore` is compiled
-    // with `-fno-exceptions`, so `try` cannot appear there at all - see Raster.cppm on why the
+    // This block is what put the module in the host-tools zone (#116): governed code does not
+    // throw, and ADR-005 makes that a rule rather than a preference. See Raster.cppm on why the
     // zone moved rather than the code.
     try {
         return rasteriseImpl(request);

--- a/tools/text/Raster.cpp
+++ b/tools/text/Raster.cpp
@@ -1,10 +1,9 @@
 /**
  * @file Raster.cpp
- * @brief Implementation of the governed-zone glyph rasteriser.
+ * @brief Implementation of the host-tools glyph rasteriser.
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
  * @compliance ADR-010 No on-device text shaping
  *
  * Four passes, in order:
@@ -578,8 +577,12 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     //
     // `std::length_error` is caught alongside `bad_alloc` because `resize()` raises it when a
     // request exceeds `max_size()`, which is the same condition arriving by a different name.
-    // The final `catch (...)` is defensive: nothing in the governed zone throws anything else,
-    // and if that ever stops being true this still returns rather than terminating.
+    // The final `catch (...)` is defensive: nothing else on this path throws anything else, and
+    // if that ever stops being true this still returns rather than terminating.
+    //
+    // This block is what put the module in the host-tools zone (#116). `MduXCore` is compiled
+    // with `-fno-exceptions`, so `try` cannot appear there at all - see Raster.cppm on why the
+    // zone moved rather than the code.
     try {
         return rasteriseImpl(request);
     } catch (const std::bad_alloc&) {

--- a/tools/text/Raster.cppm
+++ b/tools/text/Raster.cppm
@@ -1,28 +1,37 @@
 /**
  * @file Raster.cppm
- * @brief Governed-zone glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
+ * @brief Host-tools glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
  *        only, so the same glyph produces the same bytes on every supported toolchain.
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
- * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone: runs at build time, never on a device)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept entry point)
  * @compliance ADR-007 Evidence pipeline doctrine (the bytes this produces get committed)
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010: one
- *             module, not a host implementation and a device one that could drift)
  * @compliance ADR-010 No on-device text shaping
  *
- * Part of MduXCore. The font baker (#160, S4) imports this to fill an atlas; if a device path
- * ever needs to rasterise, it imports *this* module rather than growing a second implementation.
- * That is ADR-008 decision 1 applied to text, and it is why this file is governed rather than
- * sitting in `tools/` next to the parser that feeds it.
+ * Part of `MduXTextBakeLib`. The font baker (#160, S4) imports this to fill an atlas.
+ *
+ * ## Why this is host-tools code and not governed
+ *
+ * It was governed until issue #116, on the argument that a device path might one day want to
+ * rasterise and should import *this* module rather than grow a second implementation - ADR-008
+ * decision 1 applied to text. The argument was speculative and the cost was not: `rasterise()`
+ * allocates, and a `std::vector` reports failure by throwing, so keeping this module in
+ * `MduXCore` is incompatible with compiling the governed zone under `-fno-exceptions`. That
+ * compile mode is the thing ADR-005 calls a Class C and Vulkan SC prerequisite, and a real
+ * prerequisite outranks a hypothetical consumer.
+ *
+ * Nothing about the module's determinism changes with the move. The integer-only rule below is a
+ * property of the source, and the committed atlas bytes it produces are byte-compared in CI
+ * exactly as before.
  *
  * ## Why it does not take a `truetype::SimpleGlyph`
  *
- * `mdux.tools.truetype` (#158) is host-tools-zone code. ADR-004 forbids a governed module from
- * importing one, and the rule is mechanically checked by `mdux_verify_trust_zones()` - so this
- * module cannot name that type even though it is the obvious input. It takes `Outline` instead:
- * the same TrueType shape (points, per-contour end indices, on/off-curve flags) expressed in
- * governed types, with the baker doing a flat conversion. That indirection is the trust-zone
- * boundary made visible, not an abstraction for its own sake.
+ * It could now - `mdux.tools.truetype` (#158) is in this same zone, and the trust-zone rule that
+ * forbade naming that type no longer applies. The `Outline` input is kept anyway: it is the same
+ * TrueType shape (points, per-contour end indices, on/off-curve flags) in types that carry no
+ * parser with them, so this module stays movable back into `MduXCore` if a device path is ever
+ * built and made allocation-free. What used to be a constraint is now a deliberately preserved
+ * option, and the distinction is worth stating rather than leaving for a reader to infer.
  *
  * ## The determinism rule
  *

--- a/tools/text/Raster.cppm
+++ b/tools/text/Raster.cppm
@@ -15,10 +15,11 @@
  * It was governed until issue #116, on the argument that a device path might one day want to
  * rasterise and should import *this* module rather than grow a second implementation - ADR-008
  * decision 1 applied to text. The argument was speculative and the cost was not: `rasterise()`
- * allocates, and a `std::vector` reports failure by throwing, so keeping this module in
- * `MduXCore` is incompatible with compiling the governed zone under `-fno-exceptions`. That
- * compile mode is the thing ADR-005 calls a Class C and Vulkan SC prerequisite, and a real
- * prerequisite outranks a hypothetical consumer.
+ * allocates, and a `std::vector` reports failure by throwing, so the `noexcept` entry point below
+ * has to catch. ADR-005 forbids exactly that in the governed zone, and #116 made the rule
+ * mechanical - `mdux-governed-lint` rejects `try`/`catch` in governed source, and on GCC/Clang
+ * `governed.noThrow.symbolScan` rejects the resulting `__cxa_throw` reference in the object. A
+ * present rule outranks a hypothetical consumer.
  *
  * Nothing about the module's determinism changes with the move. The integer-only rule below is a
  * property of the source, and the committed atlas bytes it produces are byte-compared in CI
@@ -153,8 +154,10 @@ struct OutlinePoint {
 /**
  * @brief A glyph outline in font units: points, plus the index of each contour's last point.
  *
- * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in governed types because a
- * governed module may not import a host-tools one (ADR-004). `contourEnds[i]` is the index of
+ * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in parser-independent types.
+ * Until #116 that restatement was forced - a governed module may not import a host-tools one
+ * (ADR-004) - and it is now kept by choice, so this module stays movable back into `MduXCore` if
+ * a device path is ever built and made allocation-free. `contourEnds[i]` is the index of
  * the final point of contour `i`, so contour 0 is `points[0 .. contourEnds[0]]` and contour `i`
  * is `points[contourEnds[i-1] + 1 .. contourEnds[i]]` - TrueType's own convention, kept rather
  * than converted to offsets so the baker's translation stays a copy rather than a computation.

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -470,9 +470,12 @@ struct BakedGlyph {
                 continue;
             }
 
-            // Translate the parser's outline into the rasteriser's governed input type. This copy
-            // is the trust-zone boundary made concrete: mdux.text.raster is governed and cannot
-            // name a host-tools type, so the baker is what bridges them (ADR-004).
+            // Translate the parser's outline into the rasteriser's own input type. This copy was
+            // the trust-zone boundary made concrete until #116, when mdux.text.raster joined this
+            // zone; the rasteriser could now name `truetype::GlyphPoint` directly. It is kept
+            // because the decoupling is what would let the rasteriser move back into MduXCore if a
+            // device path is ever built (see Raster.cppm), and the copy costs one pass per glyph
+            // at build time.
             std::vector<raster::OutlinePoint> points;
             points.reserve(outline->points.size());
             for (const truetype::GlyphPoint& gp : outline->points) {


### PR DESCRIPTION
## Summary

Last of three for #116, and the one that closes it.

`ADR-005:54` said "the governed-zone source lint also rejects `throw`, `try`, and `catch`". No such lint had ever been written. `ADR-004` item 2 described a "mandatory CI banned-include lint" that was equally absent. This is both of them, plus the ADR rewrite that makes the documents describe only mechanisms CI runs.

### The lint

Nine rules over `MduXCore`'s sources: `throw` (GOV001), `try`/`catch` (GOV002), throwing `.value()` (GOV003), raw allocation (GOV004), filesystem and console (GOV005), clocks and randomness (GOV006), unsafe casts (GOV007), `std::fma` (GOV008), and banned platform/graphics/OS headers (GOV009). Codes are stable once published, in the shared diagnostic envelope from #118.

GOV009 closes the gap ADR-004 item 1 names explicitly: denying `MduXCore` Vulkan's include *directories* does not make a system-installed `<vulkan/vulkan.h>` unreachable, because the compiler still finds it in a default search path. Only a source check does.

Two design points carry the weight:

**The file list is parsed out of `target_sources(MduXCore ...)`, not globbed.** A glob over `include/mdux/**` also collects the adapter modules under `render/` and `vulkansc/`, which are permitted to throw and would be reported as violations — and it would miss #116's requirement that generated shader C arrays are not scanned as hand-authored governed source. Those are emitted into the build tree, so deriving from the source list excludes them by construction rather than by an exclusion pattern someone must maintain. A module added to `MduXCore` is covered the moment it is registered, which matters for #15. If the block cannot be parsed the lint exits non-zero rather than scanning nothing.

**Matching happens on the source with comments and string literals removed.** The governed tree is heavily commented and those comments discuss the very constructs banned here — `Kernels.cppm` says "Never `std::fma`", `Draw.cpp` says "a new command is needed", `Runtime.cppm` says "throw away exactly the information the incident report needs". A line-based matcher reports all three. Stripping preserves offsets, so findings still carry a real line and column.

The tree passes with two suppressions, both in `src/ml/Runtime.cpp`, both the `reinterpret_cast` that reads a caller-supplied weights blob as floats — the mechanism ADR-008 chose, guarded by an explicit alignment check on the line above. The marker is per-line and shows up in a diff.

### The ADR reconciliation

`ADR-005` gains a **"What is enforced"** section listing the three layers and naming the file that implements each. It opens with the `import std` / `-fno-exceptions` constraint from #188, and states two consequences plainly: the "usable in `-fno-exceptions` builds" consequence is marked **unmet**, and it is unreachable for any project consuming `MduXCore` through `import std`.

The section ends by saying what is claimed and what is not — governed code contains no throw expression, and *can* still reach libstdc++'s throwing helpers through ordinary `std::string` and `std::vector` use. The risk register gains that item with **"Mitigation: none today"**, because the alternative was to leave a reader with an impression the tree does not support.

`ADR-004` item 2 now names the lint. A new subsection records the zone-placement rule #187 established: a speculative future device consumer does not justify governed placement against a present constraint. The "claim, stated exactly" paragraph gains a no-throw clause and an `-fno-exceptions` exclusion.

### Also here

- `docs/architecture.md`: the trust-zone claim, the `governed` test label, the negative fixture.
- `docs/roadmap.md`: the header table said 7 delivered and 3 waves while the footer said 8 and four; nine are delivered now that #11 closes. The header also still named a commit SHA that `f4e9900` reported replacing with the release tag.
- `.gitignore`: `inputs/` as a directory rule. Five specific sub-paths were listed, leaving `inputs/CMake/` and any new folder under `inputs/Documentation/` untracked but **not ignored** — so `git add -A` would have committed exactly the material #7 and #23 purged from history and ADR-006 forbids.

Closes #116.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #184

## Dependency

- **Base branch:** `116-governed-throw-enforcement` (stacked)
- **Predecessor PR:** #188, itself stacked on #187
- **Merge order:** **must not merge until #188 has merged**, which must not merge until #187 has. The ADR text here describes the mechanism #188 adds, so merging it first would document something that does not exist — the failure mode this whole issue is about.

## Shared registries touched

- [x] Generated indexes — none changed, but `generate_ai_reference.py --check` was run to confirm
- [x] None of the others

## Rebase state

- **Rebased onto:** `6b4268e` (predecessor head), on `913fe84`, on `e96dc35` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [x] `cmake --preset ninja-gcc && cmake --build build-gcc` — clean, 0 errors
- [x] `ctest --test-dir build-gcc` — 438/438 passed
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (78 files, 0 findings)
- [x] Other:
  - `python3 tools/governed-lint/mdux_governed_lint.py` — OK (29 files checked, 0 findings); the 29 files match the 29 objects the symbol scan reads
  - `python3 -m unittest discover -s tools/governed-lint` — 31 tests, OK
  - end-to-end regression check: a `throw` appended to `src/draw/Draw.cpp` was reported at the correct file, line and column with exit status 1, then reverted
  - `mdux-evidence-lint` OK; `check_schema_type_drift.py` OK; `generate_ai_reference.py --check` up to date
  - confirmed `git status` no longer shows `inputs/`

Not run locally: the MSVC leg. The lint is toolchain-independent Python, so the Windows exposure here is inherited from #188 rather than added.

### A note on the unit tests

They are weighted toward the cases where the lint must stay **quiet**. A source lint an author routes around by rewording documentation is worse than no lint. Three of those fixtures quote block-comment interiors and needed their `/* */` delimiters to mean what they claim — without them the fixture really is code, and it failed correctly.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.

## Regulatory impact

**This is a compliance-documentation correction as much as a feature.** Two ADRs asserted enforcement that did not exist; both now describe only what CI runs, and both gained explicit statements of what they cannot claim:

- `MduXCore` cannot be built with `-fno-exceptions` (ADR-005, previously listed as an achieved positive consequence).
- Governed code can reach libstdc++'s throwing helpers (ADR-005 risk register, mitigation: none today).

`ADR-004`'s "claim, stated exactly" paragraph — the wording `sdf-documents` and `mdux-regulated-change` both require for compliance contexts — was updated in both directions, and now carries a note that every clause names a CI mechanism and every exclusion names something checked and found not to hold.

Closing #116 and #117 closes epic #11, so no enforcement gap carries into Wave 5.