### PR TITLE
Pin the gcc container to a patch release [#205]

### DIFF
--- a/.github/workflows/compliance-docs.yml
+++ b/.github/workflows/compliance-docs.yml
@@ -24,7 +24,11 @@ jobs:
   compliance-docs:
     name: Compliance & Documentation
     runs-on: ubuntu-latest
-    container: gcc:16
+    # Pinned for the reason linux-gcc16-build.yml states at length: the floating `gcc:16` tag
+    # moved to 16.2.0 and broke the module build (#205). This job does not compile modules, so it
+    # survived - but a floating toolchain makes any failure here ambiguous between "the code
+    # changed" and "the container changed", which is the property worth removing everywhere.
+    container: gcc:16.1.0
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -1,7 +1,7 @@
 name: Linux GCC 16 Build
 
 # NOTE: This project requires C++23 import std support:
-# - GCC 16+ ✅ Available via gcc:16 Docker container
+# - GCC 16+ ✅ Available via the gcc Docker image, pinned to a patch release below
 
 on:
   push:
@@ -24,7 +24,18 @@ jobs:
   linux-build-gcc16:
     name: Linux (GCC 16, Vulkan)
     runs-on: ubuntu-latest
-    container: gcc:16
+    # Pinned to a patch release, not the floating `gcc:16` tag. That tag moved from 16.1.0 to
+    # 16.2.0 on 2026-08-12 and turned develop red on a markdown-only commit (#205): GCC 16.2 could
+    # not read the module BMIs the SpecLab sources produce - "failed to read compiled module
+    # cluster ... Bad file data". The BMI format is not stable across GCC patch releases, and every
+    # other input to this job is already pinned (SpecLab to a commit SHA, CMake to 4.1.1), so the
+    # compiler was the one floating input - and the one most likely to break a C++23 modules build.
+    #
+    # Same reasoning as the CMake pin in windows-build.yml, which that file states at length after
+    # the same thing happened with `latest`. Moving to a newer GCC is a deliberate change: bump this
+    # tag in a PR of its own, so the diff that changes the compiler is the diff that fixes whatever
+    # the change breaks.
+    container: gcc:16.1.0
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -29,7 +29,18 @@ jobs:
   sanitize:
     name: ASan + UBSan (GCC 16)
     runs-on: ubuntu-latest
-    container: gcc:16
+    # Pinned to a patch release, not the floating `gcc:16` tag. That tag moved from 16.1.0 to
+    # 16.2.0 on 2026-08-12 and turned develop red on a markdown-only commit (#205): GCC 16.2 could
+    # not read the module BMIs the SpecLab sources produce - "failed to read compiled module
+    # cluster ... Bad file data". The BMI format is not stable across GCC patch releases, and every
+    # other input to this job is already pinned (SpecLab to a commit SHA, CMake to 4.1.1), so the
+    # compiler was the one floating input - and the one most likely to break a C++23 modules build.
+    #
+    # Same reasoning as the CMake pin in windows-build.yml, which that file states at length after
+    # the same thing happened with `latest`. Moving to a newer GCC is a deliberate change: bump this
+    # tag in a PR of its own, so the diff that changes the compiler is the diff that fixes whatever
+    # the change breaks.
+    container: gcc:16.1.0
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -21,7 +21,11 @@ jobs:
   security-analysis:
     name: Security Analysis
     runs-on: ubuntu-latest
-    container: gcc:16
+    # Pinned for the reason linux-gcc16-build.yml states at length: the floating `gcc:16` tag
+    # moved to 16.2.0 and broke the module build (#205). This job does not compile modules, so it
+    # survived - but a floating toolchain makes any failure here ambiguous between "the code
+    # changed" and "the container changed", which is the property worth removing everywhere.
+    container: gcc:16.1.0
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary

`develop` is red, and **nothing in the repository caused it.**

| Run | Commit | GCC | Result |
|---|---|---|---|
| 11 Aug 19:03 | `9c4f826` | **16.1.0** | pass |
| 12 Aug 08:08 | `fe060dc` | **16.2.0** | fail |

`fe060dc` is PR #204 — two markdown files under `docs/adr/`, nothing else. Its own Linux leg passed on the branch hours earlier.

Both GCC legs failed while **Windows/MSVC passed**. That asymmetry is the whole diagnosis: both GCC jobs declare `container: gcc:16`, a floating Docker tag, and it was repointed to 16.2.0 overnight. GCC 16.2 cannot read the module BMIs the SpecLab sources produce:

```
speclab.core.testsuite: error: failed to read compiled module cluster 427: Bad file data
TestRunner.cppm:59:61: fatal error: failed to load pendings for 'std::unique_ptr'
```

Every other input to those jobs is already pinned — SpecLab to a commit SHA (`tests/CMakeLists.txt:453`), CMake to 4.1.1. The compiler was the one floating input, and the one most likely to break a C++23 modules build, since the BMI format is not stable across patch releases.

### The repository had already learned this

`windows-build.yml` states it at length, about CMake:

> *"Pinned, not 'latest' … CMake changes that UUID as the feature evolves release to release, so newer CMake versions reject it … 'latest' here was the one job that floated, and it broke as soon as 'latest' moved past 4.1.1."*

The reasoning was applied to CMake and never carried across to the compiler container.

### Four jobs pinned, not two

`linux-gcc16-build` and `sanitizers` are the ones that broke. `compliance-docs` and `security-analysis` use the same floating tag, do not compile modules, and survived — they are pinned anyway. A floating toolchain makes any failure in them ambiguous between "the code changed" and "the container changed", and removing that ambiguity everywhere is cheaper than removing it wherever it has already cost something.

### Deliberately not in this PR

Moving to 16.2.0. That is a normal upgrade and belongs in its own change, so the diff that bumps the compiler is the diff that fixes whatever the bump breaks. The failing translation units are all under `_deps/speclab-src/`, so it is likely a SpecLab rebuild rather than anything in MduX.

Closes #205.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #184

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now, and **ahead of everything else** — the post-merge `develop` gate is red, which under `CONTRIBUTING.md` § "Stacked delivery" blocks dependent merges. Wave 5 S2 (#191) is in progress against this base and its PR will show the same failure for the same unrelated reason until this lands.

## Shared registries touched

- [x] None of the above — four workflow files, one line each plus comments.

## Rebase state

- **Rebased onto:** `fe060dc` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run. My local GCC is 16.1.0, so a local build would pass either way and would prove nothing about the pin.
- [ ] `ctest --test-dir build-gcc` — same reason
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (80 files)
- [x] Other: all four workflow files parse as YAML; the compiler version difference is read directly from the two job logs rather than inferred; and `grep -n "container: gcc"` confirms no floating reference is left in `.github/workflows/`.

**This PR's own CI is the real verification** — if `gcc:16.1.0` is not a valid tag the jobs fail immediately on image pull, which is unambiguous, and if it is then the legs go green on a base where `develop` is red.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** <!-- to be filled after merge -->
- [ ] That run is green.

## Regulatory impact

**Reproducibility of the build environment**, which ADR-007's evidence pipeline depends on. The byte-identity argument assumes the toolchain is a known quantity; a floating compiler tag means a re-bake could differ from a committed artifact because the container moved, and the failure would look like artifact drift rather than an environment change. Pinning removes a source of unattributable failure from the evidence chain.

No safety behaviour, risk control or traceability artifact changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized build, compliance, sanitizer, and security checks on a fixed GCC 16.1.0 compiler version.
  - Improved the consistency and reproducibility of automated validation by preventing unexpected compiler updates.
  - Future compiler upgrades will be handled deliberately through dedicated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->