### PR TITLE
Adopt the shared MedUI contract

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -28,8 +28,8 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 [issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). The implementation pins the shared
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
-[`Compliatory/MedUI`](https://github.com/Compliatory/MedUI). Do not write a `.medui` file expecting
-it to build anything in MduX until the compiler waves land.
+[`Compliatory/MedUI` at `c8cc45e`](https://github.com/Compliatory/MedUI/tree/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d).
+Do not write a `.medui` file expecting it to build anything in MduX until the compiler waves land.
 
 ## Grammar shape
 

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -13,7 +13,7 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 ## Status: the front end is implemented; the compiler and runtime are not
 
 **A `.medui` lexer, AST and parser exist** in the host-tools zone as of issue #192 (`tools/medui/`), and
-the diagnostic codes they emit are registered as `MDX-E###` (#191). They parse a screen and reject
+the diagnostic codes they emit are registered as `MEDUI-E###` (#191). They parse a screen and reject
 the grammar's structural violations; they resolve nothing.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
@@ -25,9 +25,11 @@ What exists now is the layer a `.medui` compiler will target: `mdux.draw` descri
 bounded vertex, index and command buffers with a compiler-computed budget, and
 `mdux.render.vulkan` renders one. So the compiler's job is to emit a `DrawList` and a
 `DrawBudget`, not to invent a rendering path. `.medui` itself is
-[issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). This skill describes the *target*
-grammar, adapted from the sibling Rust project TrustSC, so authoring work can start the moment the
-compiler exists — do not write a `.medui` file expecting it to build anything yet.
+[issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). The implementation pins the shared
+contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
+grammar, component semantics, diagnostics, and portable guidance live in
+[`Compliatory/MedUI`](https://github.com/Compliatory/MedUI). Do not write a `.medui` file expecting
+it to build anything in MduX until the compiler waves land.
 
 ## Grammar shape
 

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -33,6 +33,8 @@ jobs:
   clang-build:
     name: Linux (Clang, Vulkan)
     runs-on: ubuntu-latest
+    env:
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -41,6 +43,14 @@ jobs:
       # reason to survive into .git/config where any later build or test step could read it
       # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
+        persist-credentials: false
+
+    - name: Checkout pinned MedUI conformance contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Compliatory/MedUI
+        ref: 763499016fdf16e9ba697cc938647ea67e8f8145
+        path: .medui-conformance
         persist-credentials: false
 
     - name: Setup CMake (latest)

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -34,7 +34,7 @@ jobs:
     name: Linux (Clang, Vulkan)
     runs-on: ubuntu-latest
     env:
-      MEDUI_CONFORMANCE_DIR: ${{ runner.temp }}/medui-conformance
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -50,7 +50,7 @@ jobs:
       with:
         repository: Compliatory/MedUI
         ref: 763499016fdf16e9ba697cc938647ea67e8f8145
-        path: ${{ runner.temp }}/medui-conformance
+        path: .medui-conformance
         persist-credentials: false
 
     - name: Setup CMake (latest)

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -45,11 +45,23 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Resolve the pinned MedUI contract commit
+      id: medui-contract
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="$(sed -n 's/^commit = "\([0-9a-f]\{40\}\)"$/\1/p' medui-conformance.toml)"
+        if [ -z "$commit" ]; then
+          echo "medui-conformance.toml has no 40-character commit pin" >&2
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
     - name: Checkout pinned MedUI conformance contract
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: Compliatory/MedUI
-        ref: 763499016fdf16e9ba697cc938647ea67e8f8145
+        ref: ${{ steps.medui-contract.outputs.commit }}
         path: .medui-conformance
         persist-credentials: false
 

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -34,7 +34,7 @@ jobs:
     name: Linux (Clang, Vulkan)
     runs-on: ubuntu-latest
     env:
-      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
+      MEDUI_CONFORMANCE_DIR: ${{ runner.temp }}/medui-conformance
 
     steps:
     - name: Checkout repository
@@ -50,7 +50,7 @@ jobs:
       with:
         repository: Compliatory/MedUI
         ref: 763499016fdf16e9ba697cc938647ea67e8f8145
-        path: .medui-conformance
+        path: ${{ runner.temp }}/medui-conformance
         persist-credentials: false
 
     - name: Setup CMake (latest)

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -37,7 +37,7 @@ jobs:
     # the change breaks.
     container: gcc:16.1.0
     env:
-      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
+      MEDUI_CONFORMANCE_DIR: ${{ runner.temp }}/medui-conformance
 
     steps:
     - name: Checkout repository
@@ -53,7 +53,7 @@ jobs:
       with:
         repository: Compliatory/MedUI
         ref: 763499016fdf16e9ba697cc938647ea67e8f8145
-        path: .medui-conformance
+        path: ${{ runner.temp }}/medui-conformance
         persist-credentials: false
 
     - name: Install dependencies

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -48,11 +48,23 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Resolve the pinned MedUI contract commit
+      id: medui-contract
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="$(sed -n 's/^commit = "\([0-9a-f]\{40\}\)"$/\1/p' medui-conformance.toml)"
+        if [ -z "$commit" ]; then
+          echo "medui-conformance.toml has no 40-character commit pin" >&2
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
     - name: Checkout pinned MedUI conformance contract
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: Compliatory/MedUI
-        ref: 763499016fdf16e9ba697cc938647ea67e8f8145
+        ref: ${{ steps.medui-contract.outputs.commit }}
         path: .medui-conformance
         persist-credentials: false
 

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -36,6 +36,8 @@ jobs:
     # tag in a PR of its own, so the diff that changes the compiler is the diff that fixes whatever
     # the change breaks.
     container: gcc:16.1.0
+    env:
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -44,6 +46,14 @@ jobs:
       # reason to survive into .git/config where any later build or test step could read it
       # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
+        persist-credentials: false
+
+    - name: Checkout pinned MedUI conformance contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Compliatory/MedUI
+        ref: 763499016fdf16e9ba697cc938647ea67e8f8145
+        path: .medui-conformance
         persist-credentials: false
 
     - name: Install dependencies

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -37,7 +37,7 @@ jobs:
     # the change breaks.
     container: gcc:16.1.0
     env:
-      MEDUI_CONFORMANCE_DIR: ${{ runner.temp }}/medui-conformance
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -53,7 +53,7 @@ jobs:
       with:
         repository: Compliatory/MedUI
         ref: 763499016fdf16e9ba697cc938647ea67e8f8145
-        path: ${{ runner.temp }}/medui-conformance
+        path: .medui-conformance
         persist-credentials: false
 
     - name: Install dependencies

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -41,6 +41,8 @@ jobs:
     # tag in a PR of its own, so the diff that changes the compiler is the diff that fixes whatever
     # the change breaks.
     container: gcc:16.1.0
+    env:
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -49,6 +51,26 @@ jobs:
       # reason to survive into .git/config where any later build or test step could read it
       # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
+        persist-credentials: false
+
+    - name: Resolve the pinned MedUI contract commit
+      id: medui-contract
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="$(sed -n 's/^commit = "\([0-9a-f]\{40\}\)"$/\1/p' medui-conformance.toml)"
+        if [ -z "$commit" ]; then
+          echo "medui-conformance.toml has no 40-character commit pin" >&2
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+    - name: Checkout pinned MedUI conformance contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Compliatory/MedUI
+        ref: ${{ steps.medui-contract.outputs.commit }}
+        path: .medui-conformance
         persist-credentials: false
 
     - name: Install dependencies

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -25,7 +25,7 @@ jobs:
     name: Windows (MSVC, Vulkan)
     runs-on: windows-latest
     env:
-      MEDUI_CONFORMANCE_DIR: ${{ runner.temp }}/medui-conformance
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -41,7 +41,7 @@ jobs:
       with:
         repository: Compliatory/MedUI
         ref: 763499016fdf16e9ba697cc938647ea67e8f8145
-        path: ${{ runner.temp }}/medui-conformance
+        path: .medui-conformance
         persist-credentials: false
 
     # Pinned, not 'latest': CMakeLists.txt hardcodes CMAKE_EXPERIMENTAL_CXX_IMPORT_STD

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -25,7 +25,7 @@ jobs:
     name: Windows (MSVC, Vulkan)
     runs-on: windows-latest
     env:
-      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
+      MEDUI_CONFORMANCE_DIR: ${{ runner.temp }}/medui-conformance
 
     steps:
     - name: Checkout repository
@@ -41,7 +41,7 @@ jobs:
       with:
         repository: Compliatory/MedUI
         ref: 763499016fdf16e9ba697cc938647ea67e8f8145
-        path: .medui-conformance
+        path: ${{ runner.temp }}/medui-conformance
         persist-credentials: false
 
     # Pinned, not 'latest': CMakeLists.txt hardcodes CMAKE_EXPERIMENTAL_CXX_IMPORT_STD

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,6 +24,8 @@ jobs:
   windows-build:
     name: Windows (MSVC, Vulkan)
     runs-on: windows-latest
+    env:
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -32,6 +34,14 @@ jobs:
       # reason to survive into .git/config where any later build or test step could read it
       # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
+        persist-credentials: false
+
+    - name: Checkout pinned MedUI conformance contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Compliatory/MedUI
+        ref: 763499016fdf16e9ba697cc938647ea67e8f8145
+        path: .medui-conformance
         persist-credentials: false
 
     # Pinned, not 'latest': CMakeLists.txt hardcodes CMAKE_EXPERIMENTAL_CXX_IMPORT_STD

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -36,11 +36,23 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Resolve the pinned MedUI contract commit
+      id: medui-contract
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="$(sed -n 's/^commit = "\([0-9a-f]\{40\}\)"$/\1/p' medui-conformance.toml)"
+        if [ -z "$commit" ]; then
+          echo "medui-conformance.toml has no 40-character commit pin" >&2
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
     - name: Checkout pinned MedUI conformance contract
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: Compliatory/MedUI
-        ref: 763499016fdf16e9ba697cc938647ea67e8f8145
+        ref: ${{ steps.medui-contract.outputs.commit }}
         path: .medui-conformance
         persist-credentials: false
 

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ GEMINI.md
 # CI sets PYTHONDONTWRITEBYTECODE=1, but a local run of the self-tests still leaves these behind.
 __pycache__/
 *.pyc
+
+# Ephemeral exact-SHA checkout of the shared MedUI conformance contract in CI.
+.medui-conformance/

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -6,7 +6,7 @@ Accepted (2026-08-11)
 ## Shared decision identity
 
 This local C++ decision implements
-[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/763499016fdf16e9ba697cc938647ea67e8f8145/decisions/MEDUI-DEC-001-build-time-compilation.md)
+[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d/decisions/MEDUI-DEC-001-build-time-compilation.md)
 and the bounded-language portion of `MEDUI-DEC-002`. Its ADR number remains permanent and local;
 cross-repository citations use the shared identity.
 

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -3,6 +3,13 @@
 ## Status
 Accepted (2026-08-11)
 
+## Shared decision identity
+
+This local C++ decision implements
+[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/763499016fdf16e9ba697cc938647ea67e8f8145/decisions/MEDUI-DEC-001-build-time-compilation.md)
+and the bounded-language portion of `MEDUI-DEC-002`. Its ADR number remains permanent and local;
+cross-repository citations use the shared identity.
+
 ## Context
 
 `.medui` is to become the single authored UI source for MduX (issue #15). The decision this record

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -3,6 +3,13 @@
 ## Status
 Accepted (2026-08-11)
 
+## Shared decision identity
+
+This record is MduX's C++ and evidence-format realization of
+[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/763499016fdf16e9ba697cc938647ea67e8f8145/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
+and `MEDUI-DEC-004`. The shared records define meaning; this ADR remains authoritative for
+canonical JSON, generated C++ modules/headers, and MduX's committed artifact layout.
+
 ## Context
 
 [ADR-011](ADR-011-deterministic-medui-compile-boundary.md) fixes *where* the work happens: every

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -6,7 +6,7 @@ Accepted (2026-08-11)
 ## Shared decision identity
 
 This record is MduX's C++ and evidence-format realization of
-[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/763499016fdf16e9ba697cc938647ea67e8f8145/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
+[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
 and `MEDUI-DEC-004`. The shared records define meaning; this ADR remains authoritative for
 canonical JSON, generated C++ modules/headers, and MduX's committed artifact layout.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); at S2 only the `MDX-E` diagnostic registry (#191) — the parser (#192), emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191) and parser (#192) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.

--- a/docs/governance/schemas/diagnostic.schema.json
+++ b/docs/governance/schemas/diagnostic.schema.json
@@ -42,7 +42,7 @@
           },
           "code": {
             "type": "string",
-            "description": "Short stable identifier for the kind of finding, such as 'MDX-D011' or 'FB001'. This is the field an agent keys off, so its meaning must not change once published - reword the message instead. The empty string is permitted, and means the tool has not assigned a code to this finding; `mdux::tools::cli::render` omits the bracketed code from its text form in that case.",
+            "description": "Short stable identifier for the kind of finding, such as 'MDX-D011', 'MEDUI-E015', or 'FB001'. MedUI codes are owned by the pinned Compliatory/MedUI contract; other families remain local. This is the field an agent keys off, so its meaning must not change once published - reword the message instead. The empty string is permitted, and means the tool has not assigned a code to this finding; `mdux::tools::cli::render` omits the bracketed code from its text form in that case.",
             "pattern": "^([A-Za-z0-9][A-Za-z0-9-]*)?$"
           },
           "severity": {

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,0 +1,4 @@
+repository = "https://github.com/Compliatory/MedUI"
+version = "0.1.0-candidate"
+commit = "763499016fdf16e9ba697cc938647ea67e8f8145"
+capabilities = ["syntax"]

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,6 +1,6 @@
 repository = "https://github.com/Compliatory/MedUI"
 version = "0.1.0-candidate"
-commit = "f22f6046be46451ea3b7f56a3f36a220279037d8"
+commit = "c8cc45ecec2f2dfd84940b9efc17c613e691cc0d"
 capabilities = ["syntax"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,4 +1,7 @@
 repository = "https://github.com/Compliatory/MedUI"
 version = "0.1.0-candidate"
-commit = "763499016fdf16e9ba697cc938647ea67e8f8145"
+commit = "f22f6046be46451ea3b7f56a3f36a220279037d8"
 capabilities = ["syntax"]
+# Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
+# byte columns, so every pinned position is matched in full.
+positions = "full"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -685,6 +685,7 @@ add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
     medui/ParserTests.cpp
+    medui/SharedConformanceTests.cpp
 )
 
 target_link_libraries(medui_tools_spec PRIVATE MduX::MeduiLib speclab::speclab)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -707,7 +707,10 @@ if(TARGET __CMAKE::CXX23)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_compile_options(medui_tools_spec PRIVATE /experimental:module /std:c++latest)
+    # SharedConformanceTests uses getenv() only to read CI configuration. Suppress MSVC's
+    # blanket deprecation warning for that test at the target boundary instead of adding
+    # compiler-control macros and pragmas to the C++ source.
+    target_compile_options(medui_tools_spec PRIVATE /experimental:module /std:c++latest /wd4996)
 endif()
 
 mdux_discover_tests(medui_tools_spec)

--- a/tests/medui/DiagnosticsTests.cpp
+++ b/tests/medui/DiagnosticsTests.cpp
@@ -55,13 +55,13 @@ constexpr std::array<md::Code, 22> allCodes{
 };
 
 [[nodiscard]] bool wellFormedId(std::string_view id) {
-    // `MDX-E` followed by exactly three digits. The schema's `code` pattern is looser - it admits
+    // `MEDUI-E` followed by exactly three digits. The schema's `code` pattern is looser - it admits
     // the bakers' `TXT001` too - so this checks the narrower shape this tool committed to, which
     // the schema alone would not catch.
-    if (id.size() != 8 || !id.starts_with("MDX-E")) {
+    if (id.size() != 10 || !id.starts_with("MEDUI-E")) {
         return false;
     }
-    return std::all_of(id.begin() + 5, id.end(),
+    return std::all_of(id.begin() + 7, id.end(),
                        [](char c) { return c >= '0' && c <= '9'; });
 }
 
@@ -127,7 +127,7 @@ const mdux::spec::Register everyIdIsUnique{
     }};
 
 const mdux::spec::Register everyIdIsWellFormed{
-    "Every identifier is MDX-E followed by three digits",
+    "Every identifier is MEDUI-E followed by three digits",
     "evidence-unit",
     [] {
         return speclab::Test("medui-diagnostics-shape")
@@ -138,6 +138,25 @@ const mdux::spec::Register everyIdIsWellFormed{
                 for (const md::CodeInfo& row : md::registry()) {
                     checks.expect(wellFormedId(row.id),
                                   std::format("'{}' is well formed", row.id));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register legacyAliasesPreserveNumbers{
+    "The one-release MDX-E aliases preserve every diagnostic number",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostic-legacy-aliases")
+            .Given("the shared diagnostic registry", [] {})
+            .When("a legacy identifier is requested", [] {})
+            .Then("only the namespace changes", [] {
+                mdux::spec::Checks checks;
+                for (const md::CodeInfo& row : md::registry()) {
+                    const std::string alias = md::legacyId(row.code);
+                    checks.expect(alias == std::string{"MDX"} + std::string{row.id.substr(5)},
+                                  std::format("{} maps without changing its suffix", row.id));
                 }
                 checks.raise();
             })
@@ -204,7 +223,7 @@ const mdux::spec::Register diagnoseCarriesRegisteredIdentity{
                 mdux::spec::Checks checks;
                 const cli::Diagnostic d = md::diagnose(md::Code::UnknownColorToken, "screen.medui",
                                                        12, 5, "Theme.Colors.Wrong is not a token");
-                checks.expect(d.code == "MDX-E030", std::format("code is MDX-E030, got '{}'", d.code));
+                checks.expect(d.code == "MEDUI-E030", std::format("code is MEDUI-E030, got '{}'", d.code));
                 checks.expect(d.severity == cli::Severity::Error, "severity comes from the registry");
                 checks.expect(d.line == 12 && d.column == 5, "position is carried through");
                 checks.expect(!d.fixHint.empty(), "the registry's fix hint is used when none is given");
@@ -247,7 +266,7 @@ const mdux::spec::Register positionsMayBeAbsent{
                 const cli::Diagnostic d = md::diagnose(md::Code::RecipeUnreadable, "recipe.toml", 0,
                                                        0, "could not open recipe.toml");
                 checks.expect(d.line == 0 && d.column == 0, "no position invented");
-                checks.expect(d.code == "MDX-E000", "code is carried");
+                checks.expect(d.code == "MEDUI-E000", "code is carried");
                 checks.raise();
             })
             .Execute();
@@ -260,7 +279,7 @@ const mdux::spec::Register unregisteredValuesFailLoudly{
         // `Code` has a fixed underlying type, so `static_cast<Code>(200)` is a well-formed value of
         // the type - not undefined behaviour - and the completeness scenario above cannot reach it,
         // because it walks the enumerators. An earlier revision returned the first row here, which
-        // would have attached MDX-E000's severity and fix hint to an unrelated failure. Two
+        // would have attached MEDUI-E000's severity and fix hint to an unrelated failure. Two
         // reviewers objected to that independently; this scenario is what keeps the objection
         // answered.
         return speclab::Test("medui-diagnostics-unregistered")

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -32,15 +32,6 @@ namespace {
 namespace md = mdux::tools::medui;
 namespace cli = mdux::tools::cli;
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996) // Test-only environment lookup; no mutable buffer is involved.
-#endif
-[[nodiscard]] const char* conformanceRoot() { return std::getenv("MEDUI_CONFORMANCE_DIR"); }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 [[nodiscard]] std::string fixture(std::string_view name) {
     const std::filesystem::path path =
         std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
@@ -48,21 +39,6 @@ namespace cli = mdux::tools::cli;
     if (!in) {
         throw speclab::core::AssertionFailure(
             std::format("fixture {} could not be opened at {}", name, path.generic_string()),
-            std::source_location::current());
-    }
-    std::ostringstream buffer;
-    buffer << in.rdbuf();
-    return buffer.str();
-}
-
-[[nodiscard]] std::optional<std::string> sharedFixture(std::string_view relative) {
-    const char* root = conformanceRoot();
-    if (root == nullptr || *root == '\0') { return std::nullopt; }
-    const std::filesystem::path path = std::filesystem::path{root} / relative;
-    std::ifstream in{path, std::ios::binary};
-    if (!in) {
-        throw speclab::core::AssertionFailure(
-            std::format("shared fixture could not be opened at {}", path.generic_string()),
             std::source_location::current());
     }
     std::ostringstream buffer;
@@ -701,43 +677,6 @@ const mdux::spec::Register screenPositionIsTheKeyword{
                     checks.expect(r.screen->position.column == 1,
                                   std::format("column 1, the 'Screen' keyword, got {}",
                                               r.screen->position.column));
-                }
-                checks.raise();
-            })
-            .Execute();
-    }};
-
-const mdux::spec::Register sharedSyntaxCandidate{
-    "The parser conforms to the pinned shared MedUI syntax candidate",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-shared-syntax-candidate")
-            .Given("the exact checkout named by medui-conformance.toml", [] {})
-            .When("its portable syntax cases are parsed", [] {})
-            .Then("comments parse and nested Row reports the shared identity and position", [] {
-                mdux::spec::Checks checks;
-                const auto accepted = sharedFixture(
-                    "conformance/syntax/accepted-comments/source.medui");
-                const auto nested = sharedFixture(
-                    "conformance/syntax/rejected-nested-row/source.medui");
-                if (!accepted || !nested) {
-                    // Ordinary offline builds keep their local fixture suite. CI sets the path.
-                    return;
-                }
-                const md::ParseResult acceptedResult = md::parse(*accepted, "source.medui");
-                checks.expect(acceptedResult.ok(),
-                              std::format("comments case parses, got {}",
-                                          codesOf(acceptedResult.diagnostics)));
-                const md::ParseResult nestedResult = md::parse(*nested, "source.medui");
-                const cli::Diagnostic* diagnostic =
-                    find(nestedResult.diagnostics, md::Code::NestedRow);
-                checks.expect(diagnostic != nullptr,
-                              std::format("MEDUI-E015 reported, got {}",
-                                          codesOf(nestedResult.diagnostics)));
-                if (diagnostic != nullptr) {
-                    checks.expect(diagnostic->line == 6 && diagnostic->column == 9,
-                                  std::format("position 6:9, got {}:{}", diagnostic->line,
-                                              diagnostic->column));
                 }
                 checks.raise();
             })

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -27,10 +27,26 @@ import mdux.tools.medui.parser;
 
 #include "../framework/SpecLabBridge.hpp"
 
+#include <cstdlib>
+
 namespace {
 
 namespace md = mdux::tools::medui;
 namespace cli = mdux::tools::cli;
+
+[[nodiscard]] std::optional<std::string> environmentValue(const char* name) {
+#ifdef _WIN32
+    char* value = nullptr;
+    std::size_t length = 0;
+    if (::_dupenv_s(&value, &length, name) != 0 || value == nullptr) { return std::nullopt; }
+    std::string result{value};
+    std::free(value);
+    return result;
+#else
+    const char* value = std::getenv(name);
+    return value == nullptr ? std::nullopt : std::optional<std::string>{value};
+#endif
+}
 
 [[nodiscard]] std::string fixture(std::string_view name) {
     const std::filesystem::path path =
@@ -47,9 +63,9 @@ namespace cli = mdux::tools::cli;
 }
 
 [[nodiscard]] std::optional<std::string> sharedFixture(std::string_view relative) {
-    const char* root = std::getenv("MEDUI_CONFORMANCE_DIR");
-    if (root == nullptr || *root == '\0') { return std::nullopt; }
-    const std::filesystem::path path = std::filesystem::path{root} / relative;
+    const std::optional<std::string> root = environmentValue("MEDUI_CONFORMANCE_DIR");
+    if (!root.has_value() || root->empty()) { return std::nullopt; }
+    const std::filesystem::path path = std::filesystem::path{*root} / relative;
     std::ifstream in{path, std::ios::binary};
     if (!in) {
         throw speclab::core::AssertionFailure(

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -32,19 +32,14 @@ namespace {
 namespace md = mdux::tools::medui;
 namespace cli = mdux::tools::cli;
 
-[[nodiscard]] std::optional<std::string> environmentValue(const char* name) {
-#ifdef _WIN32
-    char* value = nullptr;
-    std::size_t length = 0;
-    if (::_dupenv_s(&value, &length, name) != 0 || value == nullptr) { return std::nullopt; }
-    std::string result{value};
-    std::free(value);
-    return result;
-#else
-    const char* value = std::getenv(name);
-    return value == nullptr ? std::nullopt : std::optional<std::string>{value};
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996) // Test-only environment lookup; no mutable buffer is involved.
 #endif
-}
+[[nodiscard]] const char* conformanceRoot() { return std::getenv("MEDUI_CONFORMANCE_DIR"); }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 [[nodiscard]] std::string fixture(std::string_view name) {
     const std::filesystem::path path =
@@ -61,9 +56,9 @@ namespace cli = mdux::tools::cli;
 }
 
 [[nodiscard]] std::optional<std::string> sharedFixture(std::string_view relative) {
-    const std::optional<std::string> root = environmentValue("MEDUI_CONFORMANCE_DIR");
-    if (!root.has_value() || root->empty()) { return std::nullopt; }
-    const std::filesystem::path path = std::filesystem::path{*root} / relative;
+    const char* root = conformanceRoot();
+    if (root == nullptr || *root == '\0') { return std::nullopt; }
+    const std::filesystem::path path = std::filesystem::path{root} / relative;
     std::ifstream in{path, std::ios::binary};
     if (!in) {
         throw speclab::core::AssertionFailure(

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -46,6 +46,21 @@ namespace cli = mdux::tools::cli;
     return buffer.str();
 }
 
+[[nodiscard]] std::optional<std::string> sharedFixture(std::string_view relative) {
+    const char* root = std::getenv("MEDUI_CONFORMANCE_DIR");
+    if (root == nullptr || *root == '\0') { return std::nullopt; }
+    const std::filesystem::path path = std::filesystem::path{root} / relative;
+    std::ifstream in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(
+            std::format("shared fixture could not be opened at {}", path.generic_string()),
+            std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
 /// True when `code` appears among `diagnostics`.
 [[nodiscard]] bool has(const std::vector<cli::Diagnostic>& diagnostics, md::Code code) {
     const std::string_view wanted = md::id(code);
@@ -233,19 +248,19 @@ const mdux::spec::Register valuesKeepTheirKinds{
 // ---------------------------------------------------------------------------
 
 const mdux::spec::Register nestedRowRejected{
-    "A Row inside a Row is MDX-E015, at the inner Row",
+    "A Row inside a Row is MEDUI-E015, at the inner Row",
     "evidence-unit",
     [] {
         return speclab::Test("medui-reject-nested-row")
             .Given("a screen with a nested Row", [] {})
             .When("it is parsed", [] {})
-            .Then("MDX-E015 names the inner Row's position", [] {
+            .Then("MEDUI-E015 names the inner Row's position", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse(fixture("rejected-nested-row.medui"),
                                                     "rejected-nested-row.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::NestedRow);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E015 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E015 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 6, std::format("at line 6, got {}", d->line));
                     checks.expect(d->column == 9, std::format("at column 9, got {}", d->column));
@@ -257,19 +272,19 @@ const mdux::spec::Register nestedRowRejected{
     }};
 
 const mdux::spec::Register forbiddenConstructRejected{
-    "A control-flow keyword is MDX-E016",
+    "A control-flow keyword is MEDUI-E016",
     "evidence-unit",
     [] {
         return speclab::Test("medui-reject-forbidden")
             .Given("a screen containing 'if'", [] {})
             .When("it is parsed", [] {})
-            .Then("MDX-E016 names it at its position", [] {
+            .Then("MEDUI-E016 names it at its position", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse(fixture("rejected-forbidden-construct.medui"),
                                                     "rejected-forbidden-construct.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::ForbiddenConstruct);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E016 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 3, std::format("at line 3, got {}", d->line));
                     checks.expect(d->column == 5, std::format("at column 5, got {}", d->column));
@@ -282,19 +297,19 @@ const mdux::spec::Register forbiddenConstructRejected{
     }};
 
 const mdux::spec::Register duplicateIdRejected{
-    "A repeated node id is MDX-E014, pointing at the second one",
+    "A repeated node id is MEDUI-E014, pointing at the second one",
     "evidence-unit",
     [] {
         return speclab::Test("medui-reject-duplicate-id")
             .Given("two nodes sharing an id", [] {})
             .When("the screen is parsed", [] {})
-            .Then("MDX-E014 names the second and cites the first", [] {
+            .Then("MEDUI-E014 names the second and cites the first", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse(fixture("rejected-duplicate-id.medui"),
                                                     "rejected-duplicate-id.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::DuplicateNodeId);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E014 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E014 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 8, std::format("at the second id, line 8, got {}",
                                                             d->line));
@@ -309,19 +324,19 @@ const mdux::spec::Register duplicateIdRejected{
     }};
 
 const mdux::spec::Register unknownUnitRejected{
-    "A length in a unit other than px is MDX-E010",
+    "A length in a unit other than px is MEDUI-E010",
     "evidence-unit",
     [] {
         return speclab::Test("medui-reject-bad-unit")
             .Given("a width written as 10rem", [] {})
             .When("the screen is parsed", [] {})
-            .Then("MDX-E010 says what units exist", [] {
+            .Then("MEDUI-E010 says what units exist", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse(fixture("rejected-bad-unit.medui"),
                                                     "rejected-bad-unit.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E010 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E010 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 5, std::format("at line 5, got {}", d->line));
                     checks.expect(d->column == 18, std::format("at column 18, got {}", d->column));
@@ -389,7 +404,7 @@ const mdux::spec::Register commentsAreSkipped{
     }};
 
 const mdux::spec::Register invalidUtf8Rejected{
-    "A source that is not valid UTF-8 is rejected whole, with MDX-E004",
+    "A source that is not valid UTF-8 is rejected whole, with MEDUI-E004",
     "evidence-unit",
     [] {
         // Whole rather than at the byte: past an invalid sequence there are no defined character
@@ -397,13 +412,13 @@ const mdux::spec::Register invalidUtf8Rejected{
         return speclab::Test("medui-lex-bad-utf8")
             .Given("a source containing a lone continuation byte", [] {})
             .When("it is lexed", [] {})
-            .Then("MDX-E004 is reported and no tokens are produced", [] {
+            .Then("MEDUI-E004 is reported and no tokens are produced", [] {
                 mdux::spec::Checks checks;
                 std::string source = "Screen A { }\n";
                 source += '\x80';
                 const md::LexResult r = md::lex(source, "bad.medui");
                 checks.expect(has(r.diagnostics, md::Code::SourceNotUtf8),
-                              std::format("MDX-E004 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E004 reported, got {}", codesOf(r.diagnostics)));
                 checks.expect(r.tokens.empty(), "no tokens, so no invented positions");
                 checks.raise();
             })
@@ -431,7 +446,7 @@ const mdux::spec::Register severalProblemsInOneRun{
                     "}\n",
                     "two.medui");
                 const auto count = std::ranges::count_if(
-                    r.diagnostics, [](const cli::Diagnostic& d) { return d.code == "MDX-E010"; });
+                    r.diagnostics, [](const cli::Diagnostic& d) { return d.code == "MEDUI-E010"; });
                 checks.expect(count >= 2,
                               std::format("at least two findings, got {}",
                                           codesOf(r.diagnostics)));
@@ -487,7 +502,7 @@ const mdux::spec::Register trailingContentRejected{
                 const md::ParseResult two = md::parse("Screen A { }\nScreen B { }\n", "t.medui");
                 const cli::Diagnostic* d2 = find(two.diagnostics, md::Code::UnexpectedToken);
                 checks.expect(d2 != nullptr,
-                              std::format("MDX-E010 for a second Screen, got {}",
+                              std::format("MEDUI-E010 for a second Screen, got {}",
                                           codesOf(two.diagnostics)));
                 if (d2 != nullptr) {
                     checks.expect(d2->line == 2 && d2->column == 1,
@@ -498,7 +513,7 @@ const mdux::spec::Register trailingContentRejected{
                 const md::ParseResult junk = md::parse("Screen A { } garbage\n", "t.medui");
                 const cli::Diagnostic* dj = find(junk.diagnostics, md::Code::UnexpectedToken);
                 checks.expect(dj != nullptr,
-                              std::format("MDX-E010 for trailing junk, got {}",
+                              std::format("MEDUI-E010 for trailing junk, got {}",
                                           codesOf(junk.diagnostics)));
                 if (dj != nullptr) {
                     checks.expect(dj->line == 1 && dj->column == 14,
@@ -511,12 +526,12 @@ const mdux::spec::Register trailingContentRejected{
     }};
 
 const mdux::spec::Register annotatedChildOutsideRowRejected{
-    "An annotated child is rejected outside a Row, and a Row inside one is still MDX-E015",
+    "An annotated child is rejected outside a Row, and a Row inside one is still MEDUI-E015",
     "evidence-unit",
     [] {
         // Reported independently by three reviewers on #209. The unannotated path enforced
         // "only a Row has children"; the annotated path did not, so `Card { @x Label { } }`
-        // was accepted - and `Card { @x Row { } }` put a Row at depth two with no MDX-E015,
+        // was accepted - and `Card { @x Row { } }` put a Row at depth two with no MEDUI-E015,
         // because the annotated path also passed insideRow = false.
         return speclab::Test("medui-reject-annotated-child")
             .Given("an annotated child under a non-Row parent", [] {})
@@ -527,7 +542,7 @@ const mdux::spec::Register annotatedChildOutsideRowRejected{
                     md::parse("Screen A {\n Card {\n  @x Label { }\n }\n}\n", "a.medui");
                 const cli::Diagnostic* dc = find(child.diagnostics, md::Code::UnexpectedToken);
                 checks.expect(dc != nullptr,
-                              std::format("MDX-E010 for an annotated child, got {}",
+                              std::format("MEDUI-E010 for an annotated child, got {}",
                                           codesOf(child.diagnostics)));
                 if (dc != nullptr) {
                     checks.expect(dc->line == 3 && dc->column == 3,
@@ -537,21 +552,21 @@ const mdux::spec::Register annotatedChildOutsideRowRejected{
                 }
 
                 // A Row under a non-Row is rejected as a child, *not* as a nested Row: the parent
-                // is a Card, so MDX-E015 would be the wrong code. The nested-Row rule is asserted
+                // is a Card, so MEDUI-E015 would be the wrong code. The nested-Row rule is asserted
                 // separately below, where the parent really is a Row.
                 const md::ParseResult row =
                     md::parse("Screen A {\n Card {\n  @x Row { }\n }\n}\n", "a.medui");
                 checks.expect(find(row.diagnostics, md::Code::UnexpectedToken) != nullptr,
-                              std::format("MDX-E010 for an annotated Row under a Card, got {}",
+                              std::format("MEDUI-E010 for an annotated Row under a Card, got {}",
                                           codesOf(row.diagnostics)));
 
                 // An *annotated* Row inside a Row is the case the gate previously let through
-                // with no diagnostic at all. It must be MDX-E015, exactly as the unannotated form.
+                // with no diagnostic at all. It must be MEDUI-E015, exactly as the unannotated form.
                 const md::ParseResult nested =
                     md::parse("Screen A {\n Row {\n  @x Row { }\n }\n}\n", "a.medui");
                 const cli::Diagnostic* dn = find(nested.diagnostics, md::Code::NestedRow);
                 checks.expect(dn != nullptr,
-                              std::format("MDX-E015 for an annotated nested Row, got {}",
+                              std::format("MEDUI-E015 for an annotated nested Row, got {}",
                                           codesOf(nested.diagnostics)));
                 if (dn != nullptr) {
                     checks.expect(dn->line == 3 && dn->column == 6,
@@ -571,7 +586,7 @@ const mdux::spec::Register annotatedChildOutsideRowRejected{
     }};
 
 const mdux::spec::Register forbiddenWordInLayoutRejected{
-    "A control-flow keyword as a layout kind is MDX-E016",
+    "A control-flow keyword as a layout kind is MEDUI-E016",
     "evidence-unit",
     [] {
         // "Wherever an identifier may appear" did not include the layout kind, so `layout: if { }`
@@ -579,12 +594,12 @@ const mdux::spec::Register forbiddenWordInLayoutRejected{
         return speclab::Test("medui-reject-forbidden-layout")
             .Given("layout: if { }", [] {})
             .When("it is parsed", [] {})
-            .Then("MDX-E016 is reported", [] {
+            .Then("MEDUI-E016 is reported", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse("Screen A {\n layout: if { }\n}\n", "l.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::ForbiddenConstruct);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E016 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 2 && d->column == 10,
                                   std::format("at 2:10, the 'if', got {}:{}", d->line, d->column));
@@ -599,7 +614,7 @@ const mdux::spec::Register onlyThemeColorsIsAColourToken{
     "evidence-unit",
     [] {
         // Every dotted path was classified ColorToken, so `Foo.Bar` would have reached #193's
-        // theme lookup and produced MDX-E030 "not in the governed table" for a value that never
+        // theme lookup and produced MEDUI-E030 "not in the governed table" for a value that never
         // claimed to name a colour.
         return speclab::Test("medui-value-colour-classification")
             .Given("three dotted paths", [] {})
@@ -677,6 +692,43 @@ const mdux::spec::Register screenPositionIsTheKeyword{
                     checks.expect(r.screen->position.column == 1,
                                   std::format("column 1, the 'Screen' keyword, got {}",
                                               r.screen->position.column));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register sharedSyntaxCandidate{
+    "The parser conforms to the pinned shared MedUI syntax candidate",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-shared-syntax-candidate")
+            .Given("the exact checkout named by medui-conformance.toml", [] {})
+            .When("its portable syntax cases are parsed", [] {})
+            .Then("comments parse and nested Row reports the shared identity and position", [] {
+                mdux::spec::Checks checks;
+                const auto accepted = sharedFixture(
+                    "conformance/syntax/accepted-comments/source.medui");
+                const auto nested = sharedFixture(
+                    "conformance/syntax/rejected-nested-row/source.medui");
+                if (!accepted || !nested) {
+                    // Ordinary offline builds keep their local fixture suite. CI sets the path.
+                    return;
+                }
+                const md::ParseResult acceptedResult = md::parse(*accepted, "source.medui");
+                checks.expect(acceptedResult.ok(),
+                              std::format("comments case parses, got {}",
+                                          codesOf(acceptedResult.diagnostics)));
+                const md::ParseResult nestedResult = md::parse(*nested, "source.medui");
+                const cli::Diagnostic* diagnostic =
+                    find(nestedResult.diagnostics, md::Code::NestedRow);
+                checks.expect(diagnostic != nullptr,
+                              std::format("MEDUI-E015 reported, got {}",
+                                          codesOf(nestedResult.diagnostics)));
+                if (diagnostic != nullptr) {
+                    checks.expect(diagnostic->line == 6 && diagnostic->column == 9,
+                                  std::format("position 6:9, got {}:{}", diagnostic->line,
+                                              diagnostic->column));
                 }
                 checks.raise();
             })

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -27,8 +27,6 @@ import mdux.tools.medui.parser;
 
 #include "../framework/SpecLabBridge.hpp"
 
-#include <cstdlib>
-
 namespace {
 
 namespace md = mdux::tools::medui;

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -90,6 +90,11 @@ struct Manifest {
     Positions positions{Positions::Full};
 };
 
+/// `governance/versioning.md` makes an unknown key an error rather than something to ignore, so a
+/// misspelled `capabilties` fails here instead of silently claiming nothing.
+constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "version", "commit",
+                                                            "capabilities", "positions"};
+
 [[nodiscard]] Manifest manifest() {
     const std::filesystem::path path =
         std::filesystem::path{MDUX_REPO_ROOT} / "medui-conformance.toml";
@@ -100,6 +105,14 @@ struct Manifest {
     Manifest result{.commit = root.require("commit").asString(),
                     .capabilities = root.require("capabilities").asStringArray(),
                     .positions = Positions::Full};
+
+    for (const auto& entry : root.entries()) {
+        if (std::ranges::find(knownManifestKeys, entry.first) == knownManifestKeys.end()) {
+            fail(std::format("{}: unknown key '{}'; the consumer manifest rejects keys it does "
+                             "not define",
+                             path.generic_string(), entry.first));
+        }
+    }
 
     const std::string declared = root.require("positions").asString();
     if (declared == "full") {

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -53,14 +53,7 @@ constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
     throw speclab::core::AssertionFailure(std::move(message), where);
 }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996) // Test-only environment lookup; no mutable buffer is involved.
-#endif
 [[nodiscard]] const char* env(const char* name) { return std::getenv(name); }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 [[nodiscard]] bool isSet(const char* name) {
     const char* value = env(name);
@@ -73,6 +66,103 @@ constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
     std::ostringstream buffer;
     buffer << in.rdbuf();
     return buffer.str();
+}
+
+[[nodiscard]] std::string trim(std::string value) {
+    const auto isWhitespace = [](unsigned char c) {
+        return std::isspace(c) != 0;
+    };
+    const auto first = std::ranges::find_if_not(value, isWhitespace);
+    const auto last  = std::ranges::find_if_not(value | std::views::reverse, isWhitespace).base();
+    if (first >= last) {
+        return {};
+    }
+    return std::string{first, last};
+}
+
+[[nodiscard]] bool isCommitSha(std::string_view value) {
+    return value.size() == 40 && std::ranges::all_of(value, [](unsigned char c) {
+               return std::isxdigit(c) != 0;
+           });
+}
+
+[[nodiscard]] std::filesystem::path resolveGitDirectory(const std::filesystem::path& root) {
+    const std::filesystem::path dotGit = root / ".git";
+    if (std::filesystem::is_directory(dotGit)) {
+        return dotGit;
+    }
+    if (!std::filesystem::is_regular_file(dotGit)) {
+        fail(std::format("{} has no .git metadata; cannot verify the checked-out MedUI revision", root.generic_string()));
+    }
+
+    constexpr std::string_view prefix{"gitdir: "};
+    const std::string          metadata = trim(readFile(dotGit));
+    if (!metadata.starts_with(prefix)) {
+        fail(std::format("{} has malformed gitdir metadata", dotGit.generic_string()));
+    }
+    std::filesystem::path directory{metadata.substr(prefix.size())};
+    if (directory.is_relative()) {
+        directory = root / directory;
+    }
+    return directory.lexically_normal();
+}
+
+[[nodiscard]] std::filesystem::path resolveCommonGitDirectory(const std::filesystem::path& gitDirectory) {
+    const std::filesystem::path marker = gitDirectory / "commondir";
+    if (!std::filesystem::is_regular_file(marker)) {
+        return gitDirectory;
+    }
+
+    std::filesystem::path common{trim(readFile(marker))};
+    if (common.is_relative()) {
+        common = gitDirectory / common;
+    }
+    return common.lexically_normal();
+}
+
+[[nodiscard]] std::string checkoutRevision(const std::filesystem::path& root) {
+    const std::filesystem::path gitDirectory = resolveGitDirectory(root);
+    const std::string           head         = trim(readFile(gitDirectory / "HEAD"));
+    if (isCommitSha(head)) {
+        return head;
+    }
+
+    constexpr std::string_view prefix{"ref: "};
+    if (!head.starts_with(prefix)) {
+        fail(std::format("{} has malformed HEAD metadata", gitDirectory.generic_string()));
+    }
+    const std::string reference = head.substr(prefix.size());
+    if (!reference.starts_with("refs/") || reference.contains("..") || reference.contains('\\')) {
+        fail(std::format("{} names an unsafe HEAD reference '{}'", gitDirectory.generic_string(), reference));
+    }
+
+    const std::filesystem::path commonDirectory = resolveCommonGitDirectory(gitDirectory);
+    for (const std::filesystem::path& directory : {gitDirectory, commonDirectory}) {
+        const std::filesystem::path looseReference = directory / reference;
+        if (std::filesystem::is_regular_file(looseReference)) {
+            const std::string revision = trim(readFile(looseReference));
+            if (isCommitSha(revision)) {
+                return revision;
+            }
+            fail(std::format("{} does not contain a commit SHA", looseReference.generic_string()));
+        }
+    }
+
+    const std::filesystem::path packedReferences = commonDirectory / "packed-refs";
+    if (std::filesystem::is_regular_file(packedReferences)) {
+        std::istringstream lines{readFile(packedReferences)};
+        for (std::string line; std::getline(lines, line);) {
+            const std::size_t separator = line.find(' ');
+            if (separator != std::string::npos && line.substr(separator + 1) == reference) {
+                const std::string revision = line.substr(0, separator);
+                if (isCommitSha(revision)) {
+                    return revision;
+                }
+                fail(std::format("{} has a malformed entry for '{}'", packedReferences.generic_string(), reference));
+            }
+        }
+    }
+    fail(std::format("could not resolve HEAD reference '{}' under {}", reference, gitDirectory.generic_string()));
 }
 
 // ---------------------------------------------------------------------------
@@ -126,10 +216,7 @@ constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "versi
                          path.generic_string(), declared));
     }
 
-    const bool wellFormed =
-        result.commit.size() == 40 &&
-        std::ranges::all_of(result.commit, [](unsigned char c) { return std::isxdigit(c) != 0; });
-    if (!wellFormed) {
+    if (!isCommitSha(result.commit)) {
         fail(std::format("{} must pin a 40-character commit SHA, got '{}'", path.generic_string(),
                          result.commit));
     }
@@ -217,7 +304,7 @@ struct Case {
     result.phase = requireString(*document, "phase", path);
 
     const std::string source = requireString(*document, "source", path);
-    if (source.contains('/') || !source.ends_with(".medui")) {
+    if (source.contains('/') || source.contains('\\') || !source.ends_with(".medui")) {
         fail(std::format("{}: source must be a sibling .medui file, got '{}'",
                          path.generic_string(), source));
     }
@@ -328,18 +415,30 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
         return;
     }
 
-    checks.expect(!result.ok(),
-                  std::format("{}: rejected, but the parser accepted it", item.id));
+    checks.expect(!result.ok(), std::format("{}: rejected, but the parser accepted it", item.id));
 
+    std::vector<bool> consumed(result.diagnostics.size(), false);
     for (const ExpectedDiagnostic& expected : item.diagnostics) {
-        const auto match = std::ranges::find_if(
-            result.diagnostics,
-            [&expected](const cli::Diagnostic& d) { return d.code == expected.code; });
-        const bool reported = match != result.diagnostics.end();
-        checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code,
-                                            codesOf(result.diagnostics)));
-        if (reported) { checkPosition(item, expected, *match, positions, checks); }
+        std::size_t match = result.diagnostics.size();
+        for (std::size_t index = 0; index < result.diagnostics.size(); ++index) {
+            if (!consumed[index] && result.diagnostics[index].code == expected.code) {
+                match = index;
+                break;
+            }
+        }
+        const bool reported = match != result.diagnostics.size();
+        checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code, codesOf(result.diagnostics)));
+        if (reported) {
+            consumed[match] = true;
+            checkPosition(item, expected, result.diagnostics[match], positions, checks);
+        }
     }
+
+    checks.expect(std::ranges::all_of(consumed,
+                                      [](bool value) {
+                                          return value;
+                                      }),
+                  std::format("{}: every emitted diagnostic is expected, got {}", item.id, codesOf(result.diagnostics)));
 }
 
 }  // namespace
@@ -392,7 +491,16 @@ const mdux::spec::Register pinnedCasesPass{
                     return;
                 }
 
-                const std::vector<Case> cases = loadCases(std::filesystem::path{root});
+                const std::filesystem::path checkout{root};
+                const std::string           actualCommit = checkoutRevision(checkout);
+                checks.expect(actualCommit == pinned.commit,
+                              std::format("MEDUI_CONFORMANCE_DIR is checked out at {}, but "
+                                          "medui-conformance.toml pins {}",
+                                          actualCommit,
+                                          pinned.commit));
+                checks.raise();
+
+                const std::vector<Case> cases = loadCases(checkout);
                 checks.expect(!cases.empty(), "the pinned checkout contains conformance cases");
 
                 std::set<std::string> executed;

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -1,0 +1,362 @@
+/**
+ * @file SharedConformanceTests.cpp
+ * @brief The pinned `Compliatory/MedUI` conformance cases, run against this parser.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Every expectation is read from the pinned checkout's `case.json`, never from a copy in this
+ * file. A hand-written copy is a second source of truth: the shared contract can change an
+ * expected code or position and a copy keeps passing, which is the one thing pinning a contract
+ * is supposed to prevent.
+ *
+ * `MEDUI-DEC-005` says a consumer "must not silently skip a claimed phase". Two rules follow:
+ *
+ * - CI has the checkout, so a missing one there is a failure rather than a skip. A developer
+ *   without it gets a notice on stderr; `CI` in the environment turns that into a hard failure,
+ *   so the run that produces evidence can never be vacuous.
+ * - A capability named in `medui-conformance.toml` must be one this file can actually observe,
+ *   and must be backed by a case that really executed. Claiming a phase with no adapter fails
+ *   here instead of passing quietly.
+ *
+ * Only the parse phase is observable: `md::parse` answers acceptance, codes and positions.
+ * Claiming `semantics`, `layout` or `safety` additionally needs the resolver (#193), the solver
+ * (#194) and the golden pass (#196), plus a convention for the `inputs` member the case schema
+ * declares and no case yet uses — so a claim to any of them is rejected below rather than
+ * silently evaluated by a parser that cannot see those phases.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.evidence.json;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.parser;
+import mdux.tools.toml;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+namespace json = mdux::evidence::json;
+namespace toml = mdux::tools::toml;
+
+/// Phases this file can genuinely observe. Anything else in `capabilities` is a claim with no
+/// adapter behind it.
+constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
+
+[[noreturn]] void fail(std::string message,
+                       std::source_location where = std::source_location::current()) {
+    throw speclab::core::AssertionFailure(std::move(message), where);
+}
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996) // Test-only environment lookup; no mutable buffer is involved.
+#endif
+[[nodiscard]] const char* env(const char* name) { return std::getenv(name); }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+[[nodiscard]] bool isSet(const char* name) {
+    const char* value = env(name);
+    return value != nullptr && *value != '\0';
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream in{path, std::ios::binary};
+    if (!in) { fail(std::format("could not open {}", path.generic_string())); }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+// ---------------------------------------------------------------------------
+// medui-conformance.toml
+// ---------------------------------------------------------------------------
+
+struct Manifest {
+    std::string commit;
+    std::vector<std::string> capabilities;
+};
+
+[[nodiscard]] Manifest manifest() {
+    const std::filesystem::path path =
+        std::filesystem::path{MDUX_REPO_ROOT} / "medui-conformance.toml";
+    const std::string text = readFile(path);
+    const toml::Document document = toml::parse(text);
+    const toml::Table& root = document.root();
+
+    Manifest result{.commit = root.require("commit").asString(),
+                    .capabilities = root.require("capabilities").asStringArray()};
+
+    const bool wellFormed =
+        result.commit.size() == 40 &&
+        std::ranges::all_of(result.commit, [](unsigned char c) { return std::isxdigit(c) != 0; });
+    if (!wellFormed) {
+        fail(std::format("{} must pin a 40-character commit SHA, got '{}'", path.generic_string(),
+                         result.commit));
+    }
+    if (result.capabilities.empty()) {
+        // An empty claim would make this whole suite assert nothing while still looking green.
+        fail(std::format("{} claims no capabilities, so nothing would be checked",
+                         path.generic_string()));
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// conformance/**/case.json
+// ---------------------------------------------------------------------------
+
+struct ExpectedDiagnostic {
+    std::string code;
+    std::size_t line{0};
+    std::size_t column{0};
+};
+
+struct Case {
+    std::string id;
+    std::string phase;
+    std::filesystem::path source;
+    bool valid{false};
+    std::vector<ExpectedDiagnostic> diagnostics;
+};
+
+[[nodiscard]] const json::Value& member(const json::Value& object, std::string_view key,
+                                        const std::filesystem::path& path) {
+    const json::Value* found = object.find(key);
+    if (found == nullptr) {
+        fail(std::format("{}: missing required member '{}'", path.generic_string(), key));
+    }
+    return *found;
+}
+
+[[nodiscard]] std::string requireString(const json::Value& object, std::string_view key,
+                                        const std::filesystem::path& path) {
+    const auto text = member(object, key, path).asString();
+    if (!text) { fail(std::format("{}: member '{}' is not a string", path.generic_string(), key)); }
+    return std::string{*text};
+}
+
+[[nodiscard]] std::size_t requirePosition(const json::Value& object, std::string_view key,
+                                          const std::filesystem::path& path) {
+    const auto number = member(object, key, path).asInt();
+    if (!number) {
+        fail(std::format("{}: member '{}' is not an integer", path.generic_string(), key));
+    }
+    if (*number < 0) {
+        fail(std::format("{}: member '{}' is negative", path.generic_string(), key));
+    }
+    return static_cast<std::size_t>(*number);
+}
+
+/// `Value::elements()` yields an empty span for anything that is not an array, so a `diagnostics`
+/// member of the wrong shape would silently read as "no expectations" and the case would assert
+/// almost nothing. Check the kind instead of trusting the span.
+[[nodiscard]] std::span<const json::Value> requireArray(const json::Value& object,
+                                                        std::string_view key,
+                                                        const std::filesystem::path& path) {
+    const json::Value& found = member(object, key, path);
+    if (found.kind() != json::Value::Kind::Array) {
+        fail(std::format("{}: member '{}' is not an array", path.generic_string(), key));
+    }
+    return found.elements();
+}
+
+[[nodiscard]] bool requireBool(const json::Value& object, std::string_view key,
+                               const std::filesystem::path& path) {
+    const auto flag = member(object, key, path).asBool();
+    if (!flag) { fail(std::format("{}: member '{}' is not a boolean", path.generic_string(), key)); }
+    return *flag;
+}
+
+[[nodiscard]] Case readCase(const std::filesystem::path& path) {
+    const std::string text = readFile(path);
+    const auto document = json::parse(text);
+    if (!document) { fail(std::format("{}: is not valid JSON", path.generic_string())); }
+
+    Case result;
+    result.id = requireString(*document, "id", path);
+    result.phase = requireString(*document, "phase", path);
+
+    const std::string source = requireString(*document, "source", path);
+    if (source.contains('/') || !source.ends_with(".medui")) {
+        fail(std::format("{}: source must be a sibling .medui file, got '{}'",
+                         path.generic_string(), source));
+    }
+    result.source = path.parent_path() / source;
+
+    // `case.schema.json` binds the phase to the directory holding the case, so a case filed under
+    // the wrong phase is a contract error rather than something to route around.
+    const std::string directoryPhase = path.parent_path().parent_path().filename().string();
+    if (result.phase != directoryPhase) {
+        fail(std::format("{}: declares phase '{}' but sits under '{}'", path.generic_string(),
+                         result.phase, directoryPhase));
+    }
+
+    const json::Value& expected = member(*document, "expected", path);
+    result.valid = requireBool(expected, "valid", path);
+    for (const json::Value& entry : requireArray(expected, "diagnostics", path)) {
+        result.diagnostics.push_back({.code = requireString(entry, "code", path),
+                                      .line = requirePosition(entry, "line", path),
+                                      .column = requirePosition(entry, "column", path)});
+    }
+    return result;
+}
+
+[[nodiscard]] std::vector<Case> loadCases(const std::filesystem::path& root) {
+    std::vector<std::filesystem::path> paths;
+    const std::filesystem::path directory = root / "conformance";
+    if (!std::filesystem::is_directory(directory)) {
+        fail(std::format("{} has no conformance/ directory; is MEDUI_CONFORMANCE_DIR pointing at "
+                         "a Compliatory/MedUI checkout?",
+                         root.generic_string()));
+    }
+    for (const auto& entry : std::filesystem::recursive_directory_iterator{directory}) {
+        if (entry.is_regular_file() && entry.path().filename() == "case.json") {
+            paths.push_back(entry.path());
+        }
+    }
+    std::ranges::sort(paths);
+
+    std::vector<Case> cases;
+    cases.reserve(paths.size());
+    for (const std::filesystem::path& path : paths) { cases.push_back(readCase(path)); }
+    return cases;
+}
+
+// ---------------------------------------------------------------------------
+// Running one case
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] std::string join(const std::vector<std::string>& parts) {
+    std::string joined;
+    for (const std::string& part : parts) {
+        if (!joined.empty()) { joined += ", "; }
+        joined += part;
+    }
+    return joined;
+}
+
+[[nodiscard]] std::string codesOf(const std::vector<cli::Diagnostic>& diagnostics) {
+    if (diagnostics.empty()) { return "no diagnostics"; }
+    std::string joined;
+    for (const cli::Diagnostic& diagnostic : diagnostics) {
+        if (!joined.empty()) { joined += ", "; }
+        joined += std::format("{} at {}:{}", diagnostic.code, diagnostic.line, diagnostic.column);
+    }
+    return joined;
+}
+
+void runCase(const Case& item, mdux::spec::Checks& checks) {
+    const std::string source = readFile(item.source);
+    const md::ParseResult result = md::parse(source, item.source.filename().string());
+
+    if (item.valid) {
+        checks.expect(result.ok(), std::format("{}: accepted, got {}", item.id,
+                                               codesOf(result.diagnostics)));
+        return;
+    }
+
+    checks.expect(!result.ok(),
+                  std::format("{}: rejected, but the parser accepted it", item.id));
+
+    for (const ExpectedDiagnostic& expected : item.diagnostics) {
+        const auto match = std::ranges::find_if(
+            result.diagnostics,
+            [&expected](const cli::Diagnostic& d) { return d.code == expected.code; });
+        const bool reported = match != result.diagnostics.end();
+        checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code,
+                                            codesOf(result.diagnostics)));
+        if (reported) {
+            checks.expect(match->line == expected.line && match->column == expected.column,
+                          std::format("{}: {} at {}:{}, got {}:{}", item.id, expected.code,
+                                      expected.line, expected.column, match->line, match->column));
+        }
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register claimsNameAPhaseThisSuiteCanObserve{
+    "Every claimed capability is one this suite can actually check",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-shared-claims-are-observable")
+            .Given("the capabilities named in medui-conformance.toml", [] {})
+            .When("they are compared with what this suite can observe", [] {})
+            .Then("no phase is claimed without an adapter behind it", [] {
+                mdux::spec::Checks checks;
+                for (const std::string& capability : manifest().capabilities) {
+                    checks.expect(std::ranges::find(runnableCapabilities, capability) != runnableCapabilities.end(),
+                                  std::format("'{}' is observable here; add the adapter that "
+                                              "checks that phase before claiming it",
+                                              capability));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register pinnedCasesPass{
+    "The parser satisfies every pinned case in a claimed phase",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-shared-conformance")
+            .Given("the exact checkout named by medui-conformance.toml", [] {})
+            .When("each case in a claimed phase is parsed", [] {})
+            .Then("acceptance, codes and positions match the pinned expectations", [] {
+                mdux::spec::Checks checks;
+                const Manifest pinned = manifest();
+
+                const char* root = env("MEDUI_CONFORMANCE_DIR");
+                if (root == nullptr || *root == '\0') {
+                    // Never a silent skip: in CI this is the failure that keeps the claim honest,
+                    // and offline it says out loud that nothing shared was checked.
+                    checks.expect(!isSet("CI"),
+                                  "MEDUI_CONFORMANCE_DIR is set in CI, so the capabilities "
+                                  "claimed in medui-conformance.toml are actually substantiated");
+                    checks.raise();
+                    std::cerr << "MedUI conformance: SKIPPED - set MEDUI_CONFORMANCE_DIR to a "
+                                 "checkout of the pinned commit to run the shared cases locally.\n";
+                    return;
+                }
+
+                const std::vector<Case> cases = loadCases(std::filesystem::path{root});
+                checks.expect(!cases.empty(), "the pinned checkout contains conformance cases");
+
+                std::set<std::string> executed;
+                std::vector<std::string> unclaimed;
+                for (const Case& item : cases) {
+                    if (std::ranges::find(pinned.capabilities, item.phase) != pinned.capabilities.end()) {
+                        runCase(item, checks);
+                        executed.insert(item.phase);
+                    } else {
+                        unclaimed.push_back(std::format("{} ({})", item.id, item.phase));
+                    }
+                }
+
+                for (const std::string& capability : pinned.capabilities) {
+                    checks.expect(executed.contains(capability),
+                                  std::format("capability '{}' is backed by a case that ran; "
+                                              "either the pin is wrong or the claim is unsupported",
+                                              capability));
+                }
+
+                std::cerr << std::format(
+                    "MedUI conformance: {} case(s) at {}; unclaimed and not asserted: {}\n",
+                    cases.size(), pinned.commit,
+                    unclaimed.empty() ? std::string{"none"} : join(unclaimed));
+                checks.raise();
+            })
+            .Execute();
+    }};

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -79,9 +79,15 @@ constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
 // medui-conformance.toml
 // ---------------------------------------------------------------------------
 
+/// The declared diagnostic position precision from `spec/diagnostics.md`. MduX's lexer carries
+/// exact columns, so it declares `full`; the other two exist because the manifest may name them
+/// and a declaration this file ignored would be a declaration nothing checks.
+enum class Positions : std::uint8_t { Full, LineOnly, None };
+
 struct Manifest {
     std::string commit;
     std::vector<std::string> capabilities;
+    Positions positions{Positions::Full};
 };
 
 [[nodiscard]] Manifest manifest() {
@@ -92,7 +98,20 @@ struct Manifest {
     const toml::Table& root = document.root();
 
     Manifest result{.commit = root.require("commit").asString(),
-                    .capabilities = root.require("capabilities").asStringArray()};
+                    .capabilities = root.require("capabilities").asStringArray(),
+                    .positions = Positions::Full};
+
+    const std::string declared = root.require("positions").asString();
+    if (declared == "full") {
+        result.positions = Positions::Full;
+    } else if (declared == "line-only") {
+        result.positions = Positions::LineOnly;
+    } else if (declared == "none") {
+        result.positions = Positions::None;
+    } else {
+        fail(std::format("{}: positions must be \"full\", \"line-only\" or \"none\", got '{}'",
+                         path.generic_string(), declared));
+    }
 
     const bool wellFormed =
         result.commit.size() == 40 &&
@@ -253,7 +272,40 @@ struct Case {
     return joined;
 }
 
-void runCase(const Case& item, mdux::spec::Checks& checks) {
+/// `spec/diagnostics.md`, "Positions in conformance cases": a pinned position is matched as far as
+/// the declared precision goes, and reporting more than was declared fails. The declaration is
+/// checked rather than tolerated, so precision cannot move in either direction without a manifest
+/// edit. MduX reports `0` for "unknown", which is how an absent position is spelled.
+void checkPosition(const Case& item, const ExpectedDiagnostic& expected, const cli::Diagnostic& got,
+                   Positions positions, mdux::spec::Checks& checks) {
+    switch (positions) {
+    case Positions::Full:
+        checks.expect(got.line == expected.line && got.column == expected.column,
+                      std::format("{}: {} at {}:{}, got {}:{}", item.id, expected.code,
+                                  expected.line, expected.column, got.line, got.column));
+        return;
+    case Positions::LineOnly:
+        checks.expect(got.line == expected.line,
+                      std::format("{}: {} at line {}, got {}", item.id, expected.code,
+                                  expected.line, got.line));
+        checks.expect(got.column == 0,
+                      std::format("{}: medui-conformance.toml declares positions = \"line-only\", "
+                                  "but {} reported column {}. Raise the declaration to \"full\" so "
+                                  "the pinned column {} is checked.",
+                                  item.id, expected.code, got.column, expected.column));
+        return;
+    case Positions::None:
+        checks.expect(got.line == 0 && got.column == 0,
+                      std::format("{}: medui-conformance.toml declares positions = \"none\", but "
+                                  "{} reported {}:{}. Raise the declaration so the pinned position "
+                                  "{}:{} is checked.",
+                                  item.id, expected.code, got.line, got.column, expected.line,
+                                  expected.column));
+        return;
+    }
+}
+
+void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) {
     const std::string source = readFile(item.source);
     const md::ParseResult result = md::parse(source, item.source.filename().string());
 
@@ -273,11 +325,7 @@ void runCase(const Case& item, mdux::spec::Checks& checks) {
         const bool reported = match != result.diagnostics.end();
         checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code,
                                             codesOf(result.diagnostics)));
-        if (reported) {
-            checks.expect(match->line == expected.line && match->column == expected.column,
-                          std::format("{}: {} at {}:{}, got {}:{}", item.id, expected.code,
-                                      expected.line, expected.column, match->line, match->column));
-        }
+        if (reported) { checkPosition(item, expected, *match, positions, checks); }
     }
 }
 
@@ -338,7 +386,7 @@ const mdux::spec::Register pinnedCasesPass{
                 std::vector<std::string> unclaimed;
                 for (const Case& item : cases) {
                     if (std::ranges::find(pinned.capabilities, item.phase) != pinned.capabilities.end()) {
-                        runCase(item, checks);
+                        runCase(item, pinned.positions, checks);
                         executed.insert(item.phase);
                     } else {
                         unclaimed.push_back(std::format("{} ({})", item.id, item.phase));

--- a/tools/medui/Ast.cppm
+++ b/tools/medui/Ast.cppm
@@ -95,7 +95,7 @@ struct Annotation {
 /**
  * @brief A component instance, or a `Row`.
  *
- * `children` is non-empty only for `Row`. The parser rejects a `Row` inside a `Row` (`MDX-E015`),
+ * `children` is non-empty only for `Row`. The parser rejects a `Row` inside a `Row` (`MEDUI-E015`),
  * so this is one level deep by construction rather than by convention - #194's solver relies on
  * that, and ADR-011 decision 5 records why the restriction is a solver argument rather than a
  * budget one.

--- a/tools/medui/Diagnostics.cpp
+++ b/tools/medui/Diagnostics.cpp
@@ -27,81 +27,81 @@ using cli::Severity;
 // should land next to the grammar rules rather than at the end of the table, and it can only do
 // that if its block has room. The blocks are documented on the enum in Diagnostics.cppm.
 constexpr std::array<CodeInfo, 22> table{{
-    {Code::RecipeUnreadable, "MDX-E000", Severity::Error,
+    {Code::RecipeUnreadable, "MEDUI-E000", Severity::Error,
      "the recipe file could not be opened",
      "check the path passed on the command line, and that the file is readable"},
-    {Code::RecipeUnparsed, "MDX-E001", Severity::Error,
+    {Code::RecipeUnparsed, "MEDUI-E001", Severity::Error,
      "the recipe is not valid TOML in the subset mdux.tools.toml accepts",
      "see recipes/font/dejavu-ui.toml for the accepted shape; there is no [[table]] support"},
-    {Code::RecipeMissingMember, "MDX-E002", Severity::Error,
+    {Code::RecipeMissingMember, "MEDUI-E002", Severity::Error,
      "the recipe is missing a member the compiler requires",
      "add the named key; every recipe knob is required because a defaulted one would not appear "
      "in report.json (ADR-007)"},
-    {Code::SourceUnreadable, "MDX-E003", Severity::Error,
+    {Code::SourceUnreadable, "MEDUI-E003", Severity::Error,
      "the .medui source named by the recipe could not be opened", "check the path in the recipe"},
-    {Code::SourceNotUtf8, "MDX-E004", Severity::Error,
+    {Code::SourceNotUtf8, "MEDUI-E004", Severity::Error,
      "the .medui source is not valid UTF-8", "re-save the file as UTF-8 without a byte-order mark"},
 
-    {Code::UnexpectedToken, "MDX-E010", Severity::Error,
+    {Code::UnexpectedToken, "MEDUI-E010", Severity::Error,
      "the parser found a token that cannot appear here", ""},
-    {Code::UnknownComponent, "MDX-E011", Severity::Error,
+    {Code::UnknownComponent, "MEDUI-E011", Severity::Error,
      "the component name is not in the dictionary",
      "see the component table in the medui-authoring skill; the dictionary is closed"},
-    {Code::MissingRequiredField, "MDX-E012", Severity::Error,
+    {Code::MissingRequiredField, "MEDUI-E012", Severity::Error,
      "a component is missing a field its dictionary entry requires", ""},
-    {Code::UnknownField, "MDX-E013", Severity::Error,
+    {Code::UnknownField, "MEDUI-E013", Severity::Error,
      "a component carries a field its dictionary entry does not define",
      "check the spelling; unknown fields are rejected rather than ignored, so a typo cannot "
      "silently do nothing"},
-    {Code::DuplicateNodeId, "MDX-E014", Severity::Error,
+    {Code::DuplicateNodeId, "MEDUI-E014", Severity::Error,
      "two nodes in one screen share an id",
      "ids address nodes in golden references and requirement traces, so they must be unique "
      "within a screen"},
-    {Code::NestedRow, "MDX-E015", Severity::Error,
+    {Code::NestedRow, "MEDUI-E015", Severity::Error,
      "a Row contains another Row",
      "flatten the inner Row into its parent. Row is a single level so that layout stays one "
      "flattening pass (ADR-011 decision 5)"},
-    {Code::ForbiddenConstruct, "MDX-E016", Severity::Error,
+    {Code::ForbiddenConstruct, "MEDUI-E016", Severity::Error,
      "the source uses a loop, conditional, recursion or scripting construct",
      "express the screen at its maximum extent and hide what is unused. These make the primitive "
      "count depend on data the compiler cannot see, so DrawBudget could not be computed exactly "
      "(ADR-011 decision 5)"},
-    {Code::HardcodedString, "MDX-E017", Severity::Error,
+    {Code::HardcodedString, "MEDUI-E017", Severity::Error,
      "a literal string appears where a text key is required",
      "use t(\"STR-KEY\") against an approved text package. A hardcoded string cannot be validated "
      "against every approved locale, which is what the budget check needs"},
 
-    {Code::UnknownColorToken, "MDX-E030", Severity::Error,
+    {Code::UnknownColorToken, "MEDUI-E030", Severity::Error,
      "a Theme.Colors token is not in the governed table",
      "check the spelling against the theme token table. Unknown tokens are a compile error rather "
      "than a fallback colour, because a fallback would render something nobody approved"},
-    {Code::UnknownTextKey, "MDX-E031", Severity::Error,
+    {Code::UnknownTextKey, "MEDUI-E031", Severity::Error,
      "a text key is not in the approved text package at all", ""},
-    {Code::TextKeyMissingForLocale, "MDX-E032", Severity::Error,
+    {Code::TextKeyMissingForLocale, "MEDUI-E032", Severity::Error,
      "a text key exists but is missing from at least one approved locale",
      "add the translation, or remove the locale from the recipe's approved list. A key present in "
      "one locale and absent in another is a screen that renders blank on a shipped device"},
 
-    {Code::TextBudgetExceeded, "MDX-E050", Severity::Error,
+    {Code::TextBudgetExceeded, "MEDUI-E050", Severity::Error,
      "a component's bounds cannot contain the widest approved translation",
      "widen the component or shorten the translation. The check is against the widest approved "
      "locale, not the authoring one"},
-    {Code::LayoutOverflow, "MDX-E051", Severity::Error,
+    {Code::LayoutOverflow, "MEDUI-E051", Severity::Error,
      "a node does not fit the space its parent allows",
      "the solver reports overflow rather than clamping, because a clamped layout renders "
      "something the author did not describe"},
-    {Code::SurfaceExceeded, "MDX-E052", Severity::Error,
+    {Code::SurfaceExceeded, "MEDUI-E052", Severity::Error,
      "a node falls outside the declared surface", ""},
-    {Code::CharsetEscape, "MDX-E053", Severity::Error,
+    {Code::CharsetEscape, "MEDUI-E053", Severity::Error,
      "dynamic text could produce a character outside the restricted charset",
      "restrict the format, or extend the charset in the font recipe and re-bake. The charset is "
      "what makes \"no shaping on device\" checkable rather than conventional (ADR-010)"},
 
-    {Code::SafetyCriticalWithoutRequirement, "MDX-E070", Severity::Error,
+    {Code::SafetyCriticalWithoutRequirement, "MEDUI-E070", Severity::Error,
      "a @safety_critical node carries no requirement:",
      "add requirement:, or remove the annotation. A safety-critical node with no requirement "
      "cannot be traced, and tracing is what the annotation is for"},
-    {Code::UnknownCvCheck, "MDX-E071", Severity::Error,
+    {Code::UnknownCvCheck, "MEDUI-E071", Severity::Error,
      "a cv_check names a verification this compiler does not emit", ""},
 }};
 
@@ -129,7 +129,7 @@ const CodeInfo& info(Code code) {
     // test covers every *enumerator*, and `Code` has a fixed underlying type, so
     // `static_cast<Code>(200)` is a well-formed value of the type that no enumerator names. A cast,
     // a value read from data, or an uninitialised member would all have mapped silently to
-    // MDX-E000 - "the recipe file could not be opened" - with that code's severity and fix hint
+    // MEDUI-E000 - "the recipe file could not be opened" - with that code's severity and fix hint
     // attached to an unrelated failure. A registry whose purpose is that a code means one thing
     // cannot have a path that quietly assigns the wrong one.
     //
@@ -144,6 +144,11 @@ const CodeInfo& info(Code code) {
 }
 
 std::string_view id(Code code) { return info(code).id; }
+
+std::string legacyId(Code code) {
+    const std::string_view canonical = id(code);
+    return std::string{"MDX"} + std::string{canonical.substr(5)};
+}
 
 std::span<const std::string_view> retired() noexcept {
     static constexpr std::array<std::string_view, 0> none{};

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -20,23 +20,22 @@
  * is answerable by grep with any confidence, and all three are answerable by construction here.
  *
  * The shape is a `constexpr` table keyed by an enum. Call sites name `Code::UnknownColorToken`,
- * never `"MDX-E030"`, so:
+ * never `"MEDUI-E030"`, so:
  *
  * - **An unregistered code cannot be emitted.** There is no overload taking a string.
  * - **A registered-but-unused code is detectable**, because the enum is exhaustive and a test can
  *   walk it. `DiagnosticsTests.cpp` does.
  * - **A typo is a compile error** rather than a diagnostic nobody can grep for.
  *
- * ## The `MDX-E` prefix
+ * ## The shared `MEDUI-E` prefix
  *
- * `mdux-docs-lint` publishes `MDX-D###`, and the diagnostic schema names `MDX-D011` in its own
- * description, so `MDX-` + one letter + three digits is an established family and this joins it as
- * `MDX-E###`. The bakers' three-letter codes (`SHB`, `SHE`, `TXT`, `MLB`, `EVL`, `GOV`) are a
- * second, older convention; they are not changed here, and nothing needs them to be - the schema's
- * `code` pattern admits both, and `code` is opaque to a consumer that keys off it.
+ * MedUI diagnostics are owned by the pinned `Compliatory/MedUI` contract rather than by either
+ * implementation. MduX's previously published `MDX-E###` identifiers map one-to-one to the same
+ * numbered `MEDUI-E###` identifiers for one release; the upstream alias manifest records that
+ * transition. Non-MedUI tools retain their existing local code families.
  *
- * **`E` is for the language, not for "error".** Severity is a separate field, and an `MDX-E` code
- * may be a warning. Reading the letter as a severity would make `MDX-E###` at severity `warning`
+ * **`E` is for the language, not for "error".** Severity is a separate field, and a `MEDUI-E` code
+ * may be a warning. Reading the letter as a severity would make `MEDUI-E###` at severity `warning`
  * look like a mistake, so it is worth saying which reading is intended.
  *
  * ## Stability
@@ -103,7 +102,7 @@ enum class Code : std::uint8_t {
 /// One row of the registry. `constexpr`-friendly throughout: the table is built at compile time.
 struct CodeInfo {
     Code code{};
-    std::string_view id;       ///< the published `MDX-E###` string; stable once shipped
+    std::string_view id;       ///< the published `MEDUI-E###` string; stable once shipped
     cli::Severity severity{};  ///< the severity this code is emitted at, unless a call site lowers it
     std::string_view summary;  ///< what the code means, one clause, for documentation and tests
     std::string_view fixHint;  ///< what an author should do; empty when there is no single fix
@@ -138,15 +137,18 @@ struct CodeInfo {
  */
 [[nodiscard]] const CodeInfo& info(Code code);
 
-/// The published identifier, e.g. `"MDX-E030"`. Throws for an unregistered value, as `info()` does.
+/// The published identifier, e.g. `"MEDUI-E030"`. Throws for an unregistered value, as `info()` does.
 [[nodiscard]] std::string_view id(Code code);
+
+/** One-release compatibility alias, e.g. `"MDX-E030"`. Canonical output always uses [`id`]. */
+[[nodiscard]] std::string legacyId(Code code);
 
 /**
  * @brief Numbers that were published and then retired.
  *
  * Empty today, and present from the start so that the first retirement has somewhere to go rather
  * than prompting a decision under time pressure. A retired number is never reused: a consumer that
- * pinned behaviour to `MDX-E017` must not silently start matching a different rule.
+ * pinned behaviour to `MEDUI-E017` must not silently start matching a different rule.
  */
 [[nodiscard]] std::span<const std::string_view> retired() noexcept;
 

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -137,10 +137,18 @@ struct CodeInfo {
  */
 [[nodiscard]] const CodeInfo& info(Code code);
 
-/// The published identifier, e.g. `"MEDUI-E030"`. Throws for an unregistered value, as `info()` does.
+/**
+ * @brief Gets the published identifier, for example `"MEDUI-E030"`.
+ *
+ * Throws for an unregistered value, as `info()` does.
+ */
 [[nodiscard]] std::string_view id(Code code);
 
-/** One-release compatibility alias, e.g. `"MDX-E030"`. Canonical output always uses [`id`]. */
+/**
+ * @brief Gets the one-release compatibility alias, for example `"MDX-E030"`.
+ *
+ * Canonical output always uses `id()`.
+ */
 [[nodiscard]] std::string legacyId(Code code);
 
 /**

--- a/tools/medui/Lexer.cppm
+++ b/tools/medui/Lexer.cppm
@@ -109,7 +109,7 @@ struct LexResult {
  * cannot report more than one problem per run. It lexes as far as it can, so a run reports several
  * findings rather than one at a time.
  *
- * A source that is not valid UTF-8 is rejected whole, with `MDX-E004`. Continuing past that would
+ * A source that is not valid UTF-8 is rejected whole, with `MEDUI-E004`. Continuing past that would
  * mean reporting columns into a byte sequence that has no defined character boundaries.
  */
 [[nodiscard]] LexResult lex(std::string_view source, std::string file);

--- a/tools/medui/Parser.cpp
+++ b/tools/medui/Parser.cpp
@@ -308,7 +308,7 @@ private:
             if (at(TokenKind::At)) {
                 // Only a Row has children. The unannotated branch above already enforced that;
                 // this one did not, so `Card { @x Label { } }` was accepted and - worse -
-                // `Card { @x Row { } }` placed a Row at depth two with no MDX-E015, because the
+                // `Card { @x Row { } }` placed a Row at depth two with no MEDUI-E015, because the
                 // annotated path also passed insideRow=false. Reported independently by three
                 // reviewers on #209, and the AST contract in Ast.cppm says children is non-empty
                 // only for Row, which #194's single-pass solver relies on.
@@ -497,7 +497,7 @@ private:
             }
             // A dotted path is only a *colour token* when it is one. `Foo.Bar` and a truncated
             // `Theme.Colors` were both classified as ColorToken, which would have sent #193 to the
-            // theme table for a value that never named a colour - and produced MDX-E030 "not in the
+            // theme table for a value that never named a colour - and produced MEDUI-E030 "not in the
             // governed table" for what is really a malformed value.
             const bool isThemeColor = path.starts_with("Theme.Colors.") &&
                                       path.size() > std::string_view{"Theme.Colors."}.size();

--- a/tools/medui/Parser.cppm
+++ b/tools/medui/Parser.cppm
@@ -12,13 +12,13 @@
  *
  * - The shape: one `Screen`, an optional `layout:` and `surface:`, then nodes with fields.
  * - **No control flow.** `if`, `else`, `for`, `while`, `loop`, `match`, `fn`, `let`, `return` and
- *   `import` are rejected with `MDX-E016` wherever they appear. ADR-011 decision 5: each makes the
+ *   `import` are rejected with `MEDUI-E016` wherever they appear. ADR-011 decision 5: each makes the
  *   primitive count depend on data the compiler cannot see, and a `DrawBudget` that cannot be
  *   computed exactly is not a budget.
- * - **No nested `Row`** (`MDX-E015`). ADR-011 is explicit that this one is a *solver* restriction,
+ * - **No nested `Row`** (`MEDUI-E015`). ADR-011 is explicit that this one is a *solver* restriction,
  *   not a budget one - a nested Row's depth is visible and the primitive count stays exact - so the
  *   diagnostic says flatten it, and does not cite the budget argument that does not apply.
- * - **No duplicate node ids within a screen** (`MDX-E014`). Ids address nodes in golden references
+ * - **No duplicate node ids within a screen** (`MEDUI-E014`). Ids address nodes in golden references
  *   (#196) and requirement traces, so a duplicate makes those ambiguous.
  *
  * ## What it does not


### PR DESCRIPTION
## Summary

- pins the candidate `Compliatory/MedUI` contract at `c8cc45ecec2f2dfd84940b9efc17c613e691cc0d`
- replaces MedUI-specific `MDX-E###` output with canonical same-numbered `MEDUI-E###` identities
- provides one-release `legacyId()` aliases and retains the upstream migration map
- maps ADR-011/012 to shared decision identities and runs pinned syntax cases in GCC/MSVC/Clang CI

MduX claims only the `syntax` capability. Later compiler waves add semantic, layout, and safety capabilities when their shared observations pass.

Related to #15; this PR does not close the compiler epic.

## Invitation and contributor agreement

- [x] Maintainer-authored change; no separate contribution invitation is required.
- [x] Repository owner/maintainer; no contributor CLA issue applies.

Invitation / CLA issue: none — maintainer-authored

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root)
- [ ] `FILE_SET CXX_MODULES` lists
- [ ] `tools/CMakeLists.txt`
- [x] `tests/CMakeLists.txt`
- [x] Schema under `docs/governance/schemas/`
- [ ] Generated indexes
- [ ] Committed artifacts under `generated/`
- [ ] None of the above

## Rebase state

- **Rebased onto:** `20ea5ac8ac3a501cb911ffda3e0d9040e79c9b75`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — unavailable locally on macOS/AppleClang
- [ ] `ctest --test-dir build-gcc` — unavailable locally for the same toolchain reason
- [x] `PYTHONDONTWRITEBYTECODE=1 python3 tools/docs-lint/mdux_docs_lint.py` — OK (80 files)
- [x] Other: workflow YAML parsed successfully; `git diff --check` clean
- [x] Existing PR head: GCC 16, MSVC, sanitizers, CodeQL, documentation, evidence, governed-source, and security checks pass

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green. *(Not applicable before merge; no successor is gated.)*

## Regulatory impact

Potentially safety-relevant: stable diagnostic identities and architecture trace links change, but the parser's accepted/rejected behavior and device runtime behavior do not. Maintainer/domain review is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added canonical `MEDUI-E###` diagnostic identifiers.
  - Added compatibility aliases for legacy `MDX-E###` identifiers.
  - Added shared conformance validation covering parsing, diagnostics, and position precision.

- **Bug Fixes**
  - Corrected diagnostic documentation and expectations across parser and lexer guidance.

- **Documentation**
  - Updated architecture and decision records to reflect current MedUI capabilities and shared standards.

- **Tests**
  - Expanded cross-platform validation using a pinned conformance contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->