### PR TITLE
Lexer, parser, AST and the fixture corpus [#192]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,9 +10,13 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: planned, not yet implemented
+## Status: the front end is implemented; the compiler and runtime are not
 
-**There is no `.medui` parser, compiler, or runtime in MduX today.** The HTML/CSS path that used
+**A `.medui` lexer, AST and parser exist** in the host-tools zone as of issue #192 (`tools/medui/`), and
+the diagnostic codes they emit are registered as `MDX-E###` (#191). They parse a screen and reject
+the grammar's structural violations; they resolve nothing.
+
+**There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
 the file as a string, with no parsing, layout or rendering behind it - was deleted by
 [issue #127](https://github.com/ambroise-leclerc/MduX/issues/127).
@@ -96,6 +100,8 @@ verifier checks against. Rules:
 
 ## Checking a file without a full build
 
-`mdux-medui-check path/to/screen.medui` (issue #15, S11) will validate a single file and print
-diagnostics — once it exists. Until then, review a `.medui` file by hand against this grammar and
-the component table above; there is no tooling shortcut yet.
+`mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
+diagnostics — once it exists. The parser it will call already does (#192), so a syntax error, a
+nested `Row`, a control-flow keyword or a duplicate id are already detectable; what is missing is
+the command that exposes them. Until it lands, review a `.medui` file by hand against this grammar
+and the component table above.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -35,7 +35,8 @@ Screen NeuroSense500 {
     @safety_critical(cv_check: [Bounds, ColorHash])
     NumericDisplay {
         id: sedation-index;
-        width: 512px; height: 512px;
+        width: 512px;
+        height: 512px;
         position: 1392px, 80px;
         requirement: "REQ-NS-001";
         template: "TPL-SEDATION-INDEX-160";
@@ -46,6 +47,14 @@ Screen NeuroSense500 {
 ```
 
 - Sizes are `Npx` or `Fill`. `position: Xpx, Ypx` takes a node out of flow at exact pixel coords.
+- **One property per line.** The sibling implementation parses a component body line by line and
+  splits each on its first `:`, so `width: 512px; height: 512px;` on one line is read as a width of
+  `512px; height: 512px` and rejected. This example previously showed that form; it was condensed
+  prose, not a supported shorthand, and TrustSC's own `neurosense.medui` has always had the two on
+  separate lines. MduX's parser is token-based and would accept either, so a screen written this
+  way stays portable in both directions - which is the reason to write it this way.
+- `position` requires fixed `width` and `height`; `Fill` is flow-only, and combining them is a
+  compile error in the reference implementation (#194 owns this check in MduX).
 - `Row { id; height; background?; spacing? }` is a single-level horizontal group, flattened at
   compile time — it cannot nest another `Row`.
 - Text is **always** `t("STR-KEY")` against an approved text package. Hardcoded strings are a

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,20 +674,25 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issue #191)
+# .medui compiler host-tools suite (issues #191, #192)
 #
-# Links MduX::MeduiLib. At S2 the library is the diagnostic code registry and nothing else, so this
-# suite is entirely registry invariants - completeness, uniqueness, identifier shape, ordering
-# against the retired list, and the envelope diagnose() produces. Those are the questions a
-# registry exists to answer mechanically; without them the module is a table of string literals
-# with extra steps.
+# Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
+# completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
+# diagnose() produces - and the lexer and parser (#192), whose rejection cases assert the code and
+# the position rather than the message, since #191 published the codes as the contract and
+# messages are explicitly rewordable.
 add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
+    medui/ParserTests.cpp
 )
 
 target_link_libraries(medui_tools_spec PRIVATE MduX::MeduiLib speclab::speclab)
 target_include_directories(medui_tools_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+# The parser scenarios read tests/medui/fixtures/*.medui, which are real files an author could
+# open rather than string literals - #200's mdux-medui-check will be pointed at the same corpus,
+# and a fixture that exists only inside a test cannot be reused by the tool that checks files.
+target_compile_definitions(medui_tools_spec PRIVATE MDUX_REPO_ROOT="${CMAKE_SOURCE_DIR}")
 
 set_target_properties(medui_tools_spec
     PROPERTIES

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -485,13 +485,26 @@ const mdux::spec::Register trailingContentRejected{
             .Then("both are rejected", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult two = md::parse("Screen A { }\nScreen B { }\n", "t.medui");
-                checks.expect(!two.ok(),
-                              std::format("a second Screen is rejected, got {}",
+                const cli::Diagnostic* d2 = find(two.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(d2 != nullptr,
+                              std::format("MDX-E010 for a second Screen, got {}",
                                           codesOf(two.diagnostics)));
+                if (d2 != nullptr) {
+                    checks.expect(d2->line == 2 && d2->column == 1,
+                                  std::format("at 2:1, the second Screen keyword, got {}:{}",
+                                              d2->line, d2->column));
+                }
+
                 const md::ParseResult junk = md::parse("Screen A { } garbage\n", "t.medui");
-                checks.expect(!junk.ok(),
-                              std::format("trailing junk is rejected, got {}",
+                const cli::Diagnostic* dj = find(junk.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(dj != nullptr,
+                              std::format("MDX-E010 for trailing junk, got {}",
                                           codesOf(junk.diagnostics)));
+                if (dj != nullptr) {
+                    checks.expect(dj->line == 1 && dj->column == 14,
+                                  std::format("at 1:14, the junk token, got {}:{}",
+                                              dj->line, dj->column));
+                }
                 checks.raise();
             })
             .Execute();
@@ -512,21 +525,46 @@ const mdux::spec::Register annotatedChildOutsideRowRejected{
                 mdux::spec::Checks checks;
                 const md::ParseResult child =
                     md::parse("Screen A {\n Card {\n  @x Label { }\n }\n}\n", "a.medui");
-                checks.expect(!child.ok(),
-                              std::format("annotated child rejected, got {}",
+                const cli::Diagnostic* dc = find(child.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(dc != nullptr,
+                              std::format("MDX-E010 for an annotated child, got {}",
                                           codesOf(child.diagnostics)));
+                if (dc != nullptr) {
+                    checks.expect(dc->line == 3 && dc->column == 3,
+                                  std::format("at 3:3, the '@', got {}:{}", dc->line, dc->column));
+                    checks.expect(dc->message.find("Card") != std::string::npos,
+                                  "the message names the offending parent");
+                }
 
+                // A Row under a non-Row is rejected as a child, *not* as a nested Row: the parent
+                // is a Card, so MDX-E015 would be the wrong code. The nested-Row rule is asserted
+                // separately below, where the parent really is a Row.
                 const md::ParseResult row =
                     md::parse("Screen A {\n Card {\n  @x Row { }\n }\n}\n", "a.medui");
-                checks.expect(!row.ok(),
-                              std::format("annotated Row under a non-Row rejected, got {}",
+                checks.expect(find(row.diagnostics, md::Code::UnexpectedToken) != nullptr,
+                              std::format("MDX-E010 for an annotated Row under a Card, got {}",
                                           codesOf(row.diagnostics)));
+
+                // An *annotated* Row inside a Row is the case the gate previously let through
+                // with no diagnostic at all. It must be MDX-E015, exactly as the unannotated form.
+                const md::ParseResult nested =
+                    md::parse("Screen A {\n Row {\n  @x Row { }\n }\n}\n", "a.medui");
+                const cli::Diagnostic* dn = find(nested.diagnostics, md::Code::NestedRow);
+                checks.expect(dn != nullptr,
+                              std::format("MDX-E015 for an annotated nested Row, got {}",
+                                          codesOf(nested.diagnostics)));
+                if (dn != nullptr) {
+                    checks.expect(dn->line == 3 && dn->column == 6,
+                                  std::format("at 3:6, the inner Row, got {}:{}",
+                                              dn->line, dn->column));
+                }
 
                 // The unannotated form was always rejected; asserted so the two paths cannot
                 // drift apart again without a test noticing.
                 const md::ParseResult plain =
                     md::parse("Screen A {\n Card {\n  Label { }\n }\n}\n", "a.medui");
-                checks.expect(!plain.ok(), "the unannotated form stays rejected");
+                checks.expect(find(plain.diagnostics, md::Code::UnexpectedToken) != nullptr,
+                              "the unannotated form stays rejected with the same code");
                 checks.raise();
             })
             .Execute();
@@ -544,8 +582,13 @@ const mdux::spec::Register forbiddenWordInLayoutRejected{
             .Then("MDX-E016 is reported", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse("Screen A {\n layout: if { }\n}\n", "l.medui");
-                checks.expect(has(r.diagnostics, md::Code::ForbiddenConstruct),
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::ForbiddenConstruct);
+                checks.expect(d != nullptr,
                               std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 2 && d->column == 10,
+                                  std::format("at 2:10, the 'if', got {}:{}", d->line, d->column));
+                }
                 checks.raise();
             })
             .Execute();
@@ -602,8 +645,9 @@ const mdux::spec::Register backslashAtLineEndDoesNotEatTheNewline{
                               std::format("a diagnostic was reported, got {}",
                                           codesOf(r.diagnostics)));
                 if (d != nullptr) {
-                    checks.expect(d->line == 2,
-                                  std::format("at the opening quote's line 2, got {}", d->line));
+                    checks.expect(d->line == 2 && d->column == 5,
+                                  std::format("at the opening quote, 2:5, got {}:{}",
+                                              d->line, d->column));
                 }
                 // The token after the broken string must still be on line 3, which it cannot be if
                 // the newline was swallowed.

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -149,8 +149,8 @@ const mdux::spec::Register acceptedScreenShape{
                     }
                     // Position is asserted, not just presence: it is what a diagnostic three
                     // stages later will quote back to the author.
-                    checks.expect(display->position.line == 9,
-                                  std::format("declared on line 9, got {}",
+                    checks.expect(display->position.line == 11,
+                                  std::format("declared on line 11, got {}",
                                               display->position.line));
                 }
 

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -272,6 +272,7 @@ const mdux::spec::Register forbiddenConstructRejected{
                               std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 3, std::format("at line 3, got {}", d->line));
+                    checks.expect(d->column == 5, std::format("at column 5, got {}", d->column));
                     checks.expect(d->message.find("if") != std::string::npos,
                                   "the message names the offending word");
                 }
@@ -297,6 +298,7 @@ const mdux::spec::Register duplicateIdRejected{
                 if (d != nullptr) {
                     checks.expect(d->line == 8, std::format("at the second id, line 8, got {}",
                                                             d->line));
+                    checks.expect(d->column == 9, std::format("at column 9, got {}", d->column));
                     // Naming only the duplicate would leave an author hunting for the original.
                     checks.expect(d->message.find("line 4") != std::string::npos,
                                   std::format("the message cites the first, got '{}'", d->message));
@@ -322,6 +324,7 @@ const mdux::spec::Register unknownUnitRejected{
                               std::format("MDX-E010 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 5, std::format("at line 5, got {}", d->line));
+                    checks.expect(d->column == 18, std::format("at column 18, got {}", d->column));
                     checks.expect(d->fixHint.find("Npx") != std::string::npos,
                                   "the hint names the accepted form");
                 }
@@ -432,6 +435,205 @@ const mdux::spec::Register severalProblemsInOneRun{
                 checks.expect(count >= 2,
                               std::format("at least two findings, got {}",
                                           codesOf(r.diagnostics)));
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Regressions. Each of these parsed clean before review on #209.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register columnsAreUtf8Bytes{
+    "A column counts UTF-8 bytes, not code points",
+    "evidence-unit",
+    [] {
+        // Raised by @coderabbitai: every other position scenario uses ASCII, so a lexer counting
+        // code points would pass all of them. The comment before "e" is 3 ASCII + one 2-byte
+        // character (U+00E9) + 1 ASCII = 6 bytes, so `Screen` starts at byte column 7 and at code
+        // point column 6. Asserting 7 is what pins the convention shared with mdux-docs-lint.
+        return speclab::Test("medui-lex-utf8-columns")
+            .Given("a line with a multi-byte character before a token", [] {})
+            .When("it is lexed", [] {})
+            .Then("the token's column is its byte offset", [] {
+                mdux::spec::Checks checks;
+                const md::LexResult r = md::lex("/*\u00e9*/Screen A { }\n", "u.medui");
+                // `/*` is not a comment in this grammar, so those are unexpected-character
+                // diagnostics; the token positions are what this scenario is about.
+                const auto screen = std::ranges::find_if(
+                    r.tokens, [](const md::Token& t) { return t.text == "Screen"; });
+                checks.expect(screen != r.tokens.end(), "the Screen token was produced");
+                if (screen != r.tokens.end()) {
+                    checks.expect(screen->column == 7,
+                                  std::format("byte column 7 (code-point column would be 6), got {}",
+                                              screen->column));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register trailingContentRejected{
+    "Content after the screen's closing brace is rejected",
+    "evidence-unit",
+    [] {
+        // Before review this parsed clean: the closing brace was consumed and nothing looked at
+        // what followed, so a second Screen or plain garbage produced ok() == true.
+        return speclab::Test("medui-reject-trailing")
+            .Given("two screens in one source, and a source with trailing junk", [] {})
+            .When("each is parsed", [] {})
+            .Then("both are rejected", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult two = md::parse("Screen A { }\nScreen B { }\n", "t.medui");
+                checks.expect(!two.ok(),
+                              std::format("a second Screen is rejected, got {}",
+                                          codesOf(two.diagnostics)));
+                const md::ParseResult junk = md::parse("Screen A { } garbage\n", "t.medui");
+                checks.expect(!junk.ok(),
+                              std::format("trailing junk is rejected, got {}",
+                                          codesOf(junk.diagnostics)));
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register annotatedChildOutsideRowRejected{
+    "An annotated child is rejected outside a Row, and a Row inside one is still MDX-E015",
+    "evidence-unit",
+    [] {
+        // Reported independently by three reviewers on #209. The unannotated path enforced
+        // "only a Row has children"; the annotated path did not, so `Card { @x Label { } }`
+        // was accepted - and `Card { @x Row { } }` put a Row at depth two with no MDX-E015,
+        // because the annotated path also passed insideRow = false.
+        return speclab::Test("medui-reject-annotated-child")
+            .Given("an annotated child under a non-Row parent", [] {})
+            .When("it is parsed", [] {})
+            .Then("it is rejected, as the unannotated form already was", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult child =
+                    md::parse("Screen A {\n Card {\n  @x Label { }\n }\n}\n", "a.medui");
+                checks.expect(!child.ok(),
+                              std::format("annotated child rejected, got {}",
+                                          codesOf(child.diagnostics)));
+
+                const md::ParseResult row =
+                    md::parse("Screen A {\n Card {\n  @x Row { }\n }\n}\n", "a.medui");
+                checks.expect(!row.ok(),
+                              std::format("annotated Row under a non-Row rejected, got {}",
+                                          codesOf(row.diagnostics)));
+
+                // The unannotated form was always rejected; asserted so the two paths cannot
+                // drift apart again without a test noticing.
+                const md::ParseResult plain =
+                    md::parse("Screen A {\n Card {\n  Label { }\n }\n}\n", "a.medui");
+                checks.expect(!plain.ok(), "the unannotated form stays rejected");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register forbiddenWordInLayoutRejected{
+    "A control-flow keyword as a layout kind is MDX-E016",
+    "evidence-unit",
+    [] {
+        // "Wherever an identifier may appear" did not include the layout kind, so `layout: if { }`
+        // parsed clean.
+        return speclab::Test("medui-reject-forbidden-layout")
+            .Given("layout: if { }", [] {})
+            .When("it is parsed", [] {})
+            .Then("MDX-E016 is reported", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse("Screen A {\n layout: if { }\n}\n", "l.medui");
+                checks.expect(has(r.diagnostics, md::Code::ForbiddenConstruct),
+                              std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register onlyThemeColorsIsAColourToken{
+    "A dotted path is a colour token only when it is Theme.Colors.<Token>",
+    "evidence-unit",
+    [] {
+        // Every dotted path was classified ColorToken, so `Foo.Bar` would have reached #193's
+        // theme lookup and produced MDX-E030 "not in the governed table" for a value that never
+        // claimed to name a colour.
+        return speclab::Test("medui-value-colour-classification")
+            .Given("three dotted paths", [] {})
+            .When("they are parsed as values", [] {})
+            .Then("only the qualified one is a ColorToken", [] {
+                mdux::spec::Checks checks;
+                const auto kindOf = [&](std::string_view value) {
+                    const md::ParseResult r = md::parse(
+                        std::format("Screen A {{\n L {{ c: {}; }}\n}}\n", value), "v.medui");
+                    if (!r.screen || r.screen->nodes.empty() ||
+                        r.screen->nodes[0].fields.empty() ||
+                        r.screen->nodes[0].fields[0].value == nullptr) {
+                        return md::ast::ValueKind::Number;  // a sentinel none of the cases expect
+                    }
+                    return r.screen->nodes[0].fields[0].value->kind;
+                };
+                checks.expect(kindOf("Theme.Colors.ScoreDigits") == md::ast::ValueKind::ColorToken,
+                              "Theme.Colors.ScoreDigits is a ColorToken");
+                checks.expect(kindOf("Foo.Bar") == md::ast::ValueKind::Identifier,
+                              "Foo.Bar is not a ColorToken");
+                checks.expect(kindOf("Theme.Colors") == md::ast::ValueKind::Identifier,
+                              "a truncated Theme.Colors is not a ColorToken");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register backslashAtLineEndDoesNotEatTheNewline{
+    "A backslash at end of line does not let a string span lines",
+    "evidence-unit",
+    [] {
+        // The escape branch consumed the next byte unconditionally, so a trailing backslash ate
+        // the newline and the string ran on - skewing every position after it, and reporting the
+        // unterminated string somewhere the author never wrote one.
+        return speclab::Test("medui-lex-backslash-eol")
+            .Given("a string with a trailing backslash", [] {})
+            .When("it is lexed", [] {})
+            .Then("it is unterminated, reported at its opening quote, and lines still line up", [] {
+                mdux::spec::Checks checks;
+                const md::LexResult r = md::lex("Screen A {\n r: \"ab\\\n cd\";\n}\n", "b.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(d != nullptr,
+                              std::format("a diagnostic was reported, got {}",
+                                          codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 2,
+                                  std::format("at the opening quote's line 2, got {}", d->line));
+                }
+                // The token after the broken string must still be on line 3, which it cannot be if
+                // the newline was swallowed.
+                const auto brace = std::ranges::find_if(
+                    r.tokens, [](const md::Token& t) { return t.kind == md::TokenKind::RBrace; });
+                checks.expect(brace != r.tokens.end() && brace->line >= 3,
+                              "positions after the broken string are not skewed");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register screenPositionIsTheKeyword{
+    "A screen's position is the Screen keyword, not its name",
+    "evidence-unit",
+    [] {
+        // Ast.cppm says a node carries the position of the token that introduced it, and
+        // parseLayout/parseSurface both capture before advancing. This one captured after.
+        return speclab::Test("medui-screen-position")
+            .Given("a screen declared at a known column", [] {})
+            .When("it is parsed", [] {})
+            .Then("the position is the keyword's", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse("Screen A { }\n", "s.medui");
+                checks.expect(r.screen.has_value(), "a screen was produced");
+                if (r.screen) {
+                    checks.expect(r.screen->position.column == 1,
+                                  std::format("column 1, the 'Screen' keyword, got {}",
+                                              r.screen->position.column));
+                }
                 checks.raise();
             })
             .Execute();

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -1,0 +1,438 @@
+/**
+ * @file ParserTests.cpp
+ * @brief BDD scenarios for the `.medui` lexer and parser (issue #192).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The rejection scenarios assert on the **code**, not on the message, because #191 published the
+ * codes as the compiler's contract and messages are explicitly rewordable. They also assert the
+ * **position**, which #192 requires: a diagnostic that names the right problem at the wrong place
+ * costs an author as much time as one that names the wrong problem, and a lexer that dropped
+ * columns would make that impossible to notice from the code alone.
+ *
+ * Fixtures live in `fixtures/` as real `.medui` files rather than as string literals in this file.
+ * They are what an author would write, they can be opened in an editor, and #200's
+ * `mdux-medui-check` will be pointed at the same corpus - a fixture that only exists inside a test
+ * cannot be reused by the tool that exists to check files.
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.lexer;
+import mdux.tools.medui.parser;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    const std::filesystem::path path =
+        std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+    std::ifstream in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(
+            std::format("fixture {} could not be opened at {}", name, path.generic_string()),
+            std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+/// True when `code` appears among `diagnostics`.
+[[nodiscard]] bool has(const std::vector<cli::Diagnostic>& diagnostics, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    return std::ranges::any_of(diagnostics,
+                               [wanted](const cli::Diagnostic& d) { return d.code == wanted; });
+}
+
+[[nodiscard]] const cli::Diagnostic* find(const std::vector<cli::Diagnostic>& diagnostics,
+                                          md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto it = std::ranges::find_if(
+        diagnostics, [wanted](const cli::Diagnostic& d) { return d.code == wanted; });
+    return it == diagnostics.end() ? nullptr : &*it;
+}
+
+[[nodiscard]] std::string codesOf(const std::vector<cli::Diagnostic>& diagnostics) {
+    std::string out;
+    for (const cli::Diagnostic& d : diagnostics) {
+        if (!out.empty()) { out += ", "; }
+        out += std::format("{}@{}:{}", d.code, d.line, d.column);
+    }
+    return out.empty() ? "(none)" : out;
+}
+
+/// A node anywhere in the screen with `id: wanted`.
+[[nodiscard]] const md::ast::Node* nodeById(const md::ast::Screen& screen, std::string_view wanted) {
+    const md::ast::Node* found = nullptr;
+    const auto visit = [&](auto&& self, const md::ast::Node& node) -> void {
+        for (const md::ast::Field& f : node.fields) {
+            if (f.name == "id" && f.value != nullptr && f.value->text == wanted) {
+                found = &node;
+            }
+        }
+        for (const md::ast::Node& child : node.children) { self(self, child); }
+    };
+    for (const md::ast::Node& node : screen.nodes) { visit(visit, node); }
+    return found;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The corpus parses.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register acceptedScreenParses{
+    "The worked example from the authoring skill parses with no diagnostics",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-parse-accepted")
+            .Given("the published grammar example", [] {})
+            .When("it is parsed", [] {})
+            .Then("it yields a screen and nothing to report", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("accepted-neurosense.medui"),
+                                                    "accepted-neurosense.medui");
+                checks.expect(r.diagnostics.empty(),
+                              std::format("no diagnostics, got {}", codesOf(r.diagnostics)));
+                checks.expect(r.screen.has_value(), "a screen was produced");
+                if (r.screen) {
+                    checks.expect(r.screen->name == "NeuroSense500",
+                                  std::format("screen name, got '{}'", r.screen->name));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register acceptedScreenShape{
+    "The parsed AST carries layout, surface, annotations and a one-level Row",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-parse-shape")
+            .Given("the parsed example", [] {})
+            .When("its structure is inspected", [] {})
+            .Then("every construct survived with its position", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("accepted-neurosense.medui"),
+                                                    "accepted-neurosense.medui");
+                if (!r.screen) {
+                    checks.expect(false, "a screen was produced");
+                    checks.raise();
+                    return;
+                }
+                const md::ast::Screen& s = *r.screen;
+
+                checks.expect(s.layoutKind == "Vertical",
+                              std::format("layout kind, got '{}'", s.layoutKind));
+                checks.expect(s.layout.size() == 2, "layout carries spacing and padding");
+                checks.expect(s.surface.has_value() && s.surface->x == 1920 && s.surface->y == 1080,
+                              "surface is 1920x1080");
+                checks.expect(s.nodes.size() == 2, "two top-level nodes");
+
+                const md::ast::Node* display = nodeById(s, "sedation-index");
+                checks.expect(display != nullptr, "the NumericDisplay is present");
+                if (display != nullptr) {
+                    checks.expect(display->annotations.size() == 1, "it carries one annotation");
+                    if (!display->annotations.empty()) {
+                        checks.expect(display->annotations[0].name == "safety_critical",
+                                      "the annotation is @safety_critical");
+                    }
+                    // Position is asserted, not just presence: it is what a diagnostic three
+                    // stages later will quote back to the author.
+                    checks.expect(display->position.line == 9,
+                                  std::format("declared on line 9, got {}",
+                                              display->position.line));
+                }
+
+                const md::ast::Node* title = nodeById(s, "title");
+                checks.expect(title != nullptr, "the Row's child survived flattening-free parsing");
+
+                const md::ast::Node* row = nodeById(s, "topbar");
+                checks.expect(row != nullptr && row->children.size() == 1,
+                              "the Row holds exactly its one child");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register valuesKeepTheirKinds{
+    "Sizes, points, text keys and colour tokens parse to distinct value kinds",
+    "evidence-unit",
+    [] {
+        // The kinds are what #193 dispatches on. If `Fill` and `512px` collapsed to one kind, or a
+        // colour token arrived as a bare identifier, the next stage would have to re-lex strings.
+        return speclab::Test("medui-parse-values")
+            .Given("the parsed example", [] {})
+            .When("the NumericDisplay's fields are read", [] {})
+            .Then("each value kind is preserved and unresolved", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("accepted-neurosense.medui"),
+                                                    "accepted-neurosense.medui");
+                if (!r.screen) { checks.expect(false, "a screen was produced"); checks.raise(); return; }
+
+                const md::ast::Node* display = nodeById(*r.screen, "sedation-index");
+                const md::ast::Node* title = nodeById(*r.screen, "title");
+                if (display == nullptr || title == nullptr) {
+                    checks.expect(false, "both nodes present"); checks.raise(); return;
+                }
+                const auto fieldOf = [](const md::ast::Node& n, std::string_view name)
+                    -> const md::ast::Value* {
+                    for (const md::ast::Field& f : n.fields) {
+                        if (f.name == name) { return f.value.get(); }
+                    }
+                    return nullptr;
+                };
+
+                const md::ast::Value* width = fieldOf(*display, "width");
+                checks.expect(width != nullptr && width->kind == md::ast::ValueKind::Size &&
+                                  !width->size.fill && width->size.pixels == 512,
+                              "width is a 512px size");
+
+                const md::ast::Value* fill = fieldOf(*title, "width");
+                checks.expect(fill != nullptr && fill->kind == md::ast::ValueKind::Size &&
+                                  fill->size.fill,
+                              "Fill is a size, flagged fill");
+
+                const md::ast::Value* pos = fieldOf(*display, "position");
+                checks.expect(pos != nullptr && pos->kind == md::ast::ValueKind::Point &&
+                                  pos->point.x == 1392 && pos->point.y == 80,
+                              "position is a point");
+
+                const md::ast::Value* colour = fieldOf(*display, "color");
+                checks.expect(colour != nullptr && colour->kind == md::ast::ValueKind::ColorToken &&
+                                  colour->text == "Theme.Colors.ScoreDigits",
+                              "the colour token is carried whole and unresolved");
+
+                const md::ast::Value* text = fieldOf(*title, "text");
+                checks.expect(text != nullptr && text->kind == md::ast::ValueKind::TextKey &&
+                                  text->text == "STR-TITLE",
+                              "t(\"...\") is a text key, not a string");
+
+                const md::ast::Value* requirement = fieldOf(*display, "requirement");
+                checks.expect(requirement != nullptr &&
+                                  requirement->kind == md::ast::ValueKind::String &&
+                                  requirement->text == "REQ-NS-001",
+                              "a quoted literal stays a String, for #193 to accept or reject");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Rejections. Each asserts the code and the position.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register nestedRowRejected{
+    "A Row inside a Row is MDX-E015, at the inner Row",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-nested-row")
+            .Given("a screen with a nested Row", [] {})
+            .When("it is parsed", [] {})
+            .Then("MDX-E015 names the inner Row's position", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("rejected-nested-row.medui"),
+                                                    "rejected-nested-row.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::NestedRow);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E015 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 6, std::format("at line 6, got {}", d->line));
+                    checks.expect(d->column == 9, std::format("at column 9, got {}", d->column));
+                    checks.expect(!d->fixHint.empty(), "carries the registry's fix hint");
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register forbiddenConstructRejected{
+    "A control-flow keyword is MDX-E016",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-forbidden")
+            .Given("a screen containing 'if'", [] {})
+            .When("it is parsed", [] {})
+            .Then("MDX-E016 names it at its position", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("rejected-forbidden-construct.medui"),
+                                                    "rejected-forbidden-construct.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::ForbiddenConstruct);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 3, std::format("at line 3, got {}", d->line));
+                    checks.expect(d->message.find("if") != std::string::npos,
+                                  "the message names the offending word");
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register duplicateIdRejected{
+    "A repeated node id is MDX-E014, pointing at the second one",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-duplicate-id")
+            .Given("two nodes sharing an id", [] {})
+            .When("the screen is parsed", [] {})
+            .Then("MDX-E014 names the second and cites the first", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("rejected-duplicate-id.medui"),
+                                                    "rejected-duplicate-id.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::DuplicateNodeId);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E014 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 8, std::format("at the second id, line 8, got {}",
+                                                            d->line));
+                    // Naming only the duplicate would leave an author hunting for the original.
+                    checks.expect(d->message.find("line 4") != std::string::npos,
+                                  std::format("the message cites the first, got '{}'", d->message));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register unknownUnitRejected{
+    "A length in a unit other than px is MDX-E010",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-bad-unit")
+            .Given("a width written as 10rem", [] {})
+            .When("the screen is parsed", [] {})
+            .Then("MDX-E010 says what units exist", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("rejected-bad-unit.medui"),
+                                                    "rejected-bad-unit.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E010 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 5, std::format("at line 5, got {}", d->line));
+                    checks.expect(d->fixHint.find("Npx") != std::string::npos,
+                                  "the hint names the accepted form");
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register unterminatedStringRejected{
+    "An unterminated string is reported at its opening quote",
+    "evidence-unit",
+    [] {
+        // Reported where the string *started*, not where the line ended: the opening quote is
+        // where the author's mistake is, and a diagnostic at the newline points at the symptom.
+        return speclab::Test("medui-reject-unterminated-string")
+            .Given("a string with no closing quote", [] {})
+            .When("the source is lexed", [] {})
+            .Then("the diagnostic points at the opening quote", [] {
+                mdux::spec::Checks checks;
+                const md::LexResult r = md::lex(fixture("rejected-unterminated-string.medui"),
+                                                "rejected-unterminated-string.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(d != nullptr,
+                              std::format("a diagnostic was reported, got {}",
+                                          codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 5, std::format("at line 5, got {}", d->line));
+                    checks.expect(d->column == 22,
+                                  std::format("at the opening quote, column 22, got {}",
+                                              d->column));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Lexer properties the parser depends on.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register commentsAreSkipped{
+    "A // comment does not become a token",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-lex-comments")
+            .Given("a source with a trailing comment", [] {})
+            .When("it is lexed", [] {})
+            .Then("only the code tokens survive, with positions after the comment intact", [] {
+                mdux::spec::Checks checks;
+                const md::LexResult r = md::lex("// leading\nScreen A { } // trailing\n", "c.medui");
+                checks.expect(r.ok(), "no diagnostics");
+                checks.expect(r.tokens.size() == 5,
+                              std::format("Screen, A, {{, }}, EOF - got {}", r.tokens.size()));
+                if (r.tokens.size() >= 2) {
+                    checks.expect(r.tokens[0].line == 2,
+                                  std::format("the comment did not eat the newline, got line {}",
+                                              r.tokens[0].line));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register invalidUtf8Rejected{
+    "A source that is not valid UTF-8 is rejected whole, with MDX-E004",
+    "evidence-unit",
+    [] {
+        // Whole rather than at the byte: past an invalid sequence there are no defined character
+        // boundaries, so every column after it would be invented.
+        return speclab::Test("medui-lex-bad-utf8")
+            .Given("a source containing a lone continuation byte", [] {})
+            .When("it is lexed", [] {})
+            .Then("MDX-E004 is reported and no tokens are produced", [] {
+                mdux::spec::Checks checks;
+                std::string source = "Screen A { }\n";
+                source += '\x80';
+                const md::LexResult r = md::lex(source, "bad.medui");
+                checks.expect(has(r.diagnostics, md::Code::SourceNotUtf8),
+                              std::format("MDX-E004 reported, got {}", codesOf(r.diagnostics)));
+                checks.expect(r.tokens.empty(), "no tokens, so no invented positions");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register severalProblemsInOneRun{
+    "One run reports more than the first problem",
+    "evidence-unit",
+    [] {
+        // A compiler that stops at the first error makes fixing a screen an iterative guessing
+        // game, and #200 exists to hand an author everything at once.
+        return speclab::Test("medui-parse-recovery")
+            .Given("a screen with two independent bad fields", [] {})
+            .When("it is parsed", [] {})
+            .Then("both are reported", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(
+                    "Screen A {\n"
+                    "  surface: 800px, 600px;\n"
+                    "  Label {\n"
+                    "    width: 10rem;\n"
+                    "    height: 20rem;\n"
+                    "  }\n"
+                    "}\n",
+                    "two.medui");
+                const auto count = std::ranges::count_if(
+                    r.diagnostics, [](const cli::Diagnostic& d) { return d.code == "MDX-E010"; });
+                checks.expect(count >= 2,
+                              std::format("at least two findings, got {}",
+                                          codesOf(r.diagnostics)));
+                checks.raise();
+            })
+            .Execute();
+    }};

--- a/tests/medui/fixtures/accepted-neurosense.medui
+++ b/tests/medui/fixtures/accepted-neurosense.medui
@@ -1,0 +1,31 @@
+// The skill's own worked example, extended to exercise every construct the parser accepts.
+// Kept close to the published grammar deliberately: a fixture that drifts from the documentation
+// stops being evidence that the documentation is implementable.
+Screen NeuroSense500 {
+    layout: Vertical { spacing: 8px; padding: 0px; }
+    surface: 1920px, 1080px;
+
+    @safety_critical(cv_check: [Bounds, ColorHash])
+    NumericDisplay {
+        id: sedation-index;
+        width: 512px; height: 512px;
+        position: 1392px, 80px;
+        requirement: "REQ-NS-001";
+        template: "TPL-SEDATION-INDEX-160";
+        source: "SEDATION_INDEX";
+        color: Theme.Colors.ScoreDigits;
+    }
+
+    Row {
+        id: topbar;
+        height: 64px;
+        background: Theme.Colors.TopbarBackground;
+
+        Label {
+            id: title;
+            width: Fill; height: 64px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+    }
+}

--- a/tests/medui/fixtures/accepted-neurosense.medui
+++ b/tests/medui/fixtures/accepted-neurosense.medui
@@ -1,6 +1,8 @@
-// The skill's own worked example, extended to exercise every construct the parser accepts.
-// Kept close to the published grammar deliberately: a fixture that drifts from the documentation
-// stops being evidence that the documentation is implementable.
+// The skill's worked example, extended to exercise every construct the parser accepts.
+// One property per line, matching TrustSC's own neurosense.medui: its parser splits a component
+// body line by line, so two properties on one line are rejected there even though MduX's
+// token-based parser would accept them. Written the portable way on purpose - a fixture that
+// only compiles under one of the two implementations is not evidence the grammar is shared.
 Screen NeuroSense500 {
     layout: Vertical { spacing: 8px; padding: 0px; }
     surface: 1920px, 1080px;
@@ -8,7 +10,8 @@ Screen NeuroSense500 {
     @safety_critical(cv_check: [Bounds, ColorHash])
     NumericDisplay {
         id: sedation-index;
-        width: 512px; height: 512px;
+        width: 512px;
+        height: 512px;
         position: 1392px, 80px;
         requirement: "REQ-NS-001";
         template: "TPL-SEDATION-INDEX-160";
@@ -23,7 +26,8 @@ Screen NeuroSense500 {
 
         Label {
             id: title;
-            width: Fill; height: 64px;
+            width: Fill;
+            height: 64px;
             text: t("STR-TITLE");
             color: Theme.Colors.Title;
         }

--- a/tests/medui/fixtures/rejected-bad-unit.medui
+++ b/tests/medui/fixtures/rejected-bad-unit.medui
@@ -1,0 +1,8 @@
+Screen BadUnit {
+    surface: 800px, 600px;
+    Label {
+        id: label;
+        width: 10rem;
+        height: 10px;
+    }
+}

--- a/tests/medui/fixtures/rejected-duplicate-id.medui
+++ b/tests/medui/fixtures/rejected-duplicate-id.medui
@@ -1,0 +1,11 @@
+Screen Duplicated {
+    surface: 800px, 600px;
+    Label {
+        id: same;
+        width: 10px; height: 10px;
+    }
+    Label {
+        id: same;
+        width: 10px; height: 10px;
+    }
+}

--- a/tests/medui/fixtures/rejected-forbidden-construct.medui
+++ b/tests/medui/fixtures/rejected-forbidden-construct.medui
@@ -1,0 +1,6 @@
+Screen WithControlFlow {
+    surface: 800px, 600px;
+    if {
+        id: nope;
+    }
+}

--- a/tests/medui/fixtures/rejected-nested-row.medui
+++ b/tests/medui/fixtures/rejected-nested-row.medui
@@ -1,0 +1,11 @@
+Screen Nested {
+    surface: 800px, 600px;
+    Row {
+        id: outer;
+        height: 64px;
+        Row {
+            id: inner;
+            height: 32px;
+        }
+    }
+}

--- a/tests/medui/fixtures/rejected-unterminated-string.medui
+++ b/tests/medui/fixtures/rejected-unterminated-string.medui
@@ -1,0 +1,7 @@
+Screen Unterminated {
+    surface: 800px, 600px;
+    Label {
+        id: label;
+        requirement: "REQ-OPEN;
+    }
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,11 +271,10 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S2 (#191) this is the diagnostic code registry and nothing else. The lexer, parser and AST
-# are #192, the emitters #197, and the mdux-meduic executable and its mdux_compile_screen()
-# registration are #198 - so there is no add_executable() here yet, and no bake call site. The
-# library exists now because the registry has to live somewhere the tests can link, and because
-# every later stage adds sources to this target rather than inventing another.
+# At S3 (#192) this is the diagnostic registry (#191) plus the lexer, AST and parser. The
+# emitters are #197, and the mdux-meduic executable with its mdux_compile_screen() registration
+# is #198 - so there is still no add_executable() here and no bake call site. Every later stage
+# adds sources to this target rather than inventing another.
 add_library(MduXMeduiLib)
 add_library(MduX::MeduiLib ALIAS MduXMeduiLib)
 
@@ -285,8 +284,13 @@ target_sources(MduXMeduiLib
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         FILES
             medui/Diagnostics.cppm
+            medui/Lexer.cppm
+            medui/Ast.cppm
+            medui/Parser.cppm
     PRIVATE
         medui/Diagnostics.cpp
+        medui/Lexer.cpp
+        medui/Parser.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/medui/Ast.cppm
+++ b/tools/medui/Ast.cppm
@@ -1,0 +1,122 @@
+/**
+ * @file Ast.cppm
+ * @brief The `.medui` abstract syntax tree.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Host-only, and deliberately *unresolved*. Component names, field names and theme tokens are all
+ * carried as the strings the author wrote, with their positions. Nothing here is checked against
+ * the component dictionary or the theme table.
+ *
+ * That is the boundary between this stage (#192) and the next (#193), and it is worth stating
+ * because the opposite arrangement is the tempting one. A parser that knew the dictionary could
+ * reject an unknown component at the point it reads the name, which reads like an improvement -
+ * until adding a component means touching the parser, and until a field's meaning depends on which
+ * component encloses it, at which point the parser is doing semantic analysis with a worse error
+ * vocabulary. Keeping names as names means #193 can be replaced without this file changing.
+ *
+ * What the parser *does* enforce is structure that no dictionary can express: nesting depth, the
+ * absence of control flow, and id uniqueness. Those are properties of the grammar rather than of
+ * any particular component, so they belong here (ADR-011 decision 5).
+ *
+ * Every node carries the line and column of the token that introduced it, so a diagnostic raised
+ * three stages later can still point at the source. Positions are cheap here and impossible to
+ * reconstruct later.
+ */
+module;
+
+export module mdux.tools.medui.ast;
+
+import std;
+
+export namespace mdux::tools::medui::ast {
+
+/// Where something was written. 1-based, matching the shared diagnostic envelope.
+struct Position {
+    std::size_t line{0};
+    std::size_t column{0};
+};
+
+/// A `Npx` length, or `Fill`.
+struct Size {
+    bool fill{false};
+    std::int64_t pixels{0};
+    Position position{};
+};
+
+/// `position: Xpx, Ypx` - out-of-flow placement at exact coordinates.
+struct Point {
+    std::int64_t x{0};
+    std::int64_t y{0};
+    Position position{};
+};
+
+/// What a field's value is. `Identifier` covers bare words such as `Vertical` or `Fill`; the
+/// parser does not know which are meaningful, only which are syntactically possible.
+enum class ValueKind : std::uint8_t {
+    Size,        ///< `512px` or `Fill`
+    Point,       ///< `1392px, 80px`
+    String,      ///< `"REQ-NS-001"` - a literal, which most fields must not accept (#193)
+    TextKey,     ///< `t("STR-KEY")`
+    ColorToken,  ///< `Theme.Colors.ScoreDigits`, carried unresolved
+    Identifier,  ///< `Vertical`, `sedation-index`
+    Number,      ///< a bare integer, e.g. `spacing: 8` without a unit
+    List,        ///< `[Bounds, ColorHash]`
+};
+
+struct Value;
+
+/// One `name: value;` inside a node or a layout block.
+struct Field {
+    std::string name;
+    Position namePosition{};
+    std::shared_ptr<Value> value;  ///< shared_ptr because Value is incomplete here and lists nest
+};
+
+struct Value {
+    ValueKind kind{ValueKind::Identifier};
+    Position position{};
+
+    Size size{};                       ///< kind == Size
+    Point point{};                     ///< kind == Point
+    std::string text;                  ///< String, TextKey, ColorToken (the token name), Identifier
+    std::int64_t number{0};            ///< Number
+    std::vector<std::shared_ptr<Value>> list;  ///< List
+};
+
+/// `@safety_critical(cv_check: [Bounds, ColorHash])`, carried unresolved.
+struct Annotation {
+    std::string name;
+    Position position{};
+    std::vector<Field> arguments;
+};
+
+/**
+ * @brief A component instance, or a `Row`.
+ *
+ * `children` is non-empty only for `Row`. The parser rejects a `Row` inside a `Row` (`MDX-E015`),
+ * so this is one level deep by construction rather than by convention - #194's solver relies on
+ * that, and ADR-011 decision 5 records why the restriction is a solver argument rather than a
+ * budget one.
+ */
+struct Node {
+    std::string component;   ///< as written; not checked against the dictionary here
+    Position position{};
+    std::vector<Annotation> annotations;
+    std::vector<Field> fields;
+    std::vector<Node> children;
+};
+
+/// One `Screen <Name> { ... }`. A source declares exactly one.
+struct Screen {
+    std::string name;
+    Position position{};
+    std::vector<Field> layout;   ///< the `layout:` block's fields, e.g. spacing and padding
+    std::string layoutKind;      ///< `Vertical`; empty when no `layout:` was declared
+    Position layoutPosition{};
+    std::optional<Point> surface;
+    std::vector<Node> nodes;
+};
+
+}  // namespace mdux::tools::medui::ast

--- a/tools/medui/Lexer.cpp
+++ b/tools/medui/Lexer.cpp
@@ -1,0 +1,275 @@
+/**
+ * @file Lexer.cpp
+ * @brief The `.medui` lexer.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * One pass, one character of lookahead, no backtracking. The grammar does not need more, and a
+ * lexer a reviewer can hold in their head is worth more here than one that is clever.
+ */
+module;
+
+module mdux.tools.medui.lexer;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// An identifier body. Hyphens are included because node ids use them - `id: sedation-index;` in
+/// the skill's own example - and excluding them would force quotes on every id.
+[[nodiscard]] constexpr bool isIdentifierChar(char c) noexcept {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' ||
+           c == '-';
+}
+
+/// An identifier start. A digit cannot begin one, or `1920px` would lex as one identifier rather
+/// than a number followed by a unit - and the parser needs those separate to reject `1920rem`.
+[[nodiscard]] constexpr bool isIdentifierStart(char c) noexcept {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+}
+
+[[nodiscard]] constexpr bool isDigit(char c) noexcept { return c >= '0' && c <= '9'; }
+
+/**
+ * @brief Validates UTF-8 and reports the byte offset of the first bad sequence.
+ *
+ * Written out rather than delegated: the standard library has no UTF-8 validator, and the
+ * alternative is a SOUP entry for one function. Rejects overlong encodings, surrogates and
+ * out-of-range code points, because "it decoded to something" is not the same as "it was valid" -
+ * an overlong NUL is the classic way a filter is bypassed, and this text ends up in a committed
+ * artifact.
+ */
+[[nodiscard]] std::optional<std::size_t> firstInvalidUtf8(std::string_view s) noexcept {
+    std::size_t i = 0;
+    while (i < s.size()) {
+        const auto b0 = static_cast<unsigned char>(s[i]);
+        std::size_t extra = 0;
+        std::uint32_t cp = 0;
+        std::uint32_t lowest = 0;
+
+        if (b0 < 0x80) {
+            i += 1;
+            continue;
+        }
+        if ((b0 & 0xE0u) == 0xC0u) { extra = 1; cp = b0 & 0x1Fu; lowest = 0x80; }
+        else if ((b0 & 0xF0u) == 0xE0u) { extra = 2; cp = b0 & 0x0Fu; lowest = 0x800; }
+        else if ((b0 & 0xF8u) == 0xF0u) { extra = 3; cp = b0 & 0x07u; lowest = 0x10000; }
+        else { return i; }
+
+        if (i + extra >= s.size()) {
+            return i;
+        }
+        for (std::size_t k = 1; k <= extra; ++k) {
+            const auto bk = static_cast<unsigned char>(s[i + k]);
+            if ((bk & 0xC0u) != 0x80u) {
+                return i;
+            }
+            cp = (cp << 6) | (bk & 0x3Fu);
+        }
+        if (cp < lowest || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)) {
+            return i;  // overlong, out of range, or a surrogate
+        }
+        i += extra + 1;
+    }
+    return std::nullopt;
+}
+
+/// Tracks the cursor and its 1-based position, so every token can be stamped without recomputing.
+class Cursor {
+public:
+    explicit Cursor(std::string_view source) noexcept : source_{source} {}
+
+    [[nodiscard]] bool atEnd() const noexcept { return offset_ >= source_.size(); }
+    [[nodiscard]] char peek() const noexcept { return atEnd() ? '\0' : source_[offset_]; }
+    [[nodiscard]] char peekNext() const noexcept {
+        return offset_ + 1 < source_.size() ? source_[offset_ + 1] : '\0';
+    }
+    [[nodiscard]] std::size_t offset() const noexcept { return offset_; }
+    [[nodiscard]] std::size_t line() const noexcept { return line_; }
+    [[nodiscard]] std::size_t column() const noexcept { return column_; }
+
+    char advance() noexcept {
+        const char c = peek();
+        ++offset_;
+        if (c == '\n') {
+            ++line_;
+            column_ = 1;
+        } else {
+            ++column_;
+        }
+        return c;
+    }
+
+private:
+    std::string_view source_;
+    std::size_t offset_{0};
+    std::size_t line_{1};
+    std::size_t column_{1};
+};
+
+}  // namespace
+
+std::string_view describe(TokenKind kind) noexcept {
+    switch (kind) {
+        case TokenKind::Identifier: return "an identifier";
+        case TokenKind::Number:     return "a number";
+        case TokenKind::String:     return "a string";
+        case TokenKind::At:         return "'@'";
+        case TokenKind::LBrace:     return "'{'";
+        case TokenKind::RBrace:     return "'}'";
+        case TokenKind::LParen:     return "'('";
+        case TokenKind::RParen:     return "')'";
+        case TokenKind::LBracket:   return "'['";
+        case TokenKind::RBracket:   return "']'";
+        case TokenKind::Colon:      return "':'";
+        case TokenKind::Semicolon:  return "';'";
+        case TokenKind::Comma:      return "','";
+        case TokenKind::Dot:        return "'.'";
+        case TokenKind::EndOfFile:  return "end of file";
+    }
+    return "an unknown token";
+}
+
+LexResult lex(std::string_view source, std::string file) {
+    LexResult result;
+
+    if (const std::optional<std::size_t> bad = firstInvalidUtf8(source)) {
+        // Rejected whole rather than at the offending byte. Past an invalid sequence there are no
+        // defined character boundaries, so every column after it would be a guess.
+        result.diagnostics.push_back(diagnose(
+            Code::SourceNotUtf8, std::move(file), 0, 0,
+            std::format("not valid UTF-8: the first invalid byte sequence begins at offset {}",
+                        *bad)));
+        return result;
+    }
+
+    Cursor cursor{source};
+    const auto push = [&result](TokenKind kind, std::string text, std::size_t line,
+                                std::size_t column) {
+        result.tokens.push_back(Token{.kind = kind,
+                                      .text = std::move(text),
+                                      .line = line,
+                                      .column = column});
+    };
+
+    while (!cursor.atEnd()) {
+        const char c = cursor.peek();
+
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+            static_cast<void>(cursor.advance());
+            continue;
+        }
+        if (c == '/' && cursor.peekNext() == '/') {
+            while (!cursor.atEnd() && cursor.peek() != '\n') {
+                static_cast<void>(cursor.advance());
+            }
+            continue;
+        }
+
+        const std::size_t line = cursor.line();
+        const std::size_t column = cursor.column();
+
+        if (isIdentifierStart(c)) {
+            const std::size_t start = cursor.offset();
+            while (!cursor.atEnd() && isIdentifierChar(cursor.peek())) {
+                static_cast<void>(cursor.advance());
+            }
+            push(TokenKind::Identifier,
+                 std::string{source.substr(start, cursor.offset() - start)}, line, column);
+            continue;
+        }
+
+        if (isDigit(c)) {
+            const std::size_t start = cursor.offset();
+            while (!cursor.atEnd() && isDigit(cursor.peek())) {
+                static_cast<void>(cursor.advance());
+            }
+            push(TokenKind::Number, std::string{source.substr(start, cursor.offset() - start)},
+                 line, column);
+            continue;
+        }
+
+        if (c == '"') {
+            static_cast<void>(cursor.advance());  // the opening quote
+            std::string value;
+            bool terminated = false;
+            while (!cursor.atEnd()) {
+                const char ch = cursor.peek();
+                if (ch == '"') {
+                    static_cast<void>(cursor.advance());
+                    terminated = true;
+                    break;
+                }
+                if (ch == '\n') {
+                    break;  // a string does not span lines; report it at the opening quote
+                }
+                if (ch == '\\') {
+                    static_cast<void>(cursor.advance());
+                    const char esc = cursor.peek();
+                    switch (esc) {
+                        case '"':  value += '"';  static_cast<void>(cursor.advance()); break;
+                        case '\\': value += '\\'; static_cast<void>(cursor.advance()); break;
+                        case 'n':  value += '\n'; static_cast<void>(cursor.advance()); break;
+                        case 't':  value += '\t'; static_cast<void>(cursor.advance()); break;
+                        default:
+                            // An unknown escape is an error rather than a literal backslash. A
+                            // silently-kept `\d` in a requirement id is the kind of thing that
+                            // survives review and then fails a trace years later.
+                            result.diagnostics.push_back(diagnose(
+                                Code::UnexpectedToken, file, cursor.line(), cursor.column(),
+                                std::format("unknown escape '\\{}' in a string",
+                                            esc == '\0' ? '?' : esc),
+                                "the supported escapes are \\\" \\\\ \\n and \\t"));
+                            static_cast<void>(cursor.advance());
+                            break;
+                    }
+                    continue;
+                }
+                value += cursor.advance();
+            }
+            if (!terminated) {
+                result.diagnostics.push_back(diagnose(
+                    Code::UnexpectedToken, file, line, column, "unterminated string",
+                    "add the closing quote; a string may not span lines"));
+                continue;
+            }
+            push(TokenKind::String, std::move(value), line, column);
+            continue;
+        }
+
+        const auto single = [&](TokenKind kind) {
+            static_cast<void>(cursor.advance());
+            push(kind, std::string{c}, line, column);
+        };
+
+        switch (c) {
+            case '@': single(TokenKind::At);        continue;
+            case '{': single(TokenKind::LBrace);    continue;
+            case '}': single(TokenKind::RBrace);    continue;
+            case '(': single(TokenKind::LParen);    continue;
+            case ')': single(TokenKind::RParen);    continue;
+            case '[': single(TokenKind::LBracket);  continue;
+            case ']': single(TokenKind::RBracket);  continue;
+            case ':': single(TokenKind::Colon);     continue;
+            case ';': single(TokenKind::Semicolon); continue;
+            case ',': single(TokenKind::Comma);     continue;
+            case '.': single(TokenKind::Dot);       continue;
+            default: break;
+        }
+
+        result.diagnostics.push_back(diagnose(
+            Code::UnexpectedToken, file, line, column,
+            std::format("unexpected character '{}'", c)));
+        static_cast<void>(cursor.advance());
+    }
+
+    push(TokenKind::EndOfFile, {}, cursor.line(), cursor.column());
+    return result;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Lexer.cpp
+++ b/tools/medui/Lexer.cpp
@@ -209,6 +209,14 @@ LexResult lex(std::string_view source, std::string file) {
                     break;  // a string does not span lines; report it at the opening quote
                 }
                 if (ch == '\\') {
+                    // A backslash at end of line or end of file is not an escape. Consuming the
+                    // next byte regardless let a string swallow its own newline and run on into
+                    // the following line, skewing every position after it - and the unterminated
+                    // string would then be reported somewhere the author never wrote one.
+                    const char next = cursor.peekNext();
+                    if (next == '\n' || next == '\0') {
+                        break;  // leaves `terminated` false: reported at the opening quote
+                    }
                     static_cast<void>(cursor.advance());
                     const char esc = cursor.peek();
                     switch (esc) {

--- a/tools/medui/Lexer.cppm
+++ b/tools/medui/Lexer.cppm
@@ -1,0 +1,117 @@
+/**
+ * @file Lexer.cppm
+ * @brief Hand-written `.medui` lexer: source text to positioned tokens.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Host-only, like the rest of the compiler. Hand-written rather than generated, for the reason
+ * `mdux.tools.truetype` and `mdux.tools.toml` are: a generator is a SOUP entry, a build-time
+ * dependency and a second language in the tree, and this grammar is small enough that none of that
+ * buys anything. It is also the shape a reviewer can read.
+ *
+ * ## Every token carries a line and a column
+ *
+ * Not a convenience. The shared diagnostic envelope (#118) defines `line` and `column` as
+ * independent, 1-based, with 0 meaning "no precise position on this axis" - and #192 requires a
+ * fixture to assert the position rather than only the code. A lexer that tracked lines alone would
+ * make that impossible for every diagnostic downstream, so positions are carried from the first
+ * stage rather than reconstructed later.
+ *
+ * Columns count UTF-8 *bytes*, not code points, and the header comment on `Token` says so. A
+ * multi-byte character before a token therefore shifts its reported column. That is the same
+ * convention `mdux-docs-lint` and `mdux-governed-lint` use, and matching them matters more than
+ * being clever: an agent consuming the shared envelope should not need to know which tool produced
+ * a finding to interpret its column.
+ *
+ * ## Comments
+ *
+ * `//` to end of line. The `medui-authoring` skill's grammar block does not show a comment, and
+ * this is the one place the lexer accepts something the skill does not illustrate. It is included
+ * deliberately: a screen carries `requirement:` strings and `@safety_critical` annotations, and a
+ * language for describing safety-relevant UI in which an author cannot write down *why* is a
+ * language that pushes that reasoning somewhere the compiler never sees. Recorded here rather than
+ * assumed, so the decision is reviewable; if it is rejected, deleting `skipComment()` and the
+ * fixture that covers it is the whole change.
+ *
+ * Block comments are deliberately absent. They need nesting rules, they invite commented-out
+ * screens, and nothing here needs them.
+ */
+module;
+
+export module mdux.tools.medui.lexer;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief What a token is.
+ *
+ * Deliberately small. The parser decides what an identifier *means* - `Screen`, `Row`, a component
+ * name, a field name and a theme token are all `Identifier` here - because a lexer that classified
+ * them would need the component dictionary, and the dictionary belongs to a later stage (#193).
+ * Keeping that knowledge out means adding a component never touches this file.
+ */
+enum class TokenKind : std::uint8_t {
+    Identifier,   ///< `Screen`, `NumericDisplay`, `width`, `Fill`, `sedation-index`
+    Number,       ///< an integer literal; `px` arrives as a separate Identifier token
+    String,       ///< `"REQ-NS-001"`, with the quotes removed and escapes resolved
+    At,           ///< `@`, opening an annotation
+    LBrace,       ///< `{`
+    RBrace,       ///< `}`
+    LParen,       ///< `(`
+    RParen,       ///< `)`
+    LBracket,     ///< `[`
+    RBracket,     ///< `]`
+    Colon,        ///< `:`
+    Semicolon,    ///< `;`
+    Comma,        ///< `,`
+    Dot,          ///< `.`, joining `Theme.Colors.<Token>`
+    EndOfFile,
+};
+
+[[nodiscard]] std::string_view describe(TokenKind kind) noexcept;
+
+/**
+ * @brief One token, with where it started.
+ *
+ * `line` and `column` are 1-based, matching the shared envelope. `column` counts UTF-8 bytes from
+ * the line start, not code points - see the file header.
+ *
+ * `text` borrows from the source buffer for identifiers and numbers, and owns for strings, whose
+ * escapes are resolved during lexing. One `std::string` either way keeps the type simple; this is
+ * a host tool compiling one screen, and a borrow-versus-own union would be optimising the wrong
+ * thing.
+ */
+struct Token {
+    TokenKind kind{TokenKind::EndOfFile};
+    std::string text;
+    std::size_t line{0};
+    std::size_t column{0};
+};
+
+/// The tokens of one source, or the diagnostics that stopped it being tokenised.
+struct LexResult {
+    std::vector<Token> tokens;
+    std::vector<cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept { return diagnostics.empty(); }
+};
+
+/**
+ * @brief Tokenises `source`, attributing every diagnostic to `file`.
+ *
+ * Never throws for malformed input: a bad character or an unterminated string becomes a
+ * diagnostic, because a compiler that throws on the input it exists to reject is a compiler that
+ * cannot report more than one problem per run. It lexes as far as it can, so a run reports several
+ * findings rather than one at a time.
+ *
+ * A source that is not valid UTF-8 is rejected whole, with `MDX-E004`. Continuing past that would
+ * mean reporting columns into a byte sequence that has no defined character boundaries.
+ */
+[[nodiscard]] LexResult lex(std::string_view source, std::string file);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Parser.cpp
+++ b/tools/medui/Parser.cpp
@@ -40,11 +40,15 @@ public:
     [[nodiscard]] std::vector<cli::Diagnostic> take() { return std::move(diagnostics_); }
 
     [[nodiscard]] std::optional<ast::Screen> parseScreen() {
+        // Captured before expectWord() consumes it: Ast.cppm says a node carries the position of
+        // the token that introduced it, and parseLayout/parseSurface both do this. This one read
+        // the position *after* advancing, so it pointed at the screen name.
+        const ast::Position screenKeyword = position();
         if (!expectWord("Screen")) {
             return std::nullopt;
         }
         ast::Screen screen;
-        screen.position = position();
+        screen.position = screenKeyword;
 
         const Token* name = expect(TokenKind::Identifier, "a screen name");
         if (name == nullptr) {
@@ -62,6 +66,16 @@ public:
             }
         }
         static_cast<void>(expect(TokenKind::RBrace, "'}' closing the screen"));
+
+        // A source declares exactly one screen. Without this, `Screen A { } Screen B { }` and
+        // `Screen A { } garbage` both parsed clean and returned a screen - the trailing content was
+        // simply never looked at. #200's file checker would have reported such a file as valid.
+        if (!at(TokenKind::EndOfFile)) {
+            report(Code::UnexpectedToken,
+                   std::format("unexpected {} after the screen's closing brace",
+                               describe(current().kind)),
+                   "a .medui source declares exactly one Screen, and nothing follows it");
+        }
 
         checkDuplicateIds(screen);
         return screen;
@@ -171,6 +185,11 @@ private:
         screen.layoutPosition = position();
         static_cast<void>(advance());  // 'layout'
         if (expect(TokenKind::Colon, "':' after 'layout'") == nullptr) {
+            return false;
+        }
+        // Before expect(): a forbidden word is an Identifier, so without this `layout: if { }`
+        // parsed clean. "Wherever an identifier may appear" has to include this one.
+        if (rejectIfForbidden()) {
             return false;
         }
         const Token* kind = expect(TokenKind::Identifier, "a layout kind such as 'Vertical'");
@@ -287,6 +306,20 @@ private:
                 continue;
             }
             if (at(TokenKind::At)) {
+                // Only a Row has children. The unannotated branch above already enforced that;
+                // this one did not, so `Card { @x Label { } }` was accepted and - worse -
+                // `Card { @x Row { } }` placed a Row at depth two with no MDX-E015, because the
+                // annotated path also passed insideRow=false. Reported independently by three
+                // reviewers on #209, and the AST contract in Ast.cppm says children is non-empty
+                // only for Row, which #194's single-pass solver relies on.
+                if (!isRow) {
+                    report(Code::UnexpectedToken,
+                           std::format("'{}' cannot contain another component", node.component),
+                           "only a Row holds child components; move this out, or make the parent "
+                           "a Row");
+                    recover();
+                    continue;
+                }
                 std::vector<ast::Annotation> childAnnotations;
                 bool bad = false;
                 while (at(TokenKind::At)) {
@@ -295,7 +328,7 @@ private:
                     childAnnotations.push_back(std::move(*annotation));
                 }
                 if (bad || !parseNodeInto(node.children, std::move(childAnnotations),
-                                          /*insideRow=*/isRow)) {
+                                          /*insideRow=*/true)) {
                     recover();
                 }
                 continue;
@@ -462,7 +495,24 @@ private:
                 path += part->text;
                 dotted = true;
             }
-            value->kind = dotted ? ast::ValueKind::ColorToken : ast::ValueKind::Identifier;
+            // A dotted path is only a *colour token* when it is one. `Foo.Bar` and a truncated
+            // `Theme.Colors` were both classified as ColorToken, which would have sent #193 to the
+            // theme table for a value that never named a colour - and produced MDX-E030 "not in the
+            // governed table" for what is really a malformed value.
+            const bool isThemeColor = path.starts_with("Theme.Colors.") &&
+                                      path.size() > std::string_view{"Theme.Colors."}.size();
+            // `dotted` no longer decides anything: an unqualified dotted path and a bare word are
+            // both just identifiers for #193 to interpret. Kept as a named variable only for the
+            // diagnostic below, so the reader is told which shape was seen.
+            value->kind = isThemeColor ? ast::ValueKind::ColorToken : ast::ValueKind::Identifier;
+            if (dotted && !isThemeColor) {
+                // Not an error here - #193 owns what a field may hold - but worth saying, because
+                // a dotted path that is not a theme colour is almost always a mistyped one.
+                report(Code::UnexpectedToken,
+                       std::format("'{}' is not a Theme.Colors token", path),
+                       "colours are written Theme.Colors.<Token>; other dotted paths have no "
+                       "meaning in this grammar");
+            }
             value->text = std::move(path);
             return value;
         }

--- a/tools/medui/Parser.cpp
+++ b/tools/medui/Parser.cpp
@@ -1,0 +1,537 @@
+/**
+ * @file Parser.cpp
+ * @brief The `.medui` recursive-descent parser.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+module;
+
+module mdux.tools.medui.parser;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.lexer;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// Words that must never appear. Not a style rule - see ADR-011 decision 5 and the module header.
+///
+/// Matched on identifiers only, so a *field* called `for` would also be rejected. That is intended:
+/// the point is that the language has no control flow, and a field named after a construct the
+/// language does not have is at best confusing.
+constexpr std::array<std::string_view, 11> forbiddenWords{
+    "if", "else", "for", "while", "loop", "match", "fn", "let", "return", "import", "while_let",
+};
+
+[[nodiscard]] bool isForbidden(std::string_view word) noexcept {
+    return std::ranges::find(forbiddenWords, word) != forbiddenWords.end();
+}
+
+class Parser {
+public:
+    Parser(std::vector<Token> tokens, std::string file)
+        : tokens_{std::move(tokens)}, file_{std::move(file)} {}
+
+    [[nodiscard]] std::vector<cli::Diagnostic> take() { return std::move(diagnostics_); }
+
+    [[nodiscard]] std::optional<ast::Screen> parseScreen() {
+        if (!expectWord("Screen")) {
+            return std::nullopt;
+        }
+        ast::Screen screen;
+        screen.position = position();
+
+        const Token* name = expect(TokenKind::Identifier, "a screen name");
+        if (name == nullptr) {
+            return std::nullopt;
+        }
+        screen.name = name->text;
+
+        if (expect(TokenKind::LBrace, "'{' after the screen name") == nullptr) {
+            return std::nullopt;
+        }
+
+        while (!at(TokenKind::RBrace) && !at(TokenKind::EndOfFile)) {
+            if (!parseScreenMember(screen)) {
+                recover();
+            }
+        }
+        static_cast<void>(expect(TokenKind::RBrace, "'}' closing the screen"));
+
+        checkDuplicateIds(screen);
+        return screen;
+    }
+
+private:
+    // -- token access -------------------------------------------------------
+
+    [[nodiscard]] const Token& current() const noexcept { return tokens_[index_]; }
+    [[nodiscard]] bool at(TokenKind kind) const noexcept { return current().kind == kind; }
+    [[nodiscard]] ast::Position position() const noexcept {
+        return ast::Position{.line = current().line, .column = current().column};
+    }
+
+    const Token& advance() noexcept {
+        const Token& t = tokens_[index_];
+        if (index_ + 1 < tokens_.size()) {
+            ++index_;
+        }
+        return t;
+    }
+
+    void report(Code code, std::string message, std::string fixHint = {}) {
+        diagnostics_.push_back(
+            diagnose(code, file_, current().line, current().column, std::move(message),
+                     std::move(fixHint)));
+    }
+
+    const Token* expect(TokenKind kind, std::string_view what) {
+        if (at(kind)) {
+            return &advance();
+        }
+        report(Code::UnexpectedToken,
+               std::format("expected {}, found {}", what, describe(current().kind)));
+        return nullptr;
+    }
+
+    bool expectWord(std::string_view word) {
+        if (at(TokenKind::Identifier) && current().text == word) {
+            static_cast<void>(advance());
+            return true;
+        }
+        report(Code::UnexpectedToken,
+               std::format("expected '{}', found {}", word, describe(current().kind)));
+        return false;
+    }
+
+    /// Skips to just past the next `;`, or to a `}` which the caller's loop will see.
+    void recover() {
+        while (!at(TokenKind::EndOfFile)) {
+            if (at(TokenKind::Semicolon)) {
+                static_cast<void>(advance());
+                return;
+            }
+            if (at(TokenKind::RBrace)) {
+                return;
+            }
+            static_cast<void>(advance());
+        }
+    }
+
+    /// Rejects a control-flow word wherever an identifier may appear. Returns true if it fired.
+    bool rejectIfForbidden() {
+        if (at(TokenKind::Identifier) && isForbidden(current().text)) {
+            report(Code::ForbiddenConstruct,
+                   std::format("'{}' is not part of the .medui language", current().text));
+            return true;
+        }
+        return false;
+    }
+
+    // -- grammar ------------------------------------------------------------
+
+    bool parseScreenMember(ast::Screen& screen) {
+        if (rejectIfForbidden()) {
+            return false;
+        }
+        if (at(TokenKind::At)) {
+            std::vector<ast::Annotation> annotations;
+            while (at(TokenKind::At)) {
+                std::optional<ast::Annotation> annotation = parseAnnotation();
+                if (!annotation) {
+                    return false;
+                }
+                annotations.push_back(std::move(*annotation));
+            }
+            return parseNodeInto(screen.nodes, std::move(annotations), /*insideRow=*/false);
+        }
+        if (!at(TokenKind::Identifier)) {
+            report(Code::UnexpectedToken,
+                   std::format("expected a component, 'layout' or 'surface', found {}",
+                               describe(current().kind)));
+            return false;
+        }
+
+        const std::string word = current().text;
+        if (word == "layout") {
+            return parseLayout(screen);
+        }
+        if (word == "surface") {
+            return parseSurface(screen);
+        }
+        return parseNodeInto(screen.nodes, {}, /*insideRow=*/false);
+    }
+
+    bool parseLayout(ast::Screen& screen) {
+        screen.layoutPosition = position();
+        static_cast<void>(advance());  // 'layout'
+        if (expect(TokenKind::Colon, "':' after 'layout'") == nullptr) {
+            return false;
+        }
+        const Token* kind = expect(TokenKind::Identifier, "a layout kind such as 'Vertical'");
+        if (kind == nullptr) {
+            return false;
+        }
+        screen.layoutKind = kind->text;
+
+        if (at(TokenKind::LBrace)) {
+            static_cast<void>(advance());
+            while (!at(TokenKind::RBrace) && !at(TokenKind::EndOfFile)) {
+                std::optional<ast::Field> field = parseField();
+                if (!field) {
+                    recover();
+                    continue;
+                }
+                screen.layout.push_back(std::move(*field));
+            }
+            static_cast<void>(expect(TokenKind::RBrace, "'}' closing the layout block"));
+        }
+        if (at(TokenKind::Semicolon)) {
+            static_cast<void>(advance());
+        }
+        return true;
+    }
+
+    bool parseSurface(ast::Screen& screen) {
+        const ast::Position where = position();
+        static_cast<void>(advance());  // 'surface'
+        if (expect(TokenKind::Colon, "':' after 'surface'") == nullptr) {
+            return false;
+        }
+        std::optional<std::int64_t> width = parsePixels();
+        if (!width || expect(TokenKind::Comma, "',' between the surface dimensions") == nullptr) {
+            return false;
+        }
+        std::optional<std::int64_t> height = parsePixels();
+        if (!height) {
+            return false;
+        }
+        screen.surface = ast::Point{.x = *width, .y = *height, .position = where};
+        static_cast<void>(expect(TokenKind::Semicolon, "';' after the surface"));
+        return true;
+    }
+
+    std::optional<ast::Annotation> parseAnnotation() {
+        ast::Annotation annotation;
+        annotation.position = position();
+        static_cast<void>(advance());  // '@'
+
+        const Token* name = expect(TokenKind::Identifier, "an annotation name");
+        if (name == nullptr) {
+            return std::nullopt;
+        }
+        annotation.name = name->text;
+
+        if (at(TokenKind::LParen)) {
+            static_cast<void>(advance());
+            while (!at(TokenKind::RParen) && !at(TokenKind::EndOfFile)) {
+                std::optional<ast::Field> argument = parseField(/*terminated=*/false);
+                if (!argument) {
+                    return std::nullopt;
+                }
+                annotation.arguments.push_back(std::move(*argument));
+                if (at(TokenKind::Comma)) {
+                    static_cast<void>(advance());
+                }
+            }
+            if (expect(TokenKind::RParen, "')' closing the annotation") == nullptr) {
+                return std::nullopt;
+            }
+        }
+        return annotation;
+    }
+
+    bool parseNodeInto(std::vector<ast::Node>& into, std::vector<ast::Annotation> annotations,
+                       bool insideRow) {
+        if (rejectIfForbidden()) {
+            return false;
+        }
+        const Token* component = expect(TokenKind::Identifier, "a component name");
+        if (component == nullptr) {
+            return false;
+        }
+
+        ast::Node node;
+        node.component = component->text;
+        node.position = ast::Position{.line = component->line, .column = component->column};
+        node.annotations = std::move(annotations);
+
+        const bool isRow = node.component == "Row";
+        if (isRow && insideRow) {
+            // ADR-011 decision 5: a solver restriction, not a budget one. The hint says so, and
+            // deliberately does not borrow the budget argument, which does not apply here.
+            diagnostics_.push_back(diagnose(
+                Code::NestedRow, file_, node.position.line, node.position.column,
+                "a Row cannot contain another Row"));
+        }
+
+        if (expect(TokenKind::LBrace, "'{' after the component name") == nullptr) {
+            return false;
+        }
+
+        while (!at(TokenKind::RBrace) && !at(TokenKind::EndOfFile)) {
+            if (rejectIfForbidden()) {
+                recover();
+                continue;
+            }
+            // A nested component inside a Row is `Identifier {`; a field is `Identifier :`.
+            if (isRow && at(TokenKind::Identifier) && peekIsBrace()) {
+                if (!parseNodeInto(node.children, {}, /*insideRow=*/true)) {
+                    recover();
+                }
+                continue;
+            }
+            if (at(TokenKind::At)) {
+                std::vector<ast::Annotation> childAnnotations;
+                bool bad = false;
+                while (at(TokenKind::At)) {
+                    std::optional<ast::Annotation> annotation = parseAnnotation();
+                    if (!annotation) { bad = true; break; }
+                    childAnnotations.push_back(std::move(*annotation));
+                }
+                if (bad || !parseNodeInto(node.children, std::move(childAnnotations),
+                                          /*insideRow=*/isRow)) {
+                    recover();
+                }
+                continue;
+            }
+            std::optional<ast::Field> field = parseField();
+            if (!field) {
+                recover();
+                continue;
+            }
+            node.fields.push_back(std::move(*field));
+        }
+        static_cast<void>(expect(TokenKind::RBrace, "'}' closing the component"));
+
+        into.push_back(std::move(node));
+        return true;
+    }
+
+    [[nodiscard]] bool peekIsBrace() const noexcept {
+        return index_ + 1 < tokens_.size() && tokens_[index_ + 1].kind == TokenKind::LBrace;
+    }
+
+    std::optional<ast::Field> parseField(bool terminated = true) {
+        if (rejectIfForbidden()) {
+            return std::nullopt;
+        }
+        const Token* name = expect(TokenKind::Identifier, "a field name");
+        if (name == nullptr) {
+            return std::nullopt;
+        }
+        ast::Field field;
+        field.name = name->text;
+        field.namePosition = ast::Position{.line = name->line, .column = name->column};
+
+        if (expect(TokenKind::Colon, "':' after the field name") == nullptr) {
+            return std::nullopt;
+        }
+        std::shared_ptr<ast::Value> value = parseValue();
+        if (value == nullptr) {
+            return std::nullopt;
+        }
+        field.value = std::move(value);
+
+        if (terminated) {
+            static_cast<void>(expect(TokenKind::Semicolon, "';' after the field"));
+        }
+        return field;
+    }
+
+    std::optional<std::int64_t> parsePixels() {
+        const Token* number = expect(TokenKind::Number, "a pixel count");
+        if (number == nullptr) {
+            return std::nullopt;
+        }
+        if (!at(TokenKind::Identifier) || current().text != "px") {
+            report(Code::UnexpectedToken,
+                   std::format("expected 'px' after {}, found {}", number->text,
+                               describe(current().kind)),
+                   "lengths are written as Npx, e.g. 512px; there are no other units");
+            return std::nullopt;
+        }
+        static_cast<void>(advance());  // 'px'
+
+        std::int64_t pixels = 0;
+        const auto [ptr, ec] = std::from_chars(
+            number->text.data(), number->text.data() + number->text.size(), pixels);
+        if (ec != std::errc{}) {
+            report(Code::UnexpectedToken,
+                   std::format("'{}' is not a pixel count this compiler can represent",
+                               number->text));
+            return std::nullopt;
+        }
+        static_cast<void>(ptr);
+        return pixels;
+    }
+
+    std::shared_ptr<ast::Value> parseValue() {
+        auto value = std::make_shared<ast::Value>();
+        value->position = position();
+
+        if (at(TokenKind::String)) {
+            value->kind = ast::ValueKind::String;
+            value->text = advance().text;
+            return value;
+        }
+        if (at(TokenKind::LBracket)) {
+            static_cast<void>(advance());
+            value->kind = ast::ValueKind::List;
+            while (!at(TokenKind::RBracket) && !at(TokenKind::EndOfFile)) {
+                std::shared_ptr<ast::Value> element = parseValue();
+                if (element == nullptr) {
+                    return nullptr;
+                }
+                value->list.push_back(std::move(element));
+                if (at(TokenKind::Comma)) {
+                    static_cast<void>(advance());
+                }
+            }
+            if (expect(TokenKind::RBracket, "']' closing the list") == nullptr) {
+                return nullptr;
+            }
+            return value;
+        }
+        if (at(TokenKind::Number)) {
+            const Token& number = current();
+            std::optional<std::int64_t> pixels = parsePixels();
+            if (pixels) {
+                // `Xpx, Ypx` is a point; a lone `Xpx` is a size. The comma decides.
+                if (at(TokenKind::Comma)) {
+                    static_cast<void>(advance());
+                    std::optional<std::int64_t> y = parsePixels();
+                    if (!y) {
+                        return nullptr;
+                    }
+                    value->kind = ast::ValueKind::Point;
+                    value->point = ast::Point{.x = *pixels, .y = *y, .position = value->position};
+                    return value;
+                }
+                value->kind = ast::ValueKind::Size;
+                value->size = ast::Size{.fill = false, .pixels = *pixels,
+                                        .position = value->position};
+                return value;
+            }
+            // parsePixels() already reported. Fall back to a bare number so the AST stays usable.
+            value->kind = ast::ValueKind::Number;
+            static_cast<void>(std::from_chars(number.text.data(),
+                                              number.text.data() + number.text.size(),
+                                              value->number));
+            return value;
+        }
+        if (at(TokenKind::Identifier)) {
+            if (rejectIfForbidden()) {
+                return nullptr;
+            }
+            const std::string word = current().text;
+
+            if (word == "t" && peekIs(TokenKind::LParen)) {
+                static_cast<void>(advance());  // 't'
+                static_cast<void>(advance());  // '('
+                const Token* key = expect(TokenKind::String, "a text key, as t(\"STR-KEY\")");
+                if (key == nullptr || expect(TokenKind::RParen, "')' closing t(") == nullptr) {
+                    return nullptr;
+                }
+                value->kind = ast::ValueKind::TextKey;
+                value->text = key->text;
+                return value;
+            }
+            if (word == "Fill") {
+                static_cast<void>(advance());
+                value->kind = ast::ValueKind::Size;
+                value->size = ast::Size{.fill = true, .pixels = 0, .position = value->position};
+                return value;
+            }
+
+            // A dotted path: `Theme.Colors.ScoreDigits`. Kept whole and unresolved (#193).
+            std::string path = advance().text;
+            bool dotted = false;
+            while (at(TokenKind::Dot)) {
+                static_cast<void>(advance());
+                const Token* part = expect(TokenKind::Identifier, "a name after '.'");
+                if (part == nullptr) {
+                    return nullptr;
+                }
+                path += '.';
+                path += part->text;
+                dotted = true;
+            }
+            value->kind = dotted ? ast::ValueKind::ColorToken : ast::ValueKind::Identifier;
+            value->text = std::move(path);
+            return value;
+        }
+
+        report(Code::UnexpectedToken,
+               std::format("expected a value, found {}", describe(current().kind)));
+        return nullptr;
+    }
+
+    [[nodiscard]] bool peekIs(TokenKind kind) const noexcept {
+        return index_ + 1 < tokens_.size() && tokens_[index_ + 1].kind == kind;
+    }
+
+    // -- post-parse structural checks ---------------------------------------
+
+    /// Ids must be unique across the whole screen, not merely within a parent: golden references
+    /// (#196) and requirement traces address a node by id alone.
+    void checkDuplicateIds(const ast::Screen& screen) {
+        std::map<std::string, ast::Position> seen;
+        const auto visit = [&](auto&& self, const ast::Node& node) -> void {
+            for (const ast::Field& field : node.fields) {
+                if (field.name != "id" || field.value == nullptr) {
+                    continue;
+                }
+                const std::string& id = field.value->text;
+                if (id.empty()) {
+                    continue;
+                }
+                const auto [it, inserted] = seen.emplace(id, field.namePosition);
+                if (!inserted) {
+                    diagnostics_.push_back(diagnose(
+                        Code::DuplicateNodeId, file_, field.namePosition.line,
+                        field.namePosition.column,
+                        std::format("node id '{}' is already used at line {}, column {}", id,
+                                    it->second.line, it->second.column)));
+                }
+            }
+            for (const ast::Node& child : node.children) {
+                self(self, child);
+            }
+        };
+        for (const ast::Node& node : screen.nodes) {
+            visit(visit, node);
+        }
+    }
+
+    std::vector<Token> tokens_;
+    std::string file_;
+    std::size_t index_{0};
+    std::vector<cli::Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+ParseResult parse(std::string_view source, std::string file) {
+    ParseResult result;
+
+    LexResult lexed = lex(source, file);
+    result.diagnostics = std::move(lexed.diagnostics);
+    if (lexed.tokens.empty()) {
+        return result;  // only when the source was rejected whole, e.g. bad UTF-8
+    }
+
+    Parser parser{std::move(lexed.tokens), std::move(file)};
+    result.screen = parser.parseScreen();
+    std::vector<cli::Diagnostic> parsed = parser.take();
+    result.diagnostics.insert(result.diagnostics.end(), std::make_move_iterator(parsed.begin()),
+                              std::make_move_iterator(parsed.end()));
+    return result;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Parser.cppm
+++ b/tools/medui/Parser.cppm
@@ -1,0 +1,65 @@
+/**
+ * @file Parser.cppm
+ * @brief Recursive-descent `.medui` parser: tokens to an unresolved AST.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Host-only, hand-written, one token of lookahead. What it enforces and what it deliberately does
+ * not are both worth stating, because the boundary is the design.
+ *
+ * ## What it enforces
+ *
+ * - The shape: one `Screen`, an optional `layout:` and `surface:`, then nodes with fields.
+ * - **No control flow.** `if`, `else`, `for`, `while`, `loop`, `match`, `fn`, `let`, `return` and
+ *   `import` are rejected with `MDX-E016` wherever they appear. ADR-011 decision 5: each makes the
+ *   primitive count depend on data the compiler cannot see, and a `DrawBudget` that cannot be
+ *   computed exactly is not a budget.
+ * - **No nested `Row`** (`MDX-E015`). ADR-011 is explicit that this one is a *solver* restriction,
+ *   not a budget one - a nested Row's depth is visible and the primitive count stays exact - so the
+ *   diagnostic says flatten it, and does not cite the budget argument that does not apply.
+ * - **No duplicate node ids within a screen** (`MDX-E014`). Ids address nodes in golden references
+ *   (#196) and requirement traces, so a duplicate makes those ambiguous.
+ *
+ * ## What it does not
+ *
+ * Component names, field names and theme tokens are carried unresolved. The component dictionary
+ * and the theme table belong to #193, and a parser that consulted them would have to change every
+ * time a component is added. See `Ast.cppm` for the argument in full.
+ *
+ * ## Recovery
+ *
+ * On an unexpected token the parser skips to the next `;` or `}` and continues, so one run reports
+ * several problems rather than the first. A compiler that stops at the first error makes fixing a
+ * screen an iterative guessing game, and #200's `mdux-medui-check` exists precisely to give an
+ * author everything at once.
+ */
+module;
+
+export module mdux.tools.medui.parser;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+
+export namespace mdux::tools::medui {
+
+/// The parsed screen, or the diagnostics that stopped it parsing.
+struct ParseResult {
+    std::optional<ast::Screen> screen;
+    std::vector<cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept { return screen.has_value() && diagnostics.empty(); }
+};
+
+/**
+ * @brief Lexes and parses `source`, attributing diagnostics to `file`.
+ *
+ * Never throws for malformed input. A `screen` is returned whenever enough parsed to be worth
+ * examining, *even alongside diagnostics* - #200 wants to report a text-budget problem and a
+ * syntax problem in the same run where it can. Callers must therefore check `ok()` or the
+ * diagnostics, not merely whether `screen` is engaged.
+ */
+[[nodiscard]] ParseResult parse(std::string_view source, std::string file);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Parser.cppm
+++ b/tools/medui/Parser.cppm
@@ -27,6 +27,20 @@
  * and the theme table belong to #193, and a parser that consulted them would have to change every
  * time a component is added. See `Ast.cppm` for the argument in full.
  *
+ * ## Whitespace, and a one-way portability note
+ *
+ * This parser is token-based, so `width: 512px; height: 512px;` on one line parses exactly as the
+ * two-line form. TrustSC's reference implementation is *line*-based: it splits a component body
+ * line by line and takes each line's first `:`, so the one-line form is read there as a width of
+ * `512px; height: 512px` and rejected.
+ *
+ * That makes MduX's accepted grammar a strict superset, and portability one-way: every screen
+ * TrustSC accepts compiles here, and a screen written with two properties on a line does not
+ * compile there. The superset is not the problem - a token-based parser is the better tool, and
+ * narrowing it to match a line-based one would buy nothing. What matters is that authored screens
+ * stay portable, so the `medui-authoring` skill now documents one property per line and the
+ * fixture corpus is written that way.
+ *
  * ## Recovery
  *
  * On an unexpected token the parser skips to the next `;` or `}` and continues, so one run reports


### PR DESCRIPTION
## Summary

Wave 5 S3 — the first stage that actually emits the `MDX-E` codes #191 registered.

Hand-written, one token of lookahead, no generator. Same reasoning as `mdux.tools.truetype` and `mdux.tools.toml`: a generator is a SOUP entry, a build-time dependency and a second language in the tree, and this grammar is small enough that none of that buys anything.

## The boundary this stage draws

Component names, field names and theme tokens are carried **unresolved** — the strings the author wrote, with their positions. Nothing is checked against the component dictionary or the theme table.

The opposite is the tempting arrangement: a parser that knew the dictionary could reject an unknown component where it reads the name. That reads like an improvement until adding a component means touching the parser, and until a field's meaning depends on which component encloses it — at which point the parser is doing semantic analysis with a worse error vocabulary. Keeping names as names means **#193 can be replaced without this file changing**.

What it *does* enforce is structure no dictionary can express: nesting depth, absence of control flow, id uniqueness. Those are properties of the grammar rather than of any component.

## Positions carried from the first stage

Every token has a 1-based line and column; every AST node keeps the position of the token that introduced it. Not a convenience — #192 requires fixtures to assert positions, and a lexer tracking lines alone would make that impossible for every downstream diagnostic. Columns count UTF-8 **bytes**, matching `mdux-docs-lint` and `mdux-governed-lint`: an agent reading the shared envelope shouldn't need to know which tool produced a finding to interpret its column.

## Decisions worth your review

- **`//` comments are accepted**, and the skill's grammar block doesn't show one. Deliberate: a screen carries `requirement:` strings and `@safety_critical` annotations, and a language for describing safety-relevant UI where an author can't write down *why* pushes that reasoning somewhere the compiler never sees. If you'd rather not, deleting the comment branch and one fixture is the whole change.
- **Invalid UTF-8 rejects the source whole** (`MDX-E004`), not at the offending byte — past an invalid sequence there are no defined character boundaries, so every column after it would be invented.
- **An unterminated string reports at its opening quote**, not the newline. The quote is where the mistake is.
- **Nested `Row`'s diagnostic doesn't cite the budget argument.** ADR-011 decision 5 is explicit that this one is a *solver* restriction — a nested Row's depth is visible and the primitive count stays exact. The hint says flatten it.
- **Recovery skips to the next `;` or `}`**, so one run reports several problems. A compiler that stops at the first makes fixing a screen a guessing game, and #200 exists to hand an author everything at once.

## Fixtures are real files

`tests/medui/fixtures/*.medui` — openable in an editor, not string literals. #200's `mdux-medui-check` will be pointed at the same corpus, and a fixture that exists only inside a test can't be reused by the tool that checks files.

Every rejection scenario asserts the **code and the position**, never the message: #191 published the codes as the contract, and messages are explicitly rewordable.

Closes #192.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #184

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked. #207 (the codes this emits) and #208 are merged.
- **Merge order:** mergeable now. Predecessor of #193, which resolves what this deliberately leaves unresolved.

## Shared registries touched

- [x] `tools/CMakeLists.txt` — three modules added to the existing `MduXMeduiLib`
- [x] `tests/CMakeLists.txt` — one source added to `medui_tools_spec`, plus `MDUX_REPO_ROOT`
- [x] `FILE_SET CXX_MODULES` lists — `Lexer.cppm`, `Ast.cppm`, `Parser.cppm`
- [x] None of the others

## Rebase state

- **Rebased onto:** `0e236bf` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [x] `cmake --preset ninja-gcc && cmake --build build-gcc` — clean
- [x] `ctest --test-dir build-gcc` — **458/458** (447 + 11)
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (80 files)
- [x] Other: `mdux_verify_trust_zones()` still 2 governed targets, with `MduXMeduiLib` deliberately not among them; `mdux-governed-lint` OK (29 files); `mdux-evidence-lint` OK (45 files)

### Checked for teeth, not assumed

Two things a passing test suite would not have told me:

1. **The reported position was verified against the fixture by hand.** The nested-`Row` diagnostic claims line 6, column 9; `sed -n '6p' | cat -A` shows eight spaces then `Row {`, so column 9 is the `R`. An assertion agreeing with a bug would have passed just as happily.
2. **Disabling the check makes the scenario fail.** Short-circuiting the nested-`Row` branch turned that test red rather than leaving it quietly green. Reverted after checking.

Toolchain: GCC 16.1.0, matching the container pin.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** <!-- to be filled after merge -->
- [ ] That run is green.

## Regulatory impact

**This is where a `.medui` screen first meets a rule.** Three of ADR-011's safety-relevant restrictions become mechanical here rather than documented:

- control flow is rejected (`MDX-E016`), which is what keeps `DrawBudget` exactly computable;
- nested `Row` is rejected (`MDX-E015`), keeping layout a single flattening pass;
- duplicate node ids are rejected (`MDX-E014`) — ids address nodes in golden references (#196) and requirement traces, so a duplicate makes both ambiguous.

Nothing here validates a *requirement*, a locale or a text budget; those are #193 and #195, and this PR asserts no coverage of them. No trust-zone change: `MduXMeduiLib` remains host-tools, never linked into a device target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading and parsing `.medui` interface definitions.
  * Added validation for layouts, dimensions, values, annotations, identifiers, and supported language constructs.
  * Added source-positioned diagnostics for malformed syntax, invalid UTF-8, unsupported escapes, and other input errors.
  * Added recovery to report multiple issues in one run.
  * Added support for comments, localized text, themed elements, and nested row layouts.

* **Documentation**
  * Updated authoring guidance with parser capabilities, grammar rules, and limitations.

* **Tests**
  * Added comprehensive accepted and rejected `.medui` examples covering parser and diagnostic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->