### PR TITLE
S7 — Golden references for safety-critical nodes [#196]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,16 +10,18 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: parsing, semantic validation, bounded layout, and text budgets are implemented; emission and runtime are not
+## Status: the front end through golden references is implemented; emission and runtime are not
 
-**A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, and
-text-budget check exist** in the host-tools zone (`tools/medui/`). The diagnostic codes they emit
-are registered as `MEDUI-E###` (#191). The parser rejects structural violations (#192); the
-analyzer checks the closed component dictionary, each field's value domain, theme-token names, and
-text-key presence across every approved locale (#193); the solver flattens Vertical/Row layout to
-absolute rectangles without floating-point arithmetic (#194); and the budget check measures each
-resolved box against the widest approved translation and each named dynamic-text source against the
-font package's restricted charset (#195). The AST keeps names unresolved.
+**A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, text-budget
+check, and golden-reference pass exist** in the host-tools zone (`tools/medui/`). The diagnostic
+codes they emit are registered as `MEDUI-E###` (#191). The parser rejects structural violations
+(#192); the analyzer checks the closed component dictionary, each field's value domain, theme-token
+names, and text-key presence across every approved locale (#193); the solver flattens Vertical/Row
+layout to absolute rectangles without floating-point arithmetic (#194); the budget check measures
+each resolved box against the widest approved translation and each named dynamic-text source
+against the font package's restricted charset (#195); and the golden pass applies the
+`@safety_critical` rules and derives the reference set #16's verifier will consume (#196). The AST
+keeps names unresolved.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -111,9 +113,10 @@ verifier checks against. Rules:
 ## Checking a file without a full build
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser, analyzer, solver, and budget check it will call already
-detect syntax errors, structural violations, unknown dictionary/theme names, hardcoded text in
-localizable fields, wrong field value domains, incomplete locale keys, layout overflow, a box that
-cannot contain its widest approved translation, and a dynamic-text source that could escape the
-baked charset; what is missing is the command that exposes them. Until it lands, review a `.medui`
+diagnostics — once it exists. The parser, analyzer, solver, budget check, and golden pass it will
+call already detect syntax errors, structural violations, unknown dictionary/theme names, hardcoded
+text in localizable fields, wrong field value domains, incomplete locale keys, layout overflow, a
+box that cannot contain its widest approved translation, a dynamic-text source that could escape
+the baked charset, a `@safety_critical` node with no `requirement:`, and an unknown `cv_check`;
+what is missing is the command that exposes them. Until it lands, review a `.medui`
 file by hand against this grammar and the component table above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,10 @@ Three decisions from that programme apply repository-wide:
    digest or golden-vector mismatch. See [ADR-008](docs/adr/ADR-008-zero-soup-ml-inference.md).
 
 Waves 1 to 4 of that roadmap have shipped (v0.2.0, v0.3.0, v0.4.0, v0.5.0). Wave 4 was the font
-and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), now
-unblocked.
+and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), in progress:
+seven of its twelve children have landed, taking a screen from source to a bounded, budgeted,
+golden-annotated set of rectangles. The emitters (`#197`), the CMake integration (`#198`) and the
+runtime (`#199`) are what remain.
 
 Treat any AGENTS.md section below that describes current architecture as authoritative for *today's
 code*; treat this subsection as the direction that code is moving in.
@@ -330,7 +332,7 @@ is one of the things that would have caught that earlier.
 | [`mdux-regulated-change`](.agents/skills/mdux-regulated-change/SKILL.md) | A change can affect safety behavior, risk controls, compliance metadata, traceability, auditability, lifecycle documents, or claims about medical-device standards. | Impact classification, affected-artifact identification, proportionate documentation updates, traceability, review/escalation triggers, evidence-vs-intent-vs-certification distinctions. |
 | [`regulatory-citations`](.agents/skills/regulatory-citations/SKILL.md) | Writing or reviewing anything that claims alignment with IEC 62304, ISO 13485, ISO 14971, IEC 62366-1, or IEC 81001-5-1. | Citation-key format, the `Justification` object, the prohibition on reproducing normative text. **Target convention** — see § 2's parity-programme note. |
 | [`evidence-pipeline`](.agents/skills/evidence-pipeline/SKILL.md) | Adding or modifying a baked asset (font, shader, image, `.medui` screen, ML model) or anything under `generated/`. | Recipe→baker→committed-artifact doctrine, canonical-JSON rules, why `generated/` is never hand-edited. **Live** — `mdux-shaderbake` and `mdux-mlbake` both register through `mdux_bake_artifact()`, and `generated/shader/` and `generated/model/` are committed and byte-verified. |
-| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. **Planned** — no `.medui` compiler exists yet (issue `#15`). |
+| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. **Partly live** — the compiler's front end validates a screen (parser, semantics, layout, text budgets, goldens), but nothing emits or renders one yet, so a `.medui` file still builds nothing (issue `#15`). |
 | [`sdf-documents`](.agents/skills/sdf-documents/SKILL.md) | Filling in or reviewing a `software_development_file/` document. | Structure, the summarize-don't-duplicate rule, citing into the corpus. **Live** — `software_development_file/` exists with templates and records (issue `#9`). |
 
 Detailed procedures live in the skill files, not here — this table only routes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,9 @@ Three decisions from that programme apply repository-wide:
 Waves 1 to 4 of that roadmap have shipped (v0.2.0, v0.3.0, v0.4.0, v0.5.0). Wave 4 was the font
 and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), in progress:
 seven of its twelve children have landed, taking a screen from source to a bounded, budgeted,
-golden-annotated set of rectangles. The emitters (`#197`), the CMake integration (`#198`) and the
-runtime (`#199`) are what remain.
+golden-annotated set of rectangles. Five remain — the emitters (`#197`), the CMake integration and
+`mdux-meduic` (`#198`), the allocation-free screen runtime (`#199`), `mdux-medui-check` (`#200`) and
+the first end-to-end screen (`#201`).
 
 Treat any AGENTS.md section below that describes current architecture as authoritative for *today's
 code*; treat this subsection as the direction that code is moving in.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
-| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, integer-only bounded layout, and per-locale text budgets; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, integer-only bounded layout, per-locale text budgets, and golden references for safety-critical nodes; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), integer-only bounded layout solver (#194), and the text-budget check that measures resolved boxes against the widest approved translation (#195) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), integer-only bounded layout solver (#194), the text-budget check that measures resolved boxes against the widest approved translation (#195), and the golden references that say where safety-critical content must appear (#196) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, bounded layout, and text budgets are implemented; packaging and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, bounded layout, text budgets, and golden references are implemented; packaging and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 16 August 2026
-> Verified against `develop` @ `d3efe11` · 16 August 2026 · `#15` current through `#195`
+> Backlog · ambroise-leclerc/MduX · updated 17 August 2026
+> Verified against `develop` @ `163371b` · 17 August 2026 · `#15` current through `#196`
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
@@ -9,10 +9,11 @@ backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draw
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. Six of its twelve children have landed — the ADRs,
-the diagnostic registry, the front end, semantic analysis, bounded layout, and per-locale text
-budgets — so the compiler now reads a `.medui` file, resolves it to a bounded box tree, and refuses
-a box that cannot hold its widest approved translation. #196 is next.
+that generates the screens it draws. Seven of its twelve children have landed — the ADRs,
+the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
+and golden references — so the compiler now reads a `.medui` file, resolves it to a bounded box
+tree, refuses a box that cannot hold its widest approved translation, and says where safety-critical
+content must appear. #197 is next: the emitters that write all of it down.
 
 | Metric | Count |
 |---|---|
@@ -25,13 +26,13 @@ a box that cannot hold its widest approved translation. #196 is next.
 
 ### Where the two diverge
 
-Re-verified against `develop` on 16 August 2026. Eight of the nine rows have closed since
+Re-verified against `develop` on 17 August 2026. Eight of the nine rows have closed since
 this table was first written; the one that remains is the `.medui` authoring story, which is
 the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler's front end has landed — lexer, parser, AST, semantic analysis, bounded layout and per-locale text budgets, all host-only and conformance-tested against the shared MedUI spec. What is still ahead is the back end: goldens, the emitters, and the runtime that consumes them. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler's front end has landed — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec. What is still ahead is the back end: the emitters, and the runtime that consumes them. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Five artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
@@ -56,7 +57,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S6 done · S7 next)
+Wave 5 · in progress        #15 (S1–S7 done · S8 next)
 Wave 6                      #16  #17
 ```
 
@@ -236,14 +237,15 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 6/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 7/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
 Rust shares types across the crate boundary; C++ can do better.
 
 The front end is in the tree and conformance-tested against the shared MedUI spec
-(`medui-conformance.toml`, capabilities `syntax`, `semantics`, `layout`). ADR-011 and
+(`medui-conformance.toml`, capabilities `syntax`, `semantics`, `layout`, `safety` — the last claimed
+with #196, which is what made the pinned `MEDUI-E070` case executable rather than skipped). ADR-011 and
 ADR-012 were amended by #203 before any code depended on them: the compiled screen is
 locale-free, so the per-locale text stays in the text package — which is why S6 measures every
 approved locale and reserves the worst of them, rather than sizing a box to the locale its author
@@ -255,8 +257,8 @@ happened to read.
 - #193 S4 Theme tokens and locale-checked strings · _closed_
 - #194 S5 Bounded layout and `Row` flattening · _closed (PR #212)_
 - #195 S6 Text-budget validation against every approved locale · _closed_
-- #196 S7 Golden references for safety-critical nodes · **next**
-- #197 S8 Canonical package and C++ emitters
+- #196 S7 Golden references for safety-critical nodes · _closed_
+- #197 S8 Canonical package and C++ emitters · **next**
 - #198 S9 CMake integration and the `mdux-meduic` host tool
 - #199 S10 Allocation-free screen runtime
 - #200 S11 `mdux-medui-check`
@@ -366,6 +368,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Verified at `develop` @ `d3efe11` · 16 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 6/12) · no enforcement gaps outstanding_
+_Verified at `develop` @ `163371b` · 17 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 7/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,7 +1,7 @@
 repository = "https://github.com/Compliatory/MedUI"
 version = "0.1.0"
 commit = "d5136a8518bd499760ecff2aad215d3721329f20"
-capabilities = ["syntax", "semantics", "layout"]
+capabilities = ["syntax", "semantics", "layout", "safety"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.
 positions = "full"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,7 +674,7 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issues #191, #192, #193, #194, #195)
+# .medui compiler host-tools suite (issues #191, #192, #193, #194, #195, #196)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
 # completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
@@ -686,6 +686,10 @@ mdux_discover_tests(text_tools_spec)
 # widest-approved-translation rule is only checkable when two locales differ by a width the test
 # chose. The packages are still validated by the schema modules that own their formats, so the
 # measurements are taken from artifacts that would be legal on disk.
+#
+# GoldenTests (#196) reads tests/medui/fixtures/accepted-goldens.medui, which carries every rule
+# ADR-011 fixes for golden references in one screen - including the node that matches both rules and
+# must therefore appear exactly once.
 add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
@@ -693,6 +697,7 @@ add_executable(medui_tools_spec
     medui/SemanticTests.cpp
     medui/LayoutTests.cpp
     medui/TextBudgetTests.cpp
+    medui/GoldenTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/medui/GoldenTests.cpp
+++ b/tests/medui/GoldenTests.cpp
@@ -1,0 +1,397 @@
+/**
+ * @brief BDD scenarios for golden references on safety-critical nodes (issue #196).
+ * @file GoldenTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * The predicate is the whole subject here: which nodes are selected, that a node matching both
+ * rules is selected exactly once, and that what a golden pins for dynamic content is where it
+ * appears rather than what it says. `accepted-goldens.medui` carries all of that in one screen an
+ * author could open, which is why it is a fixture rather than a string literal - #200's
+ * `mdux-medui-check` will be pointed at the same corpus.
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.parser;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+/// Reads one real authoring fixture from the repository corpus.
+[[nodiscard]] std::string fixture(std::string_view name) {
+    const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+    std::ifstream               in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened at {}", name, path.generic_string()),
+                                              std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] md::ast::Screen parseOrFail(std::string_view source) {
+    md::ParseResult parsed = md::parse(source, "goldens.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("golden test source did not parse", std::source_location::current());
+    }
+    return std::move(*parsed.screen);
+}
+
+/// Parses and resolves, failing the scenario rather than the assertion if the screen is malformed.
+[[nodiscard]] md::LayoutResult layoutOf(std::string_view source, std::int64_t width, std::int64_t height) {
+    const md::ast::Screen screen   = parseOrFail(source);
+    md::LayoutResult      resolved = md::resolveLayout(screen, "goldens.medui", {.surfaceWidth = width, .surfaceHeight = height});
+    if (!resolved.ok()) {
+        throw speclab::core::AssertionFailure("golden test source did not resolve", std::source_location::current());
+    }
+    return resolved;
+}
+
+/// Wraps a component body in a screen whose declared surface matches the build surface.
+[[nodiscard]] std::string screenWith(std::string_view body) {
+    return std::format("Screen Test {{\n"
+                       "    layout: Vertical {{ spacing: 0px; padding: 0px; }}\n"
+                       "    surface: 200px, 100px;\n"
+                       "{}"
+                       "}}\n",
+                       body);
+}
+
+/// One annotated Button, with the annotation argument the scenario is about.
+[[nodiscard]] std::string annotatedButton(std::string_view annotation) {
+    return screenWith(std::format("    {}\n"
+                                  "    Button {{ id: action; width: 100px; height: 40px; label: t(\"STR-ACTION\"); "
+                                  "color: Theme.Colors.PrimaryAction; source: \"ACTION\"; requirement: \"REQ-1\"; }}\n",
+                                  annotation));
+}
+
+/// Spelled as a predicate rather than as a projected `find`: the projection yields `std::string`
+/// and the needle is a `string_view`, and the range concepts do not owe us that comparison.
+[[nodiscard]] const md::GoldenReference* find(std::span<const md::GoldenReference> references, std::string_view nodeId) {
+    const auto found = std::ranges::find_if(references, [nodeId](const md::GoldenReference& reference) {
+        return reference.nodeId == nodeId;
+    });
+    return found == references.end() ? nullptr : &*found;
+}
+
+/// How many entries name `nodeId`. One is the whole point for a node matching both rules.
+[[nodiscard]] std::ptrdiff_t countFor(std::span<const md::GoldenReference> references, std::string_view nodeId) {
+    return std::ranges::count_if(references, [nodeId](const md::GoldenReference& reference) {
+        return reference.nodeId == nodeId;
+    });
+}
+
+[[nodiscard]] const cli::Diagnostic* find(const md::SafetyResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    });
+    return found == result.diagnostics.end() ? nullptr : &*found;
+}
+
+/// Renders a check list as `Bounds+ColorHash`, so a failure says what was emitted.
+[[nodiscard]] std::string describe(std::span<const md::CvCheck> checks) {
+    std::string rendered;
+    for (const md::CvCheck check : checks) {
+        if (!rendered.empty()) {
+            rendered += '+';
+        }
+        rendered += md::spell(check);
+    }
+    return rendered.empty() ? std::string{"<none>"} : rendered;
+}
+
+}  // namespace
+
+const mdux::spec::Register predicateSelectsTheRightNodes{
+    "The predicate selects annotated and positioned nodes, and nothing else",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-predicate")
+            .Given("a screen with an annotated node, a positioned node, one of each, and a plain one", [] {})
+            .When("the golden set is derived from the resolved screen", [] {})
+            .Then("four entries appear in source order and the plain node is absent",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300));
+
+                      const std::vector<std::string_view> expected{"action", "pinned", "score", "state"};
+                      checks.expect(references.size() == expected.size(), std::format("four nodes are pinned, got {}", references.size()));
+                      for (std::size_t index = 0; index < std::min(references.size(), expected.size()); ++index) {
+                          checks.expect(references[index].nodeId == expected[index],
+                                        std::format("entry {} is '{}', got '{}'", index, expected[index], references[index].nodeId));
+                      }
+                      checks.expect(find(references, "plain") == nullptr, "a node with neither an annotation nor a position is not pinned");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register positionAlonePinsBounds{
+    "A declared position pins bounds without an annotation, and an annotation pins what it names",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-position-and-annotation")
+            .Given("a positioned Label and an annotated Button naming only ColorHash", [] {})
+            .When("their entries are read", [] {})
+            .Then("the position yields Bounds and the annotation yields exactly what it asked for",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300));
+
+                      const md::GoldenReference* pinned = find(references, "pinned");
+                      checks.expect(pinned != nullptr, "the positioned node is pinned");
+                      if (pinned != nullptr) {
+                          checks.expect(pinned->cvChecks == std::vector{md::CvCheck::Bounds},
+                                        std::format("a declared position pins Bounds, got {}", describe(pinned->cvChecks)));
+                          checks.expect(pinned->bounds == md::LayoutRect{250, 0, 100, 40}, "the pinned rectangle is the resolved one");
+                          checks.expect(pinned->textKey == "STR-PINNED" && pinned->colorToken == "Theme.Colors.Title",
+                                        "a static Label pins its key and its tint");
+                      }
+
+                      const md::GoldenReference* action = find(references, "action");
+                      checks.expect(action != nullptr, "the annotated node is pinned");
+                      if (action != nullptr) {
+                          checks.expect(action->cvChecks == std::vector{md::CvCheck::ColorHash},
+                                        std::format("an unpositioned annotation pins only what it names, got {}", describe(action->cvChecks)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register bothRulesMergeIntoOneEntry{
+    "A node matching both rules is pinned exactly once, with the checks merged",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-merged-entry")
+            .Given("a NumericDisplay that is both @safety_critical(Bounds, ColorHash) and positioned", [] {})
+            .When("the golden set is derived", [] {})
+            .Then("there is one entry for it, with Bounds present once",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300));
+
+                      const std::ptrdiff_t count = countFor(references, "score");
+                      checks.expect(count == 1, std::format("one entry, never two, got {}", count));
+
+                      const md::GoldenReference* score = find(references, "score");
+                      if (score != nullptr) {
+                          checks.expect(score->cvChecks == std::vector{md::CvCheck::Bounds, md::CvCheck::ColorHash},
+                                        std::format("the automatic Bounds merges with the annotation, got {}", describe(score->cvChecks)));
+                          checks.expect(score->bounds == md::LayoutRect{250, 60, 120, 60}, "the merged entry keeps the resolved rectangle");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register dynamicContentPinsPlaceNotValue{
+    "Dynamic content pins where it appears and in what tint, never the value that varies",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-dynamic-content")
+            .Given("a NumericDisplay with a colour, and a StatusIndicator whose states and colours are lists", [] {})
+            .When("their entries are read", [] {})
+            .Then("neither pins a text key, and the one whose tint varies pins no colour either",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300));
+
+                      const md::GoldenReference* score = find(references, "score");
+                      if (score != nullptr) {
+                          checks.expect(score->textKey.empty(), "a numeric display pins no text");
+                          checks.expect(score->colorToken == "Theme.Colors.ScoreDigits", "its single declared tint is pinned");
+                      }
+
+                      const md::GoldenReference* state = find(references, "state");
+                      checks.expect(state != nullptr, "the positioned status indicator is pinned");
+                      if (state != nullptr) {
+                          checks.expect(state->textKey.empty(), "the state on screen is the varying part, so no key is pinned");
+                          checks.expect(state->colorToken.empty(), "its tint varies per state, so no colour is pinned");
+                          checks.expect(state->cvChecks == std::vector{md::CvCheck::Bounds}, "what remains checkable is where it appears");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register checksAreSortedAndDeduplicated{
+    "Check lists are sorted and deduplicated, so one screen has one serialisation",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-canonical-checks")
+            .Given("an annotation naming ColorHash before Bounds, and Bounds twice", [] {})
+            .When("the entry is derived", [] {})
+            .Then("the list reads Bounds, ColorHash exactly once each",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(
+                          layoutOf(annotatedButton("@safety_critical(cv_check: [ColorHash, Bounds, Bounds])"), 200, 100));
+
+                      checks.expect(references.size() == 1, "the annotated node is pinned");
+                      if (references.size() == 1) {
+                          checks.expect(references.front().cvChecks == std::vector{md::CvCheck::Bounds, md::CvCheck::ColorHash},
+                                        std::format("checks are canonical, got {}", describe(references.front().cvChecks)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register annotationWithoutChecksStillPinsBounds{
+    "An annotation naming no check still pins bounds rather than emitting an empty golden",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-annotation-without-checks")
+            .Given("@safety_critical with no cv_check argument", [] {})
+            .When("the entry is derived", [] {})
+            .Then("it pins Bounds, read from the rule that a declared position alone is enough",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(annotatedButton("@safety_critical"), 200, 100));
+
+                      checks.expect(references.size() == 1, "the annotated node is pinned");
+                      if (references.size() == 1) {
+                          checks.expect(references.front().cvChecks == std::vector{md::CvCheck::Bounds},
+                                        std::format("an entry a verifier can act on, got {}", describe(references.front().cvChecks)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register rowBackgroundCarriesItsAnnotation{
+    "An annotated Row is pinned through the background it paints",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-row-background")
+            .Given("a Row carrying @safety_critical and a background", [] {})
+            .When("the golden set is derived", [] {})
+            .Then("the synthetic background entry carries the Row's band and its tint",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string  source = screenWith(
+                          "    @safety_critical(cv_check: [Bounds])\n"
+                           "    Row { id: topbar; height: 40px; background: Theme.Colors.Title;\n"
+                           "        Label { id: title; width: Fill; height: 40px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; }\n"
+                           "    }\n");
+                      const auto references = md::collectGoldens(layoutOf(source, 200, 100));
+
+                      const md::GoldenReference* background = find(references, "topbar-background");
+                      checks.expect(background != nullptr, "the Row's painted band is what carries the annotation");
+                      if (background != nullptr) {
+                          checks.expect(background->bounds == md::LayoutRect{0, 0, 200, 40}, "the band is the Row's resolved rectangle");
+                          checks.expect(background->colorToken == "Theme.Colors.Title", "the background token is the tint to verify");
+                      }
+                      checks.expect(find(references, "title") == nullptr, "an unannotated, unpositioned child is not pinned");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register safetyCriticalNeedsARequirement{
+    "A @safety_critical node with no requirement is MEDUI-E070, reported at the annotation",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-missing-requirement")
+            .Given("the rejected-safety-without-requirement fixture", [] {})
+            .When("the annotation rules are validated", [] {})
+            .Then("MEDUI-E070 names the component and points at the '@'",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const md::ast::Screen  screen = parseOrFail(fixture("rejected-safety-without-requirement.medui"));
+                      const md::SafetyResult result = md::validateSafetyAnnotations(screen, "rejected-safety-without-requirement.medui");
+
+                      const cli::Diagnostic* reported = find(result, md::Code::SafetyCriticalWithoutRequirement);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(reported != nullptr, "MEDUI-E070 is reported");
+                      if (reported != nullptr) {
+                          checks.expect(reported->line == 11 && reported->column == 5,
+                                        std::format("the diagnostic points at the annotation, got {}:{}", reported->line, reported->column));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register acceptedFixturePassesValidation{
+    "Every annotation in the accepted fixture satisfies the rules",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-accepted-validates")
+            .Given("the accepted-goldens fixture", [] {})
+            .When("the annotation rules are validated", [] {})
+            .Then("nothing is reported, so the golden scenarios measure a legal screen",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const md::ast::Screen  screen = parseOrFail(fixture("accepted-goldens.medui"));
+                      const md::SafetyResult result = md::validateSafetyAnnotations(screen, "accepted-goldens.medui");
+                      checks.expect(result.ok(), std::format("the fixture validates, got {} diagnostics", result.diagnostics.size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unknownCvCheckIsRejected{
+    "A cv_check outside the closed set is MEDUI-E071, and a malformed one is MEDUI-E033",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-unknown-cv-check")
+            .Given("cv_check: [Bounds, Wobble] and cv_check: [\"Bounds\"]", [] {})
+            .When("each is validated", [] {})
+            .Then("the unknown name and the wrong value form are reported separately",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const md::ast::Screen  unknown       = parseOrFail(annotatedButton("@safety_critical(cv_check: [Bounds, Wobble])"));
+                      const md::SafetyResult unknownResult = md::validateSafetyAnnotations(unknown, "goldens.medui");
+                      const cli::Diagnostic* reported      = find(unknownResult, md::Code::UnknownCvCheck);
+                      checks.expect(reported != nullptr, "MEDUI-E071 is reported");
+                      checks.expect(reported != nullptr && reported->message.find("Wobble") != std::string::npos,
+                                    "the diagnostic names the check that does not exist");
+
+                      const md::ast::Screen  malformed       = parseOrFail(annotatedButton("@safety_critical(cv_check: [\"Bounds\"])"));
+                      const md::SafetyResult malformedResult = md::validateSafetyAnnotations(malformed, "goldens.medui");
+                      checks.expect(find(malformedResult, md::Code::FieldValueKind) != nullptr, "a quoted check is the wrong value form, not an unknown name");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register collectionAssumesValidation{
+    "Deriving goldens from an unvalidated screen throws rather than emitting one nobody can verify",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-gate-throws")
+            .Given("a screen whose cv_check names a verification this compiler does not emit", [] {})
+            .When("the golden set is derived without validating first", [] {})
+            .Then("it is std::logic_error, not a golden with a check the verifier cannot run",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const md::LayoutResult resolved = layoutOf(annotatedButton("@safety_critical(cv_check: [Wobble])"), 200, 100);
+
+                      bool threw = false;
+                      try {
+                          [[maybe_unused]] const auto ignored = md::collectGoldens(resolved);
+                      } catch (const std::logic_error&) {
+                          threw = true;
+                      }
+                      checks.expect(threw, "the validation gate is assumed, and its absence is a programming error");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/GoldenTests.cpp
+++ b/tests/medui/GoldenTests.cpp
@@ -15,12 +15,14 @@
 
 import std;
 import speclab;
+import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.ast;
 import mdux.tools.medui.diagnostics;
 import mdux.tools.medui.goldens;
 import mdux.tools.medui.layout;
 import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
 
 #include "../framework/SpecLabBridge.hpp"
 
@@ -274,30 +276,143 @@ const mdux::spec::Register annotationWithoutChecksStillPinsBounds{
             .Execute();
     }};
 
-const mdux::spec::Register rowBackgroundCarriesItsAnnotation{
-    "An annotated Row is pinned through the background it paints",
+const mdux::spec::Register annotatedContainerIsRejected{
+    "A component the dictionary gives no requirement cannot be safety-critical",
     "evidence-unit",
     [] {
-        return speclab::Test("medui-goldens-row-background")
-            .Given("a Row carrying @safety_critical and a background", [] {})
-            .When("the golden set is derived", [] {})
-            .Then("the synthetic background entry carries the Row's band and its tint",
+        return speclab::Test("medui-goldens-annotated-row")
+            .Given("a Row carrying @safety_critical - Label, Clock and Image are in the same position", [] {})
+            .When("the annotation rules are validated", [] {})
+            .Then("MEDUI-E070 explains that the component takes no requirement at all",
                   [] {
                       mdux::spec::Checks checks;
-                      const std::string  source = screenWith(
-                          "    @safety_critical(cv_check: [Bounds])\n"
-                           "    Row { id: topbar; height: 40px; background: Theme.Colors.Title;\n"
-                           "        Label { id: title; width: Fill; height: 40px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; }\n"
-                           "    }\n");
-                      const auto references = md::collectGoldens(layoutOf(source, 200, 100));
 
-                      const md::GoldenReference* background = find(references, "topbar-background");
-                      checks.expect(background != nullptr, "the Row's painted band is what carries the annotation");
-                      if (background != nullptr) {
-                          checks.expect(background->bounds == md::LayoutRect{0, 0, 200, 40}, "the band is the Row's resolved rectangle");
-                          checks.expect(background->colorToken == "Theme.Colors.Title", "the background token is the tint to verify");
-                      }
-                      checks.expect(find(references, "title") == nullptr, "an unannotated, unpositioned child is not pinned");
+                      // The pinned component model gives Row only id, height, spacing and
+                      // background. It can therefore never carry a requirement:, so it can never
+                      // satisfy the annotation rule - which makes an annotated Row a screen that
+                      // does not compile rather than a golden over a container. An earlier revision
+                      // of this suite pinned the opposite behaviour by reaching collectGoldens()
+                      // without validating first; that path is unreachable in a real driver.
+                      //
+                      // Row is the clearest case rather than the only one: Label, Clock, Image,
+                      // SignalTrace and VulkanViewport take no requirement either, so the same
+                      // diagnostic answers an annotation on any of them.
+                      const std::string source = screenWith(
+                          "    @safety_critical(cv_check: [Bounds])\n"
+                          "    Row { id: topbar; height: 40px; background: Theme.Colors.Title;\n"
+                          "        Label { id: title; width: Fill; height: 40px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; }\n"
+                          "    }\n");
+                      const md::ast::Screen  screen = parseOrFail(source);
+                      const md::SafetyResult result = md::validateSafetyAnnotations(screen, "goldens.medui");
+
+                      const cli::Diagnostic* reported = find(result, md::Code::SafetyCriticalWithoutRequirement);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(reported != nullptr, "MEDUI-E070 is reported");
+                      checks.expect(reported != nullptr && reported->message.find("takes no requirement") != std::string::npos,
+                                    "the diagnostic names the real problem rather than asking for a field Row cannot have");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register onlyAuthoredNodesArePinned{"A Row's synthetic background is not a golden of its own", "evidence-unit", [] {
+                                                          return speclab::Test("medui-goldens-synthetic-nodes")
+                                                              .Given("a Row with a background and one positioned child", [] {})
+                                                              .When("the golden set is derived", [] {})
+                                                              .Then("the child is pinned and the synthetic background is not",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+                                                                        const std::string  source = screenWith(
+                                                                            "    Row { id: topbar; height: 40px; background: Theme.Colors.Title;\n"
+                                                                             "        Label { id: title; width: 60px; height: 20px; position: 10px, 10px; "
+                                                                             "text: t(\"STR-TITLE\"); color: Theme.Colors.Title; }\n"
+                                                                             "    }\n");
+                                                                        const auto references = md::collectGoldens(layoutOf(source, 200, 100));
+
+                                                                        checks.expect(find(references, "topbar-background") == nullptr,
+                                                                                      "a synthetic node describes nothing an author wrote");
+                                                                        checks.expect(find(references, "title") != nullptr, "the positioned child is pinned");
+                                                                        checks.expect(references.size() == 1,
+                                                                                      std::format("exactly one entry, got {}", references.size()));
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register blankRequirementIsNotTraceable{
+    "An empty requirement is no requirement, through the full analyze then validate order",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-blank-requirement")
+            .Given("a @safety_critical Button whose requirement is the empty string", [] {})
+            .When("semantic analysis accepts it and the annotation rules run", [] {})
+            .Then("MEDUI-E070 rejects it anyway, because there is nothing to trace",
+                  [] {
+                      mdux::spec::Checks    checks;
+                      const md::ast::Screen screen = parseOrFail(screenWith("    @safety_critical(cv_check: [Bounds])\n"
+                                                                            "    Button { id: action; width: 100px; height: 40px; label: t(\"STR-ACTION\"); "
+                                                                            "color: Theme.Colors.PrimaryAction; source: \"ACTION\"; requirement: \"\"; }\n"));
+
+                      // The gap this covers is that `requirement:` is a String field and the
+                      // semantic domain accepts every quoted string, `""` included - so the
+                      // analyze step below really does pass, and the safety rule is the only thing
+                      // standing between an empty requirement and a golden.
+                      const std::array<std::string_view, 1> themeTokens{"Theme.Colors.PrimaryAction"};
+                      mdux::text::TextPackage               package;
+                      package.header.id   = "goldens-en-US";
+                      package.atlasId     = "goldens-atlas";
+                      package.locale      = "en-US";
+                      package.sidecarPath = "runs.bin";
+                      package.runs.push_back(mdux::text::TextRun{.id = "STR-ACTION", .byteOffset = 0, .byteLength = 0, .sha256 = {}});
+                      const std::array textPackages{package};
+
+                      const md::SemanticResult semantic = md::analyze(screen,
+                                                                      "goldens.medui",
+                                                                      md::SemanticInputs{.themeTokens = themeTokens, .textPackages = textPackages});
+                      checks.expect(semantic.ok(),
+                                    std::format("semantic analysis accepts the empty requirement, got {} diagnostics", semantic.diagnostics.size()));
+
+                      const md::SafetyResult safety   = md::validateSafetyAnnotations(screen, "goldens.medui");
+                      const cli::Diagnostic* reported = find(safety, md::Code::SafetyCriticalWithoutRequirement);
+                      checks.expect(!safety.ok(), "the safety rule rejects it");
+                      checks.expect(reported != nullptr && reported->message.find("empty") != std::string::npos,
+                                    "the diagnostic says the requirement is empty rather than absent");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register colorHashNeedsATintToCompare{
+    "ColorHash is refused where no single declared tint exists",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-colorhash-needs-a-tint")
+            .Given("an annotated StatusIndicator whose colors: is a list, and a Clock with no colour", [] {})
+            .When("each annotation is validated", [] {})
+            .Then("MEDUI-E071 refuses the check rather than pinning one with nothing to compare against",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const md::ast::Screen indicator = parseOrFail(
+                          screenWith("    @safety_critical(cv_check: [Bounds, ColorHash])\n"
+                                     "    StatusIndicator { id: state; width: 120px; height: 40px; requirement: \"REQ-1\"; "
+                                     "source: \"STATE\"; states: [t(\"STR-OK\"), t(\"STR-ALARM\")]; "
+                                     "colors: [Theme.Colors.Title, Theme.Colors.ScoreDigits]; }\n"));
+                      const md::SafetyResult indicatorResult = md::validateSafetyAnnotations(indicator, "goldens.medui");
+                      const cli::Diagnostic* refused         = find(indicatorResult, md::Code::UnknownCvCheck);
+                      checks.expect(!indicatorResult.ok(), "a per-state tint is not one a golden can pin");
+                      checks.expect(refused != nullptr && refused->message.find("ColorHash") != std::string::npos, "the diagnostic names the check it refuses");
+
+                      const md::ast::Screen clock = parseOrFail(screenWith("    @safety_critical(cv_check: [ColorHash])\n"
+                                                                           "    Clock { id: now; width: 100px; height: 40px; format: HH_MM; }\n"));
+                      checks.expect(find(md::validateSafetyAnnotations(clock, "goldens.medui"), md::Code::UnknownCvCheck) != nullptr,
+                                    "a component with no colour field cannot be tint-checked either");
+
+                      // The control: a single declared token is exactly what ColorHash needs, and
+                      // the accepted fixture leans on that for both `action` and `score`.
+                      const md::ast::Screen  button       = parseOrFail(annotatedButton("@safety_critical(cv_check: [ColorHash])"));
+                      const md::SafetyResult buttonResult = md::validateSafetyAnnotations(button, "goldens.medui");
+                      checks.expect(buttonResult.ok(), std::format("one declared tint is enough, got {} diagnostics", buttonResult.diagnostics.size()));
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -19,11 +19,15 @@
  *   and must be backed by a case that really executed. Claiming a phase with no adapter fails
  *   here instead of passing quietly.
  *
- * Syntax, semantics and layout are observable: `md::parse` answers syntax acceptance,
+ * Syntax, semantics, layout and safety are observable: `md::parse` answers syntax acceptance,
  * `md::analyze` checks the portable theme-token and per-locale key views in semantic case inputs,
- * and `md::resolveLayout` runs the integer-only bounded solver. Claiming `safety` still needs the
- * golden pass (#196), so that claim is rejected below rather than silently evaluated by a stage
- * that cannot see it.
+ * `md::resolveLayout` runs the integer-only bounded solver, and `md::validateSafetyAnnotations`
+ * applies the `@safety_critical` rules (#196).
+ *
+ * The safety adapter deliberately does not run semantic analysis first. Those rules are decidable
+ * from source alone, the shared case schema carries no inputs for a safety case, and a screen that
+ * declares no `surface:` - as `MEDUI-CASE-SAFETY-MISSING-REQUIREMENT` does not - cannot reach the
+ * solver at all. Running analyze would add theme and locale findings the case never claimed.
  */
 
 import std;
@@ -34,6 +38,7 @@ import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.ast;
 import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.goldens;
 import mdux.tools.medui.layout;
 import mdux.tools.medui.parser;
 import mdux.tools.medui.semantic;
@@ -50,7 +55,7 @@ namespace toml = mdux::tools::toml;
 
 /// Phases this file can genuinely observe. Anything else in `capabilities` is a claim with no
 /// adapter behind it.
-constexpr std::array<std::string_view, 3> runnableCapabilities{"syntax", "semantics", "layout"};
+constexpr std::array<std::string_view, 4> runnableCapabilities{"syntax", "semantics", "layout", "safety"};
 
 [[noreturn]] void fail(std::string message, std::source_location where = std::source_location::current()) {
     throw speclab::core::AssertionFailure(std::move(message), where);
@@ -666,6 +671,11 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
             md::LayoutResult resolved = md::resolveLayout(*parsed.screen, file, inputs);
             diagnostics.insert(diagnostics.end(), std::make_move_iterator(resolved.diagnostics.begin()), std::make_move_iterator(resolved.diagnostics.end()));
         }
+    }
+
+    if (item.phase == "safety" && parsed.screen) {
+        md::SafetyResult safety = md::validateSafetyAnnotations(*parsed.screen, file);
+        diagnostics.insert(diagnostics.end(), std::make_move_iterator(safety.diagnostics.begin()), std::make_move_iterator(safety.diagnostics.end()));
     }
 
     const bool accepted = parsed.screen.has_value() && diagnostics.empty();

--- a/tests/medui/fixtures/accepted-goldens.medui
+++ b/tests/medui/fixtures/accepted-goldens.medui
@@ -1,0 +1,66 @@
+// Every rule ADR-011 fixes for golden references, in one screen a reviewer can read.
+//
+//   action  @safety_critical only          -> one entry, the checks the annotation names
+//   pinned  position: only                 -> one entry, an automatic Bounds
+//   score   annotated *and* positioned     -> exactly one entry, checks merged and deduplicated
+//   state   dynamic content                -> bounds and nothing that varies: no text, no tint
+//   plain   neither                        -> no entry at all
+//
+// Deliberately not a Label for `action`: the dictionary gives Label no `requirement:` field, and a
+// @safety_critical node must carry one. Button, NumericDisplay and StatusIndicator are the
+// components where an annotation and a requirement can coexist.
+Screen Goldens {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 400px, 300px;
+
+    @safety_critical(cv_check: [ColorHash])
+    Button {
+        id: action;
+        width: 200px;
+        height: 40px;
+        label: t("STR-ACTION");
+        color: Theme.Colors.PrimaryAction;
+        source: "ACTION";
+        requirement: "REQ-G-001";
+    }
+
+    Label {
+        id: pinned;
+        width: 100px;
+        height: 40px;
+        position: 250px, 0px;
+        text: t("STR-PINNED");
+        color: Theme.Colors.Title;
+    }
+
+    @safety_critical(cv_check: [Bounds, ColorHash])
+    NumericDisplay {
+        id: score;
+        width: 120px;
+        height: 60px;
+        position: 250px, 60px;
+        requirement: "REQ-G-002";
+        template: "TPL-SCORE";
+        source: "SCORE";
+        color: Theme.Colors.ScoreDigits;
+    }
+
+    StatusIndicator {
+        id: state;
+        width: 120px;
+        height: 40px;
+        position: 250px, 140px;
+        requirement: "REQ-G-003";
+        source: "STATE";
+        states: [t("STR-OK"), t("STR-ALARM")];
+        colors: [Theme.Colors.Title, Theme.Colors.ScoreDigits];
+    }
+
+    Label {
+        id: plain;
+        width: 100px;
+        height: 40px;
+        text: t("STR-PLAIN");
+        color: Theme.Colors.Title;
+    }
+}

--- a/tests/medui/fixtures/rejected-safety-without-requirement.medui
+++ b/tests/medui/fixtures/rejected-safety-without-requirement.medui
@@ -1,0 +1,20 @@
+// A @safety_critical node with nothing to trace it to. MEDUI-E070, reported at the annotation
+// rather than at the node: the annotation is the claim that needs a requirement behind it.
+//
+// `requirement:` is optional on Button, so nothing earlier in the compiler objects - which is the
+// point. Without this rule a safety-critical node could ship with no requirement at all, and the
+// annotation would be decoration.
+Screen Unsafe {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 200px, 100px;
+
+    @safety_critical(cv_check: [Bounds])
+    Button {
+        id: action;
+        width: 100px;
+        height: 40px;
+        label: t("STR-ACTION");
+        color: Theme.Colors.PrimaryAction;
+        source: "ACTION";
+    }
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,9 +271,10 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S6 (#195) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
-# integer-only bounded layout solver, and the text-budget check that measures a resolved box against
-# the widest approved translation. The emitters are #197, and the mdux-meduic executable with its
+# At S7 (#196) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
+# integer-only bounded layout solver, the text-budget check that measures a resolved box against the
+# widest approved translation (#195), and the golden references that say where safety-critical
+# content must appear. The emitters are #197, and the mdux-meduic executable with its
 # mdux_compile_screen() registration is #198 - so there is still no add_executable() here and no
 # bake call site. Every later stage adds sources to this target rather than inventing another.
 #
@@ -295,6 +296,7 @@ target_sources(MduXMeduiLib
             medui/Semantic.cppm
             medui/Layout.cppm
             medui/TextBudget.cppm
+            medui/Goldens.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -302,6 +304,7 @@ target_sources(MduXMeduiLib
         medui/Semantic.cpp
         medui/Layout.cpp
         medui/TextBudget.cpp
+        medui/Goldens.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/medui/Goldens.cpp
+++ b/tools/medui/Goldens.cpp
@@ -63,6 +63,29 @@ constexpr std::string_view cvCheckArgument = "cv_check";
     return nullptr;
 }
 
+/// Whether the component dictionary gives this component a `requirement:` field at all.
+///
+/// `Row` does not have one, and the dictionary is the pinned shared contract rather than something
+/// this compiler may extend - so a container cannot carry `@safety_critical`, and the diagnostic
+/// should say that rather than asking an author to add a field the language will then reject.
+[[nodiscard]] bool admitsRequirement(const ast::Node& node) noexcept {
+    const std::span<const ComponentRule> dictionary = componentDictionary();
+    const auto                           component  = std::ranges::find(dictionary, node.component, &ComponentRule::name);
+    if (component == dictionary.end()) {
+        return false;
+    }
+    return std::ranges::any_of(component->fields, [](const FieldRule& rule) {
+        return rule.name == "requirement";
+    });
+}
+
+/// Whether `text` carries anything a requirement identifier could be. Blank is not traceable.
+[[nodiscard]] bool isBlank(std::string_view text) noexcept {
+    return std::ranges::all_of(text, [](unsigned char character) {
+        return std::isspace(character) != 0;
+    });
+}
+
 /// The text a golden pins, or empty when the node draws none - or draws one that varies.
 ///
 /// Only a single static key qualifies. A list-valued field such as `StatusIndicator`'s `states:` is
@@ -170,11 +193,8 @@ private:
     void validateAnnotation(const ast::Node& node, const ast::Annotation& annotation) {
         // Reported at the annotation rather than at the node: the annotation is the claim that
         // needs a requirement behind it, and the shared case pins that position.
-        if (fieldFor(node, "requirement") == nullptr) {
-            report(Code::SafetyCriticalWithoutRequirement,
-                   annotation.position,
-                   std::format("component '{}' is annotated @safety_critical but declares no requirement", node.component));
-        }
+        validateRequirement(node, annotation);
+        validateColorHashIsDerivable(node, annotation);
 
         const ast::Field* argument = argumentFor(annotation, cvCheckArgument);
         if (argument == nullptr || argument->value == nullptr) {
@@ -189,6 +209,89 @@ private:
             return;
         }
         validateCheckValue(*argument->value);
+    }
+
+    /**
+     * @brief Requires something to trace the annotation to, not merely a field that exists.
+     *
+     * Presence alone was the first revision's rule and it was too weak: `requirement:` is a
+     * `String` field, `Semantic.cpp`'s domain check accepts every quoted string including `""`, and
+     * a safety-critical node whose requirement is the empty string is exactly the untraceable node
+     * this rule exists to prevent. A blank value therefore reports `MEDUI-E070` as an absent one
+     * does - the code means "carries no requirement", and an empty string carries none.
+     *
+     * The rule is enforced here rather than by tightening `FieldDomain::String`, because the
+     * traceability requirement belongs to the annotation. `template:` and `source:` are the same
+     * domain and are not the same claim.
+     */
+    void validateRequirement(const ast::Node& node, const ast::Annotation& annotation) {
+        const ast::Field* requirement = fieldFor(node, "requirement");
+        if (requirement != nullptr && requirement->value != nullptr && requirement->value->kind == ast::ValueKind::String
+            && !isBlank(requirement->value->text)) {
+            return;
+        }
+
+        // A container cannot satisfy this rule at all: the pinned dictionary gives `Row` no
+        // `requirement:`, so saying "add requirement:" would send an author to a field the language
+        // then rejects as unknown. Say what is actually wrong instead.
+        if (!admitsRequirement(node)) {
+            report(Code::SafetyCriticalWithoutRequirement,
+                   annotation.position,
+                   std::format("component '{}' takes no requirement in the shared component model, so it cannot be "
+                               "@safety_critical; annotate the content it contains instead",
+                               node.component));
+            return;
+        }
+        report(Code::SafetyCriticalWithoutRequirement,
+               annotation.position,
+               requirement == nullptr ? std::format("component '{}' is annotated @safety_critical but declares no requirement", node.component)
+                                      : std::format("component '{}' is annotated @safety_critical but its requirement is empty", node.component));
+    }
+
+    /**
+     * @brief Refuses a `ColorHash` check on a node whose expected tint cannot be derived.
+     *
+     * `cv_checks` and `color_token` are two halves of one claim: a verifier asked for `ColorHash`
+     * reads the token to know what tint to expect. A `StatusIndicator` declares `colors:` as a list,
+     * one per state, and a `Clock`, `Image` or `VulkanViewport` declares none at all - so a golden
+     * over either would ask for a check with nothing to check it against.
+     *
+     * Rejecting is the fail-closed reading, and it is a decision this issue has to take rather than
+     * defer, because the reference shape is frozen here for #16 and #197. The alternative - carrying
+     * a per-state list of expected tints - is a genuine extension of the shape, and one both
+     * consumers would have to agree to; it belongs with the components that would need it (#17),
+     * not with a stage inventing a field ahead of them.
+     */
+    void validateColorHashIsDerivable(const ast::Node& node, const ast::Annotation& annotation) {
+        const ast::Field* argument = argumentFor(annotation, cvCheckArgument);
+        if (argument == nullptr || argument->value == nullptr || !colorTokenOf(node).empty()) {
+            return;
+        }
+
+        const auto namesColorHash = [](const ast::Value& value) {
+            return value.kind == ast::ValueKind::Identifier && parseCvCheck(value.text) == CvCheck::ColorHash;
+        };
+
+        const ast::Value* offending = nullptr;
+        if (argument->value->kind == ast::ValueKind::List) {
+            for (const std::shared_ptr<ast::Value>& element : argument->value->list) {
+                if (element != nullptr && namesColorHash(*element)) {
+                    offending = element.get();
+                    break;
+                }
+            }
+        } else if (namesColorHash(*argument->value)) {
+            offending = argument->value.get();
+        }
+
+        if (offending != nullptr) {
+            report(Code::UnknownCvCheck,
+                   offending->position,
+                   std::format("{} needs one declared colour token to compare against, and component '{}' declares "
+                               "none that a golden could pin",
+                               spell(CvCheck::ColorHash),
+                               node.component));
+        }
     }
 
     void validateCheckValue(const ast::Value& value) {
@@ -243,6 +346,15 @@ std::vector<GoldenReference> collectGoldens(const LayoutResult& layout) {
     std::vector<GoldenReference> references;
 
     for (const ResolvedNode& node : layout.nodes) {
+        // Goldens describe authored nodes. The only synthetic node the solver produces is a Row's
+        // background, and a Row cannot be annotated - the pinned dictionary gives it no
+        // `requirement:`, so `validateSafetyAnnotations()` rejects the annotation before layout runs
+        // - nor positioned, since `position:` is not one of its fields either. Skipping it states
+        // that rather than leaving a reader to derive it from two other files.
+        if (node.synthetic) {
+            continue;
+        }
+
         std::vector<CvCheck> checks;
 
         const bool annotated = std::ranges::any_of(node.source.annotations, isSafetyCritical);

--- a/tools/medui/Goldens.cpp
+++ b/tools/medui/Goldens.cpp
@@ -1,0 +1,287 @@
+/**
+ * @file Goldens.cpp
+ * @brief The `@safety_critical` annotation rules, and the golden set they select.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ */
+module;
+
+module mdux.tools.medui.goldens;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.semantic;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// The one annotation that participates in the predicate. Others are carried by the AST and ignored
+/// here; naming a rule for them would need a diagnostic code no accepted document has argued for.
+constexpr std::string_view safetyCritical = "safety_critical";
+
+/// The argument that lists the verifications a golden asks for.
+constexpr std::string_view cvCheckArgument = "cv_check";
+
+[[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
+    const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
+    return found == node.fields.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const ast::Field* argumentFor(const ast::Annotation& annotation, std::string_view name) noexcept {
+    const auto found = std::ranges::find(annotation.arguments, name, &ast::Field::name);
+    return found == annotation.arguments.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool isSafetyCritical(const ast::Annotation& annotation) noexcept {
+    return annotation.name == safetyCritical;
+}
+
+/// Finds a component's field of one value domain, from the dictionary semantic analysis publishes.
+///
+/// The dictionary rather than a list of field names: `text` on a `Label` and `label` on a `Button`
+/// are the same kind of thing, and a second list here would be one more place to forget a component.
+[[nodiscard]] const ast::Field* fieldOfDomain(const ast::Node& node, FieldDomain domain) noexcept {
+    const std::span<const ComponentRule> dictionary = componentDictionary();
+    const auto                           component  = std::ranges::find(dictionary, node.component, &ComponentRule::name);
+    if (component == dictionary.end()) {
+        return nullptr;
+    }
+    for (const FieldRule& rule : component->fields) {
+        if (rule.domain != domain) {
+            continue;
+        }
+        if (const ast::Field* field = fieldFor(node, rule.name)) {
+            return field;
+        }
+    }
+    return nullptr;
+}
+
+/// The text a golden pins, or empty when the node draws none - or draws one that varies.
+///
+/// Only a single static key qualifies. A list-valued field such as `StatusIndicator`'s `states:` is
+/// deliberately not read: the state on screen is the varying part, and a golden that pinned one
+/// would fail whenever the device showed another.
+[[nodiscard]] std::string textKeyOf(const ast::Node& node) {
+    const ast::Field* field = fieldOfDomain(node, FieldDomain::TextKey);
+    if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::TextKey) {
+        return {};
+    }
+    return field->value->text;
+}
+
+/// The colour token a golden pins, or empty when the node declares none - or declares several.
+///
+/// `StatusIndicator`'s `colors:` is a list, one per state, and which one is on screen is the
+/// varying part. It is left unread for the same reason `states:` is: a golden pins the tint a
+/// verifier can rely on, and a component that legitimately changes tint has none.
+[[nodiscard]] std::string colorTokenOf(const ast::Node& node) {
+    const ast::Field* field = fieldOfDomain(node, FieldDomain::ColorToken);
+    if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::ColorToken) {
+        return {};
+    }
+    return field->value->text;
+}
+
+/// Adds `check` unless it is already present. The list is short - two values exist - so a scan
+/// costs less than the set that would replace it, and it keeps insertion order out of the result.
+void addCheck(std::vector<CvCheck>& checks, CvCheck check) {
+    if (std::ranges::find(checks, check) == checks.end()) {
+        checks.push_back(check);
+    }
+}
+
+/// Collects the checks one annotation asks for, failing loudly if validation was bypassed.
+///
+/// Accepts both `cv_check: [Bounds, ColorHash]` and the single-value `cv_check: Bounds`. The shared
+/// language writes the list form and so does every example here; the single form is accepted because
+/// it means one unambiguous thing, and rejecting it would need a diagnostic for a shape no author
+/// could misread.
+void collectAnnotationChecks(const ast::Annotation& annotation, std::vector<CvCheck>& into) {
+    const ast::Field* argument = argumentFor(annotation, cvCheckArgument);
+    if (argument == nullptr || argument->value == nullptr) {
+        return;
+    }
+
+    const auto take = [&into](const ast::Value& value) {
+        if (value.kind != ast::ValueKind::Identifier) {
+            throw std::logic_error(std::format("goldens received a cv_check value that is not a name at line {}, column {}; "
+                                               "validateSafetyAnnotations() is a required gate",
+                                               value.position.line,
+                                               value.position.column));
+        }
+        const std::optional<CvCheck> check = parseCvCheck(value.text);
+        if (!check.has_value()) {
+            throw std::logic_error(std::format("goldens received unknown cv_check '{}' at line {}, column {}; "
+                                               "validateSafetyAnnotations() is a required gate",
+                                               value.text,
+                                               value.position.line,
+                                               value.position.column));
+        }
+        addCheck(into, *check);
+    };
+
+    if (argument->value->kind == ast::ValueKind::List) {
+        for (const std::shared_ptr<ast::Value>& element : argument->value->list) {
+            if (element == nullptr) {
+                throw std::logic_error("goldens received an empty cv_check element; validateSafetyAnnotations() is a required gate");
+            }
+            take(*element);
+        }
+        return;
+    }
+    take(*argument->value);
+}
+
+/// One pass over a parsed screen, applying the annotation rules.
+class Validator {
+public:
+    explicit Validator(std::string file) : file_{std::move(file)} {}
+
+    [[nodiscard]] SafetyResult run(const ast::Screen& screen) {
+        for (const ast::Node& node : screen.nodes) {
+            validateNode(node);
+        }
+        return SafetyResult{.diagnostics = std::move(diagnostics_)};
+    }
+
+private:
+    void report(Code code, ast::Position position, std::string message) {
+        diagnostics_.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
+    }
+
+    void validateNode(const ast::Node& node) {
+        for (const ast::Annotation& annotation : node.annotations) {
+            if (isSafetyCritical(annotation)) {
+                validateAnnotation(node, annotation);
+            }
+        }
+        for (const ast::Node& child : node.children) {
+            validateNode(child);
+        }
+    }
+
+    void validateAnnotation(const ast::Node& node, const ast::Annotation& annotation) {
+        // Reported at the annotation rather than at the node: the annotation is the claim that
+        // needs a requirement behind it, and the shared case pins that position.
+        if (fieldFor(node, "requirement") == nullptr) {
+            report(Code::SafetyCriticalWithoutRequirement,
+                   annotation.position,
+                   std::format("component '{}' is annotated @safety_critical but declares no requirement", node.component));
+        }
+
+        const ast::Field* argument = argumentFor(annotation, cvCheckArgument);
+        if (argument == nullptr || argument->value == nullptr) {
+            return;
+        }
+        if (argument->value->kind == ast::ValueKind::List) {
+            for (const std::shared_ptr<ast::Value>& element : argument->value->list) {
+                if (element != nullptr) {
+                    validateCheckValue(*element);
+                }
+            }
+            return;
+        }
+        validateCheckValue(*argument->value);
+    }
+
+    void validateCheckValue(const ast::Value& value) {
+        if (value.kind != ast::ValueKind::Identifier) {
+            // MEDUI-E033 rather than a new code: an annotation argument is an `ast::Field`, and
+            // "a field value has the wrong semantic kind" is exactly what a quoted or numeric
+            // cv_check is. A code invented for the annotation case would mean the same thing twice.
+            report(Code::FieldValueKind, value.position, "cv_check takes a name, or a list of names, from the closed set");
+            return;
+        }
+        if (!parseCvCheck(value.text).has_value()) {
+            report(Code::UnknownCvCheck,
+                   value.position,
+                   std::format("'{}' is not a verification this compiler emits; the set is {} and {}",
+                               value.text,
+                               spell(CvCheck::Bounds),
+                               spell(CvCheck::ColorHash)));
+        }
+    }
+
+    std::string                  file_;
+    std::vector<cli::Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+std::string_view spell(CvCheck check) noexcept {
+    switch (check) {
+        case CvCheck::Bounds:
+            return "Bounds";
+        case CvCheck::ColorHash:
+            return "ColorHash";
+    }
+    return "";
+}
+
+std::optional<CvCheck> parseCvCheck(std::string_view name) noexcept {
+    if (name == spell(CvCheck::Bounds)) {
+        return CvCheck::Bounds;
+    }
+    if (name == spell(CvCheck::ColorHash)) {
+        return CvCheck::ColorHash;
+    }
+    return std::nullopt;
+}
+
+SafetyResult validateSafetyAnnotations(const ast::Screen& screen, std::string file) {
+    return Validator{std::move(file)}.run(screen);
+}
+
+std::vector<GoldenReference> collectGoldens(const LayoutResult& layout) {
+    std::vector<GoldenReference> references;
+
+    for (const ResolvedNode& node : layout.nodes) {
+        std::vector<CvCheck> checks;
+
+        const bool annotated = std::ranges::any_of(node.source.annotations, isSafetyCritical);
+        for (const ast::Annotation& annotation : node.source.annotations) {
+            if (isSafetyCritical(annotation)) {
+                collectAnnotationChecks(annotation, checks);
+            }
+        }
+
+        // ADR-011: a declared position is a safety-relevant claim by itself, so it adds `Bounds`
+        // whether or not the node is annotated. A node matching both rules is here exactly once,
+        // because this loop walks resolved nodes rather than the two rules in turn - which is what
+        // makes "one merged entry, never two" a property of the shape rather than of a later dedupe.
+        if (node.positioned) {
+            addCheck(checks, CvCheck::Bounds);
+        }
+
+        if (!annotated && !node.positioned) {
+            continue;
+        }
+
+        // An annotation naming no check still selects the node, and pins its bounds. That is read
+        // from ADR-011's positioned rule rather than invented: if a declared position alone is
+        // enough to make a rectangle worth verifying, an explicit safety-critical claim cannot be
+        // worth less. The alternative - an entry with no checks - would be a golden a verifier
+        // reads and does nothing with.
+        if (checks.empty()) {
+            addCheck(checks, CvCheck::Bounds);
+        }
+        std::ranges::sort(checks);
+
+        references.push_back(GoldenReference{.nodeId     = node.id,
+                                             .bounds     = node.bounds,
+                                             .textKey    = textKeyOf(node.source),
+                                             .colorToken = colorTokenOf(node.source),
+                                             .cvChecks   = std::move(checks)});
+    }
+
+    return references;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Goldens.cppm
+++ b/tools/medui/Goldens.cppm
@@ -25,7 +25,19 @@
  * - a node matching both emits exactly **one** entry, with the two check lists merged and
  *   deduplicated - never two entries for one node;
  * - a `@safety_critical` node with no `requirement:` is an error (`MEDUI-E070`), because a
- *   safety-critical node that cannot be traced is the thing the annotation exists to prevent.
+ *   safety-critical node that cannot be traced is the thing the annotation exists to prevent. An
+ *   *empty* requirement is the same error: `requirement:` is a `String` field and the semantic
+ *   domain accepts `""`, so presence alone would let an untraceable node through the rule written
+ *   to stop it.
+ *
+ * One consequence of the pinned component model, stated because it is easy to read the predicate as
+ * promising otherwise: **only a component the dictionary gives a `requirement:` can be
+ * safety-critical.** That is `CriticalButton`, `Button`, `NumericDisplay`, `StatusIndicator` and
+ * `TextInput`. `Row` takes only `id`, `height`, `spacing` and `background`; `Label`, `Clock`,
+ * `Image`, `SignalTrace` and `VulkanViewport` take no requirement either - so an annotation on any
+ * of them always fails the rule above. That is the shared contract's answer rather than this
+ * compiler's, and the diagnostic says so instead of asking an author to add a field the language
+ * would then reject.
  *
  * The consequence worth stating: the file's content is *exactly determined* by the screen. That is
  * what lets #197's consistency test compare sets rather than resolve references - it applies this
@@ -63,6 +75,11 @@
  * deduplicated so that one screen has one serialisation - `goldens.json` is byte-compared across
  * toolchains like every other committed artifact, and a set whose order depended on which rule
  * selected the node first would not survive that.
+ *
+ * The two members are halves of one claim, which is why a `ColorHash` check is *refused* for a node
+ * with no single declared colour token rather than emitted beside an absent `color_token`. A
+ * verifier asked to compare a tint has to be told which tint; a reference that asked without saying
+ * would be one #16 could only skip.
  *
  * ## What a golden pins for dynamic content, and what it must not
  *
@@ -129,9 +146,13 @@ struct SafetyResult {
 /**
  * @brief Checks the `@safety_critical` annotation rules on a parsed screen.
  *
- * Reports `MEDUI-E070` for an annotated node with no `requirement:`, at the annotation, and
- * `MEDUI-E071` for a `cv_check` naming a verification outside the closed set, at the offending
- * name. Diagnostics accumulate in source order.
+ * Reports, all at the position of the offending token and in source order:
+ *
+ * - `MEDUI-E070` for an annotated node whose `requirement:` is absent, blank, or unavailable to the
+ *   component at all, at the annotation;
+ * - `MEDUI-E071` for a `cv_check` naming a verification outside the closed set, and for a
+ *   `ColorHash` on a node whose expected tint cannot be derived, at the offending name;
+ * - `MEDUI-E033` for a `cv_check` value that is not a name.
  *
  * Deliberately AST-level: see the module comment for why the shared contract requires these two
  * codes to be reportable without a resolved layout.
@@ -152,11 +173,9 @@ struct SafetyResult {
  * that is not a name, or a name outside the closed set - means it was bypassed, and throws
  * `std::logic_error` rather than emitting a golden nobody can verify.
  *
- * One corner the shared contract does not pin: an annotated `Row` contributes the entry for its
- * background, since that rectangle is the Row's resolved band and the only thing it paints. A Row
- * with no `background:` paints nothing and so contributes no entry - the annotation belongs on the
- * content in that case, and a golden over an unpainted container is not something a verifier could
- * check.
+ * Only authored nodes are described. The solver's one synthetic node is a Row's background, and a
+ * Row can be neither annotated nor positioned, so it is never selected - see the interface comment
+ * above for why a container cannot be safety-critical at all.
  *
  * @throws std::logic_error if the annotation gate was bypassed.
  */

--- a/tools/medui/Goldens.cppm
+++ b/tools/medui/Goldens.cppm
@@ -1,0 +1,165 @@
+/**
+ * @file Goldens.cppm
+ * @brief Golden references for safety-critical nodes: which nodes a verifier must check, where they
+ *        must appear, and in what tint.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Host-only. A golden reference is the compiler's statement of what a rendered frame must show for
+ * the content that matters clinically, written down at build time so that #16's verifier checks a
+ * frame against a reviewed expectation rather than against the source that produced it. ADR-012
+ * decision 1 commits them to `generated/screen/<id>/goldens.json`, beside the screen package and
+ * outside it - a reviewer approving a moved safety-critical rectangle should see that hunk on its
+ * own, and a goldens-only change should have its own digest.
+ *
+ * ## The predicate is fixed, not chosen here
+ *
+ * ADR-011 settles which nodes are selected, and #16 must use the same rule, so it is restated
+ * rather than re-decided:
+ *
+ * - a node carrying `@safety_critical` emits an entry;
+ * - **any** node with an explicit `position:` emits an entry with a `Bounds` check, annotated or
+ *   not, because a declared position is a safety-relevant claim by itself;
+ * - a node matching both emits exactly **one** entry, with the two check lists merged and
+ *   deduplicated - never two entries for one node;
+ * - a `@safety_critical` node with no `requirement:` is an error (`MEDUI-E070`), because a
+ *   safety-critical node that cannot be traced is the thing the annotation exists to prevent.
+ *
+ * The consequence worth stating: the file's content is *exactly determined* by the screen. That is
+ * what lets #197's consistency test compare sets rather than resolve references - it applies this
+ * predicate to the compiled nodes, derives the id set the goldens must contain, and asserts
+ * equality. A test that only checked that listed ids resolve would accept the dangerous direction
+ * silently, because a safety-critical node whose golden was dropped looks exactly like a screen
+ * with fewer safety-critical nodes (ADR-012, consequences).
+ *
+ * ## Why validation and emission are separate calls
+ *
+ * `validateSafetyAnnotations()` reads the parsed screen; `collectGoldens()` reads the resolved one.
+ * The split is not tidiness: the annotation rules are decidable from source alone, and the shared
+ * conformance suite requires that. `MEDUI-CASE-SAFETY-MISSING-REQUIREMENT` pins `MEDUI-E070` on a
+ * screen that declares no `surface:`, which the layout solver cannot resolve at all - so a design
+ * that could only report `MEDUI-E070` after layout could not satisfy the contract it implements.
+ *
+ * The order for a compiler driver is therefore: parse, analyze, validate annotations, resolve
+ * layout, collect goldens.
+ *
+ * ## The emitted shape, agreed here
+ *
+ * #196 is where the shape is settled, because #197 serialises it and #16 consumes it, and agreeing
+ * it after either of those exists means changing a committed artifact. `GoldenReference` maps
+ * one-to-one onto the canonical JSON:
+ *
+ * ```json
+ * { "node_id": "sedation-index",
+ *   "bounds": { "x": 1392, "y": 80, "width": 512, "height": 512 },
+ *   "text_key": "STR-SEDATION-LABEL",
+ *   "color_token": "Theme.Colors.ScoreDigits",
+ *   "cv_checks": ["Bounds", "ColorHash"] }
+ * ```
+ *
+ * `text_key` and `color_token` are omitted when the node has none. `cv_checks` is sorted and
+ * deduplicated so that one screen has one serialisation - `goldens.json` is byte-compared across
+ * toolchains like every other committed artifact, and a set whose order depended on which rule
+ * selected the node first would not survive that.
+ *
+ * ## What a golden pins for dynamic content, and what it must not
+ *
+ * A `NumericDisplay`, `Clock`, `SignalTrace` or `StatusIndicator` shows a value that changes. The
+ * golden pins **where** that content appears and **in what tint**, never what the value is: pinning
+ * a live number would make the verifier fail whenever the demonstrator changed, which trains a team
+ * to ignore it. So `text_key` is filled only from a field whose value is a single static key, and a
+ * list-valued field such as `StatusIndicator`'s `states:` leaves it empty - the state shown is
+ * exactly the varying part.
+ */
+module;
+
+export module mdux.tools.medui.goldens;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.layout;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief A verification #16's driver performs against a rendered frame.
+ *
+ * The closed set the shared language defines. Order is the serialisation order: `cv_checks` is
+ * sorted by this enumeration so that a screen has one canonical form.
+ */
+enum class CvCheck : std::uint8_t {
+    Bounds,    ///< the node's content occupies the rectangle the compiler resolved
+    ColorHash  ///< the node's content carries the tint its colour token resolves to
+};
+
+/// The spelling an author writes and the serialiser emits, e.g. `Bounds`.
+[[nodiscard]] std::string_view spell(CvCheck check) noexcept;
+
+/// The check `name` spells, or nothing when the name is not one of the closed set.
+[[nodiscard]] std::optional<CvCheck> parseCvCheck(std::string_view name) noexcept;
+
+/**
+ * @brief One golden reference: what a verifier must find, and where.
+ *
+ * Field names mirror the canonical JSON members one-to-one; see the module comment for the mapping.
+ * `textKey` and `colorToken` are empty when the node draws neither.
+ */
+struct GoldenReference {
+    std::string          nodeId;
+    LayoutRect           bounds{};
+    std::string          textKey;
+    std::string          colorToken;
+    std::vector<CvCheck> cvChecks;  ///< sorted, deduplicated, never empty
+
+    [[nodiscard]] bool operator==(const GoldenReference&) const = default;
+};
+
+/// Accumulated annotation diagnostics; an empty result admits the screen to layout and emission.
+struct SafetyResult {
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Checks the `@safety_critical` annotation rules on a parsed screen.
+ *
+ * Reports `MEDUI-E070` for an annotated node with no `requirement:`, at the annotation, and
+ * `MEDUI-E071` for a `cv_check` naming a verification outside the closed set, at the offending
+ * name. Diagnostics accumulate in source order.
+ *
+ * Deliberately AST-level: see the module comment for why the shared contract requires these two
+ * codes to be reportable without a resolved layout.
+ */
+[[nodiscard]] SafetyResult validateSafetyAnnotations(const ast::Screen& screen, std::string file);
+
+/**
+ * @brief Derives the golden set from a resolved screen.
+ *
+ * Entries follow resolved-node order, which is the order the compiled package lists its nodes in,
+ * so a set comparison and a diff both read top to bottom.
+ *
+ * Returns references rather than a result type with a diagnostic list: every rule that can fail was
+ * decided by `validateSafetyAnnotations()`, and a permanently empty diagnostic vector would suggest
+ * this stage can reject a screen when it cannot.
+ *
+ * That validation is a required gate. A malformed annotation reaching here - a `cv_check` value
+ * that is not a name, or a name outside the closed set - means it was bypassed, and throws
+ * `std::logic_error` rather than emitting a golden nobody can verify.
+ *
+ * One corner the shared contract does not pin: an annotated `Row` contributes the entry for its
+ * background, since that rectangle is the Row's resolved band and the only thing it paints. A Row
+ * with no `background:` paints nothing and so contributes no entry - the annotation belongs on the
+ * content in that case, and a golden over an unpainted container is not something a verifier could
+ * check.
+ *
+ * @throws std::logic_error if the annotation gate was bypassed.
+ */
+[[nodiscard]] std::vector<GoldenReference> collectGoldens(const LayoutResult& layout);
+
+}  // namespace mdux::tools::medui


### PR DESCRIPTION
## Summary

S7 of the `.medui` compiler: the stage that decides which nodes a rendered-truth verifier must
check, where they must appear, and in what tint. Adds `mdux.tools.medui.goldens`
(`tools/medui/Goldens.{cppm,cpp}`).

ADR-011 fixes the predicate and #16 must use the same one, so it is restated rather than re-decided:

- a node carrying `@safety_critical` is selected;
- **any** node with an explicit `position:` is selected with an automatic `Bounds` check, annotated
  or not;
- a node matching both is selected **exactly once**, with the check lists merged and deduplicated;
- a `@safety_critical` node whose `requirement:` is absent **or blank** is `MEDUI-E070` — the field
  is a `String` and the semantic domain accepts `""`, so presence alone would let an untraceable
  node through the rule written to stop it;
- and only a component the dictionary gives a `requirement:` can carry the annotation at all, which
  is `CriticalButton`, `Button`, `NumericDisplay`, `StatusIndicator` and `TextInput`. `Row`,
  `Label`, `Clock`, `Image`, `SignalTrace` and `VulkanViewport` take none, so an annotation on any
  of them is rejected rather than silently unpinned.

**Two entry points, because the shared contract requires it.** `validateSafetyAnnotations()` applies
the annotation rules to a *parsed* screen and needs no layout;
`MEDUI-CASE-SAFETY-MISSING-REQUIREMENT` pins `MEDUI-E070` on a screen that declares no `surface:`,
which the solver cannot resolve at all — so a design that could only report it after layout could not
satisfy the contract it implements. `collectGoldens()` derives the set from the *resolved* screen and
returns references rather than a result type, because every rule that can fail was already decided
by the first call. A driver's order is parse → analyze → validate annotations → layout → collect.

**The safety phase becomes observable**, so `medui-conformance.toml` claims it and the shared harness
executes the pinned case instead of listing it unclaimed. The adapter deliberately skips semantic
analysis: a safety case carries no theme or locale inputs, and running `analyze` would add findings
the case never claimed.

**The shape is settled here**, as the issue asks, because #197 serialises it and #16 consumes it:
`node_id`, `bounds`, `text_key?`, `color_token?`, `cv_checks`, with `cv_checks` sorted and
deduplicated so one screen has one serialisation — `goldens.json` is byte-compared like every other
committed artifact.

**Dynamic content pins place and tint, never the value.** A list-valued `states:` or `colors:` leaves
`text_key` and `color_token` empty, because the state on screen is exactly the varying part; a golden
that pinned one would fail whenever the device showed another, which trains a team to ignore it.

Three judgement calls, each documented where it is made and listed here so a reviewer does not have
to find them:

1. **An annotation naming no `cv_check` still pins `Bounds`.** Read from ADR-011's rule that a
   declared position alone is enough — if that makes a rectangle worth verifying, an explicit
   safety-critical claim cannot be worth less. The alternative is an entry a verifier reads and does
   nothing with.
2. **A `ColorHash` check is refused where no single declared tint exists** — a `StatusIndicator`
   whose `colors:` is a list, or a `Clock`, `Image` or `VulkanViewport` with no colour at all.
   `cv_checks` and `color_token` are halves of one claim, and a reference that asked for a
   comparison while carrying no expectation is one #16 could only skip. Encoding per-state tints
   instead would extend the shape both #16 and #197 consume, so it belongs with the wave that owns
   state-dependent components (#17) — but it is cheaper to decide now than after `goldens.json` is
   committed, so say the word and it lands here.
3. **A malformed `cv_check` value reuses `MEDUI-E033`** rather than taking a new code. An annotation
   argument is an `ast::Field`, and "a field value has the wrong semantic kind" is exactly what a
   quoted or numeric check is; a new code would mean the same thing twice.

Closes #196

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change.
- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: none — maintainer-authored, so neither box applies.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked — #213 (S6) merged as `163371b`, and its post-merge `develop` run
  was green before this branch was cut
- **Merge order:** mergeable now

## Shared registries touched

- [x] `FILE_SET CXX_MODULES` lists — `medui/Goldens.cppm` added
- [x] `tools/CMakeLists.txt` — `MduXMeduiLib` sources
- [x] `tests/CMakeLists.txt` — `medui_tools_spec` sources
- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`

Also edits `medui-conformance.toml`, which is a pinned-contract manifest rather than a build
registry: `capabilities` gains `safety`.

## Rebase state

- **Rebased onto:** `163371b` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — **not run locally.** The preset is
      Linux-only, and the local macOS toolchain cannot complete a module build: with CMake 4.1.2 and
      Homebrew GCC 16.1.0 the configure succeeds but the build fails inside CMake's synthesized
      `__CMAKE::CXX23` target, because GCC's scan of `bits/std.cc` reports no module interface unit.
      That is before any MduX source compiles, and disabling ccache does not change it.
- [ ] `ctest --test-dir build-gcc` — not run locally, for the same reason.
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — `OK (80 files checked, 0 findings)`
- [x] `clang-format` applied to the new sources with the repository's `.clang-format`.

- [x] CI on `b6c8326` (this head): Linux (GCC 16, Vulkan) **521/521 tests passed**, Windows (MSVC,
      Vulkan) and ASan + UBSan (GCC 16) green, every lint and analysis leg green. The golden suite is
      14 scenarios. (The first Windows and osv-scan runs on this head failed while GitHub was
      returning 429/503 for action downloads — neither reached a compiler — and passed on re-run.)

With `safety` claimed, the pinned `MEDUI-CASE-SAFETY-MISSING-REQUIREMENT` case now executes at full
position precision under `medui-shared-conformance` rather than being skipped as unclaimed.

## Review round two

`b6c8326` addresses every finding on the first head; each is answered in its own thread.

- **Empty requirement (P1).** Blank is now the same error as absent, with `medui-goldens-blank-requirement`
  driving analyze → validate so the scenario shows *where* the gap was: semantic analysis genuinely
  accepts `requirement: ""`.
- **`ColorHash` with no tint (P1).** Refused, per judgement call 2 above, with
  `medui-goldens-colorhash-needs-a-tint` covering the annotated `StatusIndicator`, the no-colour
  `Clock`, and a positive control.
- **Annotated `Row` unreachable (P1, also raised by Copilot).** The behaviour is removed rather than
  supported: `Row` takes no `requirement:` in the pinned model, so it never reaches collection, and
  the previous scenario only saw that path by skipping the validation gate. `collectGoldens()` now
  skips synthetic nodes explicitly, and `medui-goldens-annotated-row` pins the rejection through
  parse → validate.
- **AGENTS.md remaining children.** Now lists all five (#197–#201) rather than three.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** pending
- [ ] That run is green.

## Regulatory impact

Safety-relevant, and this is the change that creates the evidence rather than one that could weaken
it. A golden reference is the compiler's written statement of what a rendered frame must show for
the content that matters clinically, produced at build time so #16's verifier checks a frame against
a reviewed expectation rather than against the source that produced it. ADR-012 § "Decision 1"
commits the file beside the screen package precisely so that a moved safety-critical rectangle is a
reviewable hunk with its own digest.

The rule with the most traceability weight is `MEDUI-E070`: a `@safety_critical` node with no
`requirement:` fails to compile, so a safety-critical node cannot exist without something to trace
it to. `requirement:` is optional on `Button` and `TextInput`, which is exactly why the annotation
needs its own rule.

Artifacts updated: `docs/architecture.md`, `README.md`, `.agents/skills/medui-authoring/SKILL.md`,
`docs/roadmap.md`, and `AGENTS.md` — whose skill table still described the compiler as "Planned — no
`.medui` compiler exists yet", an underclaim by five children that misroutes an agent deciding
whether to read the skill. No ADR changes: ADR-011 and ADR-012 already decided this and are cited
from the module rather than restated. No new certification or compliance claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added golden references for safety-critical interface elements.
  * Added validation for safety annotations, required checks, and unsupported checks.
  * Added support for collecting and validating pinned bounds, text, colors, and dynamic content.

* **Bug Fixes**
  * Improved diagnostics for missing safety requirements and invalid checks.
  * Prevented golden-reference collection when safety validation has not passed.

* **Tests**
  * Added comprehensive coverage for accepted and rejected safety scenarios.

* **Documentation**
  * Updated implementation status, architecture documentation, and roadmap progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
