### PR TITLE
Amend ADR-011/012: keep the compiled screen locale-free, matching TrustSC [#203]

### DIFF
--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -20,8 +20,11 @@ storage sized from that budget and never grown. A compiler that could not comput
 build time would leave that type with no way to be used as designed.
 
 **Text shaping is already forbidden on device.** ADR-010 settled that static text bakes to
-positioned glyph runs and dynamic text is restricted to a validated charset. A `.medui` runtime
-that resolved `t("STR-KEY")` itself would reopen the question ADR-010 closed.
+positioned glyph runs and dynamic text is restricted to a validated charset. A `.medui` runtime that
+*shaped* `t("STR-KEY")` — chose glyphs, applied substitutions, measured — would reopen the question
+ADR-010 closed. Looking a key up to find the run ADR-010 already baked does not: the shaping
+happened on the build machine either way, and the lookup is a bounded scan of a fixed table. That
+distinction is what lets the Decision below keep keys in the package rather than baked runs.
 
 **The governed zone is a hostile place to put a parser.** ADR-004 keeps `MduXCore` on `std` alone,
 and issue #116 made ADR-005's no-throwing rule mechanical — `mdux-governed-lint` rejects
@@ -40,7 +43,8 @@ consumes. That choice determines whether a device build links a parser at all.
 ## Medical Device Considerations
 
 ### IEC 62304 implications (software lifecycle)
-- **Verification moves left.** A screen whose layout, text budgets and colour tokens are resolved at
+- **Verification moves left.** A screen whose layout is solved, whose text budgets are checked and
+  whose colour tokens and text keys are *validated* at
   build time can be rejected by a build, and a build failure is an artifact of the development
   process rather than a field observation. A screen resolved at runtime can only be verified by
   running it, on every input that changes it.
@@ -78,9 +82,10 @@ device runtime performs none of them, and turns that layout into vertices.**
 | Emit golden references (see rule below) | build machine | host tools |
 | **Build a `DrawList` from a compiled screen** | **device** | **governed** |
 
-*Layout*, not *geometry*: the compiler produces rectangles, colours and budgets, and the runtime
-produces vertices and indices from them. ADR-012 decision 2 explains why the vertex data cannot be
-baked. Both records use the word this way, and neither uses "geometry" for the compiled form.
+*Layout*, not *geometry*: the compiler produces rectangles, budgets and the validated token and key
+*names* each node draws with, and the runtime produces vertices and indices from them. ADR-012
+decision 2 explains why the vertex data cannot be baked. Both records use the word this way, and
+neither uses "geometry" for the compiled form.
 
 **Resolution is validated at build time; the last substitution is a bounded table lookup.** A
 `Theme.Colors.<Token>` and a `t("STR-KEY")` are both *checked* by the compiler — an unknown token
@@ -103,11 +108,17 @@ by looking each node's `text_key` up for the running locale. TrustSC does exactl
 `ScreenTextLayout::from_screen(screen, package, locale)`.
 
 The consequence that decides it: **adding an approved locale touches no screen artifact at all.**
-The alternative — one screen package per locale, carrying baked runs — would add a file and a
-`evidence.screen.<id>` per locale, and would re-baked every screen when a translation changed.
+The alternative — one screen package per locale, carrying baked runs — would add a file and an
+`evidence.screen.<id>` per locale, and would rebake every screen when a translation changed.
 Translations change far more often than layouts, and coupling the two makes the frequent change
-rewrite the stable artifact. It would also oblige a single-package variant to size `DrawBudget` for
-the widest locale on every device, including devices shipping only one.
+rewrite the stable artifact.
+
+**The cost of choosing this way, stated as a cost.** A locale-free screen does not know which locale
+it will be paired with, so its `DrawBudget` has to cover the widest approved translation — and a
+device shipping only `en-US` carries the German or Finnish ceiling in its buffers. Per-locale
+packages would size each budget to its own locale, and that is their one real advantage; it is
+given up deliberately. Buffer headroom is cheap and recoverable, while a translation update that
+rewrites every screen's digest is neither.
 
 Two things this does *not* relax. The compiler still validates every key against every approved
 locale, and still validates text budgets against the widest approved translation (#195) — that work

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -71,7 +71,7 @@ device runtime performs none of them, and turns that layout into vertices.**
 | Stage | Where | Zone |
 |---|---|---|
 | Lex, parse, build AST | build machine | host tools |
-| Resolve theme tokens to literal RGBA8, and text keys to baked glyph runs | build machine | host tools |
+| Validate theme tokens and text keys against every approved locale | build machine | host tools |
 | Solve layout, flatten `Row`, compute absolute rectangles | build machine | host tools |
 | Validate text budgets against every approved locale | build machine | host tools |
 | Compute the `DrawBudget` | build machine | host tools |
@@ -82,19 +82,38 @@ device runtime performs none of them, and turns that layout into vertices.**
 produces vertices and indices from them. ADR-012 decision 2 explains why the vertex data cannot be
 baked. Both records use the word this way, and neither uses "geometry" for the compiled form.
 
-**Resolved means literal, not looked up.** A `Theme.Colors.<Token>` becomes an RGBA8 value in the
-package, not a token name the runtime resolves against a table; a `t("STR-KEY")` becomes the baked
-glyph run for that locale, not a key the runtime looks up. The authoring names are retained
-*alongside* the resolved values — for diff readability, for the golden references, and for
-diagnostics — but nothing on the device reads them to decide what to draw. A runtime holding an
-unresolved token would be performing the last step of a resolution this ADR places on the build
-machine, which is the boundary being drawn rather than a detail of it.
+**Resolution is validated at build time; the last substitution is a bounded table lookup.** A
+`Theme.Colors.<Token>` and a `t("STR-KEY")` are both *checked* by the compiler — an unknown token
+is a compile error, and a key missing from any approved locale is a compile error naming the locale
+— and both are then carried into the package **as names**, resolved on device against a governed
+table.
 
-Baking the glyph runs makes *which locale* a property of the artifact rather than of the running
-device, and this ADR does not settle whether one compiled screen carries every approved locale or
-whether there is one per locale. Colours have no such multiplicity; text does, because the budget
-row above validates against every approved locale. ADR-012 decision 1 owns the file layout and
-records the question against #197 and #198.
+An earlier draft of this ADR required the opposite: RGBA8 values and baked glyph runs in the screen
+package, on the argument that a runtime holding a token would be "performing the last step of a
+resolution this ADR places on the build machine". That argument was definitional rather than
+consequential, and it is withdrawn. What this boundary exists to keep off the device is *parsing*
+and *unbounded work*; a lookup in a fixed, governed table is neither. The sibling project reached
+this conclusion first — `resolve_color_token()` and `THEME_COLORS` are in TrustSC's governed
+`trustsc-ui` crate, and its `CompiledScreenPackage` carries `text_key` and `color_token` — and the
+parity programme's direction is MduX moving toward it.
+
+**A compiled screen is locale-free.** It carries no locale field and no glyph runs. Per-locale
+glyph runs stay in the text package where ADR-010 already put them, and the two are joined on device
+by looking each node's `text_key` up for the running locale. TrustSC does exactly this in
+`ScreenTextLayout::from_screen(screen, package, locale)`.
+
+The consequence that decides it: **adding an approved locale touches no screen artifact at all.**
+The alternative — one screen package per locale, carrying baked runs — would add a file and a
+`evidence.screen.<id>` per locale, and would re-baked every screen when a translation changed.
+Translations change far more often than layouts, and coupling the two makes the frequent change
+rewrite the stable artifact. It would also oblige a single-package variant to size `DrawBudget` for
+the widest locale on every device, including devices shipping only one.
+
+Two things this does *not* relax. The compiler still validates every key against every approved
+locale, and still validates text budgets against the widest approved translation (#195) — that work
+does not move to the device just because the substitution does. And the lookup must be a bounded
+scan of a fixed table with a `Result` on miss, never an allocation or a throw; `mdux-governed-lint`
+and `governed.noThrow.symbolScan` hold the runtime to that.
 
 **Golden references cover safety-critical nodes and explicitly-positioned ones.** Two rules from
 the `medui-authoring` skill, stated here because ADR-012 depends on the same predicate: a

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -64,7 +64,7 @@ safety-critical nodes live.
 
 | File | Committed | Contents |
 |---|---|---|
-| `package.json` | yes | the compiled screen: resolved nodes, absolute rectangles, `DrawBudget`, requirement ids, and the validated `Theme.Colors.<Token>` and `t("STR-KEY")` names each node draws with. **No locale field, no glyph runs, no RGBA8** |
+| `package.json` | yes | the compiled screen: compiled nodes, absolute rectangles, `DrawBudget`, requirement ids, and the validated `Theme.Colors.<Token>` and `t("STR-KEY")` names each node draws with. **No locale field, no glyph runs, no RGBA8** |
 | `goldens.json` | yes | one golden reference per node matching ADR-011's predicate: `@safety_critical`, or an explicit `position:`, or both merged into one entry (#196). Always written, as `[]` when a screen matches no node |
 | `report.json` | yes | the ADR-007 bake report: inputs, digests, tool version |
 
@@ -230,7 +230,8 @@ human should read.
 - ADR-004: Trust zones in C++ — why the compiler is host-only
 - ADR-007: Evidence pipeline doctrine — the committed-artifact model, canonical JSON, bake reports
 - ADR-008: Zero-SOUP ML inference — decision 2, the constexpr-package end state #153 pursues
-- ADR-010: No on-device text shaping — why text is resolved before the device sees it
+- ADR-010: No on-device text shaping — why text is *shaped* before the device sees it; the
+  key-to-run lookup this record leaves on device is not shaping
 - ADR-011: The deterministic `.medui` compile boundary — the decision this one details
 - `cmake/MduXShaderEmit.cmake` and `tools/shader/Emit.cppm` — the bake-versus-emit argument in full
 - Issues #196, #197, #198 and #16

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -64,14 +64,15 @@ safety-critical nodes live.
 
 | File | Committed | Contents |
 |---|---|---|
-| `package.json` | yes | the compiled screen: resolved nodes, absolute rectangles, `DrawBudget`, literal RGBA8 colours, baked glyph runs, requirement ids — plus the authoring names each resolved value came from |
+| `package.json` | yes | the compiled screen: resolved nodes, absolute rectangles, `DrawBudget`, requirement ids, and the validated `Theme.Colors.<Token>` and `t("STR-KEY")` names each node draws with. **No locale field, no glyph runs, no RGBA8** |
 | `goldens.json` | yes | one golden reference per node matching ADR-011's predicate: `@safety_critical`, or an explicit `position:`, or both merged into one entry (#196). Always written, as `[]` when a screen matches no node |
 | `report.json` | yes | the ADR-007 bake report: inputs, digests, tool version |
 
-The colour and text columns are **resolved values, not lookups** — ADR-011 fixes that boundary, and
-the distinction matters here because a package carrying only a token name would oblige the runtime
-to resolve it. The authoring names ride along beside the resolved values so that a diff is readable
-and a golden reference can name what an author wrote, but nothing on the device reads them.
+The colour and text columns are **validated names, not baked values** — ADR-011 fixes that boundary.
+The compiler proves every token exists and every key is present in every approved locale, and the
+device performs the substitution by a bounded lookup in a governed table. Carrying names rather than
+values is also what makes the package readable in a diff: a reviewer sees
+`Theme.Colors.ScoreDigits`, not `[33, 184, 107, 255]`.
 
 Canonical JSON throughout, written through `mdux.evidence.json`. Registered via
 `mdux_bake_artifact()`, so each screen gets a build-tree bake, an `-update` target and an
@@ -87,13 +88,17 @@ that way, both binding on #198:
   slug from the screen name rather than using it, and the mapping has to be injective and recorded
   in the recipe, since two screens differing only in case would otherwise collide.
 
-**Open: whether locales multiply this layout.** Since the package carries baked glyph runs rather
-than text keys, one screen with three approved locales is either one package holding all three or
-three packages. The layout above assumes the former and does not argue for it; `mdux.text.schema`'s
-`TextPackage` took the latter shape — a single `locale` field, "the runtime reads no others"
-(`include/mdux/text/Schema.cppm:145`). #197 settles it when it defines the schema and #198 when it
-lays out `generated/screen/`; whichever is chosen, the `evidence.screen.<id>` id has to stay unique,
-which is the constraint that makes this a layout question rather than a schema detail.
+**Locales do not multiply this layout.** One screen, one directory, whatever the approved locale
+count — because ADR-011 keeps the package locale-free and leaves the per-locale glyph runs in the
+text package. `mdux.text.schema`'s `TextPackage` already carries a single `locale` field and "the
+runtime reads no others" (`include/mdux/text/Schema.cppm:145`), so a device pairs one screen package
+with the text package for the locale it is running.
+
+This question was recorded as open in an earlier revision, on the assumption that the screen carried
+baked glyph runs. It closes with that assumption. The reason to prefer it, stated as a consequence
+rather than a preference: **adding an approved locale rewrites no screen artifact**, so a translation
+update cannot change the digest of a screen whose layout nobody touched. In a byte-compared evidence
+pipeline that is the difference between re-verifying one artifact and re-verifying all of them.
 
 ### 2. The payload is **layout, not geometry**
 
@@ -107,10 +112,9 @@ vertices would mean baking only the static subset and computing the rest anyway 
 where one suffices, and a budget split across both.
 
 What is fixed at compile time is everything that makes the runtime's job bounded: *where* each node
-is, *how much* it may draw, and *which* atlas entries it may use — in the resolved form decision 1
-fixes, so the colours are RGBA8 values rather than tokens awaiting a lookup. Turning that into
-vertices is arithmetic over a known bound, which is exactly what a governed, allocation-free
-runtime can do.
+is, *how much* it may draw, and *which* validated token and key it draws with. Turning that into
+vertices is a bounded table lookup followed by arithmetic over a known bound, which is exactly what
+a governed, allocation-free runtime can do.
 
 ### 3. Generated C++ is emitted, never committed
 


### PR DESCRIPTION
## Summary

Re-lands an amendment that was written on #190's branch **after PR #202 had already merged**, so it never reached `develop`. My error — I read `gh pr checks 202`, saw zero failures, and treated a successful `git push` as delivery without checking the commit was on the target branch. @ambroise-leclerc caught it.

Until this merges, `develop`'s ADRs and the Wave 5 child issues **contradict each other**: ADR-011 on `develop` says "Resolved means literal, not looked up", while #193, #195, #197 and #198 were already updated to say a compiled screen is locale-free. That is the failure mode #116 existed to remove, so it is recorded in #203 rather than fixed quietly.

## The decision

Checking TrustSC before propagating #190's records to the Wave 5 children found that the sibling already answers the locale question, a third way neither ADR considered:

- `CompiledScreenPackage` (`crates/trustsc-ui/src/lib.rs:273`) has **no locale field**
- Nodes carry `text_key` and `color_token` — names, not values
- Per-locale glyph runs stay in the text package; the join happens on device via `ScreenTextLayout::from_screen(screen, package, locale)`
- `resolve_color_token()` and `THEME_COLORS` are in the governed `trustsc-ui` crate

**Adding an approved locale therefore rewrites no screen artifact.** The per-locale packaging MduX was about to choose would add one artifact per locale and rewrite every screen whenever a translation changed — and translations change far more often than layouts, so it makes the frequent change rewrite the stable artifact. In a byte-compared pipeline that is the difference between re-verifying one artifact and re-verifying all of them.

"Resolved means literal" is withdrawn. It was mine, and it was a **definitional** argument — a runtime holding a token would be "performing the last step of a resolution this ADR places on the build machine" — rather than a consequential one. What this boundary keeps off the device is *parsing* and *unbounded work*; a lookup in a fixed governed table is neither.

Two things the withdrawal does **not** relax, written into the ADR so it is not read as wider than it is:

1. The compiler still validates every colour token, every text key against every approved locale, and every text budget against the widest approved translation. That work does not move to the device because the substitution does.
2. The device lookup must be a bounded scan returning a `Result` on miss — never an allocation, never a throw. `mdux-governed-lint` and `governed.noThrow.symbolScan` enforce that once the module is in `MduXCore`.

@devjean-75 — this partly reverts your decision-2 correction in `799dbc8` and my resolved-values wording in `28b615c`. You were right that the two records contradicted each other; the fix goes the other way now, and the parity programme's direction is MduX moving toward the sibling.

Closes #203.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #184

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked. Supersedes the un-merged tail of #202's branch.
- **Merge order:** mergeable now, and **the sooner the better** — `develop` and #193/#195/#197/#198 disagree until it lands.

## Shared registries touched

- [x] None of the above — two ADR files.

## Rebase state

- **Rebased onto:** `9c4f826` (current `develop`, #202's merge commit)
- **Conflicts resolved as a union:** no conflicts. Cherry-picked cleanly, since the lost commit was written on top of the same tree that merged.

## Verification

Documentation only.

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run, nothing in the build graph changed
- [ ] `ctest --test-dir build-gcc` — not run, same reason
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (80 files, 0 findings)
- [x] Other: verified on the branch, against `develop` this time rather than against a merged PR's stale checks — ADR-011 now contains "A compiled screen is locale-free", "Resolved means literal" survives only as the withdrawal note, and ADR-012's open locale question is closed.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** <!-- to be filled after merge -->
- [ ] That run is green.

## Regulatory impact

**Amends two accepted ADRs**, so `mdux-regulated-change` applies. The change moves one substitution step from build time to a bounded device-side table lookup. It does **not** move any validation: locale coverage, unknown colour tokens and text-budget overflow all remain compile errors, which is the IEC 62304 §5.5 argument ADR-011 makes for the boundary in the first place.

The traceability consequence is unchanged — `requirement:` is still resolved at compile time and still appears in the committed package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified architecture guidance for deterministic, locale-free compiled screen packages.
  * Documented runtime lookup of validated theme tokens and text keys.
  * Confirmed locale-specific glyph data remains in text packages, so adding locales does not require rebuilding screen layouts.
  * Reaffirmed build-time validation, locale coverage checks, text budgets, rendering requirements, and non-allocating, non-throwing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->