### PR TITLE
Semantic analysis: theme tokens and locale-checked strings

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,11 +10,13 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: the front end is implemented; the compiler and runtime are not
+## Status: parsing and semantic name validation are implemented; emission and runtime are not
 
-**A `.medui` lexer, AST and parser exist** in the host-tools zone as of issue #192 (`tools/medui/`), and
-the diagnostic codes they emit are registered as `MEDUI-E###` (#191). They parse a screen and reject
-the grammar's structural violations; they resolve nothing.
+**A `.medui` lexer, AST, parser and semantic analyzer exist** in the host-tools zone
+(`tools/medui/`). The diagnostic codes they emit are registered as `MEDUI-E###` (#191). The parser
+rejects structural violations (#192); the analyzer checks the closed component dictionary, theme
+token names, and text-key presence across every approved locale (#193). It validates names but
+does not substitute them.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -28,7 +30,7 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 [issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). The implementation pins the shared
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
-[`Compliatory/MedUI` at `c8cc45e`](https://github.com/Compliatory/MedUI/tree/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d).
+[`Compliatory/MedUI` at `f966667`](https://github.com/Compliatory/MedUI/tree/f966667d3a69e892c73089e36eda9a0c2738a568).
 Do not write a `.medui` file expecting it to build anything in MduX until the compiler waves land.
 
 ## Grammar shape
@@ -103,7 +105,7 @@ verifier checks against. Rules:
 ## Checking a file without a full build
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser it will call already does (#192), so a syntax error, a
-nested `Row`, a control-flow keyword or a duplicate id are already detectable; what is missing is
-the command that exposes them. Until it lands, review a `.medui` file by hand against this grammar
-and the component table above.
+diagnostics — once it exists. The parser and analyzer it will call already detect syntax errors,
+structural violations, unknown dictionary/theme names, and incomplete locale keys; what is missing
+is the command that exposes them. Until it lands, review a `.medui` file by hand against this
+grammar and the component table above.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,13 +10,13 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: parsing and semantic name validation are implemented; emission and runtime are not
+## Status: parsing and semantic validation are implemented; emission and runtime are not
 
 **A `.medui` lexer, AST, parser and semantic analyzer exist** in the host-tools zone
 (`tools/medui/`). The diagnostic codes they emit are registered as `MEDUI-E###` (#191). The parser
-rejects structural violations (#192); the analyzer checks the closed component dictionary, theme
-token names, and text-key presence across every approved locale (#193). It validates names but
-does not substitute them.
+rejects structural violations (#192); the analyzer checks the closed component dictionary, each
+field's value domain, theme-token names, and text-key presence across every approved locale (#193).
+It does not substitute resolved values.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -30,7 +30,7 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 [issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). The implementation pins the shared
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
-[`Compliatory/MedUI` at `f966667`](https://github.com/Compliatory/MedUI/tree/f966667d3a69e892c73089e36eda9a0c2738a568).
+[`Compliatory/MedUI` at `d5136a8`](https://github.com/Compliatory/MedUI/tree/d5136a8518bd499760ecff2aad215d3721329f20).
 Do not write a `.medui` file expecting it to build anything in MduX until the compiler waves land.
 
 ## Grammar shape
@@ -73,18 +73,19 @@ Screen NeuroSense500 {
 
 ## Component dictionary (target)
 
-| Component | Required fields | Notes |
+| Component | Required fields | Optional fields |
 |---|---|---|
-| `CriticalButton` | `id, requirement, width, height, label, color, on_press` | always needs `requirement:` |
-| `Button` | `id, width, height, label, color, source` | `requirement:` optional |
-| `VulkanViewport` | `id, width, height, stream_source` | |
-| `SignalTrace` | `id, width, height, stream_source, color` | scrolling waveform |
-| `NumericDisplay` | `id, width, height, requirement, template, source, color` | live value, restricted charset |
-| `StatusIndicator` | `id, width, height, requirement, source, states` | `states: [t(...), ...]` |
-| `Label` | `id, width, height, text, color` | |
-| `Clock` | `id, width, height, format` | |
-| `Image` | `id, width, height, source` | `source: img("ID")` |
-| `TextInput` | `id, width, height, source, max_length, color` | display + caret only, no IME |
+| `Row` | `id`, `height` | `spacing`, `background` |
+| `CriticalButton` | `id`, `requirement`, `width`, `height`, `label`, `color`, `on_press` | `position` |
+| `Button` | `id`, `width`, `height`, `label`, `color`, `source` | `position`, `requirement` |
+| `VulkanViewport` | `id`, `width`, `height`, `stream_source` | `position` |
+| `SignalTrace` | `id`, `width`, `height`, `stream_source`, `color` | `position` |
+| `NumericDisplay` | `id`, `width`, `height`, `requirement`, `template`, `source`, `color` | `position` |
+| `StatusIndicator` | `id`, `width`, `height`, `requirement`, `source`, `states` | `position`, `colors` |
+| `Label` | `id`, `width`, `height`, `text`, `color` | `position` |
+| `Clock` | `id`, `width`, `height`, `format` | `position` |
+| `Image` | `id`, `width`, `height`, `source` | `position` |
+| `TextInput` | `id`, `width`, `height`, `source`, `max_length`, `color` | `position`, `charset`, `requirement` |
 
 ## `@safety_critical` — when it's mandatory, and when it's automatic
 
@@ -106,6 +107,7 @@ verifier checks against. Rules:
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
 diagnostics — once it exists. The parser and analyzer it will call already detect syntax errors,
-structural violations, unknown dictionary/theme names, and incomplete locale keys; what is missing
-is the command that exposes them. Until it lands, review a `.medui` file by hand against this
-grammar and the component table above.
+structural violations, unknown dictionary/theme names, hardcoded text in localizable fields,
+wrong field value domains, and incomplete locale keys; what is missing is the command that exposes
+them. Until it lands, review a `.medui` file by hand against this grammar and the component table
+above.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Derived from the targets and tests that build on `develop`.
 | Risk management, QMS, lifecycle *code* | **Not started** | no `mdux::risk`, `mdux::qms` or `mdux::lifecycle` exists |
 | **Not started** | | |
 | Text and glyph rendering | Planned | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) |
-| `.medui` compiler | Planned | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) |
+| `.medui` compiler | Partial | parser and semantic name validation implemented; [#15](https://github.com/ambroise-leclerc/MduX/issues/15) tracks the remaining stages |
 | Content components (`SignalTrace`, `StatusIndicator`, …) | Planned | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) |
 
 The HTML/CSS path that earlier revisions described was **deleted** by

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
+| `MduXMeduiLib` | Partial | `.medui` parsing and semantic validation; layout, packaging, and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |
@@ -151,7 +152,6 @@ Derived from the targets and tests that build on `develop`.
 | Risk management, QMS, lifecycle *code* | **Not started** | no `mdux::risk`, `mdux::qms` or `mdux::lifecycle` exists |
 | **Not started** | | |
 | Text and glyph rendering | Planned | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) |
-| `.medui` compiler | Partial | parser and semantic name validation implemented; [#15](https://github.com/ambroise-leclerc/MduX/issues/15) tracks the remaining stages |
 | Content components (`SignalTrace`, `StatusIndicator`, …) | Planned | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) |
 
 The HTML/CSS path that earlier revisions described was **deleted** by

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -6,7 +6,7 @@ Accepted (2026-08-11)
 ## Shared decision identity
 
 This local C++ decision implements
-[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d/decisions/MEDUI-DEC-001-build-time-compilation.md)
+[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/f966667d3a69e892c73089e36eda9a0c2738a568/decisions/MEDUI-DEC-001-build-time-compilation.md)
 and the bounded-language portion of `MEDUI-DEC-002`. Its ADR number remains permanent and local;
 cross-repository citations use the shared identity.
 

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -6,7 +6,7 @@ Accepted (2026-08-11)
 ## Shared decision identity
 
 This local C++ decision implements
-[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/f966667d3a69e892c73089e36eda9a0c2738a568/decisions/MEDUI-DEC-001-build-time-compilation.md)
+[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/d5136a8518bd499760ecff2aad215d3721329f20/decisions/MEDUI-DEC-001-build-time-compilation.md)
 and the bounded-language portion of `MEDUI-DEC-002`. Its ADR number remains permanent and local;
 cross-repository citations use the shared identity.
 

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -6,7 +6,7 @@ Accepted (2026-08-11)
 ## Shared decision identity
 
 This record is MduX's C++ and evidence-format realization of
-[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
+[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/f966667d3a69e892c73089e36eda9a0c2738a568/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
 and `MEDUI-DEC-004`. The shared records define meaning; this ADR remains authoritative for
 canonical JSON, generated C++ modules/headers, and MduX's committed artifact layout.
 

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -6,7 +6,7 @@ Accepted (2026-08-11)
 ## Shared decision identity
 
 This record is MduX's C++ and evidence-format realization of
-[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/f966667d3a69e892c73089e36eda9a0c2738a568/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
+[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/d5136a8518bd499760ecff2aad215d3721329f20/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
 and `MEDUI-DEC-004`. The shared records define meaning; this ADR remains authoritative for
 canonical JSON, generated C++ modules/headers, and MduX's committed artifact layout.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191) and parser (#192) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), and component/theme/locale semantic analyzer (#193) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | the replacement for the retired HTML/CSS path |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parser and semantic name validation are implemented; layout, packaging, and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parser and semantic name validation are implemented; layout, packaging, and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing and semantic validation are implemented; layout, packaging, and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,7 +1,7 @@
 repository = "https://github.com/Compliatory/MedUI"
 version = "0.1.0-candidate"
-commit = "c8cc45ecec2f2dfd84940b9efc17c613e691cc0d"
-capabilities = ["syntax"]
+commit = "f966667d3a69e892c73089e36eda9a0c2738a568"
+capabilities = ["syntax", "semantics"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.
 positions = "full"

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,6 +1,6 @@
 repository = "https://github.com/Compliatory/MedUI"
-version = "0.1.0-candidate"
-commit = "f966667d3a69e892c73089e36eda9a0c2738a568"
+version = "0.1.0"
+commit = "d5136a8518bd499760ecff2aad215d3721329f20"
 capabilities = ["syntax", "semantics"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,7 +674,7 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issues #191, #192)
+# .medui compiler host-tools suite (issues #191, #192, #193)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
 # completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
@@ -685,6 +685,7 @@ add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
     medui/ParserTests.cpp
+    medui/SemanticTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/medui/DiagnosticsTests.cpp
+++ b/tests/medui/DiagnosticsTests.cpp
@@ -29,7 +29,7 @@ namespace cli = mdux::tools::cli;
 /// cast in a loop would assume contiguity this enum does not promise. The duplication is the point
 /// - adding an enumerator without adding it here fails `every code is registered`, which is the
 /// nudge that also gets it a table row.
-constexpr std::array<md::Code, 22> allCodes{
+constexpr std::array<md::Code, 23> allCodes{
     md::Code::RecipeUnreadable,
     md::Code::RecipeUnparsed,
     md::Code::RecipeMissingMember,
@@ -46,6 +46,7 @@ constexpr std::array<md::Code, 22> allCodes{
     md::Code::UnknownColorToken,
     md::Code::UnknownTextKey,
     md::Code::TextKeyMissingForLocale,
+    md::Code::FieldValueKind,
     md::Code::TextBudgetExceeded,
     md::Code::LayoutOverflow,
     md::Code::SurfaceExceeded,

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -355,8 +355,9 @@ const mdux::spec::Register outOfRangeIntegerRejected{
                           checks.expect(d->line == 2 && d->column == 29,
                                         std::format("at the number, 2:29, got {}:{}",
                                                     d->line, d->column));
-                          checks.expect(d->message.contains("cannot represent"),
-                                        "the diagnostic explains the range failure");
+                          checks.expect(d->message.contains("integer") &&
+                                            d->message.contains("represent"),
+                                        "the diagnostic explains the integer range failure");
                       }
                       checks.raise();
                   })

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -333,6 +333,36 @@ const mdux::spec::Register unknownUnitRejected{
             .Execute();
     }};
 
+const mdux::spec::Register outOfRangeIntegerRejected{
+    "A bare integer outside the AST's range is rejected during parsing",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-out-of-range-integer")
+            .Given("a max_length larger than an int64 can represent", [] {})
+            .When("the bare integer is parsed", [] {})
+            .Then("MEDUI-E010 points at the number instead of producing a zero-valued AST node",
+                  [] {
+                      constexpr std::string_view source = R"(Screen IntegerRange {
+    TextInput { max_length: 999999999999999999999999; }
+})";
+                      const md::ParseResult r = md::parse(source, "integer-range.medui");
+                      const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
+                      mdux::spec::Checks checks;
+                      checks.expect(d != nullptr,
+                                    std::format("MEDUI-E010 reported, got {}",
+                                                codesOf(r.diagnostics)));
+                      if (d != nullptr) {
+                          checks.expect(d->line == 2 && d->column == 29,
+                                        std::format("at the number, 2:29, got {}:{}",
+                                                    d->line, d->column));
+                          checks.expect(d->message.contains("cannot represent"),
+                                        "the diagnostic explains the range failure");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register unterminatedStringRejected{
     "An unterminated string is reported at its opening quote",
     "evidence-unit",

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -359,6 +359,16 @@ const mdux::spec::Register outOfRangeIntegerRejected{
                                             d->message.contains("represent"),
                                         "the diagnostic explains the integer range failure");
                       }
+                      bool installed = false;
+                      if (r.screen && !r.screen->nodes.empty()) {
+                          installed = std::ranges::any_of(
+                              r.screen->nodes.front().fields,
+                              [](const md::ast::Field& field) {
+                                  return field.name == "max_length";
+                              });
+                      }
+                      checks.expect(!installed,
+                                    "the malformed max_length is not installed in the AST");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SemanticTests.cpp
+++ b/tests/medui/SemanticTests.cpp
@@ -218,3 +218,92 @@ const mdux::spec::Register semanticHardcodedTextPrecedence{"A literal in a text-
                                                                          })
                                                                    .Execute();
                                                            }};
+
+const mdux::spec::Register semanticFieldDomains{"Known fields reject syntactically valid values from the wrong semantic domain", "evidence-unit", [] {
+                                                    return speclab::Test("medui-semantic-field-domains")
+                                                        .Given("a Row and Label with three mismatched field value forms", [] {})
+                                                        .When("the field domains are analyzed", [] {})
+                                                        .Then("each mismatch is MEDUI-E033 at the value",
+                                                              [] {
+                                                                  constexpr std::string_view                   source = R"(Screen Domains {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Row {
+        id: content;
+        height: 40px;
+        spacing: Theme.Colors.Title;
+        Label {
+            id: t("STR-TITLE");
+            width: "120px";
+            height: 20px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+    }
+})";
+                                                                  const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                                                                  const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
+                                                                  const md::SemanticResult                     result = analyze(source, themes, packages);
+                                                                  mdux::spec::Checks                           checks;
+                                                                  checks.expect(count(result, md::Code::FieldValueKind) == 3,
+                                                                                "all three mismatches report E033");
+                                                                  checks.expect(result.diagnostics.size() == 3,
+                                                                                "domain mismatches do not cascade into name diagnostics");
+                                                                  checks.raise();
+                                                              })
+                                                        .Execute();
+                                                }};
+
+const mdux::spec::Register malformedColorIsSemanticOnly{
+    "A malformed colour path has one semantic-domain diagnostic and no syntax duplicate",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-malformed-color")
+            .Given("a Label color written as Theme.Color.Title", [] {})
+            .When("the source is parsed and analyzed", [] {})
+            .Then("only MEDUI-E033 is emitted",
+                  [] {
+                      constexpr std::string_view                   source = R"(Screen ColorPath {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Label {
+        id: title;
+        width: 120px;
+        height: 20px;
+        text: t("STR-TITLE");
+        color: Theme.Color.Title;
+    }
+})";
+                      const std::array<std::string_view, 0>        themes{};
+                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
+                      const md::SemanticResult                     result = analyze(source, themes, packages);
+                      mdux::spec::Checks                           checks;
+                      checks.expect(result.diagnostics.size() == 1, "the syntax and semantic phases do not duplicate the finding");
+                      checks.expect(count(result, md::Code::FieldValueKind) == 1, "the malformed path reports E033");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register semanticSpecialValueForms{"Image references, positive integer limits, and dotted named values retain distinct forms",
+                                                     "evidence-unit",
+                                                     [] {
+                                                         return speclab::Test("medui-semantic-special-value-forms")
+                                                             .Given("valid Image, TextInput, Clock, and CriticalButton fields", [] {})
+                                                             .When("their component-specific domains are analyzed", [] {})
+                                                             .Then("the forms are accepted without weakening another field",
+                                                                   [] {
+                                                                       constexpr std::string_view                   source = R"(Screen Forms {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Image { id: logo; width: 32px; height: 32px; source: img("LOGO"); }
+    TextInput { id: input; width: 120px; height: 20px; source: "NAME"; max_length: 16; color: Theme.Colors.Title; }
+    Clock { id: clock; width: 80px; height: 20px; format: TimeFormat.HoursMinutes; }
+    CriticalButton { id: stop; requirement: "REQ-1"; width: 80px; height: 24px; label: t("STR-STOP"); color: Theme.Colors.Title; on_press: SystemEvent.Stop; }
+})";
+                                                                       const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                                                                       const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};
+                                                                       const md::SemanticResult                     result = analyze(source, themes, packages);
+                                                                       mdux::spec::Checks                           checks;
+                                                                       checks.expect(result.ok(), "all declared value forms are accepted");
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};

--- a/tests/medui/SemanticTests.cpp
+++ b/tests/medui/SemanticTests.cpp
@@ -248,6 +248,14 @@ const mdux::spec::Register semanticFieldDomains{"Known fields reject syntactical
                                                                                 "all three mismatches report E033");
                                                                   checks.expect(result.diagnostics.size() == 3,
                                                                                 "domain mismatches do not cascade into name diagnostics");
+                                                                  if (result.diagnostics.size() == 3) {
+                                                                      checks.expect(result.diagnostics[0].line == 6 && result.diagnostics[0].column == 18,
+                                                                                    "Row spacing points at Theme.Colors.Title");
+                                                                      checks.expect(result.diagnostics[1].line == 8 && result.diagnostics[1].column == 17,
+                                                                                    "Label id points at t(\"STR-TITLE\")");
+                                                                      checks.expect(result.diagnostics[2].line == 9 && result.diagnostics[2].column == 20,
+                                                                                    "Label width points at the string literal");
+                                                                  }
                                                                   checks.raise();
                                                               })
                                                         .Execute();
@@ -278,6 +286,10 @@ const mdux::spec::Register malformedColorIsSemanticOnly{
                       mdux::spec::Checks                           checks;
                       checks.expect(result.diagnostics.size() == 1, "the syntax and semantic phases do not duplicate the finding");
                       checks.expect(count(result, md::Code::FieldValueKind) == 1, "the malformed path reports E033");
+                      if (result.diagnostics.size() == 1) {
+                          checks.expect(result.diagnostics[0].line == 8 && result.diagnostics[0].column == 16,
+                                        "E033 points at Theme.Color.Title");
+                      }
                       checks.raise();
                   })
             .Execute();
@@ -307,3 +319,36 @@ const mdux::spec::Register semanticSpecialValueForms{"Image references, positive
                                                                    })
                                                              .Execute();
                                                      }};
+
+const mdux::spec::Register semanticHardcodedTextList{
+    "A literal inside a text-key list is reported as hardcoded text at that element",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-hardcoded-text-list")
+            .Given("a StatusIndicator states list mixing a literal and a governed key", [] {})
+            .When("the list is analyzed element by element", [] {})
+            .Then("the literal reports MEDUI-E017 without hiding valid keys",
+                  [] {
+                      constexpr std::string_view source = R"(Screen States {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    StatusIndicator {
+        id: state;
+        width: 100px;
+        height: 20px;
+        requirement: "REQ-STATE";
+        source: "STATE";
+        states: ["Ready", t("STR-STOP")];
+    }
+})";
+                      const std::array<std::string_view, 0> themes{};
+                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};
+                      const md::SemanticResult result = analyze(source, themes, packages);
+                      const cli::Diagnostic* literal = find(result, md::Code::HardcodedString);
+                      mdux::spec::Checks checks;
+                      checks.expect(result.diagnostics.size() == 1, "only the literal is rejected");
+                      checks.expect(literal != nullptr && literal->line == 9 && literal->column == 18,
+                                    "E017 points at the literal list element");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/SemanticTests.cpp
+++ b/tests/medui/SemanticTests.cpp
@@ -1,0 +1,220 @@
+/**
+ * @file SemanticTests.cpp
+ * @brief BDD scenarios for `.medui` semantic analysis (issue #193).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+
+import std;
+import speclab;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+[[nodiscard]] mdux::text::TextPackage package(std::string locale, std::initializer_list<std::string_view> keys) {
+    mdux::text::TextPackage result;
+    result.header.id   = std::format("semantic-fixture-{}", locale);
+    result.atlasId     = "semantic-fixture-atlas";
+    result.locale      = std::move(locale);
+    result.sidecarPath = "runs.bin";
+    for (std::string_view key : keys) {
+        result.runs.push_back(mdux::text::TextRun{.id = std::string{key}, .byteOffset = 0, .byteLength = 0, .sha256 = {}});
+    }
+    return result;
+}
+
+[[nodiscard]] md::SemanticResult analyze(std::string_view source, std::span<const std::string_view> themes, std::span<const mdux::text::TextPackage> packages) {
+    md::ParseResult parsed = md::parse(source, "semantic-test.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("semantic test source did not parse", std::source_location::current());
+    }
+    return md::analyze(*parsed.screen, "semantic-test.medui", md::SemanticInputs{.themeTokens = themes, .textPackages = packages});
+}
+
+[[nodiscard]] const cli::Diagnostic* find(const md::SemanticResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    });
+    return found == result.diagnostics.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] std::size_t count(const md::SemanticResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    return static_cast<std::size_t>(std::ranges::count_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    }));
+}
+
+constexpr std::string_view validNested = R"(Screen Valid {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Row {
+        id: header;
+        height: 32px;
+        background: Theme.Colors.Header;
+        Label {
+            id: title;
+            width: Fill;
+            height: 32px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+    }
+})";
+
+}  // namespace
+
+const mdux::spec::Register semanticNamesResolve{"Semantic analysis accepts known names recursively without substituting the AST", "evidence-unit", [] {
+                                                    return speclab::Test("medui-semantic-known-names")
+                                                        .Given("a Row child whose theme tokens and text key exist in two locales", [] {})
+                                                        .When("the unresolved parsed screen is analyzed", [] {})
+                                                        .Then("the recursive semantic pass accepts it",
+                                                              [] {
+                                                                  const std::array<std::string_view, 2> themes{"Theme.Colors.Header", "Theme.Colors.Title"};
+                                                                  const std::array<mdux::text::TextPackage, 2> packages{package("en-US", {"STR-TITLE"}),
+                                                                                                                        package("fr-FR", {"STR-TITLE"})};
+                                                                  const md::SemanticResult                     result = analyze(validNested, themes, packages);
+                                                                  mdux::spec::Checks                           checks;
+                                                                  checks.expect(result.ok(), "known recursive names produce no diagnostics");
+                                                                  checks.raise();
+                                                              })
+                                                        .Execute();
+                                                }};
+
+const mdux::spec::Register semanticDictionaryAccumulates{
+    "The closed component dictionary reports unknown components, fields, and missing fields",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-component-dictionary")
+            .Given("one unknown component and one incomplete Label with a misspelled field", [] {})
+            .When("both nodes are analyzed in one pass", [] {})
+            .Then("all dictionary findings carry their source positions",
+                  [] {
+                      constexpr std::string_view                   source = R"(Screen Dictionary {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Mystery {
+        id: unknown;
+    }
+    Label {
+        id: title;
+        width: 80px;
+        height: 20px;
+        text: t("STR-TITLE");
+        colour: Theme.Colors.Title;
+    }
+})";
+                      const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
+                      const md::SemanticResult                     result           = analyze(source, themes, packages);
+                      const cli::Diagnostic*                       unknownComponent = find(result, md::Code::UnknownComponent);
+                      const cli::Diagnostic*                       missingField     = find(result, md::Code::MissingRequiredField);
+                      const cli::Diagnostic*                       unknownField     = find(result, md::Code::UnknownField);
+
+                      mdux::spec::Checks checks;
+                      checks.expect(result.diagnostics.size() == 3, "three independent findings accumulate");
+                      checks.expect(unknownComponent != nullptr && unknownComponent->line == 3 && unknownComponent->column == 5,
+                                    "the unknown component points at its name");
+                      checks.expect(missingField != nullptr && missingField->line == 6 && missingField->column == 5,
+                                    "the missing color points at its component");
+                      checks.expect(unknownField != nullptr && unknownField->line == 11 && unknownField->column == 9, "the unknown field points at its name");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register semanticResolutionDistinguishesFailures{
+    "Theme and text resolution distinguish global absence from a locale-specific gap",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-resolution-diagnostics")
+            .Given("unknown theme/text names and a second key missing in two approved locales", [] {})
+            .When("the screen is analyzed against three locale packages", [] {})
+            .Then("E030, E031, and one E032 per missing locale are reported",
+                  [] {
+                      constexpr std::string_view                   source = R"(Screen Resolution {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Row {
+        id: content;
+        height: 40px;
+        Label {
+            id: unknown;
+            width: 100px;
+            height: 20px;
+            text: t("STR-UNKNOWN");
+            color: Theme.Colors.Unknown;
+        }
+        Label {
+            id: partial;
+            width: 100px;
+            height: 20px;
+            text: t("STR-PARTIAL");
+            color: Theme.Colors.Title;
+        }
+    }
+})";
+                      const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                      const std::array<mdux::text::TextPackage, 3> packages{package("en-US", {"STR-PARTIAL"}), package("fr-FR", {}), package("de-DE", {})};
+                      const md::SemanticResult                     result       = analyze(source, themes, packages);
+                      const cli::Diagnostic*                       unknownKey   = find(result, md::Code::UnknownTextKey);
+                      const cli::Diagnostic*                       unknownColor = find(result, md::Code::UnknownColorToken);
+
+                      mdux::spec::Checks checks;
+                      checks.expect(count(result, md::Code::UnknownTextKey) == 1, "a key absent everywhere produces one E031");
+                      checks.expect(count(result, md::Code::TextKeyMissingForLocale) == 2, "a partially present key produces one E032 per missing locale");
+                      checks.expect(count(result, md::Code::UnknownColorToken) == 1, "an absent theme token produces E030");
+                      checks.expect(unknownKey != nullptr && unknownKey->line == 10 && unknownKey->column == 19, "E031 points at t(KEY)");
+                      checks.expect(unknownColor != nullptr && unknownColor->line == 11 && unknownColor->column == 20, "E030 points at Theme.Colors.Token");
+                      checks.expect(std::ranges::any_of(result.diagnostics,
+                                                        [](const cli::Diagnostic& d) {
+                                                            return d.code == md::id(md::Code::TextKeyMissingForLocale) && d.message.contains("fr-FR");
+                                                        }),
+                                    "a missing-locale message names fr-FR");
+                      checks.expect(std::ranges::any_of(result.diagnostics,
+                                                        [](const cli::Diagnostic& d) {
+                                                            return d.code == md::id(md::Code::TextKeyMissingForLocale) && d.message.contains("de-DE");
+                                                        }),
+                                    "a missing-locale message names de-DE");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register semanticHardcodedTextPrecedence{"A literal in a text-bearing field is rejected as hardcoded text at its value", "evidence-unit", [] {
+                                                               return speclab::Test("medui-semantic-hardcoded-text")
+                                                                   .Given("a Label whose text is a literal string", [] {})
+                                                                   .When("the text field is analyzed", [] {})
+                                                                   .Then("E017 takes precedence over a generic value-shape finding",
+                                                                         [] {
+                                                                             constexpr std::string_view                   source = R"(Screen Literal {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Label {
+        id: title;
+        width: 100px;
+        height: 20px;
+        text: "Product Name";
+        color: Theme.Colors.Title;
+    }
+})";
+                                                                             const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                                                                             const std::array<mdux::text::TextPackage, 0> packages{};
+                                                                             const md::SemanticResult result  = analyze(source, themes, packages);
+                                                                             const cli::Diagnostic*   literal = find(result, md::Code::HardcodedString);
+                                                                             mdux::spec::Checks       checks;
+                                                                             checks.expect(result.diagnostics.size() == 1,
+                                                                                           "only the specific hardcoded-text finding is emitted");
+                                                                             checks.expect(literal != nullptr && literal->line == 7 && literal->column == 15,
+                                                                                           "E017 points at the literal value");
+                                                                             checks.raise();
+                                                                         })
+                                                                   .Execute();
+                                                           }};

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -19,41 +19,43 @@
  *   and must be backed by a case that really executed. Claiming a phase with no adapter fails
  *   here instead of passing quietly.
  *
- * Only the parse phase is observable: `md::parse` answers acceptance, codes and positions.
- * Claiming `semantics`, `layout` or `safety` additionally needs the resolver (#193), the solver
- * (#194) and the golden pass (#196), plus a convention for the `inputs` member the case schema
- * declares and no case yet uses — so a claim to any of them is rejected below rather than
- * silently evaluated by a parser that cannot see those phases.
+ * Syntax and semantics are observable: `md::parse` answers syntax acceptance, and `md::analyze`
+ * checks the portable theme-token and per-locale key views in semantic case inputs. Claiming
+ * `layout` or `safety` still needs the solver (#194) and golden pass (#196), so a claim to either
+ * is rejected below rather than silently evaluated by a stage that cannot see it.
  */
 
 import std;
 import speclab;
 import mdux.core.result;
 import mdux.evidence.json;
+import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.diagnostics;
 import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
 import mdux.tools.toml;
 
 #include "../framework/SpecLabBridge.hpp"
 
 namespace {
 
-namespace md = mdux::tools::medui;
-namespace cli = mdux::tools::cli;
+namespace md   = mdux::tools::medui;
+namespace cli  = mdux::tools::cli;
 namespace json = mdux::evidence::json;
 namespace toml = mdux::tools::toml;
 
 /// Phases this file can genuinely observe. Anything else in `capabilities` is a claim with no
 /// adapter behind it.
-constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
+constexpr std::array<std::string_view, 2> runnableCapabilities{"syntax", "semantics"};
 
-[[noreturn]] void fail(std::string message,
-                       std::source_location where = std::source_location::current()) {
+[[noreturn]] void fail(std::string message, std::source_location where = std::source_location::current()) {
     throw speclab::core::AssertionFailure(std::move(message), where);
 }
 
-[[nodiscard]] const char* env(const char* name) { return std::getenv(name); }
+[[nodiscard]] const char* env(const char* name) {
+    return std::getenv(name);
+}
 
 [[nodiscard]] bool isSet(const char* name) {
     const char* value = env(name);
@@ -62,7 +64,9 @@ constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
 
 [[nodiscard]] std::string readFile(const std::filesystem::path& path) {
     std::ifstream in{path, std::ios::binary};
-    if (!in) { fail(std::format("could not open {}", path.generic_string())); }
+    if (!in) {
+        fail(std::format("could not open {}", path.generic_string()));
+    }
     std::ostringstream buffer;
     buffer << in.rdbuf();
     return buffer.str();
@@ -175,32 +179,29 @@ constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
 enum class Positions : std::uint8_t { Full, LineOnly, None };
 
 struct Manifest {
-    std::string commit;
+    std::string              commit;
     std::vector<std::string> capabilities;
-    Positions positions{Positions::Full};
+    Positions                positions{Positions::Full};
 };
 
 /// `governance/versioning.md` makes an unknown key an error rather than something to ignore, so a
 /// misspelled `capabilties` fails here instead of silently claiming nothing.
-constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "version", "commit",
-                                                            "capabilities", "positions"};
+constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "version", "commit", "capabilities", "positions"};
 
 [[nodiscard]] Manifest manifest() {
-    const std::filesystem::path path =
-        std::filesystem::path{MDUX_REPO_ROOT} / "medui-conformance.toml";
-    const std::string text = readFile(path);
-    const toml::Document document = toml::parse(text);
-    const toml::Table& root = document.root();
+    const std::filesystem::path path     = std::filesystem::path{MDUX_REPO_ROOT} / "medui-conformance.toml";
+    const std::string           text     = readFile(path);
+    const toml::Document        document = toml::parse(text);
+    const toml::Table&          root     = document.root();
 
-    Manifest result{.commit = root.require("commit").asString(),
-                    .capabilities = root.require("capabilities").asStringArray(),
-                    .positions = Positions::Full};
+    Manifest result{.commit = root.require("commit").asString(), .capabilities = root.require("capabilities").asStringArray(), .positions = Positions::Full};
 
     for (const auto& entry : root.entries()) {
         if (std::ranges::find(knownManifestKeys, entry.first) == knownManifestKeys.end()) {
             fail(std::format("{}: unknown key '{}'; the consumer manifest rejects keys it does "
                              "not define",
-                             path.generic_string(), entry.first));
+                             path.generic_string(),
+                             entry.first));
         }
     }
 
@@ -212,18 +213,15 @@ constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "versi
     } else if (declared == "none") {
         result.positions = Positions::None;
     } else {
-        fail(std::format("{}: positions must be \"full\", \"line-only\" or \"none\", got '{}'",
-                         path.generic_string(), declared));
+        fail(std::format("{}: positions must be \"full\", \"line-only\" or \"none\", got '{}'", path.generic_string(), declared));
     }
 
     if (!isCommitSha(result.commit)) {
-        fail(std::format("{} must pin a 40-character commit SHA, got '{}'", path.generic_string(),
-                         result.commit));
+        fail(std::format("{} must pin a 40-character commit SHA, got '{}'", path.generic_string(), result.commit));
     }
     if (result.capabilities.empty()) {
         // An empty claim would make this whole suite assert nothing while still looking green.
-        fail(std::format("{} claims no capabilities, so nothing would be checked",
-                         path.generic_string()));
+        fail(std::format("{} claims no capabilities, so nothing would be checked", path.generic_string()));
     }
     return result;
 }
@@ -238,16 +236,22 @@ struct ExpectedDiagnostic {
     std::size_t column{0};
 };
 
-struct Case {
-    std::string id;
-    std::string phase;
-    std::filesystem::path source;
-    bool valid{false};
-    std::vector<ExpectedDiagnostic> diagnostics;
+struct TextPackageInput {
+    std::string              locale;
+    std::vector<std::string> keys;
 };
 
-[[nodiscard]] const json::Value& member(const json::Value& object, std::string_view key,
-                                        const std::filesystem::path& path) {
+struct Case {
+    std::string                     id;
+    std::string                     phase;
+    std::filesystem::path           source;
+    bool                            valid{false};
+    std::vector<ExpectedDiagnostic> diagnostics;
+    std::vector<std::string>        themeTokens;
+    std::vector<TextPackageInput>   textPackages;
+};
+
+[[nodiscard]] const json::Value& member(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const json::Value* found = object.find(key);
     if (found == nullptr) {
         fail(std::format("{}: missing required member '{}'", path.generic_string(), key));
@@ -255,15 +259,15 @@ struct Case {
     return *found;
 }
 
-[[nodiscard]] std::string requireString(const json::Value& object, std::string_view key,
-                                        const std::filesystem::path& path) {
+[[nodiscard]] std::string requireString(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const auto text = member(object, key, path).asString();
-    if (!text) { fail(std::format("{}: member '{}' is not a string", path.generic_string(), key)); }
+    if (!text) {
+        fail(std::format("{}: member '{}' is not a string", path.generic_string(), key));
+    }
     return std::string{*text};
 }
 
-[[nodiscard]] std::size_t requirePosition(const json::Value& object, std::string_view key,
-                                          const std::filesystem::path& path) {
+[[nodiscard]] std::size_t requirePosition(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const auto number = member(object, key, path).asInt();
     if (!number) {
         fail(std::format("{}: member '{}' is not an integer", path.generic_string(), key));
@@ -277,9 +281,7 @@ struct Case {
 /// `Value::elements()` yields an empty span for anything that is not an array, so a `diagnostics`
 /// member of the wrong shape would silently read as "no expectations" and the case would assert
 /// almost nothing. Check the kind instead of trusting the span.
-[[nodiscard]] std::span<const json::Value> requireArray(const json::Value& object,
-                                                        std::string_view key,
-                                                        const std::filesystem::path& path) {
+[[nodiscard]] std::span<const json::Value> requireArray(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const json::Value& found = member(object, key, path);
     if (found.kind() != json::Value::Kind::Array) {
         fail(std::format("{}: member '{}' is not an array", path.generic_string(), key));
@@ -287,26 +289,28 @@ struct Case {
     return found.elements();
 }
 
-[[nodiscard]] bool requireBool(const json::Value& object, std::string_view key,
-                               const std::filesystem::path& path) {
+[[nodiscard]] bool requireBool(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const auto flag = member(object, key, path).asBool();
-    if (!flag) { fail(std::format("{}: member '{}' is not a boolean", path.generic_string(), key)); }
+    if (!flag) {
+        fail(std::format("{}: member '{}' is not a boolean", path.generic_string(), key));
+    }
     return *flag;
 }
 
 [[nodiscard]] Case readCase(const std::filesystem::path& path) {
-    const std::string text = readFile(path);
-    const auto document = json::parse(text);
-    if (!document) { fail(std::format("{}: is not valid JSON", path.generic_string())); }
+    const std::string text     = readFile(path);
+    const auto        document = json::parse(text);
+    if (!document) {
+        fail(std::format("{}: is not valid JSON", path.generic_string()));
+    }
 
     Case result;
-    result.id = requireString(*document, "id", path);
+    result.id    = requireString(*document, "id", path);
     result.phase = requireString(*document, "phase", path);
 
     const std::string source = requireString(*document, "source", path);
     if (source.contains('/') || source.contains('\\') || !source.ends_with(".medui")) {
-        fail(std::format("{}: source must be a sibling .medui file, got '{}'",
-                         path.generic_string(), source));
+        fail(std::format("{}: source must be a sibling .medui file, got '{}'", path.generic_string(), source));
     }
     result.source = path.parent_path() / source;
 
@@ -314,23 +318,49 @@ struct Case {
     // the wrong phase is a contract error rather than something to route around.
     const std::string directoryPhase = path.parent_path().parent_path().filename().string();
     if (result.phase != directoryPhase) {
-        fail(std::format("{}: declares phase '{}' but sits under '{}'", path.generic_string(),
-                         result.phase, directoryPhase));
+        fail(std::format("{}: declares phase '{}' but sits under '{}'", path.generic_string(), result.phase, directoryPhase));
+    }
+
+    if (const json::Value* inputs = document->find("inputs")) {
+        if (inputs->kind() != json::Value::Kind::Object) {
+            fail(std::format("{}: member 'inputs' is not an object", path.generic_string()));
+        }
+        if (inputs->find("themeTokens") != nullptr) {
+            for (const json::Value& token : requireArray(*inputs, "themeTokens", path)) {
+                const auto value = token.asString();
+                if (!value) {
+                    fail(std::format("{}: themeTokens contains a non-string", path.generic_string()));
+                }
+                result.themeTokens.emplace_back(*value);
+            }
+        }
+        if (inputs->find("textPackages") != nullptr) {
+            for (const json::Value& package : requireArray(*inputs, "textPackages", path)) {
+                TextPackageInput packageInput{.locale = requireString(package, "locale", path), .keys = {}};
+                for (const json::Value& key : requireArray(package, "keys", path)) {
+                    const auto value = key.asString();
+                    if (!value) {
+                        fail(std::format("{}: text package keys contains a non-string", path.generic_string()));
+                    }
+                    packageInput.keys.emplace_back(*value);
+                }
+                result.textPackages.push_back(std::move(packageInput));
+            }
+        }
     }
 
     const json::Value& expected = member(*document, "expected", path);
-    result.valid = requireBool(expected, "valid", path);
+    result.valid                = requireBool(expected, "valid", path);
     for (const json::Value& entry : requireArray(expected, "diagnostics", path)) {
-        result.diagnostics.push_back({.code = requireString(entry, "code", path),
-                                      .line = requirePosition(entry, "line", path),
-                                      .column = requirePosition(entry, "column", path)});
+        result.diagnostics.push_back(
+            {.code = requireString(entry, "code", path), .line = requirePosition(entry, "line", path), .column = requirePosition(entry, "column", path)});
     }
     return result;
 }
 
 [[nodiscard]] std::vector<Case> loadCases(const std::filesystem::path& root) {
     std::vector<std::filesystem::path> paths;
-    const std::filesystem::path directory = root / "conformance";
+    const std::filesystem::path        directory = root / "conformance";
     if (!std::filesystem::is_directory(directory)) {
         fail(std::format("{} has no conformance/ directory; is MEDUI_CONFORMANCE_DIR pointing at "
                          "a Compliatory/MedUI checkout?",
@@ -345,7 +375,9 @@ struct Case {
 
     std::vector<Case> cases;
     cases.reserve(paths.size());
-    for (const std::filesystem::path& path : paths) { cases.push_back(readCase(path)); }
+    for (const std::filesystem::path& path : paths) {
+        cases.push_back(readCase(path));
+    }
     return cases;
 }
 
@@ -356,17 +388,23 @@ struct Case {
 [[nodiscard]] std::string join(const std::vector<std::string>& parts) {
     std::string joined;
     for (const std::string& part : parts) {
-        if (!joined.empty()) { joined += ", "; }
+        if (!joined.empty()) {
+            joined += ", ";
+        }
         joined += part;
     }
     return joined;
 }
 
 [[nodiscard]] std::string codesOf(const std::vector<cli::Diagnostic>& diagnostics) {
-    if (diagnostics.empty()) { return "no diagnostics"; }
+    if (diagnostics.empty()) {
+        return "no diagnostics";
+    }
     std::string joined;
     for (const cli::Diagnostic& diagnostic : diagnostics) {
-        if (!joined.empty()) { joined += ", "; }
+        if (!joined.empty()) {
+            joined += ", ";
+        }
         joined += std::format("{} at {}:{}", diagnostic.code, diagnostic.line, diagnostic.column);
     }
     return joined;
@@ -376,61 +414,92 @@ struct Case {
 /// the declared precision goes, and reporting more than was declared fails. The declaration is
 /// checked rather than tolerated, so precision cannot move in either direction without a manifest
 /// edit. MduX reports `0` for "unknown", which is how an absent position is spelled.
-void checkPosition(const Case& item, const ExpectedDiagnostic& expected, const cli::Diagnostic& got,
-                   Positions positions, mdux::spec::Checks& checks) {
+void checkPosition(const Case& item, const ExpectedDiagnostic& expected, const cli::Diagnostic& got, Positions positions, mdux::spec::Checks& checks) {
     switch (positions) {
-    case Positions::Full:
-        checks.expect(got.line == expected.line && got.column == expected.column,
-                      std::format("{}: {} at {}:{}, got {}:{}", item.id, expected.code,
-                                  expected.line, expected.column, got.line, got.column));
-        return;
-    case Positions::LineOnly:
-        checks.expect(got.line == expected.line,
-                      std::format("{}: {} at line {}, got {}", item.id, expected.code,
-                                  expected.line, got.line));
-        checks.expect(got.column == 0,
-                      std::format("{}: medui-conformance.toml declares positions = \"line-only\", "
-                                  "but {} reported column {}. Raise the declaration to \"full\" so "
-                                  "the pinned column {} is checked.",
-                                  item.id, expected.code, got.column, expected.column));
-        return;
-    case Positions::None:
-        checks.expect(got.line == 0 && got.column == 0,
-                      std::format("{}: medui-conformance.toml declares positions = \"none\", but "
-                                  "{} reported {}:{}. Raise the declaration so the pinned position "
-                                  "{}:{} is checked.",
-                                  item.id, expected.code, got.line, got.column, expected.line,
-                                  expected.column));
-        return;
+        case Positions::Full:
+            checks.expect(got.line == expected.line && got.column == expected.column,
+                          std::format("{}: {} at {}:{}, got {}:{}", item.id, expected.code, expected.line, expected.column, got.line, got.column));
+            return;
+        case Positions::LineOnly:
+            checks.expect(got.line == expected.line, std::format("{}: {} at line {}, got {}", item.id, expected.code, expected.line, got.line));
+            checks.expect(got.column == 0,
+                          std::format("{}: medui-conformance.toml declares positions = \"line-only\", "
+                                      "but {} reported column {}. Raise the declaration to \"full\" so "
+                                      "the pinned column {} is checked.",
+                                      item.id,
+                                      expected.code,
+                                      got.column,
+                                      expected.column));
+            return;
+        case Positions::None:
+            checks.expect(got.line == 0 && got.column == 0,
+                          std::format("{}: medui-conformance.toml declares positions = \"none\", but "
+                                      "{} reported {}:{}. Raise the declaration so the pinned position "
+                                      "{}:{} is checked.",
+                                      item.id,
+                                      expected.code,
+                                      got.line,
+                                      got.column,
+                                      expected.line,
+                                      expected.column));
+            return;
     }
 }
 
 void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) {
-    const std::string source = readFile(item.source);
-    const md::ParseResult result = md::parse(source, item.source.filename().string());
+    const std::string            source      = readFile(item.source);
+    const std::string            file        = item.source.filename().string();
+    const md::ParseResult        parsed      = md::parse(source, file);
+    std::vector<cli::Diagnostic> diagnostics = parsed.diagnostics;
+
+    if (item.phase == "semantics" && parsed.screen) {
+        std::vector<std::string_view> themeTokens;
+        themeTokens.reserve(item.themeTokens.size());
+        for (const std::string& token : item.themeTokens) {
+            themeTokens.push_back(token);
+        }
+
+        std::vector<mdux::text::TextPackage> packages;
+        packages.reserve(item.textPackages.size());
+        for (const TextPackageInput& input : item.textPackages) {
+            mdux::text::TextPackage package;
+            package.header.id   = std::format("shared-conformance-{}", input.locale);
+            package.atlasId     = "shared-conformance-atlas";
+            package.locale      = input.locale;
+            package.sidecarPath = "runs.bin";
+            for (const std::string& key : input.keys) {
+                package.runs.push_back(mdux::text::TextRun{.id = key, .byteOffset = 0, .byteLength = 0, .sha256 = {}});
+            }
+            packages.push_back(std::move(package));
+        }
+
+        md::SemanticResult semantic = md::analyze(*parsed.screen, file, md::SemanticInputs{.themeTokens = themeTokens, .textPackages = packages});
+        diagnostics.insert(diagnostics.end(), std::make_move_iterator(semantic.diagnostics.begin()), std::make_move_iterator(semantic.diagnostics.end()));
+    }
+
+    const bool accepted = parsed.screen.has_value() && diagnostics.empty();
 
     if (item.valid) {
-        checks.expect(result.ok(), std::format("{}: accepted, got {}", item.id,
-                                               codesOf(result.diagnostics)));
+        checks.expect(accepted, std::format("{}: accepted, got {}", item.id, codesOf(diagnostics)));
         return;
     }
 
-    checks.expect(!result.ok(), std::format("{}: rejected, but the parser accepted it", item.id));
+    checks.expect(!accepted, std::format("{}: rejected, but the claimed phase accepted it", item.id));
 
-    std::vector<bool> consumed(result.diagnostics.size(), false);
+    std::vector<bool> consumed(diagnostics.size(), false);
     for (const ExpectedDiagnostic& expected : item.diagnostics) {
-        std::size_t match = result.diagnostics.size();
-        for (std::size_t index = 0; index < result.diagnostics.size(); ++index) {
-            if (!consumed[index] && result.diagnostics[index].code == expected.code) {
+        std::size_t match = diagnostics.size();
+        for (std::size_t index = 0; index < diagnostics.size(); ++index) {
+            if (!consumed[index] && diagnostics[index].code == expected.code) {
                 match = index;
                 break;
             }
         }
-        const bool reported = match != result.diagnostics.size();
-        checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code, codesOf(result.diagnostics)));
+        const bool reported = match != diagnostics.size();
+        checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code, codesOf(diagnostics)));
         if (reported) {
             consumed[match] = true;
-            checkPosition(item, expected, result.diagnostics[match], positions, checks);
+            checkPosition(item, expected, diagnostics[match], positions, checks);
         }
     }
 
@@ -438,7 +507,7 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
                                       [](bool value) {
                                           return value;
                                       }),
-                  std::format("{}: every emitted diagnostic is expected, got {}", item.id, codesOf(result.diagnostics)));
+                  std::format("{}: every emitted diagnostic is expected, got {}", item.id, codesOf(diagnostics)));
 }
 
 }  // namespace
@@ -447,85 +516,82 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
 // Scenarios
 // ---------------------------------------------------------------------------
 
-const mdux::spec::Register claimsNameAPhaseThisSuiteCanObserve{
-    "Every claimed capability is one this suite can actually check",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-shared-claims-are-observable")
-            .Given("the capabilities named in medui-conformance.toml", [] {})
-            .When("they are compared with what this suite can observe", [] {})
-            .Then("no phase is claimed without an adapter behind it", [] {
-                mdux::spec::Checks checks;
-                for (const std::string& capability : manifest().capabilities) {
-                    checks.expect(std::ranges::find(runnableCapabilities, capability) != runnableCapabilities.end(),
-                                  std::format("'{}' is observable here; add the adapter that "
-                                              "checks that phase before claiming it",
-                                              capability));
-                }
-                checks.raise();
-            })
-            .Execute();
-    }};
+const mdux::spec::Register claimsNameAPhaseThisSuiteCanObserve{"Every claimed capability is one this suite can actually check", "evidence-unit", [] {
+                                                                   return speclab::Test("medui-shared-claims-are-observable")
+                                                                       .Given("the capabilities named in medui-conformance.toml", [] {})
+                                                                       .When("they are compared with what this suite can observe", [] {})
+                                                                       .Then("no phase is claimed without an adapter behind it",
+                                                                             [] {
+                                                                                 mdux::spec::Checks checks;
+                                                                                 for (const std::string& capability : manifest().capabilities) {
+                                                                                     checks.expect(std::ranges::find(runnableCapabilities, capability)
+                                                                                                       != runnableCapabilities.end(),
+                                                                                                   std::format("'{}' is observable here; add the adapter that "
+                                                                                                               "checks that phase before claiming it",
+                                                                                                               capability));
+                                                                                 }
+                                                                                 checks.raise();
+                                                                             })
+                                                                       .Execute();
+                                                               }};
 
-const mdux::spec::Register pinnedCasesPass{
-    "The parser satisfies every pinned case in a claimed phase",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-shared-conformance")
-            .Given("the exact checkout named by medui-conformance.toml", [] {})
-            .When("each case in a claimed phase is parsed", [] {})
-            .Then("acceptance, codes and positions match the pinned expectations", [] {
-                mdux::spec::Checks checks;
-                const Manifest pinned = manifest();
+const mdux::spec::Register pinnedCasesPass{"The parser satisfies every pinned case in a claimed phase", "evidence-unit", [] {
+                                               return speclab::Test("medui-shared-conformance")
+                                                   .Given("the exact checkout named by medui-conformance.toml", [] {})
+                                                   .When("each case in a claimed phase is parsed", [] {})
+                                                   .Then("acceptance, codes and positions match the pinned expectations",
+                                                         [] {
+                                                             mdux::spec::Checks checks;
+                                                             const Manifest     pinned = manifest();
 
-                const char* root = env("MEDUI_CONFORMANCE_DIR");
-                if (root == nullptr || *root == '\0') {
-                    // Never a silent skip: in CI this is the failure that keeps the claim honest,
-                    // and offline it says out loud that nothing shared was checked.
-                    checks.expect(!isSet("CI"),
-                                  "MEDUI_CONFORMANCE_DIR is set in CI, so the capabilities "
-                                  "claimed in medui-conformance.toml are actually substantiated");
-                    checks.raise();
-                    std::cerr << "MedUI conformance: SKIPPED - set MEDUI_CONFORMANCE_DIR to a "
-                                 "checkout of the pinned commit to run the shared cases locally.\n";
-                    return;
-                }
+                                                             const char* root = env("MEDUI_CONFORMANCE_DIR");
+                                                             if (root == nullptr || *root == '\0') {
+                                                                 // Never a silent skip: in CI this is the failure that keeps the claim honest,
+                                                                 // and offline it says out loud that nothing shared was checked.
+                                                                 checks.expect(!isSet("CI"),
+                                                                               "MEDUI_CONFORMANCE_DIR is set in CI, so the capabilities "
+                                                                               "claimed in medui-conformance.toml are actually substantiated");
+                                                                 checks.raise();
+                                                                 std::cerr << "MedUI conformance: SKIPPED - set MEDUI_CONFORMANCE_DIR to a "
+                                                                              "checkout of the pinned commit to run the shared cases locally.\n";
+                                                                 return;
+                                                             }
 
-                const std::filesystem::path checkout{root};
-                const std::string           actualCommit = checkoutRevision(checkout);
-                checks.expect(actualCommit == pinned.commit,
-                              std::format("MEDUI_CONFORMANCE_DIR is checked out at {}, but "
-                                          "medui-conformance.toml pins {}",
-                                          actualCommit,
-                                          pinned.commit));
-                checks.raise();
+                                                             const std::filesystem::path checkout{root};
+                                                             const std::string           actualCommit = checkoutRevision(checkout);
+                                                             checks.expect(actualCommit == pinned.commit,
+                                                                           std::format("MEDUI_CONFORMANCE_DIR is checked out at {}, but "
+                                                                                       "medui-conformance.toml pins {}",
+                                                                                       actualCommit,
+                                                                                       pinned.commit));
+                                                             checks.raise();
 
-                const std::vector<Case> cases = loadCases(checkout);
-                checks.expect(!cases.empty(), "the pinned checkout contains conformance cases");
+                                                             const std::vector<Case> cases = loadCases(checkout);
+                                                             checks.expect(!cases.empty(), "the pinned checkout contains conformance cases");
 
-                std::set<std::string> executed;
-                std::vector<std::string> unclaimed;
-                for (const Case& item : cases) {
-                    if (std::ranges::find(pinned.capabilities, item.phase) != pinned.capabilities.end()) {
-                        runCase(item, pinned.positions, checks);
-                        executed.insert(item.phase);
-                    } else {
-                        unclaimed.push_back(std::format("{} ({})", item.id, item.phase));
-                    }
-                }
+                                                             std::set<std::string>    executed;
+                                                             std::vector<std::string> unclaimed;
+                                                             for (const Case& item : cases) {
+                                                                 if (std::ranges::find(pinned.capabilities, item.phase) != pinned.capabilities.end()) {
+                                                                     runCase(item, pinned.positions, checks);
+                                                                     executed.insert(item.phase);
+                                                                 } else {
+                                                                     unclaimed.push_back(std::format("{} ({})", item.id, item.phase));
+                                                                 }
+                                                             }
 
-                for (const std::string& capability : pinned.capabilities) {
-                    checks.expect(executed.contains(capability),
-                                  std::format("capability '{}' is backed by a case that ran; "
-                                              "either the pin is wrong or the claim is unsupported",
-                                              capability));
-                }
+                                                             for (const std::string& capability : pinned.capabilities) {
+                                                                 checks.expect(executed.contains(capability),
+                                                                               std::format("capability '{}' is backed by a case that ran; "
+                                                                                           "either the pin is wrong or the claim is unsupported",
+                                                                                           capability));
+                                                             }
 
-                std::cerr << std::format(
-                    "MedUI conformance: {} case(s) at {}; unclaimed and not asserted: {}\n",
-                    cases.size(), pinned.commit,
-                    unclaimed.empty() ? std::string{"none"} : join(unclaimed));
-                checks.raise();
-            })
-            .Execute();
-    }};
+                                                             std::cerr << std::format("MedUI conformance: {} case(s) at {}; unclaimed and not asserted: {}\n",
+                                                                                      cases.size(),
+                                                                                      pinned.commit,
+                                                                                      unclaimed.empty() ? std::string{"none"} : join(unclaimed));
+                                                             checks.raise();
+                                                         })
+                                                   .Execute();
+                                           }};

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -378,9 +378,10 @@ struct Case {
     return result;
 }
 
-// The contract is canonical, while ComponentRule is the executable transcription. Comparing the
-// two at the pinned revision prevents a new or renamed field from becoming an unreviewed local
-// dialect merely because both the implementation and its unit tests copied the old table.
+/// @brief Compares the canonical contract dictionary with the executable transcription.
+///
+/// Checking both at the pinned revision prevents a new or renamed field from becoming an
+/// unreviewed local dialect merely because implementation and unit tests copied the old table.
 using DictionaryEntry = std::tuple<std::string, std::string, bool>;
 
 [[nodiscard]] std::vector<std::string> backtickValues(std::string_view cell) {

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -84,6 +84,21 @@ constexpr std::array<std::string_view, 2> runnableCapabilities{"syntax", "semant
     return std::string{first, last};
 }
 
+void rejectUnknownMembers(const json::Value&                      object,
+                          std::initializer_list<std::string_view> known,
+                          std::string_view                        context,
+                          const std::filesystem::path&            path) {
+    for (const json::Member& entry : object.members()) {
+        if (std::ranges::find(known, entry.key) == known.end()) {
+            fail(std::format("{}: unknown {} member '{}'; shared inputs are rejected unless this "
+                             "adapter consumes them",
+                             path.generic_string(),
+                             context,
+                             entry.key));
+        }
+    }
+}
+
 [[nodiscard]] bool isCommitSha(std::string_view value) {
     return value.size() == 40 && std::ranges::all_of(value, [](unsigned char c) {
                return std::isxdigit(c) != 0;
@@ -325,6 +340,7 @@ struct Case {
         if (inputs->kind() != json::Value::Kind::Object) {
             fail(std::format("{}: member 'inputs' is not an object", path.generic_string()));
         }
+        rejectUnknownMembers(*inputs, {"themeTokens", "textPackages"}, "inputs", path);
         if (inputs->find("themeTokens") != nullptr) {
             for (const json::Value& token : requireArray(*inputs, "themeTokens", path)) {
                 const auto value = token.asString();
@@ -336,6 +352,10 @@ struct Case {
         }
         if (inputs->find("textPackages") != nullptr) {
             for (const json::Value& package : requireArray(*inputs, "textPackages", path)) {
+                if (package.kind() != json::Value::Kind::Object) {
+                    fail(std::format("{}: textPackages contains a non-object", path.generic_string()));
+                }
+                rejectUnknownMembers(package, {"locale", "keys"}, "text package", path);
                 TextPackageInput packageInput{.locale = requireString(package, "locale", path), .keys = {}};
                 for (const json::Value& key : requireArray(package, "keys", path)) {
                     const auto value = key.asString();
@@ -356,6 +376,107 @@ struct Case {
             {.code = requireString(entry, "code", path), .line = requirePosition(entry, "line", path), .column = requirePosition(entry, "column", path)});
     }
     return result;
+}
+
+// The contract is canonical, while ComponentRule is the executable transcription. Comparing the
+// two at the pinned revision prevents a new or renamed field from becoming an unreviewed local
+// dialect merely because both the implementation and its unit tests copied the old table.
+using DictionaryEntry = std::tuple<std::string, std::string, bool>;
+
+[[nodiscard]] std::vector<std::string> backtickValues(std::string_view cell) {
+    std::vector<std::string> values;
+    std::size_t              cursor = 0;
+    for (;;) {
+        const std::size_t open = cell.find('`', cursor);
+        if (open == std::string_view::npos) {
+            break;
+        }
+        const std::size_t close = cell.find('`', open + 1);
+        if (close == std::string_view::npos) {
+            fail("spec/component-model.md contains an unterminated backtick value");
+        }
+        values.emplace_back(cell.substr(open + 1, close - open - 1));
+        cursor = close + 1;
+    }
+    return values;
+}
+
+[[nodiscard]] std::vector<std::string_view> tableCells(std::string_view line) {
+    std::vector<std::string_view> cells;
+    std::size_t                   start = 1;
+    for (;;) {
+        const std::size_t separator = line.find('|', start);
+        if (separator == std::string_view::npos) {
+            break;
+        }
+        std::string_view cell = line.substr(start, separator - start);
+        while (!cell.empty() && std::isspace(static_cast<unsigned char>(cell.front())) != 0) {
+            cell.remove_prefix(1);
+        }
+        while (!cell.empty() && std::isspace(static_cast<unsigned char>(cell.back())) != 0) {
+            cell.remove_suffix(1);
+        }
+        cells.push_back(cell);
+        start = separator + 1;
+    }
+    return cells;
+}
+
+[[nodiscard]] std::set<DictionaryEntry> contractDictionary(const std::filesystem::path& checkout) {
+    const std::filesystem::path path = checkout / "spec" / "component-model.md";
+    std::istringstream          lines{readFile(path)};
+    std::set<DictionaryEntry>   entries;
+    bool                        inTable = false;
+    for (std::string line; std::getline(lines, line);) {
+        if (line.starts_with("| Construct |")) {
+            inTable = true;
+            continue;
+        }
+        if (!inTable) {
+            continue;
+        }
+        if (!line.starts_with('|')) {
+            break;
+        }
+        if (line.starts_with("|---")) {
+            continue;
+        }
+
+        const std::vector<std::string_view> cells = tableCells(line);
+        if (cells.size() != 3) {
+            fail(std::format("{}: malformed component dictionary row '{}'", path.generic_string(), line));
+        }
+        const std::vector<std::string> component = backtickValues(cells[0]);
+        if (component.size() != 1) {
+            fail(std::format("{}: component dictionary row has no single component name", path.generic_string()));
+        }
+        for (const std::string& field : backtickValues(cells[1])) {
+            entries.emplace(component.front(), field, true);
+        }
+        for (const std::string& field : backtickValues(cells[2])) {
+            entries.emplace(component.front(), field, false);
+        }
+    }
+    if (entries.empty()) {
+        fail(std::format("{}: component dictionary table is empty or missing", path.generic_string()));
+    }
+    return entries;
+}
+
+[[nodiscard]] std::set<DictionaryEntry> implementedDictionary() {
+    std::set<DictionaryEntry> entries;
+    for (const md::ComponentRule& component : md::componentDictionary()) {
+        for (const md::FieldRule& field : component.fields) {
+            entries.emplace(component.name, field.name, field.required);
+        }
+    }
+    return entries;
+}
+
+void checkComponentDictionary(const std::filesystem::path& checkout, mdux::spec::Checks& checks) {
+    checks.expect(implementedDictionary() == contractDictionary(checkout),
+                  "the implemented component/field/requiredness set exactly matches the pinned "
+                  "spec/component-model.md table");
 }
 
 [[nodiscard]] std::vector<Case> loadCases(const std::filesystem::path& root) {
@@ -564,6 +685,9 @@ const mdux::spec::Register pinnedCasesPass{"The parser satisfies every pinned ca
                                                                                        "medui-conformance.toml pins {}",
                                                                                        actualCommit,
                                                                                        pinned.commit));
+                                                             checks.raise();
+
+                                                             checkComponentDictionary(checkout, checks);
                                                              checks.raise();
 
                                                              const std::vector<Case> cases = loadCases(checkout);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,10 +271,10 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S3 (#192) this is the diagnostic registry (#191) plus the lexer, AST and parser. The
-# emitters are #197, and the mdux-meduic executable with its mdux_compile_screen() registration
-# is #198 - so there is still no add_executable() here and no bake call site. Every later stage
-# adds sources to this target rather than inventing another.
+# At S4 (#193) this is the diagnostic registry (#191), lexer, AST, parser and semantic analyzer.
+# The emitters are #197, and the mdux-meduic executable with its mdux_compile_screen()
+# registration is #198 - so there is still no add_executable() here and no bake call site. Every
+# later stage adds sources to this target rather than inventing another.
 add_library(MduXMeduiLib)
 add_library(MduX::MeduiLib ALIAS MduXMeduiLib)
 
@@ -287,10 +287,12 @@ target_sources(MduXMeduiLib
             medui/Lexer.cppm
             medui/Ast.cppm
             medui/Parser.cppm
+            medui/Semantic.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
         medui/Parser.cpp
+        medui/Semantic.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/medui/Ast.cppm
+++ b/tools/medui/Ast.cppm
@@ -59,9 +59,10 @@ enum class ValueKind : std::uint8_t {
     Point,       ///< `1392px, 80px`
     String,      ///< `"REQ-NS-001"` - a literal, which most fields must not accept (#193)
     TextKey,     ///< `t("STR-KEY")`
+    ImageRef,    ///< `img("IMAGE-ID")`
     ColorToken,  ///< `Theme.Colors.ScoreDigits`, carried unresolved
     Identifier,  ///< `Vertical`, `sedation-index`
-    Number,      ///< a bare integer, e.g. `spacing: 8` without a unit
+    Number,      ///< a bare integer, e.g. `max_length: 16`
     List,        ///< `[Bounds, ColorHash]`
 };
 
@@ -80,7 +81,7 @@ struct Value {
 
     Size size{};                       ///< kind == Size
     Point point{};                     ///< kind == Point
-    std::string text;                  ///< String, TextKey, ColorToken (the token name), Identifier
+    std::string text;                  ///< String, TextKey, ImageRef, ColorToken, Identifier
     std::int64_t number{0};            ///< Number
     std::vector<std::shared_ptr<Value>> list;  ///< List
 };

--- a/tools/medui/Diagnostics.cpp
+++ b/tools/medui/Diagnostics.cpp
@@ -26,7 +26,7 @@ using cli::Severity;
 // Numbers are assigned in blocks, with gaps left inside each block on purpose: a new grammar rule
 // should land next to the grammar rules rather than at the end of the table, and it can only do
 // that if its block has room. The blocks are documented on the enum in Diagnostics.cppm.
-constexpr std::array<CodeInfo, 22> table{{
+constexpr std::array<CodeInfo, 23> table{{
     {Code::RecipeUnreadable, "MEDUI-E000", Severity::Error,
      "the recipe file could not be opened",
      "check the path passed on the command line, and that the file is readable"},
@@ -81,6 +81,9 @@ constexpr std::array<CodeInfo, 22> table{{
      "a text key exists but is missing from at least one approved locale",
      "add the translation, or remove the locale from the recipe's approved list. A key present in "
      "one locale and absent in another is a screen that renders blank on a shipped device"},
+    {Code::FieldValueKind, "MEDUI-E033", Severity::Error,
+     "a field value has the wrong semantic kind",
+     "use the value form assigned to this field in the shared component model"},
 
     {Code::TextBudgetExceeded, "MEDUI-E050", Severity::Error,
      "a component's bounds cannot contain the widest approved translation",

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -87,6 +87,7 @@ enum class Code : std::uint8_t {
     UnknownColorToken,
     UnknownTextKey,
     TextKeyMissingForLocale,
+    FieldValueKind,
 
     // 050-069: the bounds and budgets that make the runtime's job finite.
     TextBudgetExceeded,

--- a/tools/medui/Parser.cpp
+++ b/tools/medui/Parser.cpp
@@ -432,7 +432,19 @@ private:
             return value;
         }
         if (at(TokenKind::Number)) {
-            const Token& number = current();
+            const Token number = current();
+            // A standalone integer is a semantic value form (`max_length: 16`). An identifier
+            // immediately after it still means the author attempted a unit, so route that shape
+            // through parsePixels() to retain the precise unknown-unit diagnostic.
+            if (!peekIs(TokenKind::Identifier)) {
+                static_cast<void>(advance());
+                value->kind = ast::ValueKind::Number;
+                static_cast<void>(std::from_chars(number.text.data(),
+                                                  number.text.data() + number.text.size(),
+                                                  value->number));
+                return value;
+            }
+
             std::optional<std::int64_t> pixels = parsePixels();
             if (pixels) {
                 // `Xpx, Ypx` is a point; a lone `Xpx` is a size. The comma decides.
@@ -451,12 +463,7 @@ private:
                                         .position = value->position};
                 return value;
             }
-            // parsePixels() already reported. Fall back to a bare number so the AST stays usable.
-            value->kind = ast::ValueKind::Number;
-            static_cast<void>(std::from_chars(number.text.data(),
-                                              number.text.data() + number.text.size(),
-                                              value->number));
-            return value;
+            return nullptr;
         }
         if (at(TokenKind::Identifier)) {
             if (rejectIfForbidden()) {
@@ -475,6 +482,17 @@ private:
                 value->text = key->text;
                 return value;
             }
+            if (word == "img" && peekIs(TokenKind::LParen)) {
+                static_cast<void>(advance());  // 'img'
+                static_cast<void>(advance());  // '('
+                const Token* key = expect(TokenKind::String, "an image reference, as img(\"ID\")");
+                if (key == nullptr || expect(TokenKind::RParen, "')' closing img(") == nullptr) {
+                    return nullptr;
+                }
+                value->kind = ast::ValueKind::ImageRef;
+                value->text = key->text;
+                return value;
+            }
             if (word == "Fill") {
                 static_cast<void>(advance());
                 value->kind = ast::ValueKind::Size;
@@ -484,7 +502,6 @@ private:
 
             // A dotted path: `Theme.Colors.ScoreDigits`. Kept whole and unresolved (#193).
             std::string path = advance().text;
-            bool dotted = false;
             while (at(TokenKind::Dot)) {
                 static_cast<void>(advance());
                 const Token* part = expect(TokenKind::Identifier, "a name after '.'");
@@ -493,7 +510,6 @@ private:
                 }
                 path += '.';
                 path += part->text;
-                dotted = true;
             }
             // A dotted path is only a *colour token* when it is one. `Foo.Bar` and a truncated
             // `Theme.Colors` were both classified as ColorToken, which would have sent #193 to the
@@ -501,18 +517,9 @@ private:
             // governed table" for what is really a malformed value.
             const bool isThemeColor = path.starts_with("Theme.Colors.") &&
                                       path.size() > std::string_view{"Theme.Colors."}.size();
-            // `dotted` no longer decides anything: an unqualified dotted path and a bare word are
-            // both just identifiers for #193 to interpret. Kept as a named variable only for the
-            // diagnostic below, so the reader is told which shape was seen.
+            // Any other dotted path is an Identifier for #193 to interpret. This is syntactically
+            // valid: whether a particular field admits a named value is a semantic-domain check.
             value->kind = isThemeColor ? ast::ValueKind::ColorToken : ast::ValueKind::Identifier;
-            if (dotted && !isThemeColor) {
-                // Not an error here - #193 owns what a field may hold - but worth saying, because
-                // a dotted path that is not a theme colour is almost always a mistyped one.
-                report(Code::UnexpectedToken,
-                       std::format("'{}' is not a Theme.Colors token", path),
-                       "colours are written Theme.Colors.<Token>; other dotted paths have no "
-                       "meaning in this grammar");
-            }
             value->text = std::move(path);
             return value;
         }

--- a/tools/medui/Parser.cpp
+++ b/tools/medui/Parser.cpp
@@ -437,11 +437,18 @@ private:
             // immediately after it still means the author attempted a unit, so route that shape
             // through parsePixels() to retain the precise unknown-unit diagnostic.
             if (!peekIs(TokenKind::Identifier)) {
+                std::int64_t parsed = 0;
+                const auto [ptr, ec] = std::from_chars(
+                    number.text.data(), number.text.data() + number.text.size(), parsed);
+                if (ec != std::errc{} || ptr != number.text.data() + number.text.size()) {
+                    report(Code::UnexpectedToken,
+                           std::format("'{}' is not an integer this compiler can represent",
+                                       number.text));
+                    return nullptr;
+                }
                 static_cast<void>(advance());
                 value->kind = ast::ValueKind::Number;
-                static_cast<void>(std::from_chars(number.text.data(),
-                                                  number.text.data() + number.text.size(),
-                                                  value->number));
+                value->number = parsed;
                 return value;
             }
 

--- a/tools/medui/Semantic.cpp
+++ b/tools/medui/Semantic.cpp
@@ -223,6 +223,28 @@ private:
     }
 
     void analyzeText(const ast::Value& value, FieldDomain domain) {
+        if (domain == TextKeyList && value.kind == ast::ValueKind::List) {
+            if (value.list.empty()) {
+                report(Code::FieldValueKind, value.position,
+                       std::format("text field requires {}", describe(domain)));
+                return;
+            }
+            for (const std::shared_ptr<ast::Value>& element : value.list) {
+                if (element == nullptr) {
+                    report(Code::FieldValueKind, value.position,
+                           std::format("text field requires {}", describe(domain)));
+                } else if (element->kind == ast::ValueKind::String) {
+                    report(Code::HardcodedString, element->position,
+                           "literal text cannot be checked against every approved locale");
+                } else if (element->kind != ast::ValueKind::TextKey) {
+                    report(Code::FieldValueKind, element->position,
+                           std::format("text field requires {}", describe(domain)));
+                } else {
+                    analyzeTextKey(*element);
+                }
+            }
+            return;
+        }
         if (value.kind == ast::ValueKind::String) {
             report(Code::HardcodedString, value.position, "literal text cannot be checked against every approved locale");
             return;
@@ -231,13 +253,7 @@ private:
             report(Code::FieldValueKind, value.position, std::format("text field requires {}", describe(domain)));
             return;
         }
-        if (domain == TextKey) {
-            analyzeTextKey(value);
-        } else {
-            for (const std::shared_ptr<ast::Value>& element : value.list) {
-                analyzeTextKey(*element);
-            }
-        }
+        analyzeTextKey(value);
     }
 
     void analyzeColor(const ast::Value& value, FieldDomain domain) {

--- a/tools/medui/Semantic.cpp
+++ b/tools/medui/Semantic.cpp
@@ -1,0 +1,198 @@
+/**
+ * @file Semantic.cpp
+ * @brief Component-dictionary, theme-token, and locale-key semantic checks.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+module;
+
+module mdux.tools.medui.semantic;
+
+import std;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+struct ComponentRule {
+    std::string_view name;
+    std::string_view required;
+    std::string_view allowed;
+};
+
+constexpr std::array<ComponentRule, 11> componentRules{
+    {
+     {"Row", "id height", "id height spacing background"},
+     {"CriticalButton", "id requirement width height label color on_press", "id requirement width height label color on_press position"},
+     {"Button", "id width height label color source", "id width height label color source position requirement"},
+     {"VulkanViewport", "id width height stream_source", "id width height stream_source position"},
+     {"SignalTrace", "id width height stream_source color", "id width height stream_source color position"},
+     {"NumericDisplay", "id width height requirement template source color", "id width height requirement template source color position"},
+     {"StatusIndicator", "id width height requirement source states", "id width height requirement source states position colors"},
+     {"Label", "id width height text color", "id width height text color position"},
+     {"Clock", "id width height format", "id width height format position"},
+     {"Image", "id width height source", "id width height source position"},
+     {"TextInput", "id width height source max_length color", "id width height source max_length color position charset requirement"},
+     }
+};
+
+[[nodiscard]] bool containsWord(std::string_view words, std::string_view wanted) noexcept {
+    while (!words.empty()) {
+        const std::size_t      separator = words.find(' ');
+        const std::string_view word      = words.substr(0, separator);
+        if (word == wanted) {
+            return true;
+        }
+        if (separator == std::string_view::npos) {
+            break;
+        }
+        words.remove_prefix(separator + 1);
+    }
+    return false;
+}
+
+[[nodiscard]] const ComponentRule* ruleFor(std::string_view component) noexcept {
+    const auto found = std::ranges::find(componentRules, component, &ComponentRule::name);
+    return found == componentRules.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
+    const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
+    return found == node.fields.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool isTextField(std::string_view component, std::string_view field) noexcept {
+    return (component == "Label" && field == "text") || ((component == "CriticalButton" || component == "Button") && field == "label")
+           || (component == "StatusIndicator" && field == "states");
+}
+
+[[nodiscard]] bool isColorField(std::string_view field) noexcept {
+    return field == "color" || field == "background" || field == "colors";
+}
+
+class Analyzer {
+public:
+    Analyzer(std::string file, SemanticInputs inputs) : file_{std::move(file)}, inputs_{inputs} {}
+
+    [[nodiscard]] SemanticResult run(const ast::Screen& screen) {
+        for (const ast::Node& node : screen.nodes) {
+            analyzeNode(node);
+        }
+        return SemanticResult{.diagnostics = std::move(diagnostics_)};
+    }
+
+private:
+    void report(Code code, ast::Position position, std::string message) {
+        diagnostics_.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
+    }
+
+    void analyzeTextValue(const ast::Value& value) {
+        if (value.kind == ast::ValueKind::List) {
+            for (const std::shared_ptr<ast::Value>& element : value.list) {
+                if (element != nullptr) {
+                    analyzeTextValue(*element);
+                }
+            }
+            return;
+        }
+        if (value.kind == ast::ValueKind::String) {
+            report(Code::HardcodedString, value.position, "literal text cannot be checked against every approved locale");
+            return;
+        }
+        if (value.kind != ast::ValueKind::TextKey) {
+            report(Code::UnexpectedToken, value.position, "this text field requires t(\"KEY\") or a list of text keys");
+            return;
+        }
+
+        std::vector<std::string_view> missingLocales;
+        bool                          foundAnywhere = false;
+        for (const mdux::text::TextPackage& package : inputs_.textPackages) {
+            if (package.find(value.text) != nullptr) {
+                foundAnywhere = true;
+            } else {
+                missingLocales.push_back(package.locale);
+            }
+        }
+        if (!foundAnywhere) {
+            report(Code::UnknownTextKey, value.position, std::format("text key '{}' is absent from every approved locale", value.text));
+            return;
+        }
+        for (std::string_view locale : missingLocales) {
+            report(Code::TextKeyMissingForLocale, value.position, std::format("text key '{}' is missing for approved locale '{}'", value.text, locale));
+        }
+    }
+
+    void analyzeColorValue(const ast::Value& value) {
+        if (value.kind == ast::ValueKind::List) {
+            for (const std::shared_ptr<ast::Value>& element : value.list) {
+                if (element != nullptr) {
+                    analyzeColorValue(*element);
+                }
+            }
+            return;
+        }
+        if (value.kind != ast::ValueKind::ColorToken) {
+            report(Code::UnexpectedToken, value.position, "this colour field requires Theme.Colors.<Token>");
+            return;
+        }
+        if (std::ranges::find(inputs_.themeTokens, value.text) == inputs_.themeTokens.end()) {
+            report(Code::UnknownColorToken, value.position, std::format("theme token '{}' is not in the governed table", value.text));
+        }
+    }
+
+    void analyzeNode(const ast::Node& node) {
+        const ComponentRule* rule = ruleFor(node.component);
+        if (rule == nullptr) {
+            report(Code::UnknownComponent, node.position, std::format("component '{}' is not in the component dictionary", node.component));
+        } else {
+            std::string_view required = rule->required;
+            while (!required.empty()) {
+                const std::size_t      separator = required.find(' ');
+                const std::string_view name      = required.substr(0, separator);
+                if (fieldFor(node, name) == nullptr) {
+                    report(Code::MissingRequiredField, node.position, std::format("component '{}' requires field '{}'", node.component, name));
+                }
+                if (separator == std::string_view::npos) {
+                    break;
+                }
+                required.remove_prefix(separator + 1);
+            }
+
+            for (const ast::Field& field : node.fields) {
+                if (!containsWord(rule->allowed, field.name)) {
+                    report(Code::UnknownField, field.namePosition, std::format("field '{}' is not defined for component '{}'", field.name, node.component));
+                    continue;
+                }
+                if (field.value == nullptr) {
+                    continue;
+                }
+                if (isTextField(node.component, field.name)) {
+                    analyzeTextValue(*field.value);
+                } else if (isColorField(field.name)) {
+                    analyzeColorValue(*field.value);
+                }
+            }
+        }
+
+        for (const ast::Node& child : node.children) {
+            analyzeNode(child);
+        }
+    }
+
+    std::string                  file_;
+    SemanticInputs               inputs_;
+    std::vector<cli::Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+SemanticResult analyze(const ast::Screen& screen, std::string file, SemanticInputs inputs) {
+    return Analyzer{std::move(file), inputs}.run(screen);
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Semantic.cpp
+++ b/tools/medui/Semantic.cpp
@@ -1,6 +1,6 @@
 /**
  * @file Semantic.cpp
- * @brief Component-dictionary, theme-token, and locale-key semantic checks.
+ * @brief Component-dictionary, value-domain, theme-token, and locale-key semantic checks.
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary
@@ -19,46 +19,109 @@ namespace mdux::tools::medui {
 
 namespace {
 
-struct ComponentRule {
-    std::string_view name;
-    std::string_view required;
-    std::string_view allowed;
-};
+using enum FieldDomain;
+
+constexpr FieldRule field(std::string_view name, bool required, FieldDomain domain) {
+    return FieldRule{.name = name, .required = required, .domain = domain};
+}
+
+constexpr std::array rowFields{field("id", true, Identifier),
+                               field("height", true, Size),
+                               field("spacing", false, Size),
+                               field("background", false, ColorToken)};
+constexpr std::array criticalButtonFields{field("id", true, Identifier),
+                                          field("requirement", true, String),
+                                          field("width", true, Size),
+                                          field("height", true, Size),
+                                          field("label", true, TextKey),
+                                          field("color", true, ColorToken),
+                                          field("on_press", true, Identifier),
+                                          field("position", false, Point)};
+constexpr std::array buttonFields{field("id", true, Identifier),
+                                  field("width", true, Size),
+                                  field("height", true, Size),
+                                  field("label", true, TextKey),
+                                  field("color", true, ColorToken),
+                                  field("source", true, String),
+                                  field("position", false, Point),
+                                  field("requirement", false, String)};
+constexpr std::array viewportFields{field("id", true, Identifier),
+                                    field("width", true, Size),
+                                    field("height", true, Size),
+                                    field("stream_source", true, String),
+                                    field("position", false, Point)};
+constexpr std::array signalTraceFields{field("id", true, Identifier),
+                                       field("width", true, Size),
+                                       field("height", true, Size),
+                                       field("stream_source", true, String),
+                                       field("color", true, ColorToken),
+                                       field("position", false, Point)};
+constexpr std::array numericDisplayFields{field("id", true, Identifier),
+                                          field("width", true, Size),
+                                          field("height", true, Size),
+                                          field("requirement", true, String),
+                                          field("template", true, String),
+                                          field("source", true, String),
+                                          field("color", true, ColorToken),
+                                          field("position", false, Point)};
+constexpr std::array statusIndicatorFields{field("id", true, Identifier),
+                                           field("width", true, Size),
+                                           field("height", true, Size),
+                                           field("requirement", true, String),
+                                           field("source", true, String),
+                                           field("states", true, TextKeyList),
+                                           field("position", false, Point),
+                                           field("colors", false, ColorTokenList)};
+constexpr std::array labelFields{field("id", true, Identifier),
+                                 field("width", true, Size),
+                                 field("height", true, Size),
+                                 field("text", true, TextKey),
+                                 field("color", true, ColorToken),
+                                 field("position", false, Point)};
+constexpr std::array clockFields{field("id", true, Identifier),
+                                 field("width", true, Size),
+                                 field("height", true, Size),
+                                 field("format", true, Identifier),
+                                 field("position", false, Point)};
+constexpr std::array imageFields{field("id", true, Identifier),
+                                 field("width", true, Size),
+                                 field("height", true, Size),
+                                 field("source", true, ImageRef),
+                                 field("position", false, Point)};
+constexpr std::array textInputFields{field("id", true, Identifier),
+                                     field("width", true, Size),
+                                     field("height", true, Size),
+                                     field("source", true, String),
+                                     field("max_length", true, Number),
+                                     field("color", true, ColorToken),
+                                     field("position", false, Point),
+                                     field("charset", false, Identifier),
+                                     field("requirement", false, String)};
 
 constexpr std::array<ComponentRule, 11> componentRules{
     {
-     {"Row", "id height", "id height spacing background"},
-     {"CriticalButton", "id requirement width height label color on_press", "id requirement width height label color on_press position"},
-     {"Button", "id width height label color source", "id width height label color source position requirement"},
-     {"VulkanViewport", "id width height stream_source", "id width height stream_source position"},
-     {"SignalTrace", "id width height stream_source color", "id width height stream_source color position"},
-     {"NumericDisplay", "id width height requirement template source color", "id width height requirement template source color position"},
-     {"StatusIndicator", "id width height requirement source states", "id width height requirement source states position colors"},
-     {"Label", "id width height text color", "id width height text color position"},
-     {"Clock", "id width height format", "id width height format position"},
-     {"Image", "id width height source", "id width height source position"},
-     {"TextInput", "id width height source max_length color", "id width height source max_length color position charset requirement"},
+     {"Row", rowFields},
+     {"CriticalButton", criticalButtonFields},
+     {"Button", buttonFields},
+     {"VulkanViewport", viewportFields},
+     {"SignalTrace", signalTraceFields},
+     {"NumericDisplay", numericDisplayFields},
+     {"StatusIndicator", statusIndicatorFields},
+     {"Label", labelFields},
+     {"Clock", clockFields},
+     {"Image", imageFields},
+     {"TextInput", textInputFields},
      }
 };
-
-[[nodiscard]] bool containsWord(std::string_view words, std::string_view wanted) noexcept {
-    while (!words.empty()) {
-        const std::size_t      separator = words.find(' ');
-        const std::string_view word      = words.substr(0, separator);
-        if (word == wanted) {
-            return true;
-        }
-        if (separator == std::string_view::npos) {
-            break;
-        }
-        words.remove_prefix(separator + 1);
-    }
-    return false;
-}
 
 [[nodiscard]] const ComponentRule* ruleFor(std::string_view component) noexcept {
     const auto found = std::ranges::find(componentRules, component, &ComponentRule::name);
     return found == componentRules.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const FieldRule* ruleFor(const ComponentRule& component, std::string_view name) noexcept {
+    const auto found = std::ranges::find(component.fields, name, &FieldRule::name);
+    return found == component.fields.end() ? nullptr : &*found;
 }
 
 [[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
@@ -66,13 +129,62 @@ constexpr std::array<ComponentRule, 11> componentRules{
     return found == node.fields.end() ? nullptr : &*found;
 }
 
-[[nodiscard]] bool isTextField(std::string_view component, std::string_view field) noexcept {
-    return (component == "Label" && field == "text") || ((component == "CriticalButton" || component == "Button") && field == "label")
-           || (component == "StatusIndicator" && field == "states");
+[[nodiscard]] bool listContains(const ast::Value& value, ast::ValueKind kind) noexcept {
+    return value.kind == ast::ValueKind::List && !value.list.empty() && std::ranges::all_of(value.list, [kind](const std::shared_ptr<ast::Value>& element) {
+               return element != nullptr && element->kind == kind;
+           });
 }
 
-[[nodiscard]] bool isColorField(std::string_view field) noexcept {
-    return field == "color" || field == "background" || field == "colors";
+[[nodiscard]] bool matches(const ast::Value& value, FieldDomain domain) noexcept {
+    switch (domain) {
+        case Identifier:
+            return value.kind == ast::ValueKind::Identifier;
+        case Size:
+            return value.kind == ast::ValueKind::Size;
+        case Point:
+            return value.kind == ast::ValueKind::Point;
+        case String:
+            return value.kind == ast::ValueKind::String;
+        case TextKey:
+            return value.kind == ast::ValueKind::TextKey;
+        case TextKeyList:
+            return listContains(value, ast::ValueKind::TextKey);
+        case ColorToken:
+            return value.kind == ast::ValueKind::ColorToken;
+        case ColorTokenList:
+            return listContains(value, ast::ValueKind::ColorToken);
+        case ImageRef:
+            return value.kind == ast::ValueKind::ImageRef;
+        case Number:
+            return value.kind == ast::ValueKind::Number && value.number > 0;
+    }
+    return false;
+}
+
+[[nodiscard]] std::string_view describe(FieldDomain domain) noexcept {
+    switch (domain) {
+        case Identifier:
+            return "a named value";
+        case Size:
+            return "a pixel size or Fill";
+        case Point:
+            return "a pixel coordinate pair";
+        case String:
+            return "a quoted string";
+        case TextKey:
+            return "t(\"KEY\")";
+        case TextKeyList:
+            return "a non-empty list of t(\"KEY\") values";
+        case ColorToken:
+            return "Theme.Colors.<Token>";
+        case ColorTokenList:
+            return "a non-empty list of Theme.Colors.<Token> values";
+        case ImageRef:
+            return "img(\"ID\")";
+        case Number:
+            return "a positive integer";
+    }
+    return "the field's declared value domain";
 }
 
 class Analyzer {
@@ -91,24 +203,7 @@ private:
         diagnostics_.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
     }
 
-    void analyzeTextValue(const ast::Value& value) {
-        if (value.kind == ast::ValueKind::List) {
-            for (const std::shared_ptr<ast::Value>& element : value.list) {
-                if (element != nullptr) {
-                    analyzeTextValue(*element);
-                }
-            }
-            return;
-        }
-        if (value.kind == ast::ValueKind::String) {
-            report(Code::HardcodedString, value.position, "literal text cannot be checked against every approved locale");
-            return;
-        }
-        if (value.kind != ast::ValueKind::TextKey) {
-            report(Code::UnexpectedToken, value.position, "this text field requires t(\"KEY\") or a list of text keys");
-            return;
-        }
-
+    void analyzeTextKey(const ast::Value& value) {
         std::vector<std::string_view> missingLocales;
         bool                          foundAnywhere = false;
         for (const mdux::text::TextPackage& package : inputs_.textPackages) {
@@ -127,54 +222,73 @@ private:
         }
     }
 
-    void analyzeColorValue(const ast::Value& value) {
-        if (value.kind == ast::ValueKind::List) {
+    void analyzeText(const ast::Value& value, FieldDomain domain) {
+        if (value.kind == ast::ValueKind::String) {
+            report(Code::HardcodedString, value.position, "literal text cannot be checked against every approved locale");
+            return;
+        }
+        if (!matches(value, domain)) {
+            report(Code::FieldValueKind, value.position, std::format("text field requires {}", describe(domain)));
+            return;
+        }
+        if (domain == TextKey) {
+            analyzeTextKey(value);
+        } else {
             for (const std::shared_ptr<ast::Value>& element : value.list) {
-                if (element != nullptr) {
-                    analyzeColorValue(*element);
-                }
+                analyzeTextKey(*element);
             }
+        }
+    }
+
+    void analyzeColor(const ast::Value& value, FieldDomain domain) {
+        if (!matches(value, domain)) {
+            report(Code::FieldValueKind, value.position, std::format("colour field requires {}", describe(domain)));
             return;
         }
-        if (value.kind != ast::ValueKind::ColorToken) {
-            report(Code::UnexpectedToken, value.position, "this colour field requires Theme.Colors.<Token>");
-            return;
-        }
-        if (std::ranges::find(inputs_.themeTokens, value.text) == inputs_.themeTokens.end()) {
-            report(Code::UnknownColorToken, value.position, std::format("theme token '{}' is not in the governed table", value.text));
+        const auto check = [&](const ast::Value& token) {
+            if (std::ranges::find(inputs_.themeTokens, token.text) == inputs_.themeTokens.end()) {
+                report(Code::UnknownColorToken, token.position, std::format("theme token '{}' is not in the governed table", token.text));
+            }
+        };
+        if (domain == ColorToken) {
+            check(value);
+        } else {
+            for (const std::shared_ptr<ast::Value>& element : value.list) {
+                check(*element);
+            }
         }
     }
 
     void analyzeNode(const ast::Node& node) {
-        const ComponentRule* rule = ruleFor(node.component);
-        if (rule == nullptr) {
+        const ComponentRule* component = ruleFor(node.component);
+        if (component == nullptr) {
             report(Code::UnknownComponent, node.position, std::format("component '{}' is not in the component dictionary", node.component));
         } else {
-            std::string_view required = rule->required;
-            while (!required.empty()) {
-                const std::size_t      separator = required.find(' ');
-                const std::string_view name      = required.substr(0, separator);
-                if (fieldFor(node, name) == nullptr) {
-                    report(Code::MissingRequiredField, node.position, std::format("component '{}' requires field '{}'", node.component, name));
+            for (const FieldRule& fieldRule : component->fields) {
+                if (fieldRule.required && fieldFor(node, fieldRule.name) == nullptr) {
+                    report(Code::MissingRequiredField, node.position, std::format("component '{}' requires field '{}'", node.component, fieldRule.name));
                 }
-                if (separator == std::string_view::npos) {
-                    break;
-                }
-                required.remove_prefix(separator + 1);
             }
 
-            for (const ast::Field& field : node.fields) {
-                if (!containsWord(rule->allowed, field.name)) {
-                    report(Code::UnknownField, field.namePosition, std::format("field '{}' is not defined for component '{}'", field.name, node.component));
+            for (const ast::Field& fieldValue : node.fields) {
+                const FieldRule* fieldRule = ruleFor(*component, fieldValue.name);
+                if (fieldRule == nullptr) {
+                    report(Code::UnknownField,
+                           fieldValue.namePosition,
+                           std::format("field '{}' is not defined for component '{}'", fieldValue.name, node.component));
                     continue;
                 }
-                if (field.value == nullptr) {
+                if (fieldValue.value == nullptr) {
                     continue;
                 }
-                if (isTextField(node.component, field.name)) {
-                    analyzeTextValue(*field.value);
-                } else if (isColorField(field.name)) {
-                    analyzeColorValue(*field.value);
+                if (fieldRule->domain == TextKey || fieldRule->domain == TextKeyList) {
+                    analyzeText(*fieldValue.value, fieldRule->domain);
+                } else if (fieldRule->domain == ColorToken || fieldRule->domain == ColorTokenList) {
+                    analyzeColor(*fieldValue.value, fieldRule->domain);
+                } else if (!matches(*fieldValue.value, fieldRule->domain)) {
+                    report(Code::FieldValueKind,
+                           fieldValue.value->position,
+                           std::format("field '{}' requires {}", fieldValue.name, describe(fieldRule->domain)));
                 }
             }
         }
@@ -190,6 +304,10 @@ private:
 };
 
 }  // namespace
+
+std::span<const ComponentRule> componentDictionary() noexcept {
+    return componentRules;
+}
 
 SemanticResult analyze(const ast::Screen& screen, std::string file, SemanticInputs inputs) {
     return Analyzer{std::move(file), inputs}.run(screen);

--- a/tools/medui/Semantic.cppm
+++ b/tools/medui/Semantic.cppm
@@ -5,9 +5,10 @@
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary
  *
- * This stage validates names but deliberately does not substitute them. The AST remains the
- * author's unresolved description; later compiler stages receive it only after this result is
- * successful and perform layout and emission against their own governed inputs.
+ * This stage validates the component dictionary, field value domains, and external names but
+ * deliberately does not substitute them. The AST remains the author's unresolved description;
+ * later compiler stages receive it only after this result is successful and perform layout and
+ * emission against their own governed inputs.
  */
 module;
 
@@ -19,6 +20,46 @@ import mdux.tools.cli;
 import mdux.tools.medui.ast;
 
 export namespace mdux::tools::medui {
+
+/// The syntactic value form one component field admits during semantic analysis.
+enum class FieldDomain : std::uint8_t {
+    Identifier,
+    Size,
+    Point,
+    String,
+    TextKey,
+    TextKeyList,
+    ColorToken,
+    ColorTokenList,
+    ImageRef,
+    Number,
+};
+
+/// One field admitted by a component and the value form that field accepts.
+struct FieldRule {
+    /// Field spelling from the canonical component dictionary.
+    std::string_view name;
+    /// Whether every instance of the component must carry this field.
+    bool required{false};
+    /// Syntactic value form accepted for this field.
+    FieldDomain domain{FieldDomain::Identifier};
+};
+
+/// One component and its complete closed set of fields.
+struct ComponentRule {
+    /// Component spelling from the canonical component dictionary.
+    std::string_view name;
+    /// Complete required and optional field set for the component.
+    std::span<const FieldRule> fields;
+};
+
+/**
+ * @brief The closed component dictionary implemented by this semantic stage.
+ *
+ * Exposed so the pinned shared-conformance test can compare the transcription with the contract
+ * it implements. Consumers should still treat Compliatory/MedUI as the canonical definition.
+ */
+[[nodiscard]] std::span<const ComponentRule> componentDictionary() noexcept;
 
 /**
  * @brief External name tables against which one screen is checked.
@@ -32,6 +73,7 @@ struct SemanticInputs {
     std::span<const mdux::text::TextPackage> textPackages;
 };
 
+/// Accumulated semantic diagnostics; an empty result admits the screen to the next stage.
 struct SemanticResult {
     std::vector<mdux::tools::cli::Diagnostic> diagnostics;
 
@@ -41,10 +83,10 @@ struct SemanticResult {
 };
 
 /**
- * @brief Validates component and field names, theme tokens, and locale-complete text keys.
+ * @brief Validates component fields and values, theme tokens, and locale-complete text keys.
  *
  * Diagnostics accumulate in source traversal order. The screen is never modified and resolved
- * values are not returned: successful name validation is a gate, not a substitution pass.
+ * values are not returned: successful semantic validation is a gate, not a substitution pass.
  */
 [[nodiscard]] SemanticResult analyze(const ast::Screen& screen, std::string file, SemanticInputs inputs);
 

--- a/tools/medui/Semantic.cppm
+++ b/tools/medui/Semantic.cppm
@@ -1,0 +1,51 @@
+/**
+ * @file Semantic.cppm
+ * @brief Build-time semantic analysis for parsed `.medui` screens.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * This stage validates names but deliberately does not substitute them. The AST remains the
+ * author's unresolved description; later compiler stages receive it only after this result is
+ * successful and perform layout and emission against their own governed inputs.
+ */
+module;
+
+export module mdux.tools.medui.semantic;
+
+import std;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief External name tables against which one screen is checked.
+ *
+ * Text packages are prevalidated, one per approved locale, with unique locale names. The
+ * analyzer reads only each package's locale and run IDs. Theme tokens are full names such as
+ * `Theme.Colors.Title`; their concrete colour values belong to the later emitter stage.
+ */
+struct SemanticInputs {
+    std::span<const std::string_view>        themeTokens;
+    std::span<const mdux::text::TextPackage> textPackages;
+};
+
+struct SemanticResult {
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Validates component and field names, theme tokens, and locale-complete text keys.
+ *
+ * Diagnostics accumulate in source traversal order. The screen is never modified and resolved
+ * values are not returned: successful name validation is a gate, not a substitution pass.
+ */
+[[nodiscard]] SemanticResult analyze(const ast::Screen& screen, std::string file, SemanticInputs inputs);
+
+}  // namespace mdux::tools::medui


### PR DESCRIPTION
## Summary

Adds the host-tools `mdux.tools.medui.semantic` stage: the closed component/field dictionary, field value-domain checks, governed theme-token lookup, hardcoded-text rejection, and `t("KEY")` validation across every approved `mdux.text.schema` package. Analysis leaves the AST unresolved and accumulates stable `MEDUI-E###` diagnostics with source positions.

The shared contract was extended first in [Compliatory/MedUI#10](https://github.com/Compliatory/MedUI/pull/10) and [Compliatory/MedUI#11](https://github.com/Compliatory/MedUI/pull/11). This branch pins released contract version `0.1.0` at merge commit `d5136a8518bd499760ecff2aad215d3721329f20`, claims `syntax` and `semantics`, executes its portable conformance cases, and mechanically checks that MduX's component dictionary exactly matches the pinned table.

Closes #193

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change.
- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: not applicable — this is a maintainer-authored change.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [x] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [x] `tools/CMakeLists.txt` — host-tool targets and their sources
- [x] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`
- [ ] None of the above

## Rebase state

- **Rebased onto:** `d4f969c877fe27cdf51a0c45a1d85fdad91cca85`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run locally; this macOS host has no supported C++23-modules toolchain, CI covers GCC 16 and MSVC
- [ ] `ctest --test-dir build-gcc` — not run locally; CI covers the full suite
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 80 files, 0 findings
- [x] Other: MedUI `python3 tools/validate.py` at the pinned commit — 14 cases, 23 diagnostics
- [x] Other: `python3 tools/docs-lint/generate_ai_reference.py --check`
- [x] Other: `python3 tools/docs-lint/check_schema_type_drift.py` — 7 schemas, 7 bindings, 2 closed vocabularies
- [x] Other: `git diff --check`

The docs-lint unittest suite was also run. It has four existing macOS temporary-link-test failures (`MDX-D012` instead of the expected fixture outcomes); the repository-wide lint itself passes.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** merge commit `f2c4654305242e47f7cbdcd9fb7222d1423fcdbc` — [GCC/CTest](https://github.com/ambroise-leclerc/MduX/actions/runs/31930195316), [MSVC/CTest](https://github.com/ambroise-leclerc/MduX/actions/runs/31930195274), and [sanitizers](https://github.com/ambroise-leclerc/MduX/actions/runs/31930195359); all `develop` workflows green
- [x] That run is green.

## Regulatory impact

Safety-relevant build-time acceptance behavior changes for authored UI: known fields now fail closed when their syntactic value has the wrong semantic domain, and shared conformance inputs cannot be silently ignored. Affected evidence and traceability artifacts are the semantic unit/conformance tests, `medui-conformance.toml`, ADR links, architecture/status documentation, and the authoring skill. Existing diagnostic identities and ADR decisions are reused; no certification or production-readiness claim is introduced. Maintainer/domain review completed before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added semantic validation for MedUI screens, including component fields, theme tokens, localized text, nested content, and value types.
  - Added support for image references and standalone numeric values.
  - Added clearer diagnostics for invalid field values, unknown names, missing locale keys, and malformed inputs.

- **Bug Fixes**
  - Improved dotted-path handling and pixel-value parsing.
  - Prevented invalid pixel syntax from being silently treated as plain numbers.

- **Documentation**
  - Updated compiler status, architecture guidance, conformance details, and implementation roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

