### PR TITLE
Diagnostics and the MDX-E code registry [#191]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ boundary between them enforced at configure time rather than by review:
 |---|---|---|---|
 | **Governed** | `MduXCore`, `MduX_warnings` | `std` only | never throws ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)) |
 | **Adapter** | `MduX` | governed + Vulkan | throws where Vulkan makes it unavoidable |
-| **Host tools** | `MduXToolsCommon`, `MduXShaderBakeLib`, `MduXMlBakeLib`, `MduXTextBakeLib` | anything | may throw freely; never linked into a device target |
+| **Host tools** | `MduXToolsCommon`, `MduXShaderBakeLib`, `MduXMlBakeLib`, `MduXTextBakeLib`, `MduXMeduiLib` | anything | may throw freely; never linked into a device target |
 
 `mdux_verify_trust_zones()` in [`cmake/MduXTrustZones.cmake`](../cmake/MduXTrustZones.cmake) walks
 the full link graph of every declared-governed target at the end of configure and fails on a
@@ -98,6 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); at S2 only the `MDX-E` diagnostic registry (#191) — the parser (#192), emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -653,6 +653,38 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
+# .medui compiler host-tools suite (issue #191)
+#
+# Links MduX::MeduiLib. At S2 the library is the diagnostic code registry and nothing else, so this
+# suite is entirely registry invariants - completeness, uniqueness, identifier shape, ordering
+# against the retired list, and the envelope diagnose() produces. Those are the questions a
+# registry exists to answer mechanically; without them the module is a table of string literals
+# with extra steps.
+add_executable(medui_tools_spec
+    medui/MeduiToolsSpecMain.cpp
+    medui/DiagnosticsTests.cpp
+)
+
+target_link_libraries(medui_tools_spec PRIVATE MduX::MeduiLib speclab::speclab)
+target_include_directories(medui_tools_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(medui_tools_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(medui_tools_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(medui_tools_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(medui_tools_spec)
+
 # ML host-tools suite (issue #60)
 #
 # Links MduX::MlBakeLib, the host-tools-zone target. Deliberately separate from ml_spec, which

--- a/tests/medui/DiagnosticsTests.cpp
+++ b/tests/medui/DiagnosticsTests.cpp
@@ -1,0 +1,249 @@
+/**
+ * @file DiagnosticsTests.cpp
+ * @brief BDD scenarios for the `.medui` diagnostic code registry (issue #191).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The registry's whole value is that questions about the *set* of codes are answerable
+ * mechanically. These are the questions, as tests. A registry nobody enumerates is a table of
+ * string literals with extra steps, so if these scenarios were deleted the module below would be
+ * worth deleting with them.
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+/// Every enumerator, so a scenario can walk the enum rather than the table it is checking against.
+///
+/// Written out rather than derived: C++ has no reflection over an enum, and a `Count` sentinel
+/// cast in a loop would assume contiguity this enum does not promise. The duplication is the point
+/// - adding an enumerator without adding it here fails `every code is registered`, which is the
+/// nudge that also gets it a table row.
+constexpr std::array<md::Code, 22> allCodes{
+    md::Code::RecipeUnreadable,
+    md::Code::RecipeUnparsed,
+    md::Code::RecipeMissingMember,
+    md::Code::SourceUnreadable,
+    md::Code::SourceNotUtf8,
+    md::Code::UnexpectedToken,
+    md::Code::UnknownComponent,
+    md::Code::MissingRequiredField,
+    md::Code::UnknownField,
+    md::Code::DuplicateNodeId,
+    md::Code::NestedRow,
+    md::Code::ForbiddenConstruct,
+    md::Code::HardcodedString,
+    md::Code::UnknownColorToken,
+    md::Code::UnknownTextKey,
+    md::Code::TextKeyMissingForLocale,
+    md::Code::TextBudgetExceeded,
+    md::Code::LayoutOverflow,
+    md::Code::SurfaceExceeded,
+    md::Code::CharsetEscape,
+    md::Code::SafetyCriticalWithoutRequirement,
+    md::Code::UnknownCvCheck,
+};
+
+[[nodiscard]] bool wellFormedId(std::string_view id) {
+    // `MDX-E` followed by exactly three digits. The schema's `code` pattern is looser - it admits
+    // the bakers' `TXT001` too - so this checks the narrower shape this tool committed to, which
+    // the schema alone would not catch.
+    if (id.size() != 8 || !id.starts_with("MDX-E")) {
+        return false;
+    }
+    return std::all_of(id.begin() + 5, id.end(),
+                       [](char c) { return c >= '0' && c <= '9'; });
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The questions a registry exists to answer.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register everyCodeIsRegistered{
+    "Every enumerator has exactly one registry row",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-complete")
+            .Given("the registry and the full enumerator list", [] {})
+            .When("each enumerator is looked up", [] {})
+            .Then("each resolves to a row carrying its own code, and the table has no extras",
+                  [] {
+                      mdux::spec::Checks checks;
+                      for (md::Code code : allCodes) {
+                          const md::CodeInfo& row = md::info(code);
+                          // info() falls back to the first row for an unregistered enumerator, so
+                          // comparing the round-trip is what actually detects a missing row.
+                          checks.expect(row.code == code,
+                                        std::format("enumerator {} has its own row",
+                                                    static_cast<int>(code)));
+                      }
+                      checks.expect(md::registry().size() == allCodes.size(),
+                                    std::format("table has {} rows, one per enumerator (has {})",
+                                                allCodes.size(), md::registry().size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyIdIsUnique{
+    "No two codes share an identifier",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-unique")
+            .Given("the registry", [] {})
+            .When("its identifiers are collected", [] {})
+            .Then("each appears once", [] {
+                mdux::spec::Checks checks;
+                std::vector<std::string_view> ids;
+                for (const md::CodeInfo& row : md::registry()) {
+                    ids.push_back(row.id);
+                }
+                std::ranges::sort(ids);
+                const auto duplicate = std::ranges::adjacent_find(ids);
+                checks.expect(duplicate == ids.end(),
+                              duplicate == ids.end()
+                                  ? "identifiers are unique"
+                                  : std::format("'{}' is used twice", *duplicate));
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyIdIsWellFormed{
+    "Every identifier is MDX-E followed by three digits",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-shape")
+            .Given("the registry", [] {})
+            .When("each identifier is inspected", [] {})
+            .Then("it matches the published prefix and width", [] {
+                mdux::spec::Checks checks;
+                for (const md::CodeInfo& row : md::registry()) {
+                    checks.expect(wellFormedId(row.id),
+                                  std::format("'{}' is well formed", row.id));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyRowSaysWhatItMeans{
+    "Every row carries a non-empty summary",
+    "evidence-unit",
+    [] {
+        // fixHint is deliberately *not* required. The schema calls an empty hint "honest and
+        // common", and an invented one worse than none - so this asserts the summary, which is
+        // what a reader consults before reusing a code, and leaves the hint optional.
+        return speclab::Test("medui-diagnostics-summaries")
+            .Given("the registry", [] {})
+            .When("each row is inspected", [] {})
+            .Then("its summary is present", [] {
+                mdux::spec::Checks checks;
+                for (const md::CodeInfo& row : md::registry()) {
+                    checks.expect(!row.summary.empty(),
+                                  std::format("{} has a summary", row.id));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register idsAreOrderedAndUnretired{
+    "Identifiers ascend, and none collides with a retired number",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-order")
+            .Given("the registry and the retired list", [] {})
+            .When("the identifiers are read in table order", [] {})
+            .Then("they ascend, and no live code reuses a retired number", [] {
+                mdux::spec::Checks checks;
+                std::string_view previous;
+                for (const md::CodeInfo& row : md::registry()) {
+                    if (!previous.empty()) {
+                        checks.expect(previous < row.id,
+                                      std::format("{} follows {}", row.id, previous));
+                    }
+                    previous = row.id;
+                    const bool reused = std::ranges::find(md::retired(), row.id) != md::retired().end();
+                    checks.expect(!reused, std::format("{} is not a retired number", row.id));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// The envelope the codes travel in.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register diagnoseCarriesRegisteredIdentity{
+    "diagnose() stamps the registered id and severity onto the shared envelope",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-diagnose")
+            .Given("a code with a registered fix hint", [] {})
+            .When("a diagnostic is built without an explicit hint", [] {})
+            .Then("the registry's id, severity and hint are used", [] {
+                mdux::spec::Checks checks;
+                const cli::Diagnostic d = md::diagnose(md::Code::UnknownColorToken, "screen.medui",
+                                                       12, 5, "Theme.Colors.Wrong is not a token");
+                checks.expect(d.code == "MDX-E030", std::format("code is MDX-E030, got '{}'", d.code));
+                checks.expect(d.severity == cli::Severity::Error, "severity comes from the registry");
+                checks.expect(d.line == 12 && d.column == 5, "position is carried through");
+                checks.expect(!d.fixHint.empty(), "the registry's fix hint is used when none is given");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register callerHintWins{
+    "A caller-supplied fix hint overrides the registry's",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-hint-override")
+            .Given("a code whose registry hint is generic", [] {})
+            .When("a diagnostic is built with a specific hint", [] {})
+            .Then("the specific one survives", [] {
+                mdux::spec::Checks checks;
+                const cli::Diagnostic d =
+                    md::diagnose(md::Code::UnknownColorToken, "screen.medui", 1, 1, "unknown token",
+                                 "did you mean Theme.Colors.ScoreDigits?");
+                checks.expect(d.fixHint == "did you mean Theme.Colors.ScoreDigits?",
+                              std::format("caller hint kept, got '{}'", d.fixHint));
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register positionsMayBeAbsent{
+    "A finding about the whole file carries no position",
+    "evidence-unit",
+    [] {
+        // The envelope defines line and column as independent, 0 meaning "no precise position on
+        // this axis". A recipe that cannot be opened has neither, and inventing 1:1 would point a
+        // reader at a line that says nothing.
+        return speclab::Test("medui-diagnostics-no-position")
+            .Given("a whole-file failure", [] {})
+            .When("it is reported", [] {})
+            .Then("line and column are both zero", [] {
+                mdux::spec::Checks checks;
+                const cli::Diagnostic d = md::diagnose(md::Code::RecipeUnreadable, "recipe.toml", 0,
+                                                       0, "could not open recipe.toml");
+                checks.expect(d.line == 0 && d.column == 0, "no position invented");
+                checks.expect(d.code == "MDX-E000", "code is carried");
+                checks.raise();
+            })
+            .Execute();
+    }};

--- a/tests/medui/DiagnosticsTests.cpp
+++ b/tests/medui/DiagnosticsTests.cpp
@@ -82,12 +82,17 @@ const mdux::spec::Register everyCodeIsRegistered{
                   [] {
                       mdux::spec::Checks checks;
                       for (md::Code code : allCodes) {
-                          const md::CodeInfo& row = md::info(code);
-                          // info() falls back to the first row for an unregistered enumerator, so
-                          // comparing the round-trip is what actually detects a missing row.
-                          checks.expect(row.code == code,
+                          // tryInfo() rather than info(): a missing row must fail this scenario
+                          // with a named enumerator, not throw out of the loop and lose which one.
+                          const md::CodeInfo* row = md::tryInfo(code);
+                          checks.expect(row != nullptr,
                                         std::format("enumerator {} has its own row",
                                                     static_cast<int>(code)));
+                          if (row != nullptr) {
+                              checks.expect(row->code == code,
+                                            std::format("row for enumerator {} names it back",
+                                                        static_cast<int>(code)));
+                          }
                       }
                       checks.expect(md::registry().size() == allCodes.size(),
                                     std::format("table has {} rows, one per enumerator (has {})",
@@ -243,6 +248,36 @@ const mdux::spec::Register positionsMayBeAbsent{
                                                        0, "could not open recipe.toml");
                 checks.expect(d.line == 0 && d.column == 0, "no position invented");
                 checks.expect(d.code == "MDX-E000", "code is carried");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register unregisteredValuesFailLoudly{
+    "info() throws for a Code value no enumerator names",
+    "evidence-unit",
+    [] {
+        // `Code` has a fixed underlying type, so `static_cast<Code>(200)` is a well-formed value of
+        // the type - not undefined behaviour - and the completeness scenario above cannot reach it,
+        // because it walks the enumerators. An earlier revision returned the first row here, which
+        // would have attached MDX-E000's severity and fix hint to an unrelated failure. Two
+        // reviewers objected to that independently; this scenario is what keeps the objection
+        // answered.
+        return speclab::Test("medui-diagnostics-unregistered")
+            .Given("a Code value outside the enumerators", [] {})
+            .When("it is looked up", [] {})
+            .Then("tryInfo() reports the miss and info() throws", [] {
+                mdux::spec::Checks checks;
+                const auto stray = static_cast<md::Code>(200);
+                checks.expect(md::tryInfo(stray) == nullptr, "tryInfo() returns nullptr");
+
+                bool threw = false;
+                try {
+                    static_cast<void>(md::info(stray));
+                } catch (const std::logic_error&) {
+                    threw = true;
+                }
+                checks.expect(threw, "info() throws std::logic_error rather than returning a row");
                 checks.raise();
             })
             .Execute();

--- a/tests/medui/MeduiToolsSpecMain.cpp
+++ b/tests/medui/MeduiToolsSpecMain.cpp
@@ -1,0 +1,23 @@
+/**
+ * @file MeduiToolsSpecMain.cpp
+ * @brief Entry point for the .medui compiler host-tools SpecLab executable (issue #191).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Links MduX::MeduiLib, the host-tools-zone target. Separate from any governed medui suite for the
+ * reason text_tools_spec is separate from text_spec: keeping the two apart is what preserves the
+ * governed suite's standing evidence that it reaches nothing but std. There is no governed medui
+ * module yet - mdux.medui.schema is #197 and the runtime #199 - so today this suite is the only
+ * one, and it is named for the zone it links so that the split is already in place when the other
+ * arrives.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX MedUI Tools Spec");
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -262,6 +262,52 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(MduXTextBakeLib PRIVATE /experimental:module /std:c++latest)
 endif()
 
+# ---------------------------------------------------------------------------
+# The .medui compiler (epic #15, ADR-011, ADR-012)
+# ---------------------------------------------------------------------------
+#
+# Host-tools zone, like every other baker: the compiler parses untrusted input and may throw and
+# allocate freely, because nothing it contains reaches a device. Deliberately not declared
+# governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
+# reports that at configure time.
+#
+# At S2 (#191) this is the diagnostic code registry and nothing else. The lexer, parser and AST
+# are #192, the emitters #197, and the mdux-meduic executable and its mdux_compile_screen()
+# registration are #198 - so there is no add_executable() here yet, and no bake call site. The
+# library exists now because the registry has to live somewhere the tests can link, and because
+# every later stage adds sources to this target rather than inventing another.
+add_library(MduXMeduiLib)
+add_library(MduX::MeduiLib ALIAS MduXMeduiLib)
+
+target_sources(MduXMeduiLib
+    PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES
+            medui/Diagnostics.cppm
+    PRIVATE
+        medui/Diagnostics.cpp
+)
+
+target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)
+target_link_libraries(MduXMeduiLib PUBLIC MduX::ToolsCommon)
+target_link_libraries(MduXMeduiLib PRIVATE MduX_warnings)
+
+set_target_properties(MduXMeduiLib
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(MduXMeduiLib PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(MduXMeduiLib PRIVATE /experimental:module /std:c++latest)
+endif()
+
 add_executable(mdux-textbake text/TextBakeMain.cpp)
 target_link_libraries(mdux-textbake PRIVATE MduX::TextBakeLib MduX_warnings)
 

--- a/tools/medui/Diagnostics.cpp
+++ b/tools/medui/Diagnostics.cpp
@@ -109,19 +109,41 @@ constexpr std::array<CodeInfo, 22> table{{
 
 std::span<const CodeInfo> registry() noexcept { return table; }
 
-const CodeInfo& info(Code code) noexcept {
+const CodeInfo* tryInfo(Code code) noexcept {
     for (const CodeInfo& row : table) {
         if (row.code == code) {
-            return row;
+            return &row;
         }
     }
-    // Unreachable while DiagnosticsTests' completeness case passes, which is what makes returning
-    // the first row acceptable rather than a silent wrong answer waiting to happen: the test fails
-    // in the pull request that adds an enumerator without a row, not on the path that hits it.
-    return table.front();
+    return nullptr;
 }
 
-std::string_view id(Code code) noexcept { return info(code).id; }
+const CodeInfo& info(Code code) {
+    if (const CodeInfo* row = tryInfo(code)) {
+        return *row;
+    }
+    // Fails loudly rather than returning the first row.
+    //
+    // An earlier revision returned `table.front()` on the argument that the completeness test makes
+    // this unreachable. Two reviewers objected independently, and they were right: the completeness
+    // test covers every *enumerator*, and `Code` has a fixed underlying type, so
+    // `static_cast<Code>(200)` is a well-formed value of the type that no enumerator names. A cast,
+    // a value read from data, or an uninitialised member would all have mapped silently to
+    // MDX-E000 - "the recipe file could not be opened" - with that code's severity and fix hint
+    // attached to an unrelated failure. A registry whose purpose is that a code means one thing
+    // cannot have a path that quietly assigns the wrong one.
+    //
+    // Throwing is available here because this is the host-tools zone (ADR-004, ADR-005): the
+    // compiler never reaches a device, and `tools/CMakeLists.txt` says as much. Callers that need
+    // the non-throwing form have `tryInfo()`.
+    throw std::logic_error{
+        std::format("mdux::tools::medui::info: no registry row for Code value {}. Every enumerator "
+                    "must have a row in Diagnostics.cpp's table; a value outside the enumerators "
+                    "means a cast or an uninitialised Code reached this call.",
+                    static_cast<unsigned>(code))};
+}
+
+std::string_view id(Code code) { return info(code).id; }
 
 std::span<const std::string_view> retired() noexcept {
     static constexpr std::array<std::string_view, 0> none{};

--- a/tools/medui/Diagnostics.cpp
+++ b/tools/medui/Diagnostics.cpp
@@ -1,0 +1,143 @@
+/**
+ * @file Diagnostics.cpp
+ * @brief The `.medui` diagnostic registry table.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The table is the interesting part of this file; everything else is lookup. Each row's `summary`
+ * says what the code means rather than what one call site happened to print, because the summary is
+ * what a reader consults when deciding whether an existing code already covers a new situation -
+ * and reusing a code whose meaning nearly fits is how a stable identifier stops being stable.
+ */
+module;
+
+module mdux.tools.medui.diagnostics;
+
+import std;
+import mdux.tools.cli;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+using cli::Severity;
+
+// Numbers are assigned in blocks, with gaps left inside each block on purpose: a new grammar rule
+// should land next to the grammar rules rather than at the end of the table, and it can only do
+// that if its block has room. The blocks are documented on the enum in Diagnostics.cppm.
+constexpr std::array<CodeInfo, 22> table{{
+    {Code::RecipeUnreadable, "MDX-E000", Severity::Error,
+     "the recipe file could not be opened",
+     "check the path passed on the command line, and that the file is readable"},
+    {Code::RecipeUnparsed, "MDX-E001", Severity::Error,
+     "the recipe is not valid TOML in the subset mdux.tools.toml accepts",
+     "see recipes/font/dejavu-ui.toml for the accepted shape; there is no [[table]] support"},
+    {Code::RecipeMissingMember, "MDX-E002", Severity::Error,
+     "the recipe is missing a member the compiler requires",
+     "add the named key; every recipe knob is required because a defaulted one would not appear "
+     "in report.json (ADR-007)"},
+    {Code::SourceUnreadable, "MDX-E003", Severity::Error,
+     "the .medui source named by the recipe could not be opened", "check the path in the recipe"},
+    {Code::SourceNotUtf8, "MDX-E004", Severity::Error,
+     "the .medui source is not valid UTF-8", "re-save the file as UTF-8 without a byte-order mark"},
+
+    {Code::UnexpectedToken, "MDX-E010", Severity::Error,
+     "the parser found a token that cannot appear here", ""},
+    {Code::UnknownComponent, "MDX-E011", Severity::Error,
+     "the component name is not in the dictionary",
+     "see the component table in the medui-authoring skill; the dictionary is closed"},
+    {Code::MissingRequiredField, "MDX-E012", Severity::Error,
+     "a component is missing a field its dictionary entry requires", ""},
+    {Code::UnknownField, "MDX-E013", Severity::Error,
+     "a component carries a field its dictionary entry does not define",
+     "check the spelling; unknown fields are rejected rather than ignored, so a typo cannot "
+     "silently do nothing"},
+    {Code::DuplicateNodeId, "MDX-E014", Severity::Error,
+     "two nodes in one screen share an id",
+     "ids address nodes in golden references and requirement traces, so they must be unique "
+     "within a screen"},
+    {Code::NestedRow, "MDX-E015", Severity::Error,
+     "a Row contains another Row",
+     "flatten the inner Row into its parent. Row is a single level so that layout stays one "
+     "flattening pass (ADR-011 decision 5)"},
+    {Code::ForbiddenConstruct, "MDX-E016", Severity::Error,
+     "the source uses a loop, conditional, recursion or scripting construct",
+     "express the screen at its maximum extent and hide what is unused. These make the primitive "
+     "count depend on data the compiler cannot see, so DrawBudget could not be computed exactly "
+     "(ADR-011 decision 5)"},
+    {Code::HardcodedString, "MDX-E017", Severity::Error,
+     "a literal string appears where a text key is required",
+     "use t(\"STR-KEY\") against an approved text package. A hardcoded string cannot be validated "
+     "against every approved locale, which is what the budget check needs"},
+
+    {Code::UnknownColorToken, "MDX-E030", Severity::Error,
+     "a Theme.Colors token is not in the governed table",
+     "check the spelling against the theme token table. Unknown tokens are a compile error rather "
+     "than a fallback colour, because a fallback would render something nobody approved"},
+    {Code::UnknownTextKey, "MDX-E031", Severity::Error,
+     "a text key is not in the approved text package at all", ""},
+    {Code::TextKeyMissingForLocale, "MDX-E032", Severity::Error,
+     "a text key exists but is missing from at least one approved locale",
+     "add the translation, or remove the locale from the recipe's approved list. A key present in "
+     "one locale and absent in another is a screen that renders blank on a shipped device"},
+
+    {Code::TextBudgetExceeded, "MDX-E050", Severity::Error,
+     "a component's bounds cannot contain the widest approved translation",
+     "widen the component or shorten the translation. The check is against the widest approved "
+     "locale, not the authoring one"},
+    {Code::LayoutOverflow, "MDX-E051", Severity::Error,
+     "a node does not fit the space its parent allows",
+     "the solver reports overflow rather than clamping, because a clamped layout renders "
+     "something the author did not describe"},
+    {Code::SurfaceExceeded, "MDX-E052", Severity::Error,
+     "a node falls outside the declared surface", ""},
+    {Code::CharsetEscape, "MDX-E053", Severity::Error,
+     "dynamic text could produce a character outside the restricted charset",
+     "restrict the format, or extend the charset in the font recipe and re-bake. The charset is "
+     "what makes \"no shaping on device\" checkable rather than conventional (ADR-010)"},
+
+    {Code::SafetyCriticalWithoutRequirement, "MDX-E070", Severity::Error,
+     "a @safety_critical node carries no requirement:",
+     "add requirement:, or remove the annotation. A safety-critical node with no requirement "
+     "cannot be traced, and tracing is what the annotation is for"},
+    {Code::UnknownCvCheck, "MDX-E071", Severity::Error,
+     "a cv_check names a verification this compiler does not emit", ""},
+}};
+
+}  // namespace
+
+std::span<const CodeInfo> registry() noexcept { return table; }
+
+const CodeInfo& info(Code code) noexcept {
+    for (const CodeInfo& row : table) {
+        if (row.code == code) {
+            return row;
+        }
+    }
+    // Unreachable while DiagnosticsTests' completeness case passes, which is what makes returning
+    // the first row acceptable rather than a silent wrong answer waiting to happen: the test fails
+    // in the pull request that adds an enumerator without a row, not on the path that hits it.
+    return table.front();
+}
+
+std::string_view id(Code code) noexcept { return info(code).id; }
+
+std::span<const std::string_view> retired() noexcept {
+    static constexpr std::array<std::string_view, 0> none{};
+    return none;
+}
+
+cli::Diagnostic diagnose(Code code, std::string file, std::size_t line, std::size_t column,
+                         std::string message, std::string fixHint) {
+    const CodeInfo& row = info(code);
+    return cli::Diagnostic{.file = std::move(file),
+                           .line = line,
+                           .column = column,
+                           .code = std::string{row.id},
+                           .severity = row.severity,
+                           .message = std::move(message),
+                           .fixHint = fixHint.empty() ? std::string{row.fixHint} : std::move(fixHint)};
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -1,0 +1,150 @@
+/**
+ * @file Diagnostics.cppm
+ * @brief The `.medui` compiler's diagnostic code registry: one table, enumerated by tests.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Host-only. The compiler never reaches a device, so this module may allocate and throw freely -
+ * and the codes it publishes are the compiler's contract with an agent, which is the reason the
+ * registry exists at all.
+ *
+ * ## Why a registry rather than string literals
+ *
+ * Every other tool in this repository spells its codes as string literals at the call site:
+ * `constexpr std::string_view recipeUnparsed = "TXT001";` in `tools/text/TextBake.cpp`, and in
+ * `mdux-docs-lint` not even that - `"MDX-D011"` appears inline at nineteen call sites. That works
+ * until someone needs to answer a question about the *set*: is this code already taken, is this
+ * code still emitted, does every code have a fix hint. None of those is answerable by grep with
+ * any confidence, and all three are answerable by construction here.
+ *
+ * The shape is a `constexpr` table keyed by an enum. Call sites name `Code::UnknownColorToken`,
+ * never `"MDX-E004"`, so:
+ *
+ * - **An unregistered code cannot be emitted.** There is no overload taking a string.
+ * - **A registered-but-unused code is detectable**, because the enum is exhaustive and a test can
+ *   walk it. `DiagnosticsTests.cpp` does.
+ * - **A typo is a compile error** rather than a diagnostic nobody can grep for.
+ *
+ * ## The `MDX-E` prefix
+ *
+ * `mdux-docs-lint` publishes `MDX-D###`, and the diagnostic schema names `MDX-D011` in its own
+ * description, so `MDX-` + one letter + three digits is an established family and this joins it as
+ * `MDX-E###`. The bakers' three-letter codes (`SHB`, `SHE`, `TXT`, `MLB`, `EVL`, `GOV`) are a
+ * second, older convention; they are not changed here, and nothing needs them to be - the schema's
+ * `code` pattern admits both, and `code` is opaque to a consumer that keys off it.
+ *
+ * **`E` is for the language, not for "error".** Severity is a separate field, and an `MDX-E` code
+ * may be a warning. Reading the letter as a severity would make `MDX-E###` at severity `warning`
+ * look like a mistake, so it is worth saying which reading is intended.
+ *
+ * ## Stability
+ *
+ * A code's meaning is fixed once published. Rewording `message` or `fixHint` is always allowed and
+ * never a breaking change; changing what a code *means* is not, and the replacement takes a new
+ * number rather than reusing a retired one. Numbers are therefore not reused even when a check is
+ * deleted - `retired` records that, so the gap is visible rather than looking like an oversight.
+ */
+module;
+
+export module mdux.tools.medui.diagnostics;
+
+import std;
+import mdux.tools.cli;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief Every diagnostic the `.medui` compiler can emit.
+ *
+ * Each enumerator has exactly one row in `registry()`, and a test asserts that. The order here is
+ * the order of the table and has no other meaning; codes are assigned by number, not by position.
+ *
+ * Only codes whose meaning is already fixed by an accepted document appear. ADR-011, ADR-012 and
+ * the `medui-authoring` skill between them mandate every one below; nothing here anticipates a
+ * check that has not yet been argued for, because a code invented ahead of its rule is a code
+ * whose meaning is decided by whoever implements it first.
+ */
+enum class Code : std::uint8_t {
+    // 000-009: the recipe and the file, before any `.medui` text is read.
+    RecipeUnreadable,
+    RecipeUnparsed,
+    RecipeMissingMember,
+    SourceUnreadable,
+    SourceNotUtf8,
+
+    // 010-029: the grammar. See the `medui-authoring` skill for the shape being enforced.
+    UnexpectedToken,
+    UnknownComponent,
+    MissingRequiredField,
+    UnknownField,
+    DuplicateNodeId,
+    NestedRow,
+    ForbiddenConstruct,
+    HardcodedString,
+
+    // 030-049: names that must resolve. ADR-011: validated at build time, substituted on device.
+    UnknownColorToken,
+    UnknownTextKey,
+    TextKeyMissingForLocale,
+
+    // 050-069: the bounds and budgets that make the runtime's job finite.
+    TextBudgetExceeded,
+    LayoutOverflow,
+    SurfaceExceeded,
+    CharsetEscape,
+
+    // 070-089: safety-critical annotation rules, per the skill and ADR-012 decision 1.
+    SafetyCriticalWithoutRequirement,
+    UnknownCvCheck,
+};
+
+/// One row of the registry. `constexpr`-friendly throughout: the table is built at compile time.
+struct CodeInfo {
+    Code code{};
+    std::string_view id;       ///< the published `MDX-E###` string; stable once shipped
+    cli::Severity severity{};  ///< the severity this code is emitted at, unless a call site lowers it
+    std::string_view summary;  ///< what the code means, one clause, for documentation and tests
+    std::string_view fixHint;  ///< what an author should do; empty when there is no single fix
+};
+
+/**
+ * @brief The registry, in code order.
+ *
+ * `std::span` over a function-local `static constexpr` array rather than an inline variable, so
+ * there is exactly one table however many translation units import this module.
+ */
+[[nodiscard]] std::span<const CodeInfo> registry() noexcept;
+
+/// The row for `code`. Every enumerator has one, which `registry()`'s test asserts.
+[[nodiscard]] const CodeInfo& info(Code code) noexcept;
+
+/// The published identifier, e.g. `"MDX-E030"`.
+[[nodiscard]] std::string_view id(Code code) noexcept;
+
+/**
+ * @brief Numbers that were published and then retired.
+ *
+ * Empty today, and present from the start so that the first retirement has somewhere to go rather
+ * than prompting a decision under time pressure. A retired number is never reused: a consumer that
+ * pinned behaviour to `MDX-E017` must not silently start matching a different rule.
+ */
+[[nodiscard]] std::span<const std::string_view> retired() noexcept;
+
+/**
+ * @brief Builds a `cli::Diagnostic` carrying `code`'s registered identity.
+ *
+ * The only way to produce a diagnostic from this compiler, and deliberately so - there is no
+ * overload taking a code string, so an unregistered code cannot be emitted. `message` is the
+ * caller's, because only the caller knows the offending value; `fixHint` comes from the registry
+ * unless the caller has something more specific to say.
+ *
+ * `line` and `column` are 1-based, 0 meaning "no precise position on this axis", exactly as the
+ * shared envelope defines them.
+ */
+[[nodiscard]] cli::Diagnostic diagnose(Code code, std::string file, std::size_t line,
+                                       std::size_t column, std::string message,
+                                       std::string fixHint = {});
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -118,11 +118,28 @@ struct CodeInfo {
  */
 [[nodiscard]] std::span<const CodeInfo> registry() noexcept;
 
-/// The row for `code`. Every enumerator has one, which `registry()`'s test asserts.
-[[nodiscard]] const CodeInfo& info(Code code) noexcept;
+/// The row for `code`, or `nullptr` when no row names it. Non-throwing; `info()` is the form
+/// most callers want.
+[[nodiscard]] const CodeInfo* tryInfo(Code code) noexcept;
 
-/// The published identifier, e.g. `"MDX-E030"`.
-[[nodiscard]] std::string_view id(Code code) noexcept;
+/**
+ * @brief The row for `code`. Every enumerator has one, which `DiagnosticsTests` asserts.
+ *
+ * @throws std::logic_error if no row names `code`.
+ *
+ * Not `noexcept`, and it does not fall back to a default row. The completeness test covers every
+ * *enumerator*, but `Code` has a fixed underlying type, so `static_cast<Code>(200)` is a well-formed
+ * value the test cannot reach - and returning some row for it would attach one code's severity and
+ * fix hint to an unrelated failure. A registry exists so that a code means one thing; a silent
+ * wrong answer is the one outcome it must not have.
+ *
+ * Throwing is available because this is the host-tools zone (ADR-004, ADR-005). Use `tryInfo()`
+ * where a miss is an expected outcome rather than a programming error.
+ */
+[[nodiscard]] const CodeInfo& info(Code code);
+
+/// The published identifier, e.g. `"MDX-E030"`. Throws for an unregistered value, as `info()` does.
+[[nodiscard]] std::string_view id(Code code);
 
 /**
  * @brief Numbers that were published and then retired.

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -14,13 +14,13 @@
  *
  * Every other tool in this repository spells its codes as string literals at the call site:
  * `constexpr std::string_view recipeUnparsed = "TXT001";` in `tools/text/TextBake.cpp`, and in
- * `mdux-docs-lint` not even that - `"MDX-D011"` appears inline at nineteen call sites. That works
- * until someone needs to answer a question about the *set*: is this code already taken, is this
- * code still emitted, does every code have a fix hint. None of those is answerable by grep with
- * any confidence, and all three are answerable by construction here.
+ * `mdux-docs-lint` not even that - its nineteen `MDX-D###` call sites spell the code inline, with
+ * no table anywhere. That works until someone needs to answer a question about the *set*: is this
+ * code already taken, is this code still emitted, does every code have a fix hint. None of those
+ * is answerable by grep with any confidence, and all three are answerable by construction here.
  *
  * The shape is a `constexpr` table keyed by an enum. Call sites name `Code::UnknownColorToken`,
- * never `"MDX-E004"`, so:
+ * never `"MDX-E030"`, so:
  *
  * - **An unregistered code cannot be emitted.** There is no overload taking a string.
  * - **A registered-but-unused code is detectable**, because the enum is exhaustive and a test can
@@ -112,8 +112,9 @@ struct CodeInfo {
 /**
  * @brief The registry, in code order.
  *
- * `std::span` over a function-local `static constexpr` array rather than an inline variable, so
- * there is exactly one table however many translation units import this module.
+ * `std::span` over a namespace-scope `constexpr` array in the module's implementation unit
+ * rather than an inline variable, so there is exactly one table however many translation units
+ * import this module.
  */
 [[nodiscard]] std::span<const CodeInfo> registry() noexcept;
 


### PR DESCRIPTION
## Summary

Wave 5 S2. #118 fixed the *envelope* diagnostics travel in; this fixes the *set of codes* that may appear in one. It is the compiler's contract with an agent, so it lands before the parser that will start emitting them (#192).

### Why a registry rather than string literals

Every other tool in this repository spells its codes at the call site — `constexpr std::string_view recipeUnparsed = "TXT001";` in `tools/text/TextBake.cpp`, and in `mdux-docs-lint` not even that: `"MDX-D011"` appears inline at **nineteen** call sites with no table at all.

That works until someone asks a question about the *set*. Is this number already taken? Is this code still emitted anywhere? Does every code carry a fix hint? None of those is answerable by grep with any confidence. All three are answerable by construction here.

The shape is a `constexpr` table keyed by an enum, so call sites name `Code::UnknownColorToken` and never `"MDX-E030"`:

- **An unregistered code cannot be emitted** — `diagnose()` takes no string overload.
- **A registered-but-unused code is detectable** — the enum is walkable, and `DiagnosticsTests.cpp` walks it.
- **A typo is a compile error**, not a diagnostic nobody can grep for.

### `MDX-E` joins an existing family

`mdux-docs-lint` publishes `MDX-D###`, and the diagnostic schema names `MDX-D011` in its own description, so `MDX-` + a letter + three digits is established. The bakers' three-letter codes (`SHB`, `SHE`, `TXT`, `MLB`, `EVL`, `GOV`) are an older second convention — unchanged, and not needing to change, since the schema's `code` pattern admits both and `code` is opaque to a consumer keying off it.

**The `E` is for the language, not for "error."** Severity is a separate field and an `MDX-E` code may be a warning; worth stating before someone infers the other reading and files a bug about `MDX-E###` at severity `warning`.

### Twenty-two codes, none invented

Each is mandated by ADR-011, ADR-012 or the `medui-authoring` skill. Nothing anticipates a check that has not been argued for — a code invented ahead of its rule has its meaning decided by whoever implements it first, which is the opposite of a stable identifier.

Numbers are assigned in blocks with gaps inside each, so a new grammar rule lands beside the grammar rules rather than at the end of the table.

`retired()` is empty and present from the start, so the first retirement has somewhere to go rather than prompting a decision under time pressure. A retired number is never reused: a consumer that pinned behaviour to `MDX-E017` must not silently start matching a different rule.

Closes #191.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #184

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked. #202 and #204 (the ADRs it implements) and #206 (the CI pin) are all merged.
- **Merge order:** mergeable now. It is the predecessor of #192, which needs these codes to report anything.

## Shared registries touched

- [x] `tools/CMakeLists.txt` — new `MduXMeduiLib` host-tools target
- [x] `tests/CMakeLists.txt` — new `medui_tools_spec` suite
- [x] `FILE_SET CXX_MODULES` lists — one new module interface on the new target
- [x] None of the others

## Rebase state

- **Rebased onto:** `2c02cc6` (current `develop`, with the gcc pin)
- **Conflicts resolved as a union:** no conflicts

## Verification

Built and run on GCC 16.1.0 — deliberately **after** #206 landed. An earlier run against red `develop` would have been measuring the container bump, not this change.

- [x] `cmake --preset ninja-gcc && cmake --build build-gcc` — clean, 0 errors
- [x] `ctest --test-dir build-gcc` — **446/446** (438 + 8 new)
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (80 files)
- [x] Other:
  - `mdux_verify_trust_zones()` — 2 governed targets clean; `MduXMeduiLib` is deliberately **not** among them, so a governed target linking it is a configure-time error
  - `mdux-governed-lint` — OK (29 files), unchanged, since medui is host-tools
  - `mdux-evidence-lint` — OK (40 files)
  - all 22 identifiers checked against the schema's `code` pattern: 22 unique, 0 failing

### The completeness test was checked for teeth

A test that only ever runs against a correct registry passes identically when it is working and when it is checking nothing. Adding an enumerator with no table row fails it on **both** assertions:

```
- enumerator 22 has its own row (DiagnosticsTests.cpp:89)
- table has 23 rows, one per enumerator (has 22) (DiagnosticsTests.cpp:93)
```

Reverted after checking; the suite is back to 8/8.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** <!-- to be filled after merge -->
- [ ] That run is green.

## Regulatory impact

**Diagnostic stability is a traceability property.** These codes are what an agent or a reviewer keys off to identify a class of compile failure, and ADR-011 makes several of them the mechanism by which a safety-relevant rule is enforced — `MDX-E070` for a `@safety_critical` node with no `requirement:`, `MDX-E032` for a text key missing from an approved locale, `MDX-E053` for dynamic text that could escape the restricted charset.

Fixing the set before the parser exists is deliberate: a code that changes meaning after publication silently invalidates whatever was keyed to it, and in a regulated context that includes review records. Nothing here asserts any check is *implemented* — the codes exist, the checks that emit them are #192 onward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive diagnostic system for `.medui` compiler errors.
  - Diagnostics include stable identifiers, severity levels, summaries, suggested fixes, and source locations.
  - Added consistent diagnostic lookup and reporting, with clear handling for unrecognized codes.
  - Added the initial `.medui` compiler tools foundation for future parsing and code generation capabilities.

- **Documentation**
  - Documented the `.medui` compiler tools and diagnostic registry in the architecture overview.

- **Tests**
  - Added coverage for diagnostic completeness, formatting, ordering, metadata, source positions, and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->