### PR TITLE
S5 — Bounded layout and Row flattening

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,13 +10,14 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: parsing and semantic validation are implemented; emission and runtime are not
+## Status: parsing, semantic validation, and bounded layout are implemented; emission and runtime are not
 
-**A `.medui` lexer, AST, parser and semantic analyzer exist** in the host-tools zone
-(`tools/medui/`). The diagnostic codes they emit are registered as `MEDUI-E###` (#191). The parser
-rejects structural violations (#192); the analyzer checks the closed component dictionary, each
-field's value domain, theme-token names, and text-key presence across every approved locale (#193).
-It does not substitute resolved values.
+**A `.medui` lexer, AST, parser, semantic analyzer, and integer-only bounded layout solver exist**
+in the host-tools zone (`tools/medui/`). The diagnostic codes they emit are registered as
+`MEDUI-E###` (#191). The parser rejects structural violations (#192); the analyzer checks the
+closed component dictionary, each field's value domain, theme-token names, and text-key presence
+across every approved locale (#193); and the solver flattens Vertical/Row layout to absolute
+rectangles without floating-point arithmetic (#194). The AST keeps names unresolved.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -106,8 +107,8 @@ verifier checks against. Rules:
 ## Checking a file without a full build
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser and analyzer it will call already detect syntax errors,
-structural violations, unknown dictionary/theme names, hardcoded text in localizable fields,
-wrong field value domains, and incomplete locale keys; what is missing is the command that exposes
-them. Until it lands, review a `.medui` file by hand against this grammar and the component table
-above.
+diagnostics — once it exists. The parser, analyzer, and solver it will call already detect syntax
+errors, structural violations, unknown dictionary/theme names, hardcoded text in localizable
+fields, wrong field value domains, incomplete locale keys, and layout overflow; what is missing is
+the command that exposes them. Until it lands, review a `.medui` file by hand against this grammar
+and the component table above.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -55,7 +55,9 @@ Screen NeuroSense500 {
 }
 ```
 
-- Sizes are `Npx` or `Fill`. `position: Xpx, Ypx` takes a node out of flow at exact pixel coords.
+- Sizes are `Npx` or `Fill`. `position: Xpx, Ypx` takes a node out of flow at exact absolute
+  surface coordinates. A top-level positioned node must remain inside the padded content box; a
+  positioned Row child must remain inside that Row's already-resolved absolute band.
 - **One property per line.** The sibling implementation parses a component body line by line and
   splits each on its first `:`, so `width: 512px; height: 512px;` on one line is read as a width of
   `512px; height: 512px` and rejected. This example previously showed that form; it was condensed

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
-| `MduXMeduiLib` | Partial | `.medui` parsing and semantic validation; layout, packaging, and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, and integer-only bounded layout; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), and component/theme/locale semantic analyzer (#193) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), and integer-only bounded layout solver (#194) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing and semantic validation are implemented; layout, packaging, and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, and bounded layout are implemented; packaging and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,7 +1,7 @@
 repository = "https://github.com/Compliatory/MedUI"
 version = "0.1.0"
 commit = "d5136a8518bd499760ecff2aad215d3721329f20"
-capabilities = ["syntax", "semantics"]
+capabilities = ["syntax", "semantics", "layout"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.
 positions = "full"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,7 +674,7 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issues #191, #192, #193)
+# .medui compiler host-tools suite (issues #191, #192, #193, #194)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
 # completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
@@ -686,6 +686,7 @@ add_executable(medui_tools_spec
     medui/DiagnosticsTests.cpp
     medui/ParserTests.cpp
     medui/SemanticTests.cpp
+    medui/LayoutTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/medui/LayoutTests.cpp
+++ b/tests/medui/LayoutTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @file LayoutTests.cpp
  * @brief BDD scenarios for bounded integer `.medui` layout (issue #194).
+ * @file LayoutTests.cpp
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary
@@ -26,6 +26,7 @@ static_assert(std::integral<decltype(md::LayoutRect::y)>);
 static_assert(std::integral<decltype(md::LayoutRect::width)>);
 static_assert(std::integral<decltype(md::LayoutRect::height)>);
 
+/// Reads one real authoring fixture from the repository corpus.
 [[nodiscard]] std::string fixture(std::string_view name) {
     const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
     std::ifstream               in{path, std::ios::binary};
@@ -38,6 +39,7 @@ static_assert(std::integral<decltype(md::LayoutRect::height)>);
     return buffer.str();
 }
 
+/// Parses and resolves a test source against explicit build dimensions.
 [[nodiscard]] md::LayoutResult layout(std::string_view source, std::int64_t width, std::int64_t height) {
     md::ParseResult parsed = md::parse(source, "layout.medui");
     if (!parsed.screen || !parsed.diagnostics.empty()) {
@@ -46,6 +48,7 @@ static_assert(std::integral<decltype(md::LayoutRect::height)>);
     return md::resolveLayout(*parsed.screen, "layout.medui", {.surfaceWidth = width, .surfaceHeight = height});
 }
 
+/// Finds one registered diagnostic in a layout result.
 [[nodiscard]] const cli::Diagnostic* find(const md::LayoutResult& result, md::Code code) {
     const std::string_view wanted = md::id(code);
     const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
@@ -54,6 +57,7 @@ static_assert(std::integral<decltype(md::LayoutRect::height)>);
     return found == result.diagnostics.end() ? nullptr : &*found;
 }
 
+/// Wraps component text in a minimal 100x100 Vertical screen by default.
 [[nodiscard]] std::string sourceWithBody(std::string_view body, std::int64_t width = 100, std::int64_t height = 100) {
     return std::format("Screen Test {{\n"
                        "    layout: Vertical {{ spacing: 0px; padding: 0px; }}\n"
@@ -130,6 +134,144 @@ const mdux::spec::Register positionedNodesLeaveFlow{"An explicitly positioned no
                                                             .Execute();
                                                     }};
 
+const mdux::spec::Register positionedNodeMustFitSurface{"A positioned node must remain inside the content box", "evidence-unit", [] {
+                                                            return speclab::Test("medui-layout-positioned-surface-containment")
+                                                                .Given("a 20px node at 81px,80px on a 100px square surface", [] {})
+                                                                .When("the positioned rectangle is checked", [] {})
+                                                                .Then("MEDUI-E052 is fail-closed with no resolved nodes",
+                                                                      [] {
+                                                                          mdux::spec::Checks checks;
+                                                                          const std::string  source = sourceWithBody(
+                                                                              "    Label { id: outside; width: 20px; height: 20px; "
+                                                                               "position: 81px, 80px; text: t(\"STR-OUTSIDE\"); "
+                                                                               "color: Theme.Colors.Title; }\n");
+                                                                          const md::LayoutResult result = layout(source, 100, 100);
+                                                                          checks.expect(find(result, md::Code::SurfaceExceeded) != nullptr,
+                                                                                        "MEDUI-E052 is reported");
+                                                                          checks.expect(!result.ok() && result.nodes.empty(),
+                                                                                        "the rejected screen exposes no partial layout");
+                                                                          checks.raise();
+                                                                      })
+                                                                .Execute();
+                                                        }};
+
+const mdux::spec::Register positionedNodeMustHaveArea{"A positioned node cannot have a zero fixed dimension", "evidence-unit", [] {
+                                                          return speclab::Test("medui-layout-positioned-positive-size")
+                                                              .Given("a positioned node with width 0px", [] {})
+                                                              .When("dimension preflight runs", [] {})
+                                                              .Then("MEDUI-E051 rejects the degenerate rectangle",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+                                                                        const std::string  source = sourceWithBody(
+                                                                            "    Label { id: ghost; width: 0px; height: 20px; "
+                                                                             "position: 10px, 10px; text: t(\"STR-GHOST\"); "
+                                                                             "color: Theme.Colors.Title; }\n");
+                                                                        const md::LayoutResult result = layout(source, 100, 100);
+                                                                        checks.expect(find(result, md::Code::LayoutOverflow) != nullptr,
+                                                                                      "MEDUI-E051 is reported");
+                                                                        checks.expect(!result.ok() && result.nodes.empty(),
+                                                                                      "no zero-area rectangle is emitted");
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register rowPositionsAreSurfaceAbsolute{"A positioned Row child uses absolute surface coordinates", "evidence-unit", [] {
+                                                              return speclab::Test("medui-layout-row-position-absolute")
+                                                                  .Given("padding and a preceding flow item place a Row at y=35", [] {})
+                                                                  .When("a Row child is positioned at the Row's absolute origin", [] {})
+                                                                  .Then(
+                                                                      "the authored 10,35 coordinates are preserved",
+                                                                      [] {
+                                                                          mdux::spec::Checks     checks;
+                                                                          const std::string      source = "Screen Test {\n"
+                                                                                                          "    layout: Vertical { spacing: 5px; padding: 10px; }\n"
+                                                                                                          "    surface: 100px, 100px;\n"
+                                                                                                          "    Label { id: before; width: Fill; height: 20px; "
+                                                                                                          "text: t(\"STR-BEFORE\"); color: Theme.Colors.Title; }\n"
+                                                                                                          "    Row { id: row; height: 20px; Label { id: pinned; "
+                                                                                                          "width: 20px; height: 20px; position: 10px, 35px; "
+                                                                                                          "text: t(\"STR-PINNED\"); color: Theme.Colors.Title; } }\n"
+                                                                                                          "}\n";
+                                                                          const md::LayoutResult result = layout(source, 100, 100);
+                                                                          checks.expect(result.ok(), "the absolute Row position is contained");
+                                                                          checks.expect(result.nodes.size() == 2, "the Row itself is flattened away");
+                                                                          if (result.nodes.size() == 2) {
+                                                                              checks.expect(result.nodes[1].bounds == md::LayoutRect{10, 35, 20, 20},
+                                                                                            "the Row child keeps absolute surface coordinates");
+                                                                          }
+                                                                          checks.raise();
+                                                                      })
+                                                                  .Execute();
+                                                          }};
+
+const mdux::spec::Register paddingMustLeaveContent{"Padding exactly half the surface is rejected", "evidence-unit", [] {
+                                                       return speclab::Test("medui-layout-padding-content-box")
+                                                           .Given("an empty 100px square screen with padding 50px", [] {})
+                                                           .When("the padded content box is validated", [] {})
+                                                           .Then("MEDUI-E052 reports the zero-sized box at the layout",
+                                                                 [] {
+                                                                     mdux::spec::Checks     checks;
+                                                                     const std::string      source = "Screen Test {\n"
+                                                                                                     "    layout: Vertical { spacing: 0px; padding: 50px; }\n"
+                                                                                                     "    surface: 100px, 100px;\n"
+                                                                                                     "}\n";
+                                                                     const md::LayoutResult result = layout(source, 100, 100);
+                                                                     checks.expect(find(result, md::Code::SurfaceExceeded) != nullptr,
+                                                                                   "MEDUI-E052 is reported");
+                                                                     checks.expect(!result.ok() && result.nodes.empty(),
+                                                                                   "a zero-sized content box is not accepted");
+                                                                     checks.raise();
+                                                                 })
+                                                           .Execute();
+                                                   }};
+
+const mdux::spec::Register surfacePinMustMatchBuild{"An authored surface pin must match the build surface", "evidence-unit", [] {
+                                                        return speclab::Test("medui-layout-surface-pin")
+                                                            .Given("a source declaring 100x100 and a build selecting 101x100", [] {})
+                                                            .When("surface validation runs", [] {})
+                                                            .Then("MEDUI-E052 rejects the mismatch",
+                                                                  [] {
+                                                                      mdux::spec::Checks     checks;
+                                                                      const std::string      source = sourceWithBody("");
+                                                                      const md::LayoutResult result = layout(source, 101, 100);
+                                                                      checks.expect(find(result, md::Code::SurfaceExceeded) != nullptr,
+                                                                                    "MEDUI-E052 is reported");
+                                                                      checks.expect(!result.ok() && result.nodes.empty(),
+                                                                                    "the mismatched build cannot consume a layout");
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register fillSharesMatchReference{
+    "Fill uses equal integer shares like the reference implementation",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-fill-equal-shares")
+            .Given("two Fill children sharing a 101px Row", [] {})
+            .When("the indivisible remainder is resolved", [] {})
+            .Then("both receive 50px and the final pixel remains unused",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const std::string      source = sourceWithBody("    Row { id: row; height: 20px; "
+                                                                     "Label { id: first; width: Fill; height: 20px; "
+                                                                     "text: t(\"STR-FIRST\"); color: Theme.Colors.Title; } "
+                                                                     "Label { id: second; width: Fill; height: 20px; "
+                                                                     "text: t(\"STR-SECOND\"); color: Theme.Colors.Title; } }\n",
+                                                                101,
+                                                                100);
+                      const md::LayoutResult result = layout(source, 101, 100);
+                      checks.expect(result.ok() && result.nodes.size() == 2, "the Row resolves to two leaves");
+                      if (result.nodes.size() == 2) {
+                          checks.expect(result.nodes[0].bounds == md::LayoutRect{0, 0, 50, 20}, "the first Fill receives the equal integer share");
+                          checks.expect(result.nodes[1].bounds == md::LayoutRect{50, 0, 50, 20}, "the second Fill receives the same share");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register positionedFillIsRejected{"A positioned component cannot use Fill", "evidence-unit", [] {
                                                         return speclab::Test("medui-layout-positioned-fill")
                                                             .Given("a component whose exact position contradicts a Fill width", [] {})
@@ -167,11 +309,13 @@ const mdux::spec::Register wideRowChildIsRejected{"A Row child wider than its pa
                                                                 [] {
                                                                     mdux::spec::Checks checks;
                                                                     const std::string  source = sourceWithBody(
-                                                                        "    Row { id: row; height: 20px; Label { id: title; width: 101px; "
+                                                                        "    Row { id: row; height: 20px; background: Theme.Colors.TopbarBackground; "
+                                                                         "Label { id: title; width: 101px; "
                                                                          "height: 20px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; } }\n");
                                                                     const md::LayoutResult result = layout(source, 100, 100);
                                                                     checks.expect(find(result, md::Code::LayoutOverflow) != nullptr, "MEDUI-E051 is reported");
-                                                                    checks.expect(result.nodes.empty(), "no child rectangle is emitted");
+                                                                    checks.expect(result.nodes.empty(),
+                                                                                  "the failed Row returns neither its Panel nor a child rectangle");
                                                                     checks.raise();
                                                                 })
                                                           .Execute();
@@ -198,26 +342,34 @@ const mdux::spec::Register fillWithoutRoomIsRejected{"Fill with no remaining pix
                                                              .Execute();
                                                      }};
 
-const mdux::spec::Register positionedOverlapIsRejected{"A positioned component cannot overlap a flow component", "evidence-unit", [] {
-                                                           return speclab::Test("medui-layout-positioned-overlap")
-                                                               .Given("a positioned rectangle crossing an ordinary flow rectangle", [] {})
-                                                               .When("the flat layout is checked", [] {})
-                                                               .Then("MEDUI-E051 rejects the overlap",
-                                                                     [] {
-                                                                         mdux::spec::Checks checks;
-                                                                         const std::string  source = sourceWithBody(
-                                                                             "    Label { id: flow; width: Fill; height: 30px; text: t(\"STR-FLOW\"); "
-                                                                             "color: Theme.Colors.Title; }\n"
-                                                                             "    Label { id: pinned; width: 20px; height: 20px; position: 10px, 10px; "
-                                                                             "text: t(\"STR-PINNED\"); color: Theme.Colors.Title; }\n");
-                                                                         const md::LayoutResult result = layout(source, 100, 100);
-                                                                         checks.expect(find(result, md::Code::LayoutOverflow) != nullptr,
-                                                                                       "MEDUI-E051 is reported");
-                                                                         checks.expect(!result.ok(), "overlap is not accepted as a compiled layout");
-                                                                         checks.raise();
-                                                                     })
-                                                               .Execute();
-                                                       }};
+const mdux::spec::Register positionedOverlapIsRejected{
+    "An authored Panel name cannot bypass positioned overlap checks",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-positioned-overlap")
+            .Given("a directly-built AST naming an overlapping positioned leaf Panel", [] {})
+            .When("the flat layout is checked", [] {})
+            .Then("MEDUI-E051 rejects the overlap",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string  source = sourceWithBody("    Label { id: flow; width: Fill; height: 30px; text: t(\"STR-FLOW\"); "
+                                                                 "color: Theme.Colors.Title; }\n"
+                                                                 "    Label { id: pinned; width: 20px; height: 20px; position: 10px, 10px; "
+                                                                 "text: t(\"STR-PINNED\"); color: Theme.Colors.Title; }\n");
+                      md::ParseResult    parsed = md::parse(source, "layout.medui");
+                      if (!parsed.screen || parsed.screen->nodes.size() != 2) {
+                          checks.expect(false, "the overlap fixture parses to two nodes");
+                          checks.raise();
+                          return;
+                      }
+                      parsed.screen->nodes[1].component = "Panel";
+                      const md::LayoutResult result     = md::resolveLayout(*parsed.screen, "layout.medui", {.surfaceWidth = 100, .surfaceHeight = 100});
+                      checks.expect(find(result, md::Code::LayoutOverflow) != nullptr, "MEDUI-E051 is reported");
+                      checks.expect(!result.ok(), "overlap is not accepted as a compiled layout");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
 
 const mdux::spec::Register syntheticIdsAreRechecked{"Synthetic Row background IDs participate in uniqueness", "evidence-unit", [] {
                                                         return speclab::Test("medui-layout-synthetic-id-uniqueness")
@@ -228,10 +380,10 @@ const mdux::spec::Register syntheticIdsAreRechecked{"Synthetic Row background ID
                                                                       mdux::spec::Checks checks;
                                                                       const std::string  source = sourceWithBody(
                                                                           "    Row { id: topbar; height: 20px; background: Theme.Colors.TopbarBackground; "
-                                                                          "Label { id: title; width: Fill; height: 20px; text: t(\"STR-TITLE\"); "
-                                                                          "color: Theme.Colors.Title; } }\n"
-                                                                          "    Label { id: topbar-background; width: Fill; height: 20px; "
-                                                                          "text: t(\"STR-OTHER\"); color: Theme.Colors.Title; }\n");
+                                                                           "Label { id: title; width: Fill; height: 20px; text: t(\"STR-TITLE\"); "
+                                                                           "color: Theme.Colors.Title; } }\n"
+                                                                           "    Label { id: topbar-background; width: Fill; height: 20px; "
+                                                                           "text: t(\"STR-OTHER\"); color: Theme.Colors.Title; }\n");
                                                                       const md::LayoutResult result = layout(source, 100, 100);
                                                                       checks.expect(find(result, md::Code::DuplicateNodeId) != nullptr,
                                                                                     "MEDUI-E014 is reported after synthesis");

--- a/tests/medui/LayoutTests.cpp
+++ b/tests/medui/LayoutTests.cpp
@@ -371,27 +371,33 @@ const mdux::spec::Register positionedOverlapIsRejected{
             .Execute();
     }};
 
-const mdux::spec::Register syntheticIdsAreRechecked{"Synthetic Row background IDs participate in uniqueness", "evidence-unit", [] {
-                                                        return speclab::Test("medui-layout-synthetic-id-uniqueness")
-                                                            .Given("an authored id colliding with <row-id>-background", [] {})
-                                                            .When("the Row background Panel is synthesized", [] {})
-                                                            .Then("MEDUI-E014 rejects the duplicate resolved id",
-                                                                  [] {
-                                                                      mdux::spec::Checks checks;
-                                                                      const std::string  source = sourceWithBody(
-                                                                          "    Row { id: topbar; height: 20px; background: Theme.Colors.TopbarBackground; "
-                                                                           "Label { id: title; width: Fill; height: 20px; text: t(\"STR-TITLE\"); "
-                                                                           "color: Theme.Colors.Title; } }\n"
-                                                                           "    Label { id: topbar-background; width: Fill; height: 20px; "
-                                                                           "text: t(\"STR-OTHER\"); color: Theme.Colors.Title; }\n");
-                                                                      const md::LayoutResult result = layout(source, 100, 100);
-                                                                      checks.expect(find(result, md::Code::DuplicateNodeId) != nullptr,
-                                                                                    "MEDUI-E014 is reported after synthesis");
-                                                                      checks.expect(!result.ok(), "the colliding flat node set is rejected");
-                                                                      checks.raise();
-                                                                  })
-                                                            .Execute();
-                                                    }};
+const mdux::spec::Register syntheticIdsAreRechecked{
+    "Synthetic Row background IDs participate in uniqueness",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-synthetic-id-uniqueness")
+            .Given("an authored id colliding with <row-id>-background", [] {})
+            .When("the Row background Panel is synthesized", [] {})
+            .Then("MEDUI-E014 rejects the duplicate resolved id",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const std::string      source     = sourceWithBody("    Row { id: topbar; height: 20px; background: Theme.Colors.TopbarBackground; "
+                                                                         "Label { id: title; width: Fill; height: 20px; text: t(\"STR-TITLE\"); "
+                                                                         "color: Theme.Colors.Title; } }\n"
+                                                                         "    Label { id: topbar-background; width: Fill; height: 20px; "
+                                                                         "text: t(\"STR-OTHER\"); color: Theme.Colors.Title; }\n");
+                      const md::LayoutResult result     = layout(source, 100, 100);
+                      const cli::Diagnostic* diagnostic = find(result, md::Code::DuplicateNodeId);
+                      checks.expect(diagnostic != nullptr, "MEDUI-E014 is reported after synthesis");
+                      if (diagnostic != nullptr) {
+                          checks.expect(diagnostic->line == 5 && diagnostic->column == 13,
+                                        std::format("the authored colliding id is 5:13, got {}:{}", diagnostic->line, diagnostic->column));
+                      }
+                      checks.expect(!result.ok(), "the colliding flat node set is rejected");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
 
 const mdux::spec::Register nestedRowInvariantIsChecked{
     "The solver checks the parser's single-Row-level invariant",

--- a/tests/medui/LayoutTests.cpp
+++ b/tests/medui/LayoutTests.cpp
@@ -1,0 +1,268 @@
+/**
+ * @file LayoutTests.cpp
+ * @brief BDD scenarios for bounded integer `.medui` layout (issue #194).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.parser;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+static_assert(std::integral<decltype(md::LayoutRect::x)>);
+static_assert(std::integral<decltype(md::LayoutRect::y)>);
+static_assert(std::integral<decltype(md::LayoutRect::width)>);
+static_assert(std::integral<decltype(md::LayoutRect::height)>);
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+    std::ifstream               in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened at {}", name, path.generic_string()),
+                                              std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] md::LayoutResult layout(std::string_view source, std::int64_t width, std::int64_t height) {
+    md::ParseResult parsed = md::parse(source, "layout.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("layout test source did not parse", std::source_location::current());
+    }
+    return md::resolveLayout(*parsed.screen, "layout.medui", {.surfaceWidth = width, .surfaceHeight = height});
+}
+
+[[nodiscard]] const cli::Diagnostic* find(const md::LayoutResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    });
+    return found == result.diagnostics.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] std::string sourceWithBody(std::string_view body, std::int64_t width = 100, std::int64_t height = 100) {
+    return std::format("Screen Test {{\n"
+                       "    layout: Vertical {{ spacing: 0px; padding: 0px; }}\n"
+                       "    surface: {}px, {}px;\n"
+                       "{}"
+                       "}}\n",
+                       width,
+                       height,
+                       body);
+}
+
+}  // namespace
+
+const mdux::spec::Register handDerivedRectangles{
+    "Vertical and Row layout resolves to hand-derived absolute rectangles",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-hand-derived")
+            .Given("a 1280x720 screen with padding, spacing, fixed sizes and Fill", [] {})
+            .When("the single-level Row and vertical flow are resolved", [] {})
+            .Then("the Row is flat and every integer rectangle matches the derivation",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const md::LayoutResult result = layout(fixture("accepted-layout.medui"), 1280, 720);
+                      checks.expect(result.ok(), "layout succeeds");
+
+                      const std::vector<std::pair<std::string_view, md::LayoutRect>> expected{
+                          {"topbar-background",   {16, 16, 1248, 48}},
+                          {            "title",    {16, 16, 340, 48}},
+                          {            "clock",   {372, 16, 676, 48}},
+                          {           "status",  {1064, 16, 200, 48}},
+                          {            "score",  {16, 72, 1248, 120}},
+                          {         "viewport", {16, 200, 1248, 504}},
+                      };
+                      checks.expect(result.nodes.size() == expected.size(), std::format("six flat entries, got {}", result.nodes.size()));
+                      for (std::size_t index = 0; index < std::min(result.nodes.size(), expected.size()); ++index) {
+                          checks.expect(result.nodes[index].id == expected[index].first, std::format("entry {} id is {}", index, expected[index].first));
+                          checks.expect(result.nodes[index].bounds == expected[index].second,
+                                        std::format("{} has its hand-derived rectangle", expected[index].first));
+                          checks.expect(result.nodes[index].component != "Row", std::format("{} is not a Row container", expected[index].first));
+                      }
+                      if (!result.nodes.empty()) {
+                          checks.expect(result.nodes.front().component == "Panel" && result.nodes.front().synthetic,
+                                        "the Row background becomes a synthetic Panel underlay");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register positionedNodesLeaveFlow{"An explicitly positioned node does not advance the flow cursor", "evidence-unit", [] {
+                                                        return speclab::Test("medui-layout-positioned-out-of-flow")
+                                                            .Given("one positioned node followed by one ordinary flow node", [] {})
+                                                            .When("the vertical layout is resolved", [] {})
+                                                            .Then("the flow node still begins at the padded origin",
+                                                                  [] {
+                                                                      mdux::spec::Checks checks;
+                                                                      const std::string  source = sourceWithBody(
+                                                                          "    Label { id: pinned; width: 20px; height: 20px; position: 80px, 80px; "
+                                                                           "text: t(\"STR-PINNED\"); color: Theme.Colors.Title; }\n"
+                                                                           "    Label { id: flow; width: Fill; height: 20px; text: t(\"STR-FLOW\"); "
+                                                                           "color: Theme.Colors.Title; }\n");
+                                                                      const md::LayoutResult result = layout(source, 100, 100);
+                                                                      checks.expect(result.ok(), "layout succeeds");
+                                                                      checks.expect(result.nodes.size() == 2, "both leaves are emitted");
+                                                                      if (result.nodes.size() == 2) {
+                                                                          checks.expect(result.nodes[0].bounds == md::LayoutRect{80, 80, 20, 20},
+                                                                                        "the positioned rectangle is absolute");
+                                                                          checks.expect(result.nodes[1].bounds == md::LayoutRect{0, 0, 100, 20},
+                                                                                        "the flow cursor was not advanced by the positioned node");
+                                                                      }
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register positionedFillIsRejected{"A positioned component cannot use Fill", "evidence-unit", [] {
+                                                        return speclab::Test("medui-layout-positioned-fill")
+                                                            .Given("a component whose exact position contradicts a Fill width", [] {})
+                                                            .When("layout preflight runs", [] {})
+                                                            .Then("MEDUI-E051 points at position rather than inventing a rectangle",
+                                                                  [] {
+                                                                      mdux::spec::Checks     checks;
+                                                                      const std::string      source     = sourceWithBody("    Label {\n"
+                                                                                                                         "        id: title;\n"
+                                                                                                                         "        width: Fill;\n"
+                                                                                                                         "        height: 20px;\n"
+                                                                                                                         "        position: 0px, 0px;\n"
+                                                                                                                         "        text: t(\"STR-TITLE\");\n"
+                                                                                                                         "        color: Theme.Colors.Title;\n"
+                                                                                                                         "    }\n");
+                                                                      const md::LayoutResult result     = layout(source, 100, 100);
+                                                                      const cli::Diagnostic* diagnostic = find(result, md::Code::LayoutOverflow);
+                                                                      checks.expect(!result.ok() && result.nodes.empty(), "no partial rectangle is returned");
+                                                                      checks.expect(diagnostic != nullptr, "MEDUI-E051 is reported");
+                                                                      if (diagnostic != nullptr) {
+                                                                          checks.expect(
+                                                                              diagnostic->line == 8 && diagnostic->column == 9,
+                                                                              std::format("position is 8:9, got {}:{}", diagnostic->line, diagnostic->column));
+                                                                      }
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register wideRowChildIsRejected{"A Row child wider than its parent is rejected rather than clamped", "evidence-unit", [] {
+                                                      return speclab::Test("medui-layout-wide-row-child")
+                                                          .Given("a 101px child in a 100px Row", [] {})
+                                                          .When("the Row axis is resolved", [] {})
+                                                          .Then("MEDUI-E051 is emitted and no rectangle is clamped",
+                                                                [] {
+                                                                    mdux::spec::Checks checks;
+                                                                    const std::string  source = sourceWithBody(
+                                                                        "    Row { id: row; height: 20px; Label { id: title; width: 101px; "
+                                                                         "height: 20px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; } }\n");
+                                                                    const md::LayoutResult result = layout(source, 100, 100);
+                                                                    checks.expect(find(result, md::Code::LayoutOverflow) != nullptr, "MEDUI-E051 is reported");
+                                                                    checks.expect(result.nodes.empty(), "no child rectangle is emitted");
+                                                                    checks.raise();
+                                                                })
+                                                          .Execute();
+                                                  }};
+
+const mdux::spec::Register fillWithoutRoomIsRejected{"Fill with no remaining pixels is rejected rather than resolved to zero", "evidence-unit", [] {
+                                                         return speclab::Test("medui-layout-fill-no-room")
+                                                             .Given("a fixed-height item consuming the entire surface before a Fill item", [] {})
+                                                             .When("the vertical axis is resolved", [] {})
+                                                             .Then("MEDUI-E051 is emitted before any partial layout",
+                                                                   [] {
+                                                                       mdux::spec::Checks checks;
+                                                                       const std::string  source = sourceWithBody(
+                                                                           "    Label { id: fixed; width: Fill; height: 100px; text: t(\"STR-FIXED\"); "
+                                                                            "color: Theme.Colors.Title; }\n"
+                                                                            "    Label { id: fill; width: Fill; height: Fill; text: t(\"STR-FILL\"); "
+                                                                            "color: Theme.Colors.Title; }\n");
+                                                                       const md::LayoutResult result = layout(source, 100, 100);
+                                                                       checks.expect(find(result, md::Code::LayoutOverflow) != nullptr,
+                                                                                     "MEDUI-E051 is reported");
+                                                                       checks.expect(result.nodes.empty(), "the failed axis produces no partial layout");
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};
+
+const mdux::spec::Register positionedOverlapIsRejected{"A positioned component cannot overlap a flow component", "evidence-unit", [] {
+                                                           return speclab::Test("medui-layout-positioned-overlap")
+                                                               .Given("a positioned rectangle crossing an ordinary flow rectangle", [] {})
+                                                               .When("the flat layout is checked", [] {})
+                                                               .Then("MEDUI-E051 rejects the overlap",
+                                                                     [] {
+                                                                         mdux::spec::Checks checks;
+                                                                         const std::string  source = sourceWithBody(
+                                                                             "    Label { id: flow; width: Fill; height: 30px; text: t(\"STR-FLOW\"); "
+                                                                             "color: Theme.Colors.Title; }\n"
+                                                                             "    Label { id: pinned; width: 20px; height: 20px; position: 10px, 10px; "
+                                                                             "text: t(\"STR-PINNED\"); color: Theme.Colors.Title; }\n");
+                                                                         const md::LayoutResult result = layout(source, 100, 100);
+                                                                         checks.expect(find(result, md::Code::LayoutOverflow) != nullptr,
+                                                                                       "MEDUI-E051 is reported");
+                                                                         checks.expect(!result.ok(), "overlap is not accepted as a compiled layout");
+                                                                         checks.raise();
+                                                                     })
+                                                               .Execute();
+                                                       }};
+
+const mdux::spec::Register syntheticIdsAreRechecked{"Synthetic Row background IDs participate in uniqueness", "evidence-unit", [] {
+                                                        return speclab::Test("medui-layout-synthetic-id-uniqueness")
+                                                            .Given("an authored id colliding with <row-id>-background", [] {})
+                                                            .When("the Row background Panel is synthesized", [] {})
+                                                            .Then("MEDUI-E014 rejects the duplicate resolved id",
+                                                                  [] {
+                                                                      mdux::spec::Checks checks;
+                                                                      const std::string  source = sourceWithBody(
+                                                                          "    Row { id: topbar; height: 20px; background: Theme.Colors.TopbarBackground; "
+                                                                          "Label { id: title; width: Fill; height: 20px; text: t(\"STR-TITLE\"); "
+                                                                          "color: Theme.Colors.Title; } }\n"
+                                                                          "    Label { id: topbar-background; width: Fill; height: 20px; "
+                                                                          "text: t(\"STR-OTHER\"); color: Theme.Colors.Title; }\n");
+                                                                      const md::LayoutResult result = layout(source, 100, 100);
+                                                                      checks.expect(find(result, md::Code::DuplicateNodeId) != nullptr,
+                                                                                    "MEDUI-E014 is reported after synthesis");
+                                                                      checks.expect(!result.ok(), "the colliding flat node set is rejected");
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register nestedRowInvariantIsChecked{
+    "The solver checks the parser's single-Row-level invariant",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-nested-row-invariant")
+            .Given("a directly-mutated AST that bypasses the nested Row parser rejection", [] {})
+            .When("the layout boundary receives it", [] {})
+            .Then("it fails loudly in every build configuration",
+                  [] {
+                      mdux::spec::Checks checks;
+                      md::ParseResult    parsed = md::parse(fixture("accepted-layout.medui"), "accepted-layout.medui");
+                      bool               threw  = false;
+                      if (parsed.screen && !parsed.screen->nodes.empty() && !parsed.screen->nodes.front().children.empty()) {
+                          parsed.screen->nodes.front().children.front().component = "Row";
+                          try {
+                              static_cast<void>(md::resolveLayout(*parsed.screen, "accepted-layout.medui", {.surfaceWidth = 1280, .surfaceHeight = 720}));
+                          } catch (const std::logic_error&) {
+                              threw = true;
+                          }
+                      }
+                      checks.expect(threw, "a nested Row cannot silently reach the flattening pass");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -19,10 +19,11 @@
  *   and must be backed by a case that really executed. Claiming a phase with no adapter fails
  *   here instead of passing quietly.
  *
- * Syntax and semantics are observable: `md::parse` answers syntax acceptance, and `md::analyze`
- * checks the portable theme-token and per-locale key views in semantic case inputs. Claiming
- * `layout` or `safety` still needs the solver (#194) and golden pass (#196), so a claim to either
- * is rejected below rather than silently evaluated by a stage that cannot see it.
+ * Syntax, semantics and layout are observable: `md::parse` answers syntax acceptance,
+ * `md::analyze` checks the portable theme-token and per-locale key views in semantic case inputs,
+ * and `md::resolveLayout` runs the integer-only bounded solver. Claiming `safety` still needs the
+ * golden pass (#196), so that claim is rejected below rather than silently evaluated by a stage
+ * that cannot see it.
  */
 
 import std;
@@ -32,6 +33,7 @@ import mdux.evidence.json;
 import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
 import mdux.tools.medui.parser;
 import mdux.tools.medui.semantic;
 import mdux.tools.toml;
@@ -47,7 +49,7 @@ namespace toml = mdux::tools::toml;
 
 /// Phases this file can genuinely observe. Anything else in `capabilities` is a claim with no
 /// adapter behind it.
-constexpr std::array<std::string_view, 2> runnableCapabilities{"syntax", "semantics"};
+constexpr std::array<std::string_view, 3> runnableCapabilities{"syntax", "semantics", "layout"};
 
 [[noreturn]] void fail(std::string message, std::source_location where = std::source_location::current()) {
     throw speclab::core::AssertionFailure(std::move(message), where);
@@ -597,6 +599,12 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
 
         md::SemanticResult semantic = md::analyze(*parsed.screen, file, md::SemanticInputs{.themeTokens = themeTokens, .textPackages = packages});
         diagnostics.insert(diagnostics.end(), std::make_move_iterator(semantic.diagnostics.begin()), std::make_move_iterator(semantic.diagnostics.end()));
+    }
+    if (item.phase == "layout" && parsed.screen) {
+        const std::int64_t width    = parsed.screen->surface ? parsed.screen->surface->x : 800;
+        const std::int64_t height   = parsed.screen->surface ? parsed.screen->surface->y : 600;
+        md::LayoutResult   resolved = md::resolveLayout(*parsed.screen, file, {.surfaceWidth = width, .surfaceHeight = height});
+        diagnostics.insert(diagnostics.end(), std::make_move_iterator(resolved.diagnostics.begin()), std::make_move_iterator(resolved.diagnostics.end()));
     }
 
     const bool accepted = parsed.screen.has_value() && diagnostics.empty();

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @file SharedConformanceTests.cpp
  * @brief The pinned `Compliatory/MedUI` conformance cases, run against this parser.
+ * @file SharedConformanceTests.cpp
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary
@@ -32,6 +32,7 @@ import mdux.core.result;
 import mdux.evidence.json;
 import mdux.text.schema;
 import mdux.tools.cli;
+import mdux.tools.medui.ast;
 import mdux.tools.medui.diagnostics;
 import mdux.tools.medui.layout;
 import mdux.tools.medui.parser;
@@ -534,6 +535,32 @@ void checkComponentDictionary(const std::filesystem::path& checkout, mdux::spec:
     return joined;
 }
 
+/// Collects authored external names so layout cases can pass the semantic shape gate without
+/// inventing theme or locale failures that belong to the semantics phase.
+void collectLayoutSemanticNames(const md::ast::Node& node, std::set<std::string>& themeTokens, std::set<std::string>& textKeys) {
+    const auto collectValue = [&](auto&& self, const md::ast::Value& value) -> void {
+        if (value.kind == md::ast::ValueKind::ColorToken) {
+            themeTokens.insert(value.text);
+        } else if (value.kind == md::ast::ValueKind::TextKey) {
+            textKeys.insert(value.text);
+        }
+        for (const std::shared_ptr<md::ast::Value>& element : value.list) {
+            if (element != nullptr) {
+                self(self, *element);
+            }
+        }
+    };
+
+    for (const md::ast::Field& field : node.fields) {
+        if (field.value != nullptr) {
+            collectValue(collectValue, *field.value);
+        }
+    }
+    for (const md::ast::Node& child : node.children) {
+        collectLayoutSemanticNames(child, themeTokens, textKeys);
+    }
+}
+
 /// `spec/diagnostics.md`, "Positions in conformance cases": a pinned position is matched as far as
 /// the declared precision goes, and reporting more than was declared fails. The declaration is
 /// checked rather than tolerated, so precision cannot move in either direction without a manifest
@@ -600,11 +627,45 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
         md::SemanticResult semantic = md::analyze(*parsed.screen, file, md::SemanticInputs{.themeTokens = themeTokens, .textPackages = packages});
         diagnostics.insert(diagnostics.end(), std::make_move_iterator(semantic.diagnostics.begin()), std::make_move_iterator(semantic.diagnostics.end()));
     }
-    if (item.phase == "layout" && parsed.screen) {
-        const std::int64_t width    = parsed.screen->surface ? parsed.screen->surface->x : 800;
-        const std::int64_t height   = parsed.screen->surface ? parsed.screen->surface->y : 600;
-        md::LayoutResult   resolved = md::resolveLayout(*parsed.screen, file, {.surfaceWidth = width, .surfaceHeight = height});
-        diagnostics.insert(diagnostics.end(), std::make_move_iterator(resolved.diagnostics.begin()), std::make_move_iterator(resolved.diagnostics.end()));
+    if (item.phase == "layout" && parsed.screen && diagnostics.empty()) {
+        std::set<std::string> themeTokenStorage;
+        std::set<std::string> textKeyStorage;
+        for (const md::ast::Node& node : parsed.screen->nodes) {
+            collectLayoutSemanticNames(node, themeTokenStorage, textKeyStorage);
+        }
+
+        std::vector<std::string_view> themeTokens;
+        themeTokens.reserve(themeTokenStorage.size());
+        for (const std::string& token : themeTokenStorage) {
+            themeTokens.push_back(token);
+        }
+
+        mdux::text::TextPackage textPackage;
+        textPackage.header.id   = "shared-layout-semantic-gate";
+        textPackage.atlasId     = "shared-layout-atlas";
+        textPackage.locale      = "shared-layout-locale";
+        textPackage.sidecarPath = "runs.bin";
+        for (const std::string& key : textKeyStorage) {
+            textPackage.runs.push_back(mdux::text::TextRun{.id = key, .byteOffset = 0, .byteLength = 0, .sha256 = {}});
+        }
+        const std::array textPackages{textPackage};
+
+        md::SemanticResult semantic = md::analyze(*parsed.screen, file, md::SemanticInputs{.themeTokens = themeTokens, .textPackages = textPackages});
+        diagnostics.insert(diagnostics.end(), std::make_move_iterator(semantic.diagnostics.begin()), std::make_move_iterator(semantic.diagnostics.end()));
+
+        if (diagnostics.empty()) {
+            // The shared schema has no build-surface input. Use a declared surface when present;
+            // otherwise pass the honest "unspecified" sentinel. Preflight findings such as
+            // positioned Fill remain observable, while a case that needs actual resolution must
+            // declare dimensions rather than inherit a local 800x600 invention.
+            md::LayoutInputs inputs{};
+            if (parsed.screen->surface) {
+                inputs.surfaceWidth  = parsed.screen->surface->x;
+                inputs.surfaceHeight = parsed.screen->surface->y;
+            }
+            md::LayoutResult resolved = md::resolveLayout(*parsed.screen, file, inputs);
+            diagnostics.insert(diagnostics.end(), std::make_move_iterator(resolved.diagnostics.begin()), std::make_move_iterator(resolved.diagnostics.end()));
+        }
     }
 
     const bool accepted = parsed.screen.has_value() && diagnostics.empty();

--- a/tests/medui/fixtures/accepted-layout.medui
+++ b/tests/medui/fixtures/accepted-layout.medui
@@ -1,0 +1,53 @@
+// Hand-derived layout fixture for issue #194.
+// Surface content is 1248x688 after 16px padding. The Row consumes 48px, the NumericDisplay
+// 120px, and two 8px gaps; the final Fill viewport therefore receives 504px.
+Screen MonitorLayout {
+    layout: Vertical { spacing: 8px; padding: 16px; }
+    surface: 1280px, 720px;
+
+    Row {
+        id: topbar;
+        height: 48px;
+        spacing: 16px;
+        background: Theme.Colors.TopbarBackground;
+
+        Label {
+            id: title;
+            width: 340px;
+            height: 48px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+        Clock {
+            id: clock;
+            width: Fill;
+            height: Fill;
+            format: DateTimeSeconds;
+        }
+        StatusIndicator {
+            id: status;
+            width: 200px;
+            height: 48px;
+            requirement: "REQ-STATUS-001";
+            source: "MONITOR_STATUS";
+            states: [t("STR-NOMINAL")];
+        }
+    }
+
+    NumericDisplay {
+        id: score;
+        width: Fill;
+        height: 120px;
+        requirement: "REQ-SCORE-001";
+        template: "TPL-SCORE";
+        source: "SCORE";
+        color: Theme.Colors.ScoreDigits;
+    }
+
+    VulkanViewport {
+        id: viewport;
+        width: Fill;
+        height: Fill;
+        stream_source: "MONITOR_VIEW";
+    }
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,8 +271,8 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S4 (#193) this is the diagnostic registry (#191), lexer, AST, parser and semantic analyzer.
-# The emitters are #197, and the mdux-meduic executable with its mdux_compile_screen()
+# At S5 (#194) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer and
+# integer-only bounded layout solver. The emitters are #197, and the mdux-meduic executable with its mdux_compile_screen()
 # registration is #198 - so there is still no add_executable() here and no bake call site. Every
 # later stage adds sources to this target rather than inventing another.
 add_library(MduXMeduiLib)
@@ -288,11 +288,13 @@ target_sources(MduXMeduiLib
             medui/Ast.cppm
             medui/Parser.cppm
             medui/Semantic.cppm
+            medui/Layout.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
         medui/Parser.cpp
         medui/Semantic.cpp
+        medui/Layout.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/medui/Layout.cpp
+++ b/tools/medui/Layout.cpp
@@ -1,0 +1,397 @@
+/**
+ * @file Layout.cpp
+ * @brief Integer-only Vertical/Row layout resolution.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+module;
+
+module mdux.tools.medui.layout;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+[[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
+    const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
+    return found == node.fields.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const ast::Field* fieldFor(std::span<const ast::Field> fields, std::string_view name) noexcept {
+    const auto found = std::ranges::find(fields, name, &ast::Field::name);
+    return found == fields.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const ast::Value& valueOf(const ast::Field& field) {
+    if (field.value == nullptr) {
+        throw std::logic_error(std::format("layout received null value for field '{}'", field.name));
+    }
+    return *field.value;
+}
+
+[[nodiscard]] std::string idOf(const ast::Node& node) {
+    const ast::Field* field = fieldFor(node, "id");
+    if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::Identifier || field->value->text.empty()) {
+        throw std::logic_error(std::format("layout received component '{}' without a validated id", node.component));
+    }
+    return field->value->text;
+}
+
+[[nodiscard]] const ast::Size& sizeOf(const ast::Node& node, std::string_view name) {
+    const ast::Field* field = fieldFor(node, name);
+    if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::Size) {
+        throw std::logic_error(std::format("layout received component '{}' without validated field '{}'", node.component, name));
+    }
+    return field->value->size;
+}
+
+[[nodiscard]] const ast::Point* positionOf(const ast::Node& node) {
+    const ast::Field* field = fieldFor(node, "position");
+    if (field == nullptr) {
+        return nullptr;
+    }
+    if (field->value == nullptr || field->value->kind != ast::ValueKind::Point) {
+        throw std::logic_error(std::format("layout received component '{}' with an unvalidated position", node.component));
+    }
+    return &field->value->point;
+}
+
+[[nodiscard]] ast::Position positionFieldPosition(const ast::Node& node) noexcept {
+    if (const ast::Field* field = fieldFor(node, "position")) {
+        return field->namePosition;
+    }
+    return node.position;
+}
+
+[[nodiscard]] bool contains(LayoutRect outer, LayoutRect inner) noexcept {
+    if (inner.x < outer.x || inner.y < outer.y || inner.width < 0 || inner.height < 0) {
+        return false;
+    }
+    const std::int64_t relativeX = inner.x - outer.x;
+    const std::int64_t relativeY = inner.y - outer.y;
+    return relativeX <= outer.width && relativeY <= outer.height && inner.width <= outer.width - relativeX && inner.height <= outer.height - relativeY;
+}
+
+[[nodiscard]] bool overlaps(LayoutRect first, LayoutRect second) noexcept {
+    // All accepted rectangles are non-negative and surface-contained, so these additions cannot
+    // overflow. Shared edges are adjacency, not overlap.
+    return first.x < second.x + second.width && second.x < first.x + first.width && first.y < second.y + second.height && second.y < first.y + first.height;
+}
+
+class Solver {
+public:
+    Solver(std::string file, LayoutInputs inputs)
+        : file_{std::move(file)}, inputs_{inputs}, result_{.surfaceWidth = inputs.surfaceWidth, .surfaceHeight = inputs.surfaceHeight} {}
+
+    [[nodiscard]] LayoutResult run(const ast::Screen& screen) {
+        assertSingleRowLevel(screen);
+        if (!preflightPositionedFill(screen.nodes)) {
+            return std::move(result_);
+        }
+        if (!readSurface(screen) || !readLayout(screen)) {
+            return std::move(result_);
+        }
+
+        const LayoutRect content{.x = padding_, .y = padding_, .width = inputs_.surfaceWidth - 2 * padding_, .height = inputs_.surfaceHeight - 2 * padding_};
+
+        std::vector<const ast::Node*> flow;
+        for (const ast::Node& node : screen.nodes) {
+            if (node.component == "Row" || positionOf(node) == nullptr) {
+                flow.push_back(&node);
+            }
+        }
+
+        std::vector<ast::Size> heights;
+        heights.reserve(flow.size());
+        for (const ast::Node* node : flow) {
+            heights.push_back(sizeOf(*node, "height"));
+        }
+        const auto resolvedHeights = resolveAxis(heights, content.height, spacing_, screen.layoutPosition, "vertical layout");
+        if (!resolvedHeights) {
+            return std::move(result_);
+        }
+
+        std::int64_t cursorY   = content.y;
+        std::size_t  flowIndex = 0;
+        for (const ast::Node& node : screen.nodes) {
+            if (node.component == "Row") {
+                const LayoutRect rowBounds{.x = content.x, .y = cursorY, .width = content.width, .height = (*resolvedHeights)[flowIndex]};
+                if (!resolveRow(node, rowBounds)) {
+                    return std::move(result_);
+                }
+                cursorY += rowBounds.height + spacing_;
+                ++flowIndex;
+                continue;
+            }
+
+            if (const ast::Point* position = positionOf(node)) {
+                const LayoutRect bounds{.x = position->x, .y = position->y, .width = fixedSize(node, "width"), .height = fixedSize(node, "height")};
+                if (!contains(content, bounds)) {
+                    report(Code::SurfaceExceeded, positionFieldPosition(node), std::format("component '{}' exceeds the padded surface", idOf(node)));
+                    return std::move(result_);
+                }
+                appendLeaf(node, bounds, true);
+                continue;
+            }
+
+            const ast::Size&   width         = sizeOf(node, "width");
+            const std::int64_t resolvedWidth = width.fill ? content.width : width.pixels;
+            if (resolvedWidth <= 0 || resolvedWidth > content.width) {
+                report(Code::LayoutOverflow, width.position, std::format("component '{}' is wider than the vertical layout", idOf(node)));
+                return std::move(result_);
+            }
+            const LayoutRect bounds{.x = content.x, .y = cursorY, .width = resolvedWidth, .height = (*resolvedHeights)[flowIndex]};
+            appendLeaf(node, bounds, false);
+            cursorY += bounds.height + spacing_;
+            ++flowIndex;
+        }
+
+        if (!validateUniqueIds() || !validatePositionedOverlap()) {
+            return std::move(result_);
+        }
+        return std::move(result_);
+    }
+
+private:
+    void assertSingleRowLevel(const ast::Screen& screen) const {
+        for (const ast::Node& node : screen.nodes) {
+            if (node.component != "Row" && !node.children.empty()) {
+                throw std::logic_error(std::format("layout received children on non-Row component '{}'", node.component));
+            }
+            for (const ast::Node& child : node.children) {
+                if (child.component == "Row" || !child.children.empty()) {
+                    throw std::logic_error("layout received a nested Row; the parser must reject it before layout");
+                }
+            }
+        }
+    }
+
+    bool preflightPositionedFill(std::span<const ast::Node> nodes) {
+        for (const ast::Node& node : nodes) {
+            if (positionOf(node) != nullptr && (sizeOf(node, "width").fill || sizeOf(node, "height").fill)) {
+                report(Code::LayoutOverflow,
+                       positionFieldPosition(node),
+                       std::format("component '{}': position requires fixed width and height; "
+                                   "Fill is flow-only",
+                                   idOf(node)));
+                return false;
+            }
+            if (!preflightPositionedFill(node.children)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool readSurface(const ast::Screen& screen) {
+        if (inputs_.surfaceWidth <= 0 || inputs_.surfaceHeight <= 0 || inputs_.surfaceWidth > std::numeric_limits<std::int32_t>::max()
+            || inputs_.surfaceHeight > std::numeric_limits<std::int32_t>::max()) {
+            report(Code::SurfaceExceeded, screen.position, "build surface dimensions must be positive 32-bit pixel values");
+            return false;
+        }
+        if (screen.surface && (screen.surface->x != inputs_.surfaceWidth || screen.surface->y != inputs_.surfaceHeight)) {
+            report(Code::SurfaceExceeded,
+                   screen.surface->position,
+                   std::format("declared surface {}x{} does not match build surface {}x{}",
+                               screen.surface->x,
+                               screen.surface->y,
+                               inputs_.surfaceWidth,
+                               inputs_.surfaceHeight));
+            return false;
+        }
+        return true;
+    }
+
+    bool readLayout(const ast::Screen& screen) {
+        if (screen.layoutKind != "Vertical") {
+            report(Code::ForbiddenConstruct,
+                   screen.layoutPosition,
+                   "the bounded layout solver accepts Vertical screens; Row supplies the only "
+                   "horizontal grouping");
+            return false;
+        }
+        const auto readPixel = [&](std::string_view name, std::int64_t defaultValue, std::int64_t& destination) {
+            const ast::Field* field = fieldFor(screen.layout, name);
+            if (field == nullptr) {
+                destination = defaultValue;
+                return true;
+            }
+            const ast::Value& value = valueOf(*field);
+            if (value.kind != ast::ValueKind::Size || value.size.fill || value.size.pixels < 0) {
+                report(Code::LayoutOverflow, value.position, std::format("layout {} must be a non-negative pixel size", name));
+                return false;
+            }
+            destination = value.size.pixels;
+            return true;
+        };
+        if (!readPixel("spacing", 0, spacing_) || !readPixel("padding", 0, padding_)) {
+            return false;
+        }
+        if (padding_ > inputs_.surfaceWidth / 2 || padding_ > inputs_.surfaceHeight / 2) {
+            report(Code::SurfaceExceeded, screen.layoutPosition, "layout padding leaves no surface content box");
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] std::optional<std::vector<std::int64_t>>
+    resolveAxis(std::span<const ast::Size> dimensions, std::int64_t available, std::int64_t spacing, ast::Position position, std::string_view context) {
+        const std::int64_t gaps = dimensions.empty() ? 0 : static_cast<std::int64_t>(dimensions.size() - 1);
+        if (spacing > 0 && gaps > (available / spacing)) {
+            report(Code::LayoutOverflow, position, std::format("{} spacing exceeds its available space", context));
+            return std::nullopt;
+        }
+        const std::int64_t spacingTotal = spacing * gaps;
+        std::int64_t       fixedTotal   = 0;
+        std::int64_t       fillCount    = 0;
+        for (const ast::Size& dimension : dimensions) {
+            if (dimension.fill) {
+                ++fillCount;
+                continue;
+            }
+            if (dimension.pixels <= 0 || dimension.pixels > available - spacingTotal - fixedTotal) {
+                report(Code::LayoutOverflow, dimension.position, std::format("{} exceeds its available space", context));
+                return std::nullopt;
+            }
+            fixedTotal += dimension.pixels;
+        }
+        const std::int64_t remaining = available - spacingTotal - fixedTotal;
+        const std::int64_t fillSize  = fillCount == 0 ? 0 : remaining / fillCount;
+        if (fillCount > 0 && fillSize <= 0) {
+            report(Code::LayoutOverflow, position, std::format("Fill items in {} have no remaining space", context));
+            return std::nullopt;
+        }
+
+        std::vector<std::int64_t> result;
+        result.reserve(dimensions.size());
+        for (const ast::Size& dimension : dimensions) {
+            result.push_back(dimension.fill ? fillSize : dimension.pixels);
+        }
+        return result;
+    }
+
+    bool resolveRow(const ast::Node& row, LayoutRect bounds) {
+        const std::string rowId      = idOf(row);
+        std::int64_t      rowSpacing = 0;
+        if (const ast::Field* field = fieldFor(row, "spacing")) {
+            const ast::Value& value = valueOf(*field);
+            if (value.kind != ast::ValueKind::Size || value.size.fill || value.size.pixels < 0) {
+                report(Code::LayoutOverflow, value.position, std::format("Row '{}' spacing must be a non-negative pixel size", rowId));
+                return false;
+            }
+            rowSpacing = value.size.pixels;
+        }
+
+        if (fieldFor(row, "background") != nullptr) {
+            result_.nodes.push_back(
+                ResolvedNode{.id = rowId + "-background", .component = "Panel", .bounds = bounds, .source = row, .positioned = false, .synthetic = true});
+        }
+
+        std::vector<ast::Size> widths;
+        for (const ast::Node& child : row.children) {
+            if (positionOf(child) == nullptr) {
+                widths.push_back(sizeOf(child, "width"));
+            }
+        }
+        const auto resolvedWidths = resolveAxis(widths, bounds.width, rowSpacing, row.position, std::format("Row '{}'", rowId));
+        if (!resolvedWidths) {
+            return false;
+        }
+
+        std::int64_t cursorX   = bounds.x;
+        std::size_t  flowIndex = 0;
+        for (const ast::Node& child : row.children) {
+            if (const ast::Point* position = positionOf(child)) {
+                const LayoutRect childBounds{.x = position->x, .y = position->y, .width = fixedSize(child, "width"), .height = fixedSize(child, "height")};
+                if (!contains(bounds, childBounds)) {
+                    report(Code::LayoutOverflow, positionFieldPosition(child), std::format("component '{}' escapes Row '{}'", idOf(child), rowId));
+                    return false;
+                }
+                appendLeaf(child, childBounds, true);
+                continue;
+            }
+
+            const ast::Size&   height         = sizeOf(child, "height");
+            const std::int64_t resolvedHeight = height.fill ? bounds.height : height.pixels;
+            if (resolvedHeight <= 0 || resolvedHeight > bounds.height) {
+                report(Code::LayoutOverflow, height.position, std::format("component '{}' is taller than Row '{}'", idOf(child), rowId));
+                return false;
+            }
+            const LayoutRect childBounds{.x = cursorX, .y = bounds.y, .width = (*resolvedWidths)[flowIndex], .height = resolvedHeight};
+            appendLeaf(child, childBounds, false);
+            cursorX += childBounds.width + rowSpacing;
+            ++flowIndex;
+        }
+        return true;
+    }
+
+    [[nodiscard]] std::int64_t fixedSize(const ast::Node& node, std::string_view name) const {
+        const ast::Size& size = sizeOf(node, name);
+        if (size.fill) {
+            throw std::logic_error("positioned Fill reached layout after the preflight check");
+        }
+        return size.pixels;
+    }
+
+    void appendLeaf(const ast::Node& node, LayoutRect bounds, bool positioned) {
+        result_.nodes.push_back(
+            ResolvedNode{.id = idOf(node), .component = node.component, .bounds = bounds, .source = node, .positioned = positioned, .synthetic = false});
+    }
+
+    bool validateUniqueIds() {
+        std::map<std::string_view, ast::Position> seen;
+        for (const ResolvedNode& node : result_.nodes) {
+            const auto [previous, inserted] = seen.emplace(node.id, node.source.position);
+            if (!inserted) {
+                report(Code::DuplicateNodeId,
+                       node.source.position,
+                       std::format("resolved node id '{}' is already used at line {}, column {}", node.id, previous->second.line, previous->second.column));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool validatePositionedOverlap() {
+        for (std::size_t first = 0; first < result_.nodes.size(); ++first) {
+            for (std::size_t second = first + 1; second < result_.nodes.size(); ++second) {
+                const ResolvedNode& a = result_.nodes[first];
+                const ResolvedNode& b = result_.nodes[second];
+                if (a.component == "Panel" || b.component == "Panel" || (!a.positioned && !b.positioned) || !overlaps(a.bounds, b.bounds)) {
+                    continue;
+                }
+                const ResolvedNode& positioned = a.positioned ? a : b;
+                const ResolvedNode& other      = a.positioned ? b : a;
+                report(Code::LayoutOverflow,
+                       positionFieldPosition(positioned.source),
+                       std::format("positioned component '{}' overlaps component '{}'", positioned.id, other.id));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void report(Code code, ast::Position position, std::string message) {
+        result_.diagnostics.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
+    }
+
+    std::string  file_;
+    LayoutInputs inputs_{};
+    LayoutResult result_{};
+    std::int64_t spacing_{0};
+    std::int64_t padding_{0};
+};
+
+}  // namespace
+
+LayoutResult resolveLayout(const ast::Screen& screen, std::string file, LayoutInputs inputs) {
+    return Solver{std::move(file), inputs}.run(screen);
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Layout.cpp
+++ b/tools/medui/Layout.cpp
@@ -1,6 +1,6 @@
 /**
- * @file Layout.cpp
  * @brief Integer-only Vertical/Row layout resolution.
+ * @file Layout.cpp
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary
@@ -18,16 +18,19 @@ namespace mdux::tools::medui {
 
 namespace {
 
+/// Finds a named field on one component.
 [[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
     const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
     return found == node.fields.end() ? nullptr : &*found;
 }
 
+/// Finds a named field in an arbitrary field list.
 [[nodiscard]] const ast::Field* fieldFor(std::span<const ast::Field> fields, std::string_view name) noexcept {
     const auto found = std::ranges::find(fields, name, &ast::Field::name);
     return found == fields.end() ? nullptr : &*found;
 }
 
+/// Returns a field value, failing loudly if semantic validation was bypassed.
 [[nodiscard]] const ast::Value& valueOf(const ast::Field& field) {
     if (field.value == nullptr) {
         throw std::logic_error(std::format("layout received null value for field '{}'", field.name));
@@ -35,6 +38,7 @@ namespace {
     return *field.value;
 }
 
+/// Returns a validated component identifier.
 [[nodiscard]] std::string idOf(const ast::Node& node) {
     const ast::Field* field = fieldFor(node, "id");
     if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::Identifier || field->value->text.empty()) {
@@ -43,6 +47,7 @@ namespace {
     return field->value->text;
 }
 
+/// Returns a validated size field.
 [[nodiscard]] const ast::Size& sizeOf(const ast::Node& node, std::string_view name) {
     const ast::Field* field = fieldFor(node, name);
     if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::Size) {
@@ -51,6 +56,7 @@ namespace {
     return field->value->size;
 }
 
+/// Returns an optional validated position field.
 [[nodiscard]] const ast::Point* positionOf(const ast::Node& node) {
     const ast::Field* field = fieldFor(node, "position");
     if (field == nullptr) {
@@ -62,6 +68,7 @@ namespace {
     return &field->value->point;
 }
 
+/// Returns the source position used for a positioned-node diagnostic.
 [[nodiscard]] ast::Position positionFieldPosition(const ast::Node& node) noexcept {
     if (const ast::Field* field = fieldFor(node, "position")) {
         return field->namePosition;
@@ -69,6 +76,7 @@ namespace {
     return node.position;
 }
 
+/// Tests complete rectangle containment without overflow-prone edge addition.
 [[nodiscard]] bool contains(LayoutRect outer, LayoutRect inner) noexcept {
     if (inner.x < outer.x || inner.y < outer.y || inner.width < 0 || inner.height < 0) {
         return false;
@@ -78,22 +86,29 @@ namespace {
     return relativeX <= outer.width && relativeY <= outer.height && inner.width <= outer.width - relativeX && inner.height <= outer.height - relativeY;
 }
 
+/// Tests strict AABB overlap; touching edges are legal adjacency.
 [[nodiscard]] bool overlaps(LayoutRect first, LayoutRect second) noexcept {
     // All accepted rectangles are non-negative and surface-contained, so these additions cannot
     // overflow. Shared edges are adjacency, not overlap.
     return first.x < second.x + second.width && second.x < first.x + first.width && first.y < second.y + second.height && second.y < first.y + first.height;
 }
 
+/// One fail-closed, integer-only layout pass.
 class Solver {
 public:
+    /// Captures the diagnostic path and build-selected surface.
     Solver(std::string file, LayoutInputs inputs)
         : file_{std::move(file)},
           inputs_{inputs},
           result_{.surfaceWidth = inputs.surfaceWidth, .surfaceHeight = inputs.surfaceHeight, .nodes = {}, .diagnostics = {}} {}
 
+    /// Resolves one semantically valid screen, returning no nodes on any diagnostic.
     [[nodiscard]] LayoutResult run(const ast::Screen& screen) {
         assertSingleRowLevel(screen);
         if (!preflightPositionedFill(screen.nodes)) {
+            return std::move(result_);
+        }
+        if (!preflightPositiveDimensions(screen.nodes)) {
             return std::move(result_);
         }
         if (!readSurface(screen) || !readLayout(screen)) {
@@ -161,6 +176,7 @@ public:
     }
 
 private:
+    /// Enforces the parser's one-level Row invariant for directly-built ASTs too.
     void assertSingleRowLevel(const ast::Screen& screen) const {
         for (const ast::Node& node : screen.nodes) {
             if (node.component != "Row" && !node.children.empty()) {
@@ -174,6 +190,7 @@ private:
         }
     }
 
+    /// Rejects the contradictory out-of-flow `position` plus `Fill` combination.
     bool preflightPositionedFill(std::span<const ast::Node> nodes) {
         for (const ast::Node& node : nodes) {
             if (positionOf(node) != nullptr && (sizeOf(node, "width").fill || sizeOf(node, "height").fill)) {
@@ -191,6 +208,30 @@ private:
         return true;
     }
 
+    /// Rejects zero-sized fixed component dimensions before any rectangle is emitted.
+    bool preflightPositiveDimensions(std::span<const ast::Node> nodes) {
+        for (const ast::Node& node : nodes) {
+            const auto check = [&](std::string_view name) {
+                const ast::Size& size = sizeOf(node, name);
+                if (!size.fill && size.pixels <= 0) {
+                    report(Code::LayoutOverflow, size.position, std::format("component '{}' {} must be greater than zero", idOf(node), name));
+                    return false;
+                }
+                return true;
+            };
+
+            if (node.component == "Row") {
+                if (!check("height") || !preflightPositiveDimensions(node.children)) {
+                    return false;
+                }
+            } else if (!check("width") || !check("height")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Validates build dimensions and an optional authored surface pin.
     bool readSurface(const ast::Screen& screen) {
         if (inputs_.surfaceWidth <= 0 || inputs_.surfaceHeight <= 0 || inputs_.surfaceWidth > std::numeric_limits<std::int32_t>::max()
             || inputs_.surfaceHeight > std::numeric_limits<std::int32_t>::max()) {
@@ -210,6 +251,7 @@ private:
         return true;
     }
 
+    /// Reads Vertical layout configuration and rejects an empty padded content box.
     bool readLayout(const ast::Screen& screen) {
         if (screen.layoutKind != "Vertical") {
             report(Code::ForbiddenConstruct,
@@ -235,13 +277,14 @@ private:
         if (!readPixel("spacing", 0, spacing_) || !readPixel("padding", 0, padding_)) {
             return false;
         }
-        if (padding_ > inputs_.surfaceWidth / 2 || padding_ > inputs_.surfaceHeight / 2) {
+        if (padding_ >= inputs_.surfaceWidth - padding_ || padding_ >= inputs_.surfaceHeight - padding_) {
             report(Code::SurfaceExceeded, screen.layoutPosition, "layout padding leaves no surface content box");
             return false;
         }
         return true;
     }
 
+    /// Resolves fixed and Fill sizes using TrustSC's equal-share rule; any remainder stays unused.
     [[nodiscard]] std::optional<std::vector<std::int64_t>>
     resolveAxis(std::span<const ast::Size> dimensions, std::int64_t available, std::int64_t spacing, ast::Position position, std::string_view context) {
         const std::int64_t gaps = dimensions.empty() ? 0 : static_cast<std::int64_t>(dimensions.size() - 1);
@@ -278,6 +321,7 @@ private:
         return result;
     }
 
+    /// Resolves one Row to an optional Panel followed by its flat leaf children.
     bool resolveRow(const ast::Node& row, LayoutRect bounds) {
         const std::string rowId      = idOf(row);
         std::int64_t      rowSpacing = 0;
@@ -333,6 +377,7 @@ private:
         return true;
     }
 
+    /// Returns a positioned node's fixed size after preflight validation.
     [[nodiscard]] std::int64_t fixedSize(const ast::Node& node, std::string_view name) const {
         const ast::Size& size = sizeOf(node, name);
         if (size.fill) {
@@ -341,11 +386,13 @@ private:
         return size.pixels;
     }
 
+    /// Appends an owned authored leaf to the flat result.
     void appendLeaf(const ast::Node& node, LayoutRect bounds, bool positioned) {
         result_.nodes.push_back(
             ResolvedNode{.id = idOf(node), .component = node.component, .bounds = bounds, .source = node, .positioned = positioned, .synthetic = false});
     }
 
+    /// Rechecks identifiers after synthetic background nodes have been added.
     bool validateUniqueIds() {
         std::map<std::string_view, ast::Position> seen;
         for (const ResolvedNode& node : result_.nodes) {
@@ -360,12 +407,13 @@ private:
         return true;
     }
 
+    /// Rejects overlap involving a positioned node; synthetic backgrounds are underlays.
     bool validatePositionedOverlap() {
         for (std::size_t first = 0; first < result_.nodes.size(); ++first) {
             for (std::size_t second = first + 1; second < result_.nodes.size(); ++second) {
                 const ResolvedNode& a = result_.nodes[first];
                 const ResolvedNode& b = result_.nodes[second];
-                if (a.component == "Panel" || b.component == "Panel" || (!a.positioned && !b.positioned) || !overlaps(a.bounds, b.bounds)) {
+                if (a.synthetic || b.synthetic || (!a.positioned && !b.positioned) || !overlaps(a.bounds, b.bounds)) {
                     continue;
                 }
                 const ResolvedNode& positioned = a.positioned ? a : b;
@@ -379,7 +427,9 @@ private:
         return true;
     }
 
+    /// Records one finding and discards every partial rectangle produced before it.
     void report(Code code, ast::Position position, std::string message) {
+        result_.nodes.clear();
         result_.diagnostics.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
     }
 
@@ -392,6 +442,7 @@ private:
 
 }  // namespace
 
+/// Implements the public layout-module entry point.
 LayoutResult resolveLayout(const ast::Screen& screen, std::string file, LayoutInputs inputs) {
     return Solver{std::move(file), inputs}.run(screen);
 }

--- a/tools/medui/Layout.cpp
+++ b/tools/medui/Layout.cpp
@@ -47,6 +47,14 @@ namespace {
     return field->value->text;
 }
 
+/// Returns the authored `id` field position, falling back for malformed directly-built ASTs.
+[[nodiscard]] ast::Position idFieldPosition(const ast::Node& node) noexcept {
+    if (const ast::Field* field = fieldFor(node, "id")) {
+        return field->namePosition;
+    }
+    return node.position;
+}
+
 /// Returns a validated size field.
 [[nodiscard]] const ast::Size& sizeOf(const ast::Node& node, std::string_view name) {
     const ast::Field* field = fieldFor(node, name);
@@ -194,6 +202,8 @@ private:
     bool preflightPositionedFill(std::span<const ast::Node> nodes) {
         for (const ast::Node& node : nodes) {
             if (positionOf(node) != nullptr && (sizeOf(node, "width").fill || sizeOf(node, "height").fill)) {
+                // The common MedUI conformance case pins this declaration to MEDUI-E051. Keep the
+                // shared diagnostic even though the failure is detected before axis resolution.
                 report(Code::LayoutOverflow,
                        positionFieldPosition(node),
                        std::format("component '{}': position requires fixed width and height; "
@@ -396,10 +406,11 @@ private:
     bool validateUniqueIds() {
         std::map<std::string_view, ast::Position> seen;
         for (const ResolvedNode& node : result_.nodes) {
-            const auto [previous, inserted] = seen.emplace(node.id, node.source.position);
+            const ast::Position idPosition  = idFieldPosition(node.source);
+            const auto [previous, inserted] = seen.emplace(node.id, idPosition);
             if (!inserted) {
                 report(Code::DuplicateNodeId,
-                       node.source.position,
+                       idPosition,
                        std::format("resolved node id '{}' is already used at line {}, column {}", node.id, previous->second.line, previous->second.column));
                 return false;
             }

--- a/tools/medui/Layout.cpp
+++ b/tools/medui/Layout.cpp
@@ -87,7 +87,9 @@ namespace {
 class Solver {
 public:
     Solver(std::string file, LayoutInputs inputs)
-        : file_{std::move(file)}, inputs_{inputs}, result_{.surfaceWidth = inputs.surfaceWidth, .surfaceHeight = inputs.surfaceHeight} {}
+        : file_{std::move(file)},
+          inputs_{inputs},
+          result_{.surfaceWidth = inputs.surfaceWidth, .surfaceHeight = inputs.surfaceHeight, .nodes = {}, .diagnostics = {}} {}
 
     [[nodiscard]] LayoutResult run(const ast::Screen& screen) {
         assertSingleRowLevel(screen);

--- a/tools/medui/Layout.cppm
+++ b/tools/medui/Layout.cppm
@@ -1,6 +1,6 @@
 /**
- * @file Layout.cppm
  * @brief Integer-only build-time layout resolution for `.medui` screens.
+ * @file Layout.cppm
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary
@@ -53,7 +53,8 @@ struct ResolvedNode {
     bool        synthetic{false};
 };
 
-/// Flat nodes and any diagnostic that prevented a complete layout.
+/// Flat nodes and any diagnostic that prevented a complete layout. `nodes` is empty whenever a
+/// diagnostic is present, so a caller cannot accidentally consume a partial screen.
 struct LayoutResult {
     std::int64_t                              surfaceWidth{0};
     std::int64_t                              surfaceHeight{0};
@@ -68,10 +69,14 @@ struct LayoutResult {
 /**
  * @brief Resolves a semantically-valid screen to flat absolute rectangles.
  *
- * The algorithm uses integer arithmetic only. Flow overflow, a `Fill` that resolves to no space,
- * containment failures, and positioned overlaps are diagnostics; dimensions are never clamped.
- * Positioned nodes are removed from flow. A Row contributes one vertical flow item and its
- * children are resolved horizontally in the same single pass.
+ * The algorithm uses integer arithmetic only. Multiple `Fill` items receive equal integer shares;
+ * an indivisible trailing remainder stays unused, matching the TrustSC reference behavior. Flow
+ * overflow, a `Fill` that resolves to no space, containment failures, and positioned overlaps are
+ * diagnostics; dimensions are never clamped.
+ * Positioned nodes are removed from flow. Their coordinates are absolute surface coordinates;
+ * top-level nodes must remain inside the padded content box, and Row children inside the Row's
+ * already-resolved absolute band. A Row contributes one vertical flow item and its children are
+ * resolved horizontally in the same single pass.
  *
  * The parser already rejects nested Row. Because the AST is public and can be built directly,
  * this function checks that invariant and throws `std::logic_error` if a caller bypassed the

--- a/tools/medui/Layout.cppm
+++ b/tools/medui/Layout.cppm
@@ -1,0 +1,83 @@
+/**
+ * @file Layout.cppm
+ * @brief Integer-only build-time layout resolution for `.medui` screens.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * This host-only stage turns the parser's unresolved Vertical/Row tree into a flat sequence of
+ * absolute rectangles. It owns no device behavior: later compiler stages consume this result,
+ * while the governed runtime receives only emitted, already-resolved layout.
+ */
+module;
+
+export module mdux.tools.medui.layout;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+
+export namespace mdux::tools::medui {
+
+/// Build-selected surface dimensions. A source-level `surface:` declaration, when present, must
+/// agree with these values.
+struct LayoutInputs {
+    std::int64_t surfaceWidth{0};
+    std::int64_t surfaceHeight{0};
+};
+
+/// An absolute rectangle in integer surface pixels.
+struct LayoutRect {
+    std::int64_t x{0};
+    std::int64_t y{0};
+    std::int64_t width{0};
+    std::int64_t height{0};
+
+    auto operator<=>(const LayoutRect&) const = default;
+};
+
+/**
+ * @brief One flat compiled-layout entry.
+ *
+ * `source` is an owned copy, not a pointer into the input screen, so a result remains valid after
+ * its AST is released. For an authored leaf, `id` and `component` match `source`. A Row background
+ * is represented as a synthetic `Panel`: `source` is the originating Row and `id` is
+ * `<row-id>-background`.
+ */
+struct ResolvedNode {
+    std::string id;
+    std::string component;
+    LayoutRect  bounds{};
+    ast::Node   source;
+    bool        positioned{false};
+    bool        synthetic{false};
+};
+
+/// Flat nodes and any diagnostic that prevented a complete layout.
+struct LayoutResult {
+    std::int64_t                              surfaceWidth{0};
+    std::int64_t                              surfaceHeight{0};
+    std::vector<ResolvedNode>                 nodes;
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Resolves a semantically-valid screen to flat absolute rectangles.
+ *
+ * The algorithm uses integer arithmetic only. Flow overflow, a `Fill` that resolves to no space,
+ * containment failures, and positioned overlaps are diagnostics; dimensions are never clamped.
+ * Positioned nodes are removed from flow. A Row contributes one vertical flow item and its
+ * children are resolved horizontally in the same single pass.
+ *
+ * The parser already rejects nested Row. Because the AST is public and can be built directly,
+ * this function checks that invariant and throws `std::logic_error` if a caller bypassed the
+ * parser. Other malformed-AST conditions are treated the same way: semantic analysis is a
+ * required gate before layout.
+ */
+[[nodiscard]] LayoutResult resolveLayout(const ast::Screen& screen, std::string file, LayoutInputs inputs);
+
+}  // namespace mdux::tools::medui


### PR DESCRIPTION
## Summary

Adds the host-only `mdux.tools.medui.layout` stage required by S5. It resolves `Vertical` flow and one-level `Row` groups with integer-only padding, spacing, fixed sizes, and `Fill`; removes positioned nodes from flow; validates fixed dimensions, containment, overlaps, and generated-ID collisions; and emits a fail-closed flat sequence of absolute rectangles. Row backgrounds become synthetic `<row-id>-background` Panels.

The shared MedUI `layout` capability is now advertised and executed. Review follow-up tightened zero-area and padded-surface handling, made all diagnostic results discard partial nodes, keyed background overlap exemptions on provenance rather than component names, added the required semantic gate, removed the invented shared-conformance surface, and documented absolute positioned coordinates.

Closes #194

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change.
- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: not applicable — maintainer-authored change.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [x] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [x] `tools/CMakeLists.txt` — host-tool targets and their sources
- [x] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`
- [ ] None of the above

## Rebase state

- **Rebased onto:** `f2c4654305242e47f7cbdcd9fb7222d1423fcdbc`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run locally: this checkout is on unsupported macOS; supported Linux GCC 16 and MSVC PR checks cover the C++ build.
- [ ] `ctest --test-dir build-gcc` — not run locally for the same platform reason.
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 80 files checked, 0 findings.
- [x] Other: `python3 tools/docs-lint/generate_ai_reference.py --check` passed; `python3 tools/docs-lint/check_schema_type_drift.py` passed; `clang-format` and `git diff --check` passed. The docs-lint Python unit suite retains four pre-existing macOS-only internal-link expectation failures (`MDX-D012` instead of expected `MDX-D010`/`MDX-D011`). All required PR checks pass on review commit `f856468`, including GCC 16, ASan+UBSan, MSVC, CodeQL, CodeRabbit, compliance/documentation, governance, evidence, and security.

Test coverage includes hand-derived 1280×720 rectangles; flow and Row `Fill`; the TrustSC-compatible unused integer remainder; absolute positioned Row children; out-of-flow placement; surface and Row containment; zero fixed dimensions; padding that leaves no content; authored/build surface mismatch; positioned `Fill`; overflow; fail-closed partial-node cleanup; overlap including an authored `Panel` name; synthetic-ID collision; and the directly-built nested-Row invariant.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** pending after merge; required before the S6 (#195) or S8 (#197) successor merges.
- [ ] That run is green. *(Tick after merging this PR and before merging its successor.)*

## Regulatory impact

Classification: **safety-relevant**. This build-time stage decides the absolute bounds accepted for authored UI nodes and implements the layout restriction and fail-closed overflow behavior recorded by ADR-011.

Affected design and software item: ADR-011 and host-tools target `MduXMeduiLib`. Verification evidence is in `tests/medui/LayoutTests.cpp` and the pinned shared layout case. `README.md`, `docs/architecture.md`, and the MedUI authoring skill distinguish implemented layout from still-planned packaging, emission, and runtime stages. No certification or production-readiness claim is made.

Maintainer/domain-expert review is required before merge.
