### PR TITLE
S6 — Text-budget validation against every approved locale [#195]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,14 +10,16 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: parsing, semantic validation, and bounded layout are implemented; emission and runtime are not
+## Status: parsing, semantic validation, bounded layout, and text budgets are implemented; emission and runtime are not
 
-**A `.medui` lexer, AST, parser, semantic analyzer, and integer-only bounded layout solver exist**
-in the host-tools zone (`tools/medui/`). The diagnostic codes they emit are registered as
-`MEDUI-E###` (#191). The parser rejects structural violations (#192); the analyzer checks the
-closed component dictionary, each field's value domain, theme-token names, and text-key presence
-across every approved locale (#193); and the solver flattens Vertical/Row layout to absolute
-rectangles without floating-point arithmetic (#194). The AST keeps names unresolved.
+**A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, and
+text-budget check exist** in the host-tools zone (`tools/medui/`). The diagnostic codes they emit
+are registered as `MEDUI-E###` (#191). The parser rejects structural violations (#192); the
+analyzer checks the closed component dictionary, each field's value domain, theme-token names, and
+text-key presence across every approved locale (#193); the solver flattens Vertical/Row layout to
+absolute rectangles without floating-point arithmetic (#194); and the budget check measures each
+resolved box against the widest approved translation and each named dynamic-text source against the
+font package's restricted charset (#195). The AST keeps names unresolved.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -109,8 +111,9 @@ verifier checks against. Rules:
 ## Checking a file without a full build
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser, analyzer, and solver it will call already detect syntax
-errors, structural violations, unknown dictionary/theme names, hardcoded text in localizable
-fields, wrong field value domains, incomplete locale keys, and layout overflow; what is missing is
-the command that exposes them. Until it lands, review a `.medui` file by hand against this grammar
-and the component table above.
+diagnostics — once it exists. The parser, analyzer, solver, and budget check it will call already
+detect syntax errors, structural violations, unknown dictionary/theme names, hardcoded text in
+localizable fields, wrong field value domains, incomplete locale keys, layout overflow, a box that
+cannot contain its widest approved translation, and a dynamic-text source that could escape the
+baked charset; what is missing is the command that exposes them. Until it lands, review a `.medui`
+file by hand against this grammar and the component table above.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
-| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, and integer-only bounded layout; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, integer-only bounded layout, and per-locale text budgets; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), and integer-only bounded layout solver (#194) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), integer-only bounded layout solver (#194), and the text-budget check that measures resolved boxes against the widest approved translation (#195) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, and bounded layout are implemented; packaging and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, bounded layout, and text budgets are implemented; packaging and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,15 +1,18 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 11 August 2026
-> Verified against `v0.5.0` · 11 August 2026
+> Backlog · ambroise-leclerc/MduX · updated 16 August 2026
+> Verified against `develop` @ `d3efe11` · 16 August 2026 · `#15` current through `#195`
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
 backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draws its first
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
-Wave 4 with the font and text pipeline, and #15 opens Wave 5 with the compiler that
-generates the screens it draws.
+Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
+that generates the screens it draws. Six of its twelve children have landed — the ADRs,
+the diagnostic registry, the front end, semantic analysis, bounded layout, and per-locale text
+budgets — so the compiler now reads a `.medui` file, resolves it to a bounded box tree, and refuses
+a box that cannot hold its widest approved translation. #196 is next.
 
 | Metric | Count |
 |---|---|
@@ -22,20 +25,20 @@ generates the screens it draws.
 
 ### Where the two diverge
 
-Re-verified against `develop` on 9 August 2026. Eight of the nine rows have closed since
+Re-verified against `develop` on 16 August 2026. Eight of the nine rows have closed since
 this table was first written; the one that remains is the `.medui` authoring story, which is
 the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The `.medui` compiler that generates it is still ahead — this is Track C, Wave 5. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler's front end has landed — lexer, parser, AST, semantic analysis, bounded layout and per-locale text budgets, all host-only and conformance-tested against the shared MedUI spec. What is still ahead is the back end: goldens, the emitters, and the runtime that consumes them. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Five artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
 | Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time, `mdux-governed-lint` rejects the banned construct at source level, and `governed.noThrow.symbolScan` rejects it in the emitted objects (#116). | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Closed (#8, #10). Five standards on real clause structure with per-clause indexes and JSON Schemas, plus the documentation architecture — README derived from real targets, a contiguous ADR index, and a CI lint for internal links and retired paths. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
 | Copyright | Closed (#7). Reproduced text removed from the tree and from history, with `mdux-docs-lint` in CI to keep it out. | Reproducing normative text is forbidden outright; original prose only. |
-| Tests | Closed. 438 tests on `develop`, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification, governed-zone no-throw (`governed`, #116, with a negative fixture) and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
+| Tests | Closed. 438 tests at `v0.5.0`, and more since, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification, governed-zone no-throw (`governed`, #116, with a negative fixture) and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
 | Packaging | Closed (#11). Install/export restored; MSVC, GCC and Clang presets, with MSVC and GCC 16 both green in CI. | Workspace builds `--locked` on Linux and in containers. |
 
 ## Dependency order
@@ -44,7 +47,7 @@ the whole of Track C.
 
 An epic opens when every epic it depends on has closed. Four waves have shipped
 (v0.2.0, v0.3.0, v0.4.0, v0.5.0), one epic per wave closing the dependency it held.
-Wave 5 is open now: #15's blockers were #12 and #14, both closed. #11 closed ahead of it with
+Wave 5 is in progress: #15's blockers were #12 and #14, both closed. #11 closed ahead of it with
 `#116` and `#117`, so no enforcement gap carries into the largest epic of the programme.
 #19 spans waves by design; its S3–S6 follow #15.
 
@@ -53,7 +56,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · open now           #15
+Wave 5 · in progress        #15 (S1–S6 done · S7 next)
 Wave 6                      #16  #17
 ```
 
@@ -175,12 +178,11 @@ cannot claim.
 _All eleven closed. `#117`'s PR template and merge-ordering policy land ahead of Wave 5,
 which is the most stacked epic of the programme_
 
-> **Closure depends on two independent merges**, and this line exists so that a reader can check
-> rather than assume: `#116` closes with PR #189 (the last of a three-PR stack behind #188 and
-> #187), and `#117` closes with PR #186, which targets `develop` on its own. Neither gates the
-> other in GitHub. If you are reading this and #186 is still open, the "Done" above is ahead of
-> the tree — which is precisely the kind of unearned status `#116` existed to remove, so say so
-> rather than working around it.
+> **Closure depended on two independent merges**, and this line stays so that a reader can check
+> rather than assume: `#116` closed with PR #189 (the last of a three-PR stack behind #188 and
+> #187), and `#117` closed with PR #186, which targeted `develop` on its own. All four merged on
+> 11 August 2026, so the "Done" above is behind the tree rather than ahead of it — which is the
+> only direction this status line is allowed to be wrong in.
 
 #### #12 — Evidence kernel · **Done v0.3.0**
 
@@ -234,24 +236,31 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **Ready · opens Wave 5**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 6/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
 Rust shares types across the crate boundary; C++ can do better.
 
-- S1 ADRs: DSL boundary and generated artifacts
-- S2 Diagnostics and the code registry
-- S3 Lexer, parser, AST
-- S4 Theme tokens and locale-checked strings
-- S5 Layout and row flattening
-- S6 Text-budget validation
-- S7 Golden references for safety-critical nodes
-- S8 JSON and C++ emitters
-- S9 CMake integration and host tools
-- S10 Allocation-free screen runtime
-- S11 `mdux-medui-check`
-- S12 First end-to-end screen
+The front end is in the tree and conformance-tested against the shared MedUI spec
+(`medui-conformance.toml`, capabilities `syntax`, `semantics`, `layout`). ADR-011 and
+ADR-012 were amended by #203 before any code depended on them: the compiled screen is
+locale-free, so the per-locale text stays in the text package — which is why S6 measures every
+approved locale and reserves the worst of them, rather than sizing a box to the locale its author
+happened to read.
+
+- #190 S1 ADRs: DSL boundary and generated artifacts · _closed_
+- #191 S2 Diagnostics and the MDX-E code registry · _closed_
+- #192 S3 Lexer, parser, AST and the fixture corpus · _closed_
+- #193 S4 Theme tokens and locale-checked strings · _closed_
+- #194 S5 Bounded layout and `Row` flattening · _closed (PR #212)_
+- #195 S6 Text-budget validation against every approved locale · _closed_
+- #196 S7 Golden references for safety-critical nodes · **next**
+- #197 S8 Canonical package and C++ emitters
+- #198 S9 CMake integration and the `mdux-meduic` host tool
+- #199 S10 Allocation-free screen runtime
+- #200 S11 `mdux-medui-check`
+- #201 S12 First end-to-end screen
 
 _Blocks #16, #17_
 
@@ -357,6 +366,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Verified at `v0.5.0` · 11 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 open · no enforcement gaps outstanding_
+_Verified at `develop` @ `d3efe11` · 16 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 6/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,19 +674,25 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issues #191, #192, #193, #194)
+# .medui compiler host-tools suite (issues #191, #192, #193, #194, #195)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
 # completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
 # diagnose() produces - and the lexer and parser (#192), whose rejection cases assert the code and
 # the position rather than the message, since #191 published the codes as the contract and
 # messages are explicitly rewordable.
+#
+# TextBudgetTests (#195) builds its own font and text packages rather than reading generated/: the
+# widest-approved-translation rule is only checkable when two locales differ by a width the test
+# chose. The packages are still validated by the schema modules that own their formats, so the
+# measurements are taken from artifacts that would be legal on disk.
 add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
     medui/ParserTests.cpp
     medui/SemanticTests.cpp
     medui/LayoutTests.cpp
+    medui/TextBudgetTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -16,6 +16,10 @@
  * The font is still a real `mdux::font::FontPackage` and passes `validate()`; the runs are still
  * real v1 records decoded by the same `mdux::text::draw::decodeRecord()` the device draws with.
  * What is synthetic is the vocabulary, not the format.
+ *
+ * Every call supplies both locales the fixture font approves, because the stage refuses a subset -
+ * a budget measured over some of the approved locales is not a budget. The scenarios that leave one
+ * out are the ones asserting that refusal.
  */
 
 import std;
@@ -53,15 +57,19 @@ constexpr std::int16_t baseline = 10;
 constexpr std::uint16_t spaceIndex  = 0;   ///< U+0020, blank: an advance and no coverage
 constexpr std::uint16_t letterIndex = 12;  ///< U+0041 'A'
 
+/// The id the fixture font publishes, and the id every fixture text package references.
+constexpr std::string_view fontId = "fixture-ui";
+
 /**
  * @brief The fixture font: a blank space, the ten digits, `:`, and A-C, all 8x10.
  *
  * The digits share one advance width because `validate()` requires it - the tabular-figure rule
- * from #161 - and this font is built to pass that check rather than around it.
+ * from #161 - and this font is built to pass that check rather than around it. It approves two
+ * locales, which is what makes "the complete approved set" a testable idea below.
  */
 [[nodiscard]] font::FontPackage fixtureFont() {
     font::FontPackage package;
-    package.id         = "fixture-ui";
+    package.id         = std::string{fontId};
     package.unitsPerEm = 1000;
     package.pixelSize  = 10;
     package.locales    = {"en-US", "de-DE"};
@@ -137,7 +145,7 @@ struct Locale {
 [[nodiscard]] Locale bakeLocale(std::string locale, std::span<const std::pair<std::string, std::vector<std::byte>>> runs) {
     Locale built;
     built.package.header.id   = std::format("fixture-{}", locale);
-    built.package.atlasId     = "fixture-ui";
+    built.package.atlasId     = std::string{fontId};
     built.package.locale      = std::move(locale);
     built.package.sidecarPath = "runs.bin";
 
@@ -149,13 +157,42 @@ struct Locale {
     return built;
 }
 
+/// One locale whose keys are each the given number of copies of 'A'.
+[[nodiscard]] Locale lettersLocale(std::string locale, std::span<const std::pair<std::string, std::size_t>> keys) {
+    std::vector<std::pair<std::string, std::vector<std::byte>>> runs;
+    for (const auto& [key, count] : keys) {
+        const std::vector<std::uint16_t> glyphs(count, letterIndex);
+        runs.emplace_back(key, bakeRun(glyphs));
+    }
+    return bakeLocale(std::move(locale), runs);
+}
+
 /// One locale whose single key is `count` copies of 'A'.
 [[nodiscard]] Locale letterLocale(std::string locale, std::string key, std::size_t count) {
-    const std::vector<std::uint16_t>                                    glyphs(count, letterIndex);
-    const std::array<std::pair<std::string, std::vector<std::byte>>, 1> runs{
-        std::pair{std::move(key), bakeRun(glyphs)}
+    const std::array<std::pair<std::string, std::size_t>, 1> keys{
+        std::pair{std::move(key), count}
     };
-    return bakeLocale(std::move(locale), runs);
+    return lettersLocale(std::move(locale), keys);
+}
+
+/**
+ * @brief The complete approved locale set: one package per tag the fixture font declares.
+ *
+ * The stage refuses anything else, so a scenario that is not *about* that refusal builds its
+ * locales through this type and hands over `views()`.
+ */
+struct ApprovedText {
+    Locale english;
+    Locale german;
+
+    [[nodiscard]] std::array<md::LocaleText, 2> views() const noexcept {
+        return {english.view(), german.view()};
+    }
+};
+
+/// One key in both approved locales, at the requested glyph counts.
+[[nodiscard]] ApprovedText approvedText(std::string_view key, std::size_t englishGlyphs, std::size_t germanGlyphs) {
+    return ApprovedText{.english = letterLocale("en-US", std::string{key}, englishGlyphs), .german = letterLocale("de-DE", std::string{key}, germanGlyphs)};
 }
 
 /// Wraps a component body in a screen whose declared surface matches the build surface.
@@ -203,6 +240,20 @@ struct Locale {
     return diagnostic != nullptr && diagnostic->message.find(fragment) != std::string::npos;
 }
 
+[[nodiscard]] bool mentions(const cli::Diagnostic& diagnostic, std::string_view fragment) {
+    return diagnostic.message.find(fragment) != std::string::npos;
+}
+
+/// Runs `call` and answers whether it threw the wiring error every gate below is documented to use.
+[[nodiscard]] bool throwsWiringError(const std::function<void()>& call) {
+    try {
+        call();
+    } catch (const std::logic_error&) {
+        return true;
+    }
+    return false;
+}
+
 // The governed dynamic-text table these scenarios resolve `format:` and `charset:` against. The
 // ranges are namespace-scope so the spans in a `DynamicTextRule` outlive the call that reads them.
 constexpr std::array digitsAndColon{
@@ -218,6 +269,11 @@ constexpr std::array digitsThroughLetter{
     font::CharsetRange{.first = U'0', .last = U'A'}
 };
 
+/// A single code point one past the last Unicode scalar value, which is not a character at all.
+constexpr std::array beyondUnicode{
+    font::CharsetRange{.first = static_cast<char32_t>(0x110000), .last = static_cast<char32_t>(0x110000)}
+};
+
 }  // namespace
 
 const mdux::spec::Register widestTranslationDrivesTheBudget{
@@ -229,11 +285,10 @@ const mdux::spec::Register widestTranslationDrivesTheBudget{
             .When("the resolved screen is checked against both approved locales", [] {})
             .Then("MEDUI-E050 names de-DE, the key, the required width and the available one",
                   [] {
-                      mdux::spec::Checks                  checks;
-                      const font::FontPackage             fontPackage = fixtureFont();
-                      const Locale                        english     = letterLocale("en-US", "STR-TITLE", 3);
-                      const Locale                        german      = letterLocale("de-DE", "STR-TITLE", 6);
-                      const std::array<md::LocaleText, 2> locales{english.view(), german.view()};
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
+                      const auto              locales     = approved.views();
 
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(40, 20, "STR-TITLE")),
                                                                                "budget.medui",
@@ -261,11 +316,10 @@ const mdux::spec::Register fittingScreenReportsItsWorstCase{
             .When("the resolved screen is checked", [] {})
             .Then("it compiles and the measurement names de-DE with the per-axis maximum",
                   [] {
-                      mdux::spec::Checks                  checks;
-                      const font::FontPackage             fontPackage = fixtureFont();
-                      const Locale                        english     = letterLocale("en-US", "STR-TITLE", 3);
-                      const Locale                        german      = letterLocale("de-DE", "STR-TITLE", 6);
-                      const std::array<md::LocaleText, 2> locales{english.view(), german.view()};
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
+                      const auto              locales     = approved.views();
 
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(100, 20, "STR-TITLE")),
                                                                                "budget.medui",
@@ -287,26 +341,22 @@ const mdux::spec::Register fittingScreenReportsItsWorstCase{
             .Execute();
     }};
 
-const mdux::spec::Register worstCaseSurvivesAnUnnamedLocale{
-    "The widest measurement is not lost to a locale whose tag is empty",
+const mdux::spec::Register widestLocaleWinsRegardlessOfOrder{
+    "The widest translation is recorded whichever position it holds in the input",
     "evidence-unit",
     [] {
         return speclab::Test("medui-textbudget-worst-case-not-overwritten")
-            .Given("a 58px translation in a package with an empty locale tag, then a 28px en-US one", [] {})
+            .Given("the 58px de-DE package first and the 28px en-US package second", [] {})
             .When("both are measured for the same key", [] {})
-            .Then("the recorded worst case is still 58px",
+            .Then("the recorded worst case is still 58px from de-DE",
                   [] {
                       mdux::spec::Checks      checks;
                       const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
 
-                      // An empty tag is invalid - `TextPackage::validate()` rejects it - and this
-                      // stage takes packages by pointer without re-validating, so the tag must not
-                      // double as the "nothing measured yet" sentinel. If it did, the narrower
-                      // en-US measurement below would overwrite the wider one, and the compiler
-                      // would certify a budget too small for a translation it had just measured.
-                      const Locale                        unnamed = letterLocale("", "STR-TITLE", 6);
-                      const Locale                        english = letterLocale("en-US", "STR-TITLE", 3);
-                      const std::array<md::LocaleText, 2> locales{unnamed.view(), english.view()};
+                      // Reversed on purpose: the maximum has to come from a comparison, not from
+                      // whichever package the caller happened to list last.
+                      const std::array<md::LocaleText, 2> locales{approved.german.view(), approved.english.view()};
 
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(100, 20, "STR-TITLE")),
                                                                                "budget.medui",
@@ -315,6 +365,7 @@ const mdux::spec::Register worstCaseSurvivesAnUnnamedLocale{
                       checks.expect(result.ok(), "the screen compiles");
                       checks.expect(result.measurements.size() == 1, "the field is measured");
                       if (result.measurements.size() == 1) {
+                          checks.expect(result.measurements.front().locale == "de-DE", "the widest locale is recorded");
                           checks.expect(result.measurements.front().extent.width == 58,
                                         std::format("the worst case is 58px, got {}px", result.measurements.front().extent.width));
                       }
@@ -323,71 +374,43 @@ const mdux::spec::Register worstCaseSurvivesAnUnnamedLocale{
             .Execute();
     }};
 
-const mdux::spec::Register charsetWalkCrossesRangeBoundaries{
-    "A produced range spanning a gap in the charset is caught at the gap",
+const mdux::spec::Register blankGlyphsAreNotInk{
+    "A leading blank glyph does not widen the measured extent",
     "evidence-unit",
     [] {
-        return speclab::Test("medui-textbudget-charset-gap")
-            .Given("a source producing U+0030..U+0041, which the font holds either side of a gap", [] {})
-            .When("the produced range is walked against the restricted charset", [] {})
-            .Then("MEDUI-E053 names U+003B, the first code point in the gap",
+        return speclab::Test("medui-textbudget-blank-glyphs-skipped")
+            .Given("a run that opens with a space at the pen origin and three letters after it", [] {})
+            .When("a 30px Label carrying that run is measured", [] {})
+            .Then("the ink measures 28px and the box is accepted",
                   [] {
-                      mdux::spec::Checks                       checks;
-                      const font::FontPackage                  fontPackage = fixtureFont();
-                      const std::array<md::DynamicTextRule, 1> table{
-                          md::DynamicTextRule{.name = "DIGITS_TO_A", .produces = digitsThroughLetter}
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+
+                      // Records at x = 0, 10, 20, 30: a blank space, then three letters. Counting
+                      // the space as ink would measure from x 0 and make this 38px, which a 30px
+                      // box would reject - so the acceptance below is the assertion.
+                      const std::array<std::uint16_t, 4>                                  glyphs{spaceIndex, letterIndex, letterIndex, letterIndex};
+                      const std::array<std::pair<std::string, std::vector<std::byte>>, 1> englishRuns{
+                          std::pair{std::string{"STR-TITLE"}, bakeRun(glyphs)}
                       };
+                      const ApprovedText approved{.english = bakeLocale("en-US", englishRuns), .german = letterLocale("de-DE", "STR-TITLE", 1)};
+                      const auto         locales = approved.views();
 
-                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: DIGITS_TO_A; }\n");
-                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(30, 20, "STR-TITLE")),
                                                                                "budget.medui",
-                                                                               {.font = &fontPackage, .locales = {}, .dynamicText = table});
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
 
-                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
-                      checks.expect(!result.ok(), "the screen is rejected");
-                      checks.expect(mentions(reported, "U+003B"), "the walk stops at the first code point the charset omits");
-                      checks.expect(result.diagnostics.size() == 1, std::format("one diagnostic per field, got {}", result.diagnostics.size()));
+                      checks.expect(result.ok(), "the screen compiles");
+                      checks.expect(result.measurements.size() == 1, "the field is measured");
+                      if (result.measurements.size() == 1) {
+                          checks.expect(
+                              result.measurements.front().extent == md::TextExtent{28, 10},
+                              std::format("the ink is 28x10, got {}x{}", result.measurements.front().extent.width, result.measurements.front().extent.height));
+                      }
                       checks.raise();
                   })
             .Execute();
     }};
-
-const mdux::spec::Register blankGlyphsAreNotInk{"A leading blank glyph does not widen the measured extent", "evidence-unit", [] {
-                                                    return speclab::Test("medui-textbudget-blank-glyphs-skipped")
-                                                        .Given("a run that opens with a space at the pen origin and three letters after it", [] {})
-                                                        .When("a 30px Label carrying that run is measured", [] {})
-                                                        .Then("the ink measures 28px and the box is accepted",
-                                                              [] {
-                                                                  mdux::spec::Checks      checks;
-                                                                  const font::FontPackage fontPackage = fixtureFont();
-
-                                                                  // Records at x = 0, 10, 20, 30: a blank space, then three letters. Counting
-                                                                  // the space as ink would measure from x 0 and make this 38px, which a 30px
-                                                                  // box would reject - so the acceptance below is the assertion.
-                                                                  const std::array<std::uint16_t, 4> glyphs{spaceIndex, letterIndex, letterIndex, letterIndex};
-                                                                  const std::array<std::pair<std::string, std::vector<std::byte>>, 1> runs{
-                                                                      std::pair{std::string{"STR-TITLE"}, bakeRun(glyphs)}
-                                                                  };
-                                                                  const Locale                        english = bakeLocale("en-US", runs);
-                                                                  const std::array<md::LocaleText, 1> locales{english.view()};
-
-                                                                  const md::TextBudgetResult result = md::checkTextBudgets(
-                                                                      layoutOf(labelScreen(30, 20, "STR-TITLE")),
-                                                                      "budget.medui",
-                                                                      {.font = &fontPackage, .locales = locales, .dynamicText = {}});
-
-                                                                  checks.expect(result.ok(), "the screen compiles");
-                                                                  checks.expect(result.measurements.size() == 1, "the field is measured");
-                                                                  if (result.measurements.size() == 1) {
-                                                                      checks.expect(result.measurements.front().extent == md::TextExtent{28, 10},
-                                                                                    std::format("the ink is 28x10, got {}x{}",
-                                                                                                result.measurements.front().extent.width,
-                                                                                                result.measurements.front().extent.height));
-                                                                  }
-                                                                  checks.raise();
-                                                              })
-                                                        .Execute();
-                                                }};
 
 const mdux::spec::Register heightIsBudgetedToo{"A box shorter than its translation is rejected on the vertical axis", "evidence-unit", [] {
                                                    return speclab::Test("medui-textbudget-height-exceeded")
@@ -395,10 +418,10 @@ const mdux::spec::Register heightIsBudgetedToo{"A box shorter than its translati
                                                        .When("the resolved screen is checked", [] {})
                                                        .Then("MEDUI-E050 names the height it needs and the height it has",
                                                              [] {
-                                                                 mdux::spec::Checks                  checks;
-                                                                 const font::FontPackage             fontPackage = fixtureFont();
-                                                                 const Locale                        english     = letterLocale("en-US", "STR-TITLE", 2);
-                                                                 const std::array<md::LocaleText, 1> locales{english.view()};
+                                                                 mdux::spec::Checks      checks;
+                                                                 const font::FontPackage fontPackage = fixtureFont();
+                                                                 const ApprovedText      approved    = approvedText("STR-TITLE", 2, 2);
+                                                                 const auto              locales     = approved.views();
 
                                                                  const md::TextBudgetResult result = md::checkTextBudgets(
                                                                      layoutOf(labelScreen(100, 8, "STR-TITLE")),
@@ -415,6 +438,96 @@ const mdux::spec::Register heightIsBudgetedToo{"A box shorter than its translati
                                                        .Execute();
                                                }};
 
+const mdux::spec::Register listValuedTextIsMeasuredPerElement{
+    "Every element of a list-valued text field is measured, not only the first",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-text-key-list")
+            .Given("a StatusIndicator whose states are a 28px key and a 58px key", [] {})
+            .When("a box that fits both, and then one that fits only the first, are checked", [] {})
+            .Then("both keys are measured, and the second is what the narrow box rejects",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+
+                      const std::array<std::pair<std::string, std::size_t>, 2> keys{
+                          std::pair{   std::string{"STR-OK"}, std::size_t{3}},
+                          std::pair{std::string{"STR-ALARM"}, std::size_t{6}}
+                      };
+                      const ApprovedText approved{.english = lettersLocale("en-US", keys), .german = lettersLocale("de-DE", keys)};
+                      const auto         locales = approved.views();
+
+                      const auto states = [](std::int64_t width) {
+                          return screenWith(std::format("    StatusIndicator {{ id: status; width: {}px; height: 20px; "
+                                                        "requirement: \"REQ-1\"; source: \"STATE\"; "
+                                                        "states: [t(\"STR-OK\"), t(\"STR-ALARM\")]; }}\n",
+                                                        width));
+                      };
+
+                      const md::TextBudgetResult fits = md::checkTextBudgets(layoutOf(states(100)),
+                                                                             "budget.medui",
+                                                                             {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                      checks.expect(fits.ok(), std::format("the wide box compiles, got {} diagnostics", fits.diagnostics.size()));
+                      checks.expect(fits.measurements.size() == 2, std::format("both list elements are measured, got {}", fits.measurements.size()));
+                      if (fits.measurements.size() == 2) {
+                          checks.expect(fits.measurements[0].textKey == "STR-OK" && fits.measurements[1].textKey == "STR-ALARM",
+                                        "the measurements follow the authored list order");
+                          checks.expect(fits.measurements[1].field == "states", "a list element is attributed to its field");
+                      }
+
+                      const md::TextBudgetResult narrow = md::checkTextBudgets(layoutOf(states(40)),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                      checks.expect(!narrow.ok(), "the narrow box is rejected");
+                      checks.expect(mentions(find(narrow, md::Code::TextBudgetExceeded), "STR-ALARM"), "the second element is the one that does not fit");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register diagnosticsFollowNodeAndLocaleOrder{
+    "Diagnostics accumulate in node order, then in the input order of the locales",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-diagnostic-order")
+            .Given("two 10px Labels, each too narrow for both approved translations", [] {})
+            .When("the resolved screen is checked", [] {})
+            .Then("the four diagnostics arrive title/en-US, title/de-DE, subtitle/en-US, subtitle/de-DE",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+
+                      const std::array<std::pair<std::string, std::size_t>, 2> keys{
+                          std::pair{   std::string{"STR-TITLE"}, std::size_t{3}},
+                          std::pair{std::string{"STR-SUBTITLE"}, std::size_t{3}}
+                      };
+                      const ApprovedText approved{.english = lettersLocale("en-US", keys), .german = lettersLocale("de-DE", keys)};
+                      const auto         locales = approved.views();
+
+                      const std::string source = screenWith(
+                          "    Label { id: title; width: 10px; height: 20px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; }\n"
+                          "    Label { id: subtitle; width: 10px; height: 20px; text: t(\"STR-SUBTITLE\"); color: Theme.Colors.Title; }\n");
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      checks.expect(result.diagnostics.size() == 4, std::format("every failing pair is reported, got {}", result.diagnostics.size()));
+                      if (result.diagnostics.size() == 4) {
+                          checks.expect(mentions(result.diagnostics[0], "STR-TITLE") && mentions(result.diagnostics[0], "en-US"),
+                                        "the first node's first locale comes first");
+                          checks.expect(mentions(result.diagnostics[1], "STR-TITLE") && mentions(result.diagnostics[1], "de-DE"),
+                                        "locales follow their input order within a field");
+                          checks.expect(mentions(result.diagnostics[2], "STR-SUBTITLE") && mentions(result.diagnostics[2], "en-US"),
+                                        "the second node follows the first");
+                          checks.expect(mentions(result.diagnostics[3], "STR-SUBTITLE") && mentions(result.diagnostics[3], "de-DE"),
+                                        "and its locales follow the same order");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register dynamicTextCannotEscapeTheCharset{
     "A format that can produce an unbaked character is MEDUI-E053",
     "evidence-unit",
@@ -426,6 +539,8 @@ const mdux::spec::Register dynamicTextCannotEscapeTheCharset{
                   [] {
                       mdux::spec::Checks                       checks;
                       const font::FontPackage                  fontPackage = fixtureFont();
+                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales     = approved.views();
                       const std::array<md::DynamicTextRule, 1> table{
                           md::DynamicTextRule{.name = "HH_MM_TZ", .produces = digitsAndZone}
                       };
@@ -433,12 +548,74 @@ const mdux::spec::Register dynamicTextCannotEscapeTheCharset{
                       const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM_TZ; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
-                                                                               {.font = &fontPackage, .locales = {}, .dynamicText = table});
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
 
                       const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
                       checks.expect(!result.ok(), "the screen is rejected");
                       checks.expect(mentions(reported, "HH_MM_TZ"), "the diagnostic names the dynamic-text source");
                       checks.expect(mentions(reported, "U+005A"), "the diagnostic names the code point that escapes");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register charsetWalkCrossesRangeBoundaries{
+    "A produced range spanning a gap in the charset is caught at the gap",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-gap")
+            .Given("a source producing U+0030..U+0041, which the font holds either side of a gap", [] {})
+            .When("the produced range is walked against the restricted charset", [] {})
+            .Then("MEDUI-E053 names U+003B, the first code point in the gap",
+                  [] {
+                      mdux::spec::Checks                       checks;
+                      const font::FontPackage                  fontPackage = fixtureFont();
+                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales     = approved.views();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "DIGITS_TO_A", .produces = digitsThroughLetter}
+                      };
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: DIGITS_TO_A; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(mentions(reported, "U+003B"), "the walk stops at the first code point the charset omits");
+                      checks.expect(result.diagnostics.size() == 1, std::format("one diagnostic per field, got {}", result.diagnostics.size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register rangesBeyondUnicodeAreReported{
+    "A produced range reaching past the last Unicode scalar value is reported, not clamped",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-beyond-unicode")
+            .Given("a governed entry declaring U+110000, which is not a character", [] {})
+            .When("the entry is walked", [] {})
+            .Then("MEDUI-E053 says so rather than silently measuring only the part that is",
+                  [] {
+                      mdux::spec::Checks                       checks;
+                      const font::FontPackage                  fontPackage = fixtureFont();
+                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales     = approved.views();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "OUT_OF_RANGE", .produces = beyondUnicode}
+                      };
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: OUT_OF_RANGE; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(mentions(reported, "U+110000"), "the diagnostic names the offending code point");
+                      checks.expect(mentions(reported, "not a Unicode scalar value"), "and says what is wrong with it");
                       checks.raise();
                   })
             .Execute();
@@ -455,11 +632,13 @@ const mdux::spec::Register unresolvedDynamicTextFailsClosed{
                   [] {
                       mdux::spec::Checks      checks;
                       const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto              locales     = approved.views();
 
                       const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
-                                                                               {.font = &fontPackage, .locales = {}, .dynamicText = {}});
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
 
                       const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
                       checks.expect(!result.ok(), "the screen is rejected");
@@ -481,6 +660,8 @@ const mdux::spec::Register boundedDynamicTextIsAccepted{
                   [] {
                       mdux::spec::Checks                       checks;
                       const font::FontPackage                  fontPackage = fixtureFont();
+                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales     = approved.views();
                       const std::array<md::DynamicTextRule, 1> table{
                           md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
                       };
@@ -490,7 +671,7 @@ const mdux::spec::Register boundedDynamicTextIsAccepted{
                                                                      "max_length: 16; color: Theme.Colors.Title; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
-                                                                               {.font = &fontPackage, .locales = {}, .dynamicText = table});
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
 
                       checks.expect(result.ok(), std::format("the screen compiles, got {} diagnostics", result.diagnostics.size()));
                       checks.expect(result.measurements.empty(), "a screen with no text key measures nothing");
@@ -499,59 +680,119 @@ const mdux::spec::Register boundedDynamicTextIsAccepted{
             .Execute();
     }};
 
-const mdux::spec::Register bypassedGatesThrow{"A miswired stage throws rather than emitting a diagnostic an author cannot act on", "evidence-unit", [] {
-                                                  return speclab::Test("medui-textbudget-gates-throw")
-                                                      .Given("a call with no font package, and a locale missing the key semantic analysis admitted", [] {})
-                                                      .When("the budget check runs", [] {})
-                                                      .Then("both are std::logic_error",
-                                                            [] {
-                                                                mdux::spec::Checks      checks;
-                                                                const font::FontPackage fontPackage = fixtureFont();
-                                                                const md::LayoutResult  resolved    = layoutOf(labelScreen(100, 20, "STR-TITLE"));
+const mdux::spec::Register incompleteApprovedSetIsRefused{
+    "A budget measured over some of the approved locales is refused as a wiring error",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-approved-set")
+            .Given("a font package approving en-US and de-DE", [] {})
+            .When("a caller supplies a subset, a duplicate, or a locale the font does not approve", [] {})
+            .Then("each is std::logic_error rather than a screen certified against a set nobody approved",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
+                      const md::LayoutResult  resolved    = layoutOf(labelScreen(100, 20, "STR-TITLE"));
 
-                                                                bool threwWithoutFont = false;
-                                                                try {
-                                                                    [[maybe_unused]] const md::TextBudgetResult ignored = md::checkTextBudgets(
-                                                                        resolved,
-                                                                        "budget.medui",
-                                                                        {.font = nullptr, .locales = {}, .dynamicText = {}});
-                                                                } catch (const std::logic_error&) {
-                                                                    threwWithoutFont = true;
-                                                                }
-                                                                checks.expect(threwWithoutFont, "a null font package is a wiring error, not a diagnostic");
+                      const auto check = [&](std::span<const md::LocaleText> locales) {
+                          return throwsWiringError([&] {
+                              [[maybe_unused]] const md::TextBudgetResult ignored =
+                                  md::checkTextBudgets(resolved, "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                          });
+                      };
 
-                                                                const Locale                        other = letterLocale("en-US", "STR-OTHER", 3);
-                                                                const std::array<md::LocaleText, 1> locales{other.view()};
-                                                                bool                                threwWithoutRun = false;
-                                                                try {
-                                                                    [[maybe_unused]] const md::TextBudgetResult ignored = md::checkTextBudgets(
-                                                                        resolved,
-                                                                        "budget.medui",
-                                                                        {.font = &fontPackage, .locales = locales, .dynamicText = {}});
-                                                                } catch (const std::logic_error&) {
-                                                                    threwWithoutRun = true;
-                                                                }
-                                                                checks.expect(threwWithoutRun, "an unmeasurable key means analyze() was bypassed");
-                                                                checks.raise();
-                                                            })
-                                                      .Execute();
-                                              }};
+                      // The omission this check exists for: the 58px German translation is the one
+                      // that overflows, and leaving it out is how a screen passes without it.
+                      const std::array<md::LocaleText, 1> englishOnly{approved.english.view()};
+                      checks.expect(check(englishOnly), "an approved locale that was not supplied is refused");
+
+                      const std::array<md::LocaleText, 2> duplicated{approved.english.view(), approved.english.view()};
+                      checks.expect(check(duplicated), "the same locale supplied twice is refused");
+
+                      const Locale                        unapproved = letterLocale("fr-FR", "STR-TITLE", 3);
+                      const std::array<md::LocaleText, 3> extra{approved.english.view(), approved.german.view(), unapproved.view()};
+                      checks.expect(check(extra), "a locale the font package does not approve is refused");
+
+                      const auto complete = approved.views();
+                      checks.expect(!check(complete), "the complete approved set is accepted");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register malformedPackagesAreWiringErrors{
+    "A miswired stage throws rather than emitting a diagnostic an author cannot act on",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-gates-throw")
+            .Given("a null font, a truncated sidecar, a foreign atlas, a partial record and a missing key", [] {})
+            .When("the budget check runs on each", [] {})
+            .Then("every one is std::logic_error",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const md::LayoutResult  resolved    = layoutOf(labelScreen(100, 20, "STR-TITLE"));
+
+                      const auto check = [&](std::span<const md::LocaleText> locales) {
+                          return throwsWiringError([&] {
+                              [[maybe_unused]] const md::TextBudgetResult ignored =
+                                  md::checkTextBudgets(resolved, "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                          });
+                      };
+
+                      checks.expect(throwsWiringError([&] {
+                                        [[maybe_unused]] const md::TextBudgetResult ignored =
+                                            md::checkTextBudgets(resolved, "budget.medui", {.font = nullptr, .locales = {}, .dynamicText = {}});
+                                    }),
+                                    "a null font package is a wiring error, not a diagnostic");
+
+                      // A sidecar one byte short of what its package declares. The selected run
+                      // still fits inside what was handed over, which is exactly why the check is
+                      // against the declared length rather than against this run's end.
+                      ApprovedText truncated = approvedText("STR-TITLE", 3, 6);
+                      truncated.english.sidecar.pop_back();
+                      const auto truncatedViews = truncated.views();
+                      checks.expect(check(truncatedViews), "a sidecar shorter than the package declares is refused");
+
+                      ApprovedText foreign            = approvedText("STR-TITLE", 3, 6);
+                      foreign.english.package.atlasId = "another-font";
+                      const auto foreignViews         = foreign.views();
+                      checks.expect(check(foreignViews), "a package baked against a different font is refused");
+
+                      // 17 bytes is not a whole number of 6-byte records, so the run cannot be
+                      // enumerated - the failure `mdux.text.schema` documents as the one byte
+                      // identity cannot detect once it reaches a device.
+                      ApprovedText partial                             = approvedText("STR-TITLE", 3, 6);
+                      partial.english.package.runs.front().byteLength -= 1;
+                      partial.english.package.sidecarByteLength       -= 1;
+                      partial.english.sidecar.pop_back();
+                      const auto partialViews = partial.views();
+                      checks.expect(check(partialViews), "a run whose byte length is not a whole number of records is refused");
+
+                      const ApprovedText missing      = approvedText("STR-OTHER", 3, 6);
+                      const auto         missingViews = missing.views();
+                      checks.expect(check(missingViews), "an unmeasurable key means analyze() was bypassed");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
 
 const mdux::spec::Register fixturePackagesAreRealArtifacts{
     "The fixture font and text packages satisfy their own schemas",
     "evidence-unit",
     [] {
         return speclab::Test("medui-textbudget-fixtures-validate")
-            .Given("the synthetic font package and one baked locale", [] {})
+            .Given("the synthetic font package and both approved locales", [] {})
             .When("each is validated by the module that owns its format", [] {})
-            .Then("both pass, so the measurements above are taken from legal artifacts",
+            .Then("all three pass, so the measurements above are taken from legal artifacts",
                   [] {
                       mdux::spec::Checks      checks;
                       const font::FontPackage fontPackage = fixtureFont();
-                      const Locale            english     = letterLocale("en-US", "STR-TITLE", 3);
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
 
                       checks.expect(fontPackage.validate().has_value(), "the fixture font is a valid font package");
-                      checks.expect(english.package.validate().has_value(), "the fixture locale is a valid text package");
+                      checks.expect(approved.english.package.validate().has_value(), "the fixture en-US package is valid");
+                      checks.expect(approved.german.package.validate().has_value(), "the fixture de-DE package is valid");
                       checks.expect(fontPackage.permits(U'A') && !fontPackage.permits(U'Z'),
                                     "the restricted charset holds the letters the runs use and not the one they must not");
                       checks.raise();

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -274,6 +274,11 @@ constexpr std::array beyondUnicode{
     font::CharsetRange{.first = static_cast<char32_t>(0x110000), .last = static_cast<char32_t>(0x110000)}
 };
 
+/// U+D7FF..U+E000: a range whose ends are real characters but which spans the surrogate block.
+constexpr std::array acrossSurrogates{
+    font::CharsetRange{.first = static_cast<char32_t>(0xD7FF), .last = static_cast<char32_t>(0xE000)}
+};
+
 }  // namespace
 
 const mdux::spec::Register widestTranslationDrivesTheBudget{
@@ -590,32 +595,39 @@ const mdux::spec::Register charsetWalkCrossesRangeBoundaries{
             .Execute();
     }};
 
-const mdux::spec::Register rangesBeyondUnicodeAreReported{
-    "A produced range reaching past the last Unicode scalar value is reported, not clamped",
+const mdux::spec::Register nonScalarRangesAreReported{
+    "A produced range naming something that is not a character is reported, never asked about",
     "evidence-unit",
     [] {
         return speclab::Test("medui-textbudget-charset-beyond-unicode")
-            .Given("a governed entry declaring U+110000, which is not a character", [] {})
-            .When("the entry is walked", [] {})
-            .Then("MEDUI-E053 says so rather than silently measuring only the part that is",
+            .Given("governed entries declaring U+110000, and one spanning the surrogate block", [] {})
+            .When("each entry is checked", [] {})
+            .Then("MEDUI-E053 names the first non-character in each, rather than measuring around it",
                   [] {
-                      mdux::spec::Checks                       checks;
-                      const font::FontPackage                  fontPackage = fixtureFont();
-                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
-                      const auto                               locales     = approved.views();
-                      const std::array<md::DynamicTextRule, 1> table{
-                          md::DynamicTextRule{.name = "OUT_OF_RANGE", .produces = beyondUnicode}
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto              locales     = approved.views();
+
+                      const auto reportFor = [&](std::string_view name, std::span<const font::CharsetRange> produces) {
+                          const std::array<md::DynamicTextRule, 1> table{
+                              md::DynamicTextRule{.name = name, .produces = produces}
+                          };
+                          const std::string source = screenWith(std::format("    Clock {{ id: now; width: 100px; height: 20px; format: {}; }}\n", name));
+                          return md::checkTextBudgets(layoutOf(source), "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = table});
                       };
 
-                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: OUT_OF_RANGE; }\n");
-                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
-                                                                               "budget.medui",
-                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
+                      const md::TextBudgetResult beyond = reportFor("OUT_OF_RANGE", beyondUnicode);
+                      checks.expect(!beyond.ok(), "the out-of-range entry is rejected");
+                      checks.expect(mentions(find(beyond, md::Code::CharsetEscape), "U+110000"), "the diagnostic names the offending code point");
+                      checks.expect(mentions(find(beyond, md::Code::CharsetEscape), "not a Unicode scalar value"), "and says what is wrong with it");
 
-                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
-                      checks.expect(!result.ok(), "the screen is rejected");
-                      checks.expect(mentions(reported, "U+110000"), "the diagnostic names the offending code point");
-                      checks.expect(mentions(reported, "not a Unicode scalar value"), "and says what is wrong with it");
+                      // U+D7FF and U+E000 are real characters, so a check that compared only the
+                      // ends would pass this range - and the font package is never consulted, since
+                      // a surrogate is not something any package can draw whatever its table says.
+                      const md::TextBudgetResult surrogates = reportFor("SURROGATE_SPAN", acrossSurrogates);
+                      checks.expect(!surrogates.ok(), "the surrogate-spanning entry is rejected");
+                      checks.expect(mentions(find(surrogates, md::Code::CharsetEscape), "U+D800"), "the diagnostic names the first surrogate");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -1,0 +1,490 @@
+/**
+ * @brief BDD scenarios for text-budget and dynamic-charset validation (issue #195).
+ * @file TextBudgetTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-010 No on-device text shaping
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The fixture font and the per-locale text packages are built here rather than read from
+ * `generated/`, and that is a deliberate difference from the evidence suites. A committed package
+ * pins one set of real translations; these scenarios need a *pair* of locales whose widths differ
+ * by a known number of pixels, so that "the widest approved translation is what the budget is
+ * measured against" is checkable by arithmetic rather than by whichever German string happens to be
+ * in the corpus today.
+ *
+ * The font is still a real `mdux::font::FontPackage` and passes `validate()`; the runs are still
+ * real v1 records decoded by the same `mdux::text::draw::decodeRecord()` the device draws with.
+ * What is synthetic is the vocabulary, not the format.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.font.schema;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.textbudget;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md   = mdux::tools::medui;
+namespace cli  = mdux::tools::cli;
+namespace font = mdux::font;
+namespace text = mdux::text;
+
+/// Every glyph in the fixture font is this size, so an extent is countable by hand.
+constexpr std::uint32_t glyphWidth  = 8;
+constexpr std::uint32_t glyphHeight = 10;
+
+/// The pen step the fixture runs are baked at. Not the font's advance: a baker chooses positions,
+/// and this suite chooses a round number so that a run of n glyphs is `(n - 1) * 10 + 8` wide.
+constexpr std::int16_t penStep = 10;
+
+/// The baseline every fixture run sits on. With `bitmapOriginY == glyphHeight`, ink runs from y 0.
+constexpr std::int16_t baseline = 10;
+
+/// Package indices into the fixture font's glyph table, which is sorted by code point.
+constexpr std::uint16_t spaceIndex  = 0;   ///< U+0020, blank: an advance and no coverage
+constexpr std::uint16_t letterIndex = 12;  ///< U+0041 'A'
+
+/**
+ * @brief The fixture font: a blank space, the ten digits, `:`, and A-C, all 8x10.
+ *
+ * The digits share one advance width because `validate()` requires it - the tabular-figure rule
+ * from #161 - and this font is built to pass that check rather than around it.
+ */
+[[nodiscard]] font::FontPackage fixtureFont() {
+    font::FontPackage package;
+    package.id         = "fixture-ui";
+    package.unitsPerEm = 1000;
+    package.pixelSize  = 10;
+    package.locales    = {"en-US", "de-DE"};
+    package.atlas =
+        font::AtlasMetrics{.path = "atlas.bin", .width = 64, .height = 64, .byteLength = 64 * 64, .sha256 = std::string(64, 'a'), .occupancyPercent = 50};
+
+    const auto append = [&package](char32_t codePoint, bool blank) {
+        const auto slot = static_cast<std::uint32_t>(package.glyphs.size());
+        package.glyphs.push_back(font::GlyphRecord{.codePoint       = codePoint,
+                                                   .glyphIndex      = static_cast<std::uint16_t>(slot + 1),
+                                                   .advanceWidth    = 500,
+                                                   .leftSideBearing = 0,
+                                                   .x               = (slot % 8) * glyphWidth,
+                                                   .y               = (slot / 8) * glyphHeight,
+                                                   .width           = blank ? 0 : glyphWidth,
+                                                   .height          = blank ? 0 : glyphHeight,
+                                                   .bitmapOriginX   = 0,
+                                                   .bitmapOriginY   = blank ? 0 : static_cast<std::int32_t>(glyphHeight)});
+    };
+
+    append(U' ', true);
+    for (char32_t digit = U'0'; digit <= U'9'; ++digit) {
+        append(digit, false);
+    }
+    append(U':', false);
+    for (char32_t letter = U'A'; letter <= U'C'; ++letter) {
+        append(letter, false);
+    }
+
+    package.restrictedCharset = {
+        font::CharsetRange{.first = U' ', .last = U' '},
+        font::CharsetRange{.first = U'0', .last = U':'},
+        font::CharsetRange{.first = U'A', .last = U'C'}
+    };
+    return package;
+}
+
+/// Appends one little-endian v1 run record: package glyph index, pen x, baseline y.
+void appendRecord(std::vector<std::byte>& bytes, std::uint16_t packageIndex, std::int16_t x, std::int16_t y) {
+    const auto emit16 = [&bytes](std::uint16_t value) {
+        bytes.push_back(static_cast<std::byte>(value & 0xFFu));
+        bytes.push_back(static_cast<std::byte>((value >> 8) & 0xFFu));
+    };
+    emit16(packageIndex);
+    emit16(static_cast<std::uint16_t>(x));
+    emit16(static_cast<std::uint16_t>(y));
+}
+
+/// Bakes one run: the given glyphs, one `penStep` apart, on the fixture baseline.
+[[nodiscard]] std::vector<std::byte> bakeRun(std::span<const std::uint16_t> glyphs) {
+    std::vector<std::byte> bytes;
+    for (std::size_t index = 0; index < glyphs.size(); ++index) {
+        appendRecord(bytes, glyphs[index], static_cast<std::int16_t>(static_cast<std::int64_t>(index) * penStep), baseline);
+    }
+    return bytes;
+}
+
+/// One approved locale's package and the sidecar its runs address, kept together so a test can
+/// hand `checkTextBudgets()` a `LocaleText` without managing two lifetimes.
+struct Locale {
+    text::TextPackage      package;
+    std::vector<std::byte> sidecar;
+
+    [[nodiscard]] md::LocaleText view() const noexcept {
+        return md::LocaleText{.package = &package, .sidecar = sidecar};
+    }
+};
+
+/// Builds one locale's text package from `key -> run bytes`, concatenating the sidecar in order.
+///
+/// Only the header's id is set: `TextPackage` already defaults its `kind` and `schemaVersion`, and
+/// restating them here would be a second opinion about a format this suite does not own.
+[[nodiscard]] Locale bakeLocale(std::string locale, std::span<const std::pair<std::string, std::vector<std::byte>>> runs) {
+    Locale built;
+    built.package.header.id   = std::format("fixture-{}", locale);
+    built.package.atlasId     = "fixture-ui";
+    built.package.locale      = std::move(locale);
+    built.package.sidecarPath = "runs.bin";
+
+    for (const auto& [key, bytes] : runs) {
+        built.package.runs.push_back(text::TextRun{.id = key, .byteOffset = built.sidecar.size(), .byteLength = bytes.size(), .sha256 = {}});
+        built.sidecar.insert(built.sidecar.end(), bytes.begin(), bytes.end());
+    }
+    built.package.sidecarByteLength = built.sidecar.size();
+    return built;
+}
+
+/// One locale whose single key is `count` copies of 'A'.
+[[nodiscard]] Locale letterLocale(std::string locale, std::string key, std::size_t count) {
+    const std::vector<std::uint16_t>                                    glyphs(count, letterIndex);
+    const std::array<std::pair<std::string, std::vector<std::byte>>, 1> runs{
+        std::pair{std::move(key), bakeRun(glyphs)}
+    };
+    return bakeLocale(std::move(locale), runs);
+}
+
+/// Wraps a component body in a screen whose declared surface matches the build surface.
+[[nodiscard]] std::string screenWith(std::string_view body) {
+    return std::format("Screen Test {{\n"
+                       "    layout: Vertical {{ spacing: 0px; padding: 0px; }}\n"
+                       "    surface: 200px, 100px;\n"
+                       "{}"
+                       "}}\n",
+                       body);
+}
+
+/// One `Label` of the given box, carrying one text key.
+[[nodiscard]] std::string labelScreen(std::int64_t width, std::int64_t height, std::string_view key) {
+    return screenWith(std::format("    Label {{ id: title; width: {}px; height: {}px; text: t(\"{}\"); "
+                                  "color: Theme.Colors.Title; }}\n",
+                                  width,
+                                  height,
+                                  key));
+}
+
+/// Parses and resolves a screen against the 200x100 build surface these scenarios declare.
+[[nodiscard]] md::LayoutResult layoutOf(std::string_view source) {
+    md::ParseResult parsed = md::parse(source, "budget.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("text budget test source did not parse", std::source_location::current());
+    }
+    md::LayoutResult resolved = md::resolveLayout(*parsed.screen, "budget.medui", {.surfaceWidth = 200, .surfaceHeight = 100});
+    if (!resolved.ok()) {
+        throw speclab::core::AssertionFailure("text budget test source did not resolve", std::source_location::current());
+    }
+    return resolved;
+}
+
+/// Finds one registered diagnostic in a budget result.
+[[nodiscard]] const cli::Diagnostic* find(const md::TextBudgetResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    });
+    return found == result.diagnostics.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool mentions(const cli::Diagnostic* diagnostic, std::string_view fragment) {
+    return diagnostic != nullptr && diagnostic->message.find(fragment) != std::string::npos;
+}
+
+// The governed dynamic-text table these scenarios resolve `format:` and `charset:` against. The
+// ranges are namespace-scope so the spans in a `DynamicTextRule` outlive the call that reads them.
+constexpr std::array digitsAndColon{
+    font::CharsetRange{.first = U'0', .last = U':'}
+};
+constexpr std::array digitsAndZone{
+    font::CharsetRange{.first = U'0', .last = U':'},
+    font::CharsetRange{.first = U'Z', .last = U'Z'}
+};
+
+}  // namespace
+
+const mdux::spec::Register widestTranslationDrivesTheBudget{
+    "The budget is measured against the widest approved translation, not the authoring one",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-widest-locale")
+            .Given("a 40px Label whose en-US run is 28px and whose de-DE run is 58px", [] {})
+            .When("the resolved screen is checked against both approved locales", [] {})
+            .Then("MEDUI-E050 names de-DE, the key, the required width and the available one",
+                  [] {
+                      mdux::spec::Checks                  checks;
+                      const font::FontPackage             fontPackage = fixtureFont();
+                      const Locale                        english     = letterLocale("en-US", "STR-TITLE", 3);
+                      const Locale                        german      = letterLocale("de-DE", "STR-TITLE", 6);
+                      const std::array<md::LocaleText, 2> locales{english.view(), german.view()};
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(40, 20, "STR-TITLE")),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::TextBudgetExceeded);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(result.diagnostics.size() == 1, std::format("only the failing locale is reported, got {}", result.diagnostics.size()));
+                      checks.expect(mentions(reported, "de-DE"), "the diagnostic names the locale");
+                      checks.expect(mentions(reported, "STR-TITLE"), "the diagnostic names the text key");
+                      checks.expect(mentions(reported, "58px"), "the diagnostic names the required width");
+                      checks.expect(mentions(reported, "40px"), "the diagnostic names the available width");
+                      checks.expect(result.measurements.empty(), "no measurement survives a failed budget");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register fittingScreenReportsItsWorstCase{
+    "A screen that fits every locale reports the worst case for the emitter to budget",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-worst-case-measurement")
+            .Given("a 100px Label whose widest approved translation is 58px", [] {})
+            .When("the resolved screen is checked", [] {})
+            .Then("it compiles and the measurement names de-DE with the per-axis maximum",
+                  [] {
+                      mdux::spec::Checks                  checks;
+                      const font::FontPackage             fontPackage = fixtureFont();
+                      const Locale                        english     = letterLocale("en-US", "STR-TITLE", 3);
+                      const Locale                        german      = letterLocale("de-DE", "STR-TITLE", 6);
+                      const std::array<md::LocaleText, 2> locales{english.view(), german.view()};
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(100, 20, "STR-TITLE")),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      checks.expect(result.ok(), "the screen compiles");
+                      checks.expect(result.measurements.size() == 1, std::format("one text field is measured, got {}", result.measurements.size()));
+                      if (result.measurements.size() == 1) {
+                          const md::TextMeasurement& measured = result.measurements.front();
+                          checks.expect(measured.nodeId == "title", "the measurement names the node");
+                          checks.expect(measured.field == "text", "the measurement names the field");
+                          checks.expect(measured.textKey == "STR-TITLE", "the measurement names the key");
+                          checks.expect(measured.locale == "de-DE", "the widest locale is recorded");
+                          checks.expect(measured.extent == md::TextExtent{58, 10},
+                                        std::format("the extent is 58x10, got {}x{}", measured.extent.width, measured.extent.height));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register blankGlyphsAreNotInk{"A leading blank glyph does not widen the measured extent", "evidence-unit", [] {
+                                                    return speclab::Test("medui-textbudget-blank-glyphs-skipped")
+                                                        .Given("a run that opens with a space at the pen origin and three letters after it", [] {})
+                                                        .When("a 30px Label carrying that run is measured", [] {})
+                                                        .Then("the ink measures 28px and the box is accepted",
+                                                              [] {
+                                                                  mdux::spec::Checks      checks;
+                                                                  const font::FontPackage fontPackage = fixtureFont();
+
+                                                                  // Records at x = 0, 10, 20, 30: a blank space, then three letters. Counting
+                                                                  // the space as ink would measure from x 0 and make this 38px, which a 30px
+                                                                  // box would reject - so the acceptance below is the assertion.
+                                                                  const std::array<std::uint16_t, 4> glyphs{spaceIndex, letterIndex, letterIndex, letterIndex};
+                                                                  const std::array<std::pair<std::string, std::vector<std::byte>>, 1> runs{
+                                                                      std::pair{std::string{"STR-TITLE"}, bakeRun(glyphs)}
+                                                                  };
+                                                                  const Locale                        english = bakeLocale("en-US", runs);
+                                                                  const std::array<md::LocaleText, 1> locales{english.view()};
+
+                                                                  const md::TextBudgetResult result = md::checkTextBudgets(
+                                                                      layoutOf(labelScreen(30, 20, "STR-TITLE")),
+                                                                      "budget.medui",
+                                                                      {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                                                                  checks.expect(result.ok(), "the screen compiles");
+                                                                  checks.expect(result.measurements.size() == 1, "the field is measured");
+                                                                  if (result.measurements.size() == 1) {
+                                                                      checks.expect(result.measurements.front().extent == md::TextExtent{28, 10},
+                                                                                    std::format("the ink is 28x10, got {}x{}",
+                                                                                                result.measurements.front().extent.width,
+                                                                                                result.measurements.front().extent.height));
+                                                                  }
+                                                                  checks.raise();
+                                                              })
+                                                        .Execute();
+                                                }};
+
+const mdux::spec::Register heightIsBudgetedToo{"A box shorter than its translation is rejected on the vertical axis", "evidence-unit", [] {
+                                                   return speclab::Test("medui-textbudget-height-exceeded")
+                                                       .Given("a Label 8px tall carrying a run whose ink is 10px tall", [] {})
+                                                       .When("the resolved screen is checked", [] {})
+                                                       .Then("MEDUI-E050 names the height it needs and the height it has",
+                                                             [] {
+                                                                 mdux::spec::Checks                  checks;
+                                                                 const font::FontPackage             fontPackage = fixtureFont();
+                                                                 const Locale                        english     = letterLocale("en-US", "STR-TITLE", 2);
+                                                                 const std::array<md::LocaleText, 1> locales{english.view()};
+
+                                                                 const md::TextBudgetResult result = md::checkTextBudgets(
+                                                                     layoutOf(labelScreen(100, 8, "STR-TITLE")),
+                                                                     "budget.medui",
+                                                                     {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                                                                 const cli::Diagnostic* reported = find(result, md::Code::TextBudgetExceeded);
+                                                                 checks.expect(!result.ok(), "the screen is rejected");
+                                                                 checks.expect(mentions(reported, "height"), "the diagnostic names the axis that failed");
+                                                                 checks.expect(mentions(reported, "10px"), "the diagnostic names the required height");
+                                                                 checks.expect(mentions(reported, "8px"), "the diagnostic names the available height");
+                                                                 checks.raise();
+                                                             })
+                                                       .Execute();
+                                               }};
+
+const mdux::spec::Register dynamicTextCannotEscapeTheCharset{
+    "A format that can produce an unbaked character is MEDUI-E053",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-escape")
+            .Given("a Clock whose format can emit U+005A, which the font package does not hold", [] {})
+            .When("the format is resolved against the governed dynamic-text table", [] {})
+            .Then("MEDUI-E053 names the escaping code point",
+                  [] {
+                      mdux::spec::Checks                       checks;
+                      const font::FontPackage                  fontPackage = fixtureFont();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "HH_MM_TZ", .produces = digitsAndZone}
+                      };
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM_TZ; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = {}, .dynamicText = table});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(mentions(reported, "HH_MM_TZ"), "the diagnostic names the dynamic-text source");
+                      checks.expect(mentions(reported, "U+005A"), "the diagnostic names the code point that escapes");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unresolvedDynamicTextFailsClosed{
+    "A dynamic-text source with no governed entry fails closed",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-unbounded-dynamic-source")
+            .Given("a Clock naming a format the governed table does not define", [] {})
+            .When("the format is resolved", [] {})
+            .Then("MEDUI-E053 says what it produces is not bounded, rather than passing it over",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = {}, .dynamicText = {}});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(mentions(reported, "HH_MM"), "the diagnostic names the unresolved source");
+                      checks.expect(mentions(reported, "not bounded"), "the diagnostic says why it cannot pass");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register boundedDynamicTextIsAccepted{
+    "A format inside the restricted charset compiles, and an unnamed charset is not an error",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-accepted")
+            .Given("a Clock producing digits and a colon, and a TextInput with no charset field", [] {})
+            .When("the screen is checked against the font package's restricted charset", [] {})
+            .Then("neither component is reported",
+                  [] {
+                      mdux::spec::Checks                       checks;
+                      const font::FontPackage                  fontPackage = fixtureFont();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
+                      };
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n"
+                                                                     "    TextInput { id: entry; width: 100px; height: 20px; source: \"OPERATOR_NOTE\"; "
+                                                                     "max_length: 16; color: Theme.Colors.Title; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = {}, .dynamicText = table});
+
+                      checks.expect(result.ok(), std::format("the screen compiles, got {} diagnostics", result.diagnostics.size()));
+                      checks.expect(result.measurements.empty(), "a screen with no text key measures nothing");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register bypassedGatesThrow{"A miswired stage throws rather than emitting a diagnostic an author cannot act on", "evidence-unit", [] {
+                                                  return speclab::Test("medui-textbudget-gates-throw")
+                                                      .Given("a call with no font package, and a locale missing the key semantic analysis admitted", [] {})
+                                                      .When("the budget check runs", [] {})
+                                                      .Then("both are std::logic_error",
+                                                            [] {
+                                                                mdux::spec::Checks      checks;
+                                                                const font::FontPackage fontPackage = fixtureFont();
+                                                                const md::LayoutResult  resolved    = layoutOf(labelScreen(100, 20, "STR-TITLE"));
+
+                                                                bool threwWithoutFont = false;
+                                                                try {
+                                                                    [[maybe_unused]] const md::TextBudgetResult ignored = md::checkTextBudgets(
+                                                                        resolved,
+                                                                        "budget.medui",
+                                                                        {.font = nullptr, .locales = {}, .dynamicText = {}});
+                                                                } catch (const std::logic_error&) {
+                                                                    threwWithoutFont = true;
+                                                                }
+                                                                checks.expect(threwWithoutFont, "a null font package is a wiring error, not a diagnostic");
+
+                                                                const Locale                        other = letterLocale("en-US", "STR-OTHER", 3);
+                                                                const std::array<md::LocaleText, 1> locales{other.view()};
+                                                                bool                                threwWithoutRun = false;
+                                                                try {
+                                                                    [[maybe_unused]] const md::TextBudgetResult ignored = md::checkTextBudgets(
+                                                                        resolved,
+                                                                        "budget.medui",
+                                                                        {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                                                                } catch (const std::logic_error&) {
+                                                                    threwWithoutRun = true;
+                                                                }
+                                                                checks.expect(threwWithoutRun, "an unmeasurable key means analyze() was bypassed");
+                                                                checks.raise();
+                                                            })
+                                                      .Execute();
+                                              }};
+
+const mdux::spec::Register fixturePackagesAreRealArtifacts{
+    "The fixture font and text packages satisfy their own schemas",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-fixtures-validate")
+            .Given("the synthetic font package and one baked locale", [] {})
+            .When("each is validated by the module that owns its format", [] {})
+            .Then("both pass, so the measurements above are taken from legal artifacts",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const Locale            english     = letterLocale("en-US", "STR-TITLE", 3);
+
+                      checks.expect(fontPackage.validate().has_value(), "the fixture font is a valid font package");
+                      checks.expect(english.package.validate().has_value(), "the fixture locale is a valid text package");
+                      checks.expect(fontPackage.permits(U'A') && !fontPackage.permits(U'Z'),
+                                    "the restricted charset holds the letters the runs use and not the one they must not");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -720,6 +720,51 @@ const mdux::spec::Register incompleteApprovedSetIsRefused{
             .Execute();
     }};
 
+const mdux::spec::Register unwalkableFontCharsetIsRefused{
+    "A font package whose charset table cannot be walked is refused rather than walked",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-font-charset-walkable")
+            .Given("a font package with a charset range ending at the type maximum, and one that descends", [] {})
+            .When("a screen naming a dynamic-text source is checked against each", [] {})
+            .Then("both are std::logic_error, and the walk cannot loop",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Without the up-front check this scenario would hang rather than fail: the
+                      // walk advances to `covering->last + 1`, which wraps to zero for a range
+                      // ending at the type maximum and selects the same range forever. A hang is
+                      // the one failure a test cannot report, which is why the check is up front
+                      // rather than a guard inside the loop.
+                      font::FontPackage wrapping = fixtureFont();
+                      wrapping.restrictedCharset.push_back(font::CharsetRange{.first = U'X', .last = static_cast<char32_t>(0xFFFFFFFF)});
+
+                      font::FontPackage descending = fixtureFont();
+                      descending.restrictedCharset.push_back(font::CharsetRange{.first = U'Y', .last = U'X'});
+
+                      const ApprovedText                       approved = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales  = approved.views();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
+                      };
+                      const md::LayoutResult resolved = layoutOf(screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n"));
+
+                      const auto check = [&](const font::FontPackage& fontPackage) {
+                          return throwsWiringError([&] {
+                              [[maybe_unused]] const md::TextBudgetResult ignored =
+                                  md::checkTextBudgets(resolved, "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = table});
+                          });
+                      };
+
+                      checks.expect(check(wrapping), "a charset range past the last Unicode scalar value is refused");
+                      checks.expect(check(descending), "a descending charset range is refused");
+                      checks.expect(!wrapping.validate().has_value() && !descending.validate().has_value(),
+                                    "FontPackage::validate() rejects both too - this stage guards the packages it is handed unvalidated");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register malformedPackagesAreWiringErrors{
     "A miswired stage throws rather than emitting a diagnostic an author cannot act on",
     "evidence-unit",

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -213,6 +213,11 @@ constexpr std::array digitsAndZone{
     font::CharsetRange{.first = U'Z', .last = U'Z'}
 };
 
+/// U+0030..U+0041: the digits and the colon, then the gap the fixture font does not hold, then 'A'.
+constexpr std::array digitsThroughLetter{
+    font::CharsetRange{.first = U'0', .last = U'A'}
+};
+
 }  // namespace
 
 const mdux::spec::Register widestTranslationDrivesTheBudget{
@@ -277,6 +282,71 @@ const mdux::spec::Register fittingScreenReportsItsWorstCase{
                           checks.expect(measured.extent == md::TextExtent{58, 10},
                                         std::format("the extent is 58x10, got {}x{}", measured.extent.width, measured.extent.height));
                       }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register worstCaseSurvivesAnUnnamedLocale{
+    "The widest measurement is not lost to a locale whose tag is empty",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-worst-case-not-overwritten")
+            .Given("a 58px translation in a package with an empty locale tag, then a 28px en-US one", [] {})
+            .When("both are measured for the same key", [] {})
+            .Then("the recorded worst case is still 58px",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+
+                      // An empty tag is invalid - `TextPackage::validate()` rejects it - and this
+                      // stage takes packages by pointer without re-validating, so the tag must not
+                      // double as the "nothing measured yet" sentinel. If it did, the narrower
+                      // en-US measurement below would overwrite the wider one, and the compiler
+                      // would certify a budget too small for a translation it had just measured.
+                      const Locale                        unnamed = letterLocale("", "STR-TITLE", 6);
+                      const Locale                        english = letterLocale("en-US", "STR-TITLE", 3);
+                      const std::array<md::LocaleText, 2> locales{unnamed.view(), english.view()};
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(100, 20, "STR-TITLE")),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      checks.expect(result.ok(), "the screen compiles");
+                      checks.expect(result.measurements.size() == 1, "the field is measured");
+                      if (result.measurements.size() == 1) {
+                          checks.expect(result.measurements.front().extent.width == 58,
+                                        std::format("the worst case is 58px, got {}px", result.measurements.front().extent.width));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register charsetWalkCrossesRangeBoundaries{
+    "A produced range spanning a gap in the charset is caught at the gap",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-gap")
+            .Given("a source producing U+0030..U+0041, which the font holds either side of a gap", [] {})
+            .When("the produced range is walked against the restricted charset", [] {})
+            .Then("MEDUI-E053 names U+003B, the first code point in the gap",
+                  [] {
+                      mdux::spec::Checks                       checks;
+                      const font::FontPackage                  fontPackage = fixtureFont();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "DIGITS_TO_A", .produces = digitsThroughLetter}
+                      };
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: DIGITS_TO_A; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = {}, .dynamicText = table});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(mentions(reported, "U+003B"), "the walk stops at the first code point the charset omits");
+                      checks.expect(result.diagnostics.size() == 1, std::format("one diagnostic per field, got {}", result.diagnostics.size()));
                       checks.raise();
                   })
             .Execute();

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,10 +271,15 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S5 (#194) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer and
-# integer-only bounded layout solver. The emitters are #197, and the mdux-meduic executable with its mdux_compile_screen()
-# registration is #198 - so there is still no add_executable() here and no bake call site. Every
-# later stage adds sources to this target rather than inventing another.
+# At S6 (#195) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
+# integer-only bounded layout solver, and the text-budget check that measures a resolved box against
+# the widest approved translation. The emitters are #197, and the mdux-meduic executable with its
+# mdux_compile_screen() registration is #198 - so there is still no add_executable() here and no
+# bake call site. Every later stage adds sources to this target rather than inventing another.
+#
+# The budget stage reaches mdux.text.draw and mdux.font.schema through MduX::ToolsCommon's link to
+# MduX::Core: it decodes committed run records with the same decoder the device draws them with, so
+# the byte-order and baseline contracts have one implementation rather than a host copy of one.
 add_library(MduXMeduiLib)
 add_library(MduX::MeduiLib ALIAS MduXMeduiLib)
 
@@ -289,12 +294,14 @@ target_sources(MduXMeduiLib
             medui/Parser.cppm
             medui/Semantic.cppm
             medui/Layout.cppm
+            medui/TextBudget.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
         medui/Parser.cpp
         medui/Semantic.cpp
         medui/Layout.cpp
+        medui/TextBudget.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -134,6 +134,7 @@ public:
         if (inputs_.font == nullptr) {
             throw std::logic_error("text budget requires the font package the approved locales were baked into");
         }
+        checkFontCharset();
         checkLocaleWiring();
     }
 
@@ -149,6 +150,39 @@ public:
     }
 
 private:
+    /**
+     * @brief Checks that the font package's own charset table is walkable, once.
+     *
+     * The charset walk in `checkDynamicText()` advances by jumping to the end of the range that
+     * admitted a code point. That is only a *step* if the range ends somewhere below the type's
+     * maximum: a range ending at `0xFFFFFFFF` would make `last + 1` wrap to zero and select the same
+     * range forever, so a malformed table would hang the compiler rather than fail it.
+     *
+     * `FontPackage::validate()` rejects such a range, but this stage takes the package by pointer
+     * and never re-validates it - the same reason the produced ranges are treated as untrusted.
+     * Trusting one table while distrusting the other was the inconsistency this check removes.
+     *
+     * Only what the walk relies on is checked: an ascending range that stops at a Unicode scalar
+     * value. Sortedness, overlap and glyph coverage belong to `validate()` and are not restated
+     * here, because a second partial copy of that contract is worse than none.
+     */
+    void checkFontCharset() const {
+        constexpr std::uint32_t lastScalarValue = 0x10FFFF;
+        for (const mdux::font::CharsetRange& range : inputs_.font->restrictedCharset) {
+            if (range.last < range.first) {
+                throw std::logic_error(std::format("font package '{}' declares a charset range from U+{:04X} down to U+{:04X}",
+                                                   inputs_.font->id,
+                                                   static_cast<std::uint32_t>(range.first),
+                                                   static_cast<std::uint32_t>(range.last)));
+            }
+            if (static_cast<std::uint32_t>(range.last) > lastScalarValue) {
+                throw std::logic_error(std::format("font package '{}' declares a charset range ending at U+{:04X}, past the last Unicode scalar value",
+                                                   inputs_.font->id,
+                                                   static_cast<std::uint32_t>(range.last)));
+            }
+        }
+    }
+
     /**
      * @brief Checks the supplied locales against the set the font package approves, once.
      *
@@ -362,8 +396,11 @@ private:
                 const auto covering = std::ranges::find_if(inputs_.font->restrictedCharset, [point](const mdux::font::CharsetRange& admitted) {
                     return admitted.contains(static_cast<char32_t>(point));
                 });
-                // `permits()` just said yes, so a covering range exists; stepping by one anyway
-                // keeps the loop finite rather than trusting two implementations to agree.
+                // The step is strictly forward, and both branches are bounded: `checkFontCharset()`
+                // has established that every charset range ends at a scalar value, so `last + 1`
+                // cannot wrap, and `point` is itself bounded by `last` above. `permits()` just said
+                // yes, so a covering range exists; stepping by one where it does not keeps the walk
+                // finite rather than trusting two lookups to agree.
                 point = covering == inputs_.font->restrictedCharset.end() ? point + 1 : static_cast<std::uint32_t>(covering->last) + 1;
             }
 

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -1,0 +1,309 @@
+/**
+ * @file TextBudget.cpp
+ * @brief Widest-approved-translation measurement and dynamic-text charset validation.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-010 No on-device text shaping
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+module;
+
+module mdux.tools.medui.textbudget;
+
+import std;
+import mdux.font.schema;
+import mdux.text.draw;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.semantic;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// One component field whose value names a dynamic-text source.
+///
+/// Both entries are `Identifier`-domain fields in the shared component model, and both describe
+/// text the baker never positioned. `NumericDisplay`'s `template:` and every quoted `source:` are
+/// absent on purpose - see the module comment for why a product identifier cannot be expanded into
+/// code points here.
+struct DynamicField {
+    std::string_view component;
+    std::string_view field;
+};
+
+constexpr std::array dynamicFields{
+    DynamicField{    .component = "Clock",  .field = "format"},
+    DynamicField{.component = "TextInput", .field = "charset"}
+};
+
+[[nodiscard]] bool namesDynamicText(std::string_view component, std::string_view field) noexcept {
+    return std::ranges::any_of(dynamicFields, [component, field](const DynamicField& entry) {
+        return entry.component == component && entry.field == field;
+    });
+}
+
+/// Finds a component in the dictionary semantic analysis published, rather than a second copy of it.
+[[nodiscard]] const ComponentRule* ruleFor(std::string_view component) noexcept {
+    const std::span<const ComponentRule> dictionary = componentDictionary();
+    const auto                           found      = std::ranges::find(dictionary, component, &ComponentRule::name);
+    return found == dictionary.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const FieldRule* ruleFor(const ComponentRule& component, std::string_view field) noexcept {
+    const auto found = std::ranges::find(component.fields, field, &FieldRule::name);
+    return found == component.fields.end() ? nullptr : &*found;
+}
+
+/**
+ * @brief Measures the ink one baked run paints.
+ *
+ * The decode is `mdux::text::draw::decodeRecord()` and the placement arithmetic is
+ * `addGlyphRect()`'s: the pen plus the glyph's `bitmapOriginX`, and `bitmapOriginY` *above* the
+ * record's baseline. Restating either would be the second path this stage exists to avoid, so what
+ * is restated is only the part that has no shared helper - taking the union of the rectangles.
+ *
+ * Blank glyphs are skipped exactly as `recordRun()` skips them: they paint nothing, so they cannot
+ * overflow a box visibly, and counting a trailing space as ink would reject screens that render
+ * correctly.
+ */
+[[nodiscard]] TextExtent measureRun(const mdux::font::FontPackage& fontPackage, std::span<const std::byte> records) {
+    if (records.size() % mdux::text::draw::recordSize != 0) {
+        throw std::logic_error(
+            std::format("text budget received {} bytes, which is not a whole number of {}-byte run records", records.size(), mdux::text::draw::recordSize));
+    }
+
+    bool         inked{false};
+    std::int64_t left{0};
+    std::int64_t right{0};
+    std::int64_t top{0};
+    std::int64_t bottom{0};
+
+    for (std::size_t offset = 0; offset < records.size(); offset += mdux::text::draw::recordSize) {
+        const auto placement = mdux::text::draw::decodeRecord(records.subspan(offset, mdux::text::draw::recordSize));
+        if (!placement.has_value()) {
+            throw std::logic_error(
+                std::format("text budget could not decode the run record at byte {}: {}", offset, mdux::text::draw::describe(placement.error())));
+        }
+        if (placement->packageIndex >= fontPackage.glyphs.size()) {
+            throw std::logic_error(std::format("run record at byte {} names glyph {} but font package '{}' holds {}",
+                                               offset,
+                                               placement->packageIndex,
+                                               fontPackage.id,
+                                               fontPackage.glyphs.size()));
+        }
+
+        const mdux::font::GlyphRecord& glyph = fontPackage.glyphs[placement->packageIndex];
+        if (glyph.isBlank()) {
+            continue;
+        }
+
+        const std::int64_t glyphLeft   = std::int64_t{placement->x} + glyph.bitmapOriginX;
+        const std::int64_t glyphTop    = std::int64_t{placement->y} - glyph.bitmapOriginY;
+        const std::int64_t glyphRight  = glyphLeft + glyph.width;
+        const std::int64_t glyphBottom = glyphTop + glyph.height;
+
+        if (!inked) {
+            inked  = true;
+            left   = glyphLeft;
+            right  = glyphRight;
+            top    = glyphTop;
+            bottom = glyphBottom;
+            continue;
+        }
+        left   = std::min(left, glyphLeft);
+        right  = std::max(right, glyphRight);
+        top    = std::min(top, glyphTop);
+        bottom = std::max(bottom, glyphBottom);
+    }
+
+    if (!inked) {
+        return TextExtent{};
+    }
+    return TextExtent{.width = right - left, .height = bottom - top};
+}
+
+/// One fail-closed budget pass over a resolved screen.
+class Checker {
+public:
+    /// Captures the diagnostic path and the packages a screen is measured against.
+    Checker(std::string file, TextBudgetInputs inputs) : file_{std::move(file)}, inputs_{inputs} {
+        if (inputs_.font == nullptr) {
+            throw std::logic_error("text budget requires the font package the approved locales were baked into");
+        }
+    }
+
+    /// Checks one resolved screen, returning no measurements on any diagnostic.
+    [[nodiscard]] TextBudgetResult run(const LayoutResult& layout) {
+        for (const ResolvedNode& node : layout.nodes) {
+            checkNode(node);
+        }
+        if (!diagnostics_.empty()) {
+            measurements_.clear();
+        }
+        return TextBudgetResult{.measurements = std::move(measurements_), .diagnostics = std::move(diagnostics_)};
+    }
+
+private:
+    void report(Code code, ast::Position position, std::string message) {
+        diagnostics_.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
+    }
+
+    void checkNode(const ResolvedNode& node) {
+        // An unknown component is MEDUI-E011 and belongs to semantic analysis; a synthetic Row
+        // background resolves to its originating Row, which carries no text.
+        const ComponentRule* component = ruleFor(node.source.component);
+        if (component == nullptr) {
+            return;
+        }
+
+        for (const ast::Field& field : node.source.fields) {
+            const FieldRule* fieldRule = ruleFor(*component, field.name);
+            if (fieldRule == nullptr || field.value == nullptr) {
+                continue;
+            }
+            if (fieldRule->domain == FieldDomain::TextKey) {
+                checkTextKey(node, field, *field.value);
+            } else if (fieldRule->domain == FieldDomain::TextKeyList) {
+                for (const std::shared_ptr<ast::Value>& element : field.value->list) {
+                    if (element != nullptr) {
+                        checkTextKey(node, field, *element);
+                    }
+                }
+            } else if (namesDynamicText(node.source.component, field.name)) {
+                checkDynamicText(field, *field.value);
+            }
+        }
+    }
+
+    /// Measures one key in every approved locale, reporting each locale that does not fit.
+    void checkTextKey(const ResolvedNode& node, const ast::Field& field, const ast::Value& value) {
+        if (value.kind != ast::ValueKind::TextKey) {
+            // MEDUI-E017 or MEDUI-E033, already reported by analyze(): there is no key to measure.
+            return;
+        }
+        if (inputs_.locales.empty()) {
+            throw std::logic_error(std::format("text budget was given no approved locale to measure text key '{}' against", value.text));
+        }
+
+        TextExtent  worst{};
+        std::string widestLocale;
+
+        for (const LocaleText& locale : inputs_.locales) {
+            const TextExtent extent = measure(locale, value.text);
+
+            if (extent.width > node.bounds.width) {
+                report(Code::TextBudgetExceeded,
+                       value.position,
+                       std::format("text key '{}' in locale '{}' needs {}px of width, and '{}' resolved to {}px",
+                                   value.text,
+                                   locale.package->locale,
+                                   extent.width,
+                                   node.id,
+                                   node.bounds.width));
+            }
+            if (extent.height > node.bounds.height) {
+                report(Code::TextBudgetExceeded,
+                       value.position,
+                       std::format("text key '{}' in locale '{}' needs {}px of height, and '{}' resolved to {}px",
+                                   value.text,
+                                   locale.package->locale,
+                                   extent.height,
+                                   node.id,
+                                   node.bounds.height));
+            }
+
+            if (widestLocale.empty() || extent.width > worst.width) {
+                worst.width  = extent.width;
+                widestLocale = locale.package->locale;
+            }
+            worst.height = std::max(worst.height, extent.height);
+        }
+
+        measurements_.push_back(
+            TextMeasurement{.nodeId = node.id, .field = field.name, .textKey = value.text, .locale = std::move(widestLocale), .extent = worst});
+    }
+
+    /// Measures one key against one locale's committed package.
+    [[nodiscard]] TextExtent measure(const LocaleText& locale, std::string_view key) const {
+        if (locale.package == nullptr) {
+            throw std::logic_error("text budget received an approved locale with no text package");
+        }
+        if (locale.package->atlasId != inputs_.font->id) {
+            throw std::logic_error(
+                std::format("locale '{}' was baked against font package '{}', not '{}'", locale.package->locale, locale.package->atlasId, inputs_.font->id));
+        }
+
+        const mdux::text::TextRun* run = locale.package->find(key);
+        if (run == nullptr) {
+            throw std::logic_error(std::format("text key '{}' has no run in approved locale '{}'; semantic analysis is a required gate before the budget check",
+                                               key,
+                                               locale.package->locale));
+        }
+        if (run->byteEnd() > locale.sidecar.size()) {
+            throw std::logic_error(std::format("locale '{}' declares run '{}' at bytes {}..{} of a sidecar that is {} bytes long",
+                                               locale.package->locale,
+                                               key,
+                                               run->byteOffset,
+                                               run->byteEnd(),
+                                               locale.sidecar.size()));
+        }
+
+        return measureRun(*inputs_.font, locale.sidecar.subspan(static_cast<std::size_t>(run->byteOffset), static_cast<std::size_t>(run->byteLength)));
+    }
+
+    /// Checks that a named dynamic-text source can only produce glyphs the font package holds.
+    void checkDynamicText(const ast::Field& field, const ast::Value& value) {
+        if (value.kind != ast::ValueKind::Identifier) {
+            // MEDUI-E033's, reported by analyze(): there is no name to resolve.
+            return;
+        }
+
+        // Searched as a `string_view` on both sides: the projection yields one, and comparing it
+        // with the AST's `std::string` would rest on a heterogeneous comparison the range concepts
+        // do not owe us.
+        const auto found = std::ranges::find(inputs_.dynamicText, std::string_view{value.text}, &DynamicTextRule::name);
+        if (found == inputs_.dynamicText.end()) {
+            report(Code::CharsetEscape,
+                   value.position,
+                   std::format("'{}' is not in the governed dynamic-text table, so what '{}' can produce is not bounded", value.text, field.name));
+            return;
+        }
+
+        // One diagnostic per field rather than per code point: a charset that escapes usually
+        // escapes over a whole range, and an author fixes the range rather than each character.
+        //
+        // The loop counts in `std::uint32_t` and stops at the last Unicode scalar value. A supplied
+        // range is not `FontPackage::validate()`'d, so `last` may be anything a `char32_t` holds -
+        // and `point <= last` with `last` at the type's maximum never terminates.
+        constexpr std::uint32_t lastScalarValue = 0x10FFFF;
+        for (const mdux::font::CharsetRange& range : found->produces) {
+            const std::uint32_t first = range.first;
+            const std::uint32_t last  = std::min<std::uint32_t>(range.last, lastScalarValue);
+            for (std::uint32_t point = first; point <= last; ++point) {
+                if (!inputs_.font->permits(static_cast<char32_t>(point))) {
+                    report(Code::CharsetEscape,
+                           value.position,
+                           std::format("'{}' can produce U+{:04X}, which font package '{}' cannot draw", value.text, point, inputs_.font->id));
+                    return;
+                }
+            }
+        }
+    }
+
+    std::string                  file_;
+    TextBudgetInputs             inputs_;
+    std::vector<TextMeasurement> measurements_;
+    std::vector<cli::Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+TextBudgetResult checkTextBudgets(const LayoutResult& layout, std::string file, TextBudgetInputs inputs) {
+    return Checker{std::move(file), inputs}.run(layout);
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -59,6 +59,33 @@ constexpr std::array dynamicFields{
 }
 
 /**
+ * @brief The first code point in an ascending range that is not a Unicode scalar value, if any.
+ *
+ * Two shapes are not characters and cannot be drawn by anything: the surrogate block U+D800..U+DFFF,
+ * which exists only to encode other code points in UTF-16, and anything past U+10FFFF. The lowest
+ * one a range names is returned, so the diagnostic points at the first offending code point rather
+ * than at whichever rule happened to be tested first.
+ *
+ * `range` is assumed ascending; a descending range names nothing and is the caller's to skip.
+ */
+[[nodiscard]] std::optional<std::uint32_t> firstNonScalar(mdux::font::CharsetRange range) noexcept {
+    constexpr std::uint32_t firstSurrogate  = 0xD800;
+    constexpr std::uint32_t lastSurrogate   = 0xDFFF;
+    constexpr std::uint32_t lastScalarValue = 0x10FFFF;
+
+    const auto first = static_cast<std::uint32_t>(range.first);
+    const auto last  = static_cast<std::uint32_t>(range.last);
+
+    if (first <= lastSurrogate && last >= firstSurrogate) {
+        return std::max(first, firstSurrogate);
+    }
+    if (last > lastScalarValue) {
+        return std::max(first, lastScalarValue + 1);
+    }
+    return std::nullopt;
+}
+
+/**
  * @brief Measures the ink one baked run paints.
  *
  * The decode is `mdux::text::draw::decodeRecord()` and the placement arithmetic is
@@ -373,15 +400,34 @@ private:
         // One diagnostic per field rather than per code point: a charset that escapes usually
         // escapes over a whole range, and an author fixes the range rather than each character.
         //
-        // The walk counts in `std::uint32_t` because a supplied range is not
-        // `FontPackage::validate()`'d - `last` may be anything a `char32_t` holds, and `point <=
-        // last` with `last` at the type's maximum never terminates. A descending range produces
-        // nothing and is skipped rather than reported: what a `.medui` author wrote is a name, and
-        // the shape of the table behind it is not theirs to fix.
-        constexpr std::uint32_t lastScalarValue = 0x10FFFF;
+        // The walk counts in `std::uint32_t` rather than `char32_t` because a supplied range is not
+        // `FontPackage::validate()`'d: `last` may be anything the type holds, and `point <= last`
+        // with `last` at the type's maximum would never terminate. `firstNonScalar()` below bounds
+        // every range that reaches the walk to U+10FFFF, so the counting type is now belt as well as
+        // braces - and it stays, because the bound is one edit away from being someone else's
+        // assumption. A descending range produces nothing and is skipped rather than reported: what
+        // a `.medui` author wrote is a name, and the shape of the table behind it is not theirs to
+        // fix.
         for (const mdux::font::CharsetRange& range : found->produces) {
-            const std::uint32_t last  = std::min<std::uint32_t>(range.last, lastScalarValue);
-            std::uint32_t       point = range.first;
+            if (range.last < range.first) {
+                continue;
+            }
+
+            // A range that names something which is not a character is reported before it is
+            // walked, and reported as what it is. Two shapes qualify: a code point past U+10FFFF,
+            // and the surrogate block, which exists only to encode other code points in UTF-16 and
+            // is not a scalar value either. Asking `permits()` about those would be asking the
+            // wrong question - a font package cannot draw them whatever its table claims, and a
+            // package whose table did claim them would answer yes.
+            if (const auto offending = firstNonScalar(range)) {
+                report(Code::CharsetEscape,
+                       value.position,
+                       std::format("'{}' can produce U+{:04X}, which is not a Unicode scalar value", value.text, *offending));
+                return;
+            }
+
+            const auto    last  = static_cast<std::uint32_t>(range.last);
+            std::uint32_t point = static_cast<std::uint32_t>(range.first);
 
             while (point <= last) {
                 if (!inputs_.font->permits(static_cast<char32_t>(point))) {
@@ -402,18 +448,6 @@ private:
                 // yes, so a covering range exists; stepping by one where it does not keeps the walk
                 // finite rather than trusting two lookups to agree.
                 point = covering == inputs_.font->restrictedCharset.end() ? point + 1 : static_cast<std::uint32_t>(covering->last) + 1;
-            }
-
-            // A range reaching past the last Unicode scalar value is reported rather than clamped.
-            // Clamping was the first revision's behaviour and it was wrong in the quiet direction:
-            // the table would be claiming code points that are not characters at all, and the stage
-            // would have measured the part it recognised and said nothing about the rest.
-            if (range.first <= range.last && range.last > lastScalarValue) {
-                const std::uint32_t offending = std::max<std::uint32_t>(range.first, lastScalarValue + 1);
-                report(Code::CharsetEscape,
-                       value.position,
-                       std::format("'{}' can produce U+{:04X}, which is not a Unicode scalar value", value.text, offending));
-                return;
             }
         }
     }

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -134,6 +134,7 @@ public:
         if (inputs_.font == nullptr) {
             throw std::logic_error("text budget requires the font package the approved locales were baked into");
         }
+        checkLocaleWiring();
     }
 
     /// Checks one resolved screen, returning no measurements on any diagnostic.
@@ -148,6 +149,65 @@ public:
     }
 
 private:
+    /**
+     * @brief Checks the supplied locales against the set the font package approves, once.
+     *
+     * A budget is a claim about the *worst* approved translation, so the set it was measured over
+     * has to be the approved one. Accepting a subset would let a caller hand over the locale it was
+     * looking at and receive a screen certified against a set nobody approved - and the omitted
+     * translation is precisely the one that overflows, because a locale nobody measured is a locale
+     * nobody sized for.
+     *
+     * Each package's own wiring is checked here too, rather than at the point some key happens to
+     * be measured: identity against the font, and a sidecar whose size is the one the package
+     * declares. A truncated sidecar that still contains the first run would otherwise measure that
+     * run and mismeasure everything after it, which is the failure this check exists to make loud.
+     */
+    void checkLocaleWiring() const {
+        std::vector<std::string_view> supplied;
+        supplied.reserve(inputs_.locales.size());
+
+        for (const LocaleText& locale : inputs_.locales) {
+            if (locale.package == nullptr) {
+                throw std::logic_error("text budget received an approved locale with no text package");
+            }
+            const std::string_view tag = locale.package->locale;
+
+            if (locale.package->atlasId != inputs_.font->id) {
+                throw std::logic_error(
+                    std::format("locale '{}' was baked against font package '{}', not '{}'", tag, locale.package->atlasId, inputs_.font->id));
+            }
+            if (locale.sidecar.size() != locale.package->sidecarByteLength) {
+                throw std::logic_error(std::format("locale '{}' declares a {}-byte sidecar and was given {} bytes",
+                                                   tag,
+                                                   locale.package->sidecarByteLength,
+                                                   locale.sidecar.size()));
+            }
+            if (std::ranges::any_of(supplied, [tag](std::string_view seen) {
+                    return seen == tag;
+                })) {
+                throw std::logic_error(std::format("locale '{}' was supplied twice", tag));
+            }
+            if (!std::ranges::any_of(inputs_.font->locales, [tag](std::string_view approved) {
+                    return approved == tag;
+                })) {
+                throw std::logic_error(std::format("locale '{}' is not approved by font package '{}'", tag, inputs_.font->id));
+            }
+            supplied.push_back(tag);
+        }
+
+        for (const std::string& approved : inputs_.font->locales) {
+            if (!std::ranges::any_of(supplied, [&approved](std::string_view seen) {
+                    return seen == approved;
+                })) {
+                throw std::logic_error(std::format("font package '{}' approves locale '{}', which was not supplied; a "
+                                                   "budget measured over a subset of the approved locales is not a budget",
+                                                   inputs_.font->id,
+                                                   approved));
+            }
+        }
+    }
+
     void report(Code code, ast::Position position, std::string message) {
         diagnostics_.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
     }
@@ -236,15 +296,10 @@ private:
     }
 
     /// Measures one key against one locale's committed package.
+    ///
+    /// The package's identity, and that its sidecar is whole, were settled by `checkLocaleWiring()`
+    /// before any node was read. What is left here is the range this key actually names.
     [[nodiscard]] TextExtent measure(const LocaleText& locale, std::string_view key) const {
-        if (locale.package == nullptr) {
-            throw std::logic_error("text budget received an approved locale with no text package");
-        }
-        if (locale.package->atlasId != inputs_.font->id) {
-            throw std::logic_error(
-                std::format("locale '{}' was baked against font package '{}', not '{}'", locale.package->locale, locale.package->atlasId, inputs_.font->id));
-        }
-
         const mdux::text::TextRun* run = locale.package->find(key);
         if (run == nullptr) {
             throw std::logic_error(std::format("text key '{}' has no run in approved locale '{}'; semantic analysis is a required gate before the budget check",
@@ -284,11 +339,11 @@ private:
         // One diagnostic per field rather than per code point: a charset that escapes usually
         // escapes over a whole range, and an author fixes the range rather than each character.
         //
-        // The walk counts in `std::uint32_t` and stops at the last Unicode scalar value. A supplied
-        // range is not `FontPackage::validate()`'d, so `last` may be anything a `char32_t` holds -
-        // and `point <= last` with `last` at the type's maximum never terminates. A descending
-        // range produces nothing and is skipped rather than reported: what a `.medui` author wrote
-        // is a name, and the shape of the table behind it is not theirs to fix.
+        // The walk counts in `std::uint32_t` because a supplied range is not
+        // `FontPackage::validate()`'d - `last` may be anything a `char32_t` holds, and `point <=
+        // last` with `last` at the type's maximum never terminates. A descending range produces
+        // nothing and is skipped rather than reported: what a `.medui` author wrote is a name, and
+        // the shape of the table behind it is not theirs to fix.
         constexpr std::uint32_t lastScalarValue = 0x10FFFF;
         for (const mdux::font::CharsetRange& range : found->produces) {
             const std::uint32_t last  = std::min<std::uint32_t>(range.last, lastScalarValue);
@@ -310,6 +365,18 @@ private:
                 // `permits()` just said yes, so a covering range exists; stepping by one anyway
                 // keeps the loop finite rather than trusting two implementations to agree.
                 point = covering == inputs_.font->restrictedCharset.end() ? point + 1 : static_cast<std::uint32_t>(covering->last) + 1;
+            }
+
+            // A range reaching past the last Unicode scalar value is reported rather than clamped.
+            // Clamping was the first revision's behaviour and it was wrong in the quiet direction:
+            // the table would be claiming code points that are not characters at all, and the stage
+            // would have measured the part it recognised and said nothing about the rest.
+            if (range.first <= range.last && range.last > lastScalarValue) {
+                const std::uint32_t offending = std::max<std::uint32_t>(range.first, lastScalarValue + 1);
+                report(Code::CharsetEscape,
+                       value.position,
+                       std::format("'{}' can produce U+{:04X}, which is not a Unicode scalar value", value.text, offending));
+                return;
             }
         }
     }

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -191,6 +191,13 @@ private:
 
         TextExtent  worst{};
         std::string widestLocale;
+        // An explicit "nothing measured yet" flag rather than `widestLocale.empty()`. The tag would
+        // read as a sentinel only for as long as no approved locale has an empty one - and this
+        // stage takes packages by pointer without re-validating them, so an unvalidated package
+        // with an empty `locale` would make every later locale overwrite the widest measurement
+        // with a narrower one. Under-reporting the worst case is the one direction a budget check
+        // must not fail in.
+        bool measured{false};
 
         for (const LocaleText& locale : inputs_.locales) {
             const TextExtent extent = measure(locale, value.text);
@@ -216,11 +223,12 @@ private:
                                    node.bounds.height));
             }
 
-            if (widestLocale.empty() || extent.width > worst.width) {
+            if (!measured || extent.width > worst.width) {
                 worst.width  = extent.width;
                 widestLocale = locale.package->locale;
             }
             worst.height = std::max(worst.height, extent.height);
+            measured     = true;
         }
 
         measurements_.push_back(
@@ -276,20 +284,32 @@ private:
         // One diagnostic per field rather than per code point: a charset that escapes usually
         // escapes over a whole range, and an author fixes the range rather than each character.
         //
-        // The loop counts in `std::uint32_t` and stops at the last Unicode scalar value. A supplied
+        // The walk counts in `std::uint32_t` and stops at the last Unicode scalar value. A supplied
         // range is not `FontPackage::validate()`'d, so `last` may be anything a `char32_t` holds -
-        // and `point <= last` with `last` at the type's maximum never terminates.
+        // and `point <= last` with `last` at the type's maximum never terminates. A descending
+        // range produces nothing and is skipped rather than reported: what a `.medui` author wrote
+        // is a name, and the shape of the table behind it is not theirs to fix.
         constexpr std::uint32_t lastScalarValue = 0x10FFFF;
         for (const mdux::font::CharsetRange& range : found->produces) {
-            const std::uint32_t first = range.first;
             const std::uint32_t last  = std::min<std::uint32_t>(range.last, lastScalarValue);
-            for (std::uint32_t point = first; point <= last; ++point) {
+            std::uint32_t       point = range.first;
+
+            while (point <= last) {
                 if (!inputs_.font->permits(static_cast<char32_t>(point))) {
                     report(Code::CharsetEscape,
                            value.position,
                            std::format("'{}' can produce U+{:04X}, which font package '{}' cannot draw", value.text, point, inputs_.font->id));
                     return;
                 }
+                // `permits()` decides; this only chooses the next point worth asking about. A
+                // produced range covering the whole plane would otherwise cost a million binary
+                // searches per field, where the answer changes only at a charset-range edge.
+                const auto covering = std::ranges::find_if(inputs_.font->restrictedCharset, [point](const mdux::font::CharsetRange& admitted) {
+                    return admitted.contains(static_cast<char32_t>(point));
+                });
+                // `permits()` just said yes, so a covering range exists; stepping by one anyway
+                // keeps the loop finite rather than trusting two implementations to agree.
+                point = covering == inputs_.font->restrictedCharset.end() ? point + 1 : static_cast<std::uint32_t>(covering->last) + 1;
             }
         }
     }

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -62,6 +62,11 @@
  * `charset:` on `TextInput`) is checked against the governed table in `TextBudgetInputs`, and every
  * code point that table says the name can produce must be one the font package can draw.
  *
+ * A produced range that names something which is not a character - the surrogate block, or anything
+ * past U+10FFFF - is `MEDUI-E053` before the font package is consulted at all. Nothing can draw a
+ * non-character, so `permits()` is the wrong question to ask about one, and a package whose table
+ * claimed such a code point would answer yes.
+ *
  * A name absent from the table is `MEDUI-E053` too, and that is a deliberate fail-closed reading:
  * "this name does not resolve" means the compiler cannot bound what it produces, which is
  * indistinguishable, from here, from a name that produces something unbakeable. The alternative -

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -23,9 +23,10 @@
  * So the screen a device holds is one rectangle per node for all locales, and the rectangle has to
  * be the one that survives the worst translation. German and Finnish routinely run half again the
  * length of English; a box sized against the authoring locale renders a clipped word on a shipped
- * device, in a language the author does not read, on a screen nobody re-reviewed. That is a
- * usability failure IEC 62366-1 asks to be controlled, and ADR-011's answer is to make it fail to
- * compile rather than to mitigate it downstream.
+ * device, in a language the author does not read, on a screen nobody re-reviewed. This project
+ * treats that as a usability risk to be controlled at build time, and ADR-011's answer is to make
+ * it fail to compile rather than to mitigate it downstream. Where that decision sits against the
+ * standards corpus is ADR-011's to record, not this module's to assert.
  *
  * ## What "measure" means here, and what it does not
  *
@@ -107,7 +108,12 @@ export namespace mdux::tools::medui {
  *
  * The package and the sidecar are separate because that is how they are committed - `package.json`
  * beside `runs.bin` - and the caller is what reads them. `sidecar` must be the whole file: run
- * ranges are absolute offsets into it, exactly as `TextPackage::validate()` checked them.
+ * ranges are absolute offsets into it, exactly as `TextPackage::validate()` checked them, and
+ * `checkTextBudgets()` refuses a span whose size is not the package's own `sidecarByteLength`.
+ *
+ * Refusing on the *whole* length rather than on each run's end is the difference between a check
+ * that holds and one that happens to hold: a truncated sidecar whose first run survives the cut
+ * would measure that run correctly and mismeasure - or silently skip - every run after it.
  */
 struct LocaleText {
     const mdux::text::TextPackage* package{nullptr};
@@ -136,8 +142,14 @@ struct DynamicTextRule {
  *
  * `font` is the committed font package the approved locales were baked into, and it is required:
  * there is no measurement without metrics, and a defaulted one would be a second metrics path.
- * `locales` carries every approved locale, because the budget is the worst of them and a caller
- * that passed one locale would be certifying a screen nobody checked.
+ *
+ * `locales` must be *exactly* the set the font package approves - one entry per tag in
+ * `FontPackage::locales`, none missing, none repeated, none outside it - and that is checked rather
+ * than assumed. A budget is a claim about the worst approved translation, so a caller that supplied
+ * only the locale it happened to be looking at would get a screen certified against a set nobody
+ * approved: the omitted German or Finnish translation is exactly the one that overflows, and it
+ * would overflow on a device with the compiler's blessing. Requiring the whole set makes that
+ * particular silence impossible.
  */
 struct TextBudgetInputs {
     const mdux::font::FontPackage*   font{nullptr};
@@ -194,11 +206,15 @@ struct TextBudgetResult {
  * author reading top to bottom reads them in the order they were written.
  *
  * The stage assumes its gates: `analyze()` has accepted the screen, so every text key resolves in
- * every approved locale, and `resolveLayout()` has produced these bounds. A key with no run, a
- * sidecar shorter than its package declares, a text package baked against a different font, or a
- * record naming a glyph outside the package all mean a caller wired the stages together wrongly
- * rather than an author writing a bad screen, and each throws `std::logic_error` rather than being
- * reported as a diagnostic an author cannot act on.
+ * every approved locale, and `resolveLayout()` has produced these bounds. An approved locale that
+ * was not supplied, a supplied locale the font package does not approve, a duplicate locale, a
+ * sidecar whose size is not the one its package declares, a key with no run, a text package baked
+ * against a different font, or a record naming a glyph outside the package all mean a caller wired
+ * the stages together wrongly rather than an author writing a bad screen, and each throws
+ * `std::logic_error` rather than being reported as a diagnostic an author cannot act on.
+ *
+ * The locale, sidecar, font-identity and duplicate checks run once, before any node is looked at,
+ * so a miswired call fails on the wiring rather than on whichever screen happened to have text.
  *
  * @throws std::logic_error if `inputs.font` is null, or if any gate above was bypassed.
  */

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -209,7 +209,8 @@ struct TextBudgetResult {
  * every approved locale, and `resolveLayout()` has produced these bounds. An approved locale that
  * was not supplied, a supplied locale the font package does not approve, a duplicate locale, a
  * sidecar whose size is not the one its package declares, a key with no run, a text package baked
- * against a different font, or a record naming a glyph outside the package all mean a caller wired
+ * against a different font, a font package whose restricted charset descends or reaches past the
+ * last Unicode scalar value, or a record naming a glyph outside the package all mean a caller wired
  * the stages together wrongly rather than an author writing a bad screen, and each throws
  * `std::logic_error` rather than being reported as a diagnostic an author cannot act on.
  *

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -1,0 +1,207 @@
+/**
+ * @file TextBudget.cppm
+ * @brief Build-time text-budget validation: does a resolved box contain the widest approved
+ *        translation, and can a dynamic-text source produce a character nobody baked.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-010 No on-device text shaping
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Host-only, and the last check before emission. It runs after `resolveLayout()` because a budget
+ * is a statement about a *resolved* rectangle: `width: Fill` has no width until the solver has run,
+ * and most text in a real screen sits in one.
+ *
+ * ## Why this stage exists at all
+ *
+ * A compiled screen is locale-free (ADR-011, as amended by #203): it carries `text_key` rather than
+ * glyph runs, and the device joins the two for the locale it is running. That amendment moved the
+ * *substitution* to the device and deliberately left this check behind:
+ *
+ * > The compiler still validates every key against every approved locale, and still validates text
+ * > budgets against the widest approved translation (#195).
+ *
+ * So the screen a device holds is one rectangle per node for all locales, and the rectangle has to
+ * be the one that survives the worst translation. German and Finnish routinely run half again the
+ * length of English; a box sized against the authoring locale renders a clipped word on a shipped
+ * device, in a language the author does not read, on a screen nobody re-reviewed. That is a
+ * usability failure IEC 62366-1 asks to be controlled, and ADR-011's answer is to make it fail to
+ * compile rather than to mitigate it downstream.
+ *
+ * ## What "measure" means here, and what it does not
+ *
+ * There is no shaping in this stage, and no second metrics path. The text package already holds
+ * the runs `mdux-textbake` positioned for each locale, and the font package already holds the glyph
+ * table those runs index. Measuring is therefore reading: decode each 6-byte record through
+ * `mdux::text::draw::decodeRecord()` - the same decoder the device draws with, so the byte-order
+ * and baseline contracts have one implementation - look each glyph up in the same
+ * `mdux::font::FontPackage` the runtime will, and take the extent of the rectangles that result.
+ *
+ * Re-deriving the extent from advance widths and a string would be the second path, and it would be
+ * the wrong one twice over: it would not see the baker's kerning decisions, and a disagreement
+ * between it and the baked runs would surface as a device-time clip that the compiler had certified.
+ *
+ * The extent measured is the *ink* box - what coverage the atlas actually paints - because that is
+ * what a viewer sees leave the box. `recordRun()` skips blank glyphs rather than recording empty
+ * rectangles, and this measurement skips exactly the same ones for exactly the same reason: a
+ * trailing space is not visible, so it cannot overflow visibly.
+ *
+ * Only the extent is checked, never the placement. Where a run sits inside its box - leading,
+ * centred, trailing - is the emitter's decision (#197), and a stage that assumed one alignment
+ * would reject screens the emitter would have laid out correctly.
+ *
+ * ## Dynamic text and the restricted charset
+ *
+ * Static text is safe by construction: the baker positioned it, so every glyph exists. Dynamic text
+ * is not. A `Clock` formatting a time, or a `TextInput` echoing an operator, can reach a code point
+ * nobody baked, and ADR-010 leaves the runtime no fallback - having one would mean mapping code
+ * points on device.
+ *
+ * `FontPackage::restrictedCharset` is the declared answer and `permits()` is the test. What this
+ * stage adds is the *source* side of it: a named dynamic-text value (`format:` on `Clock`,
+ * `charset:` on `TextInput`) is checked against the governed table in `TextBudgetInputs`, and every
+ * code point that table says the name can produce must be one the font package can draw.
+ *
+ * A name absent from the table is `MEDUI-E053` too, and that is a deliberate fail-closed reading:
+ * "this name does not resolve" means the compiler cannot bound what it produces, which is
+ * indistinguishable, from here, from a name that produces something unbakeable. The alternative -
+ * passing a name over in silence because no rule described it - is how a device-time surprise gets
+ * a compiler's signature on it.
+ *
+ * A `TextInput` with no `charset:` field is not checked and is not an error. The field is optional
+ * in the shared component model, and its absence means the component is restricted to the font
+ * package's own charset - which cannot escape itself. An author names a charset to *narrow* the
+ * set, never to widen it.
+ *
+ * ## What this stage deliberately does not check
+ *
+ * `TextInput` carries `max_length`, and the shared component model asks that "bounded-dynamic" text
+ * fit its box in the worst case as well. Sizing that worst case means deciding how the runtime
+ * advances the pen for text no baker positioned, and no such rule exists yet - the components that
+ * would need it are #17. Inventing one here would pin a policy in a diagnostic before the code that
+ * has to honour it is written, so the check waits for the runtime rule rather than guessing at it.
+ * `NumericDisplay`'s `template:` is left for the same reason: it is a product template identifier,
+ * and the compiler cannot expand it into code points without a table nobody has defined.
+ *
+ * ## Why the shared conformance suite does not cover these two codes
+ *
+ * `MEDUI-E050` and `MEDUI-E053` are in the pinned contract's code table, but a case cannot exercise
+ * them yet: `schemas/case.schema.json` lets a case carry theme tokens and per-locale *keys*, and
+ * neither font metrics nor a charset table. A case therefore has no way to state what a translation
+ * measures or what a format can produce. The codes are the contract's, the checks are here, and the
+ * tests below stand in until the case schema can express the inputs.
+ */
+module;
+
+export module mdux.tools.medui.textbudget;
+
+import std;
+import mdux.font.schema;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.layout;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief One approved locale: its baked text package, and the sidecar bytes its runs address.
+ *
+ * The package and the sidecar are separate because that is how they are committed - `package.json`
+ * beside `runs.bin` - and the caller is what reads them. `sidecar` must be the whole file: run
+ * ranges are absolute offsets into it, exactly as `TextPackage::validate()` checked them.
+ */
+struct LocaleText {
+    const mdux::text::TextPackage* package{nullptr};
+    std::span<const std::byte>     sidecar{};
+};
+
+/**
+ * @brief One named dynamic-text source, and every code point it is able to produce.
+ *
+ * The governed table an author's `format: HH_MM` or `charset: LATIN_BASIC` is resolved against.
+ * It is an input rather than a constant here for the same reason `themeTokens` is an input to
+ * semantic analysis: the names belong to a product's governed tables, not to the language, and a
+ * compiler that shipped its own list would be authoritative about a set it does not own.
+ *
+ * `produces` is stated as charset ranges rather than a code-point list because a set is reviewed
+ * as ranges - "U+0030..U+0039, U+003A" is checkable by eye - and because it is then the same shape
+ * as the font package's own `restrictedCharset` that it is compared against.
+ */
+struct DynamicTextRule {
+    std::string_view                          name;
+    std::span<const mdux::font::CharsetRange> produces;
+};
+
+/**
+ * @brief Everything one screen is measured against.
+ *
+ * `font` is the committed font package the approved locales were baked into, and it is required:
+ * there is no measurement without metrics, and a defaulted one would be a second metrics path.
+ * `locales` carries every approved locale, because the budget is the worst of them and a caller
+ * that passed one locale would be certifying a screen nobody checked.
+ */
+struct TextBudgetInputs {
+    const mdux::font::FontPackage*   font{nullptr};
+    std::span<const LocaleText>      locales;
+    std::span<const DynamicTextRule> dynamicText;
+};
+
+/// The ink one baked run paints, in surface pixels.
+struct TextExtent {
+    std::int64_t width{0};
+    std::int64_t height{0};
+
+    auto operator<=>(const TextExtent&) const = default;
+};
+
+/**
+ * @brief The worst approved case for one authored text value.
+ *
+ * `extent` is the per-axis maximum across every approved locale, which is what a locale-free screen
+ * has to reserve, and what #197's `DrawBudget` computation consumes rather than measuring again.
+ * `locale` names the locale that produced the widest width - the one an author needs to open when
+ * a budget fails - so on a screen whose tallest and widest translations differ, `extent.height` may
+ * come from a locale this field does not name. Width is what a budget conversation is almost always
+ * about, and naming two locales in one record would make the common case read like an edge case.
+ */
+struct TextMeasurement {
+    std::string nodeId;
+    std::string field;  ///< the authored field, e.g. `text` or `label`
+    std::string textKey;
+    std::string locale;
+    TextExtent  extent{};
+};
+
+/**
+ * @brief Measurements and any diagnostic that stopped the screen.
+ *
+ * `measurements` is empty whenever a diagnostic is present, matching `LayoutResult`: a caller
+ * cannot accidentally consume the budget of a screen that failed its budget check.
+ */
+struct TextBudgetResult {
+    std::vector<TextMeasurement>              measurements;
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Checks every text budget on a resolved screen, and every dynamic-text charset on it.
+ *
+ * Diagnostics accumulate in resolved-node order, then field order within a node, then the input
+ * order of `locales` within a field - so a screen with three bad boxes reports all three, and an
+ * author reading top to bottom reads them in the order they were written.
+ *
+ * The stage assumes its gates: `analyze()` has accepted the screen, so every text key resolves in
+ * every approved locale, and `resolveLayout()` has produced these bounds. A key with no run, a
+ * sidecar shorter than its package declares, a text package baked against a different font, or a
+ * record naming a glyph outside the package all mean a caller wired the stages together wrongly
+ * rather than an author writing a bad screen, and each throws `std::logic_error` rather than being
+ * reported as a diagnostic an author cannot act on.
+ *
+ * @throws std::logic_error if `inputs.font` is null, or if any gate above was bypassed.
+ */
+[[nodiscard]] TextBudgetResult checkTextBudgets(const LayoutResult& layout, std::string file, TextBudgetInputs inputs);
+
+}  // namespace mdux::tools::medui


### PR DESCRIPTION
## Summary

S6 of the `.medui` compiler: the stage that decides whether a resolved box can hold what will be
drawn in it. It adds `mdux.tools.medui.textbudget` (`tools/medui/TextBudget.{cppm,cpp}`), run after
`resolveLayout()` because a budget is a statement about a resolved rectangle — `width: Fill` has no
width until the solver has run.

Two checks, both codes already in the pinned contract's table:

- **`MEDUI-E050` — text budget exceeded.** For every text-bearing field, every approved locale's
  baked run is measured and compared with the node's resolved bounds, on both axes. The diagnostic
  names the locale, the key, the width (or height) required and the one available.
- **`MEDUI-E053` — dynamic text escapes its charset.** A named dynamic-text value (`format:` on
  `Clock`, `charset:` on `TextInput`) is resolved against a governed table supplied as an input, and
  every code point that table says it can produce must satisfy `FontPackage::permits()`.

Measurement reads the committed artifacts rather than re-deriving them. Each run is decoded with
`mdux::text::draw::decodeRecord()` — the same decoder the device draws with, so the byte-order and
baseline contracts have one implementation — and each glyph is looked up in the same
`mdux::font::FontPackage` the runtime will use. Blank glyphs are skipped exactly as `recordRun()`
skips them, so a space cannot overflow a box it does not paint. Only the extent is checked;
alignment inside the box is the emitter's decision (#197).

The stage also returns the per-axis worst case for each text field. ADR-011 (as amended by #203)
makes the compiled screen locale-free, so its `DrawBudget` has to cover the widest approved
translation — this is where that number is computed, once.

Three decisions worth a reviewer's attention, each argued in the module comment:

1. **A dynamic-text name absent from the governed table is `MEDUI-E053`, not a pass.** The compiler
   cannot bound what an unresolved name produces, and passing it over silently is how a device-time
   surprise acquires a compiler's signature. It does mean a build that uses `Clock` must supply the
   table.
2. **A `TextInput` with no `charset:` is not checked and not an error.** The field is optional and
   its absence means the font package's own charset, which cannot escape itself.
3. **`TextInput`'s `max_length` worst case and `NumericDisplay`'s `template:` are deliberately not
   checked.** The first needs a runtime pen-advance rule for text no baker positioned, which does
   not exist until #17; the second is a product template identifier the compiler cannot expand.
   Both omissions are documented in the module rather than left silent.

Gates are assumed rather than re-litigated, and checked before the first node is read: the supplied
locales must match `FontPackage::locales` exactly (none missing, none repeated, none outside it),
each sidecar's size must be the one its package declares, and each package must be baked against
this font. Those, a key with no run, and a missing font package are wiring errors and throw
`std::logic_error`, following `resolveLayout()`'s precedent, rather than becoming diagnostics an
author cannot act on. Requiring the *complete* approved set is the point of the first check: a
budget measured over a subset is not a budget, because the locale nobody measured is the one that
overflows.

No change to `medui-conformance.toml`. `MEDUI-E050` and `MEDUI-E053` cannot be exercised by a shared
case at the pinned schema version — `schemas/case.schema.json` carries theme tokens and per-locale
keys, but no font metrics and no charset table — so no capability is claimed that no case backs.
The suite in `tests/medui/TextBudgetTests.cpp` stands in, and says so.

`docs/roadmap.md` is also re-verified against `develop` in this PR: Wave 5 is in progress with #15
at 6/12, and the #11 closure caveat is resolved now that #186 and #189 have both merged.

Closes #195

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change.
- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: none — maintainer-authored, so neither box applies. Ticking them would
record an invitation that was never issued.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked — #212 (S5) is already merged
- **Merge order:** mergeable now

## Shared registries touched

- [x] `FILE_SET CXX_MODULES` lists — `medui/TextBudget.cppm` added
- [x] `tools/CMakeLists.txt` — `MduXMeduiLib` sources
- [x] `tests/CMakeLists.txt` — `medui_tools_spec` sources
- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`

## Rebase state

- **Rebased onto:** `d3efe11` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — **not run locally.** The preset is
      Linux-only and the local macOS toolchain cannot complete a module build: with CMake 4.1.2 and
      Homebrew GCC 16.1.0 the configure succeeds, but the build fails inside CMake's synthesized
      `__CMAKE::CXX23` target — GCC's scan of `bits/std.cc` reports no module interface unit, so the
      `std` BMI never builds. That is before any MduX source is compiled, and disabling ccache does
      not change it. CI is the only execution path here.
- [ ] `ctest --test-dir build-gcc` — not run locally, for the same reason.
- [x] CI on `24049a5` and `44b4e19`: Linux (GCC 16, Vulkan) **502/502 tests passed**, Windows
      (MSVC, Vulkan) and ASan + UBSan (GCC 16) green, with every lint and analysis leg green.
      Those runs are the first execution of this code.
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — `OK (80 files checked, 0 findings)`
- [x] Other: `clang-format` applied to the three new sources with the repository's `.clang-format`.

- [x] CI on `9b9d949` (this head): Linux (GCC 16, Vulkan) **507/507 tests passed**, Windows (MSVC,
      Vulkan) and ASan + UBSan (GCC 16) green, every lint and analysis leg green. The budget suite
      is 16 scenarios. (`8cb7cea`'s commit message said 16 when the suite was 15; the count caught
      up with it in `c5f00f9`, and the number here is the one to trust.)

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** pending
- [ ] That run is green.

## Regulatory impact

Safety-relevant, and this is the change that adds the control rather than one that could weaken it.
The failure it prevents is one a static review cannot see: a box sized to the authoring locale
renders a clipped word on a shipped device, in a language the author does not read. ADR-011 § "Two
things this does *not* relax" names #195 as where that becomes a compile error rather than a
mitigation, and this PR is that mechanism. Where that decision sits against the standards corpus is
ADR-011's to record; an earlier revision of this description and of the module comment attributed a
requirement to IEC 62366-1 without a citation, which the corpus rules forbid, and both have been
rewritten.

Artifacts updated: `docs/architecture.md`, `README.md`, `.agents/skills/medui-authoring/SKILL.md`
and `docs/roadmap.md`, each stating what the stage now enforces. No ADR changes — ADR-010 and
ADR-011 already decided this and are cited from the module rather than restated. No new
certification or compliance claim: the stage enforces a documented rule, and the two checks it does
*not* implement are named in the module comment so the gap is visible rather than assumed closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text-budget validation for resolved screens across approved locales.
  * Added horizontal and vertical overflow checks.
  * Added dynamic-text character-set validation, including unsupported glyph and unresolved-source diagnostics.
  * Added deterministic measurements identifying the widest approved translation.

* **Documentation**
  * Updated implementation status, architecture documentation, and roadmap to reflect text-budget validation progress.

* **Tests**
  * Added comprehensive coverage for locale measurements, overflow handling, dynamic text, glyph validation, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


