### PR TITLE
S8 (1/2) — The governed compiled-screen schema [#197]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ target_sources(MduXCore
             include/mdux/font/Schema.cppm
             include/mdux/text/Draw.cppm
             include/mdux/text/Schema.cppm
+            include/mdux/medui/Schema.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,7 @@ are ordinary `PRIVATE` sources.
 | `mdux.ml.schema` | `include/mdux/ml/Schema.cppm` | header-only |
 | `mdux.ml.kernels` | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
 | `mdux.ml.runtime` | `include/mdux/ml/Runtime.cppm` | `src/ml/Runtime.cpp` |
+| `mdux.medui.schema` | `include/mdux/medui/Schema.cppm` | header-only |
 
 `mdux.core.result` is a naming alias over `std::expected`, not a reimplementation
 ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)).

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -1,0 +1,249 @@
+/**
+ * @file Schema.cppm
+ * @brief Governed-zone compiled-screen types: what a `.medui` screen becomes once the compiler has
+ *        resolved it, in the form a device holds it.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Part of MduXCore, and canonical: the emitters (#197), the compiler driver (#198) and the
+ * allocation-free runtime (#199) import this rather than restating its records. Two files
+ * describing the same artifact disagree eventually, and the disagreement surfaces as a
+ * byte-comparison failure nobody can localise - the Wave 2 lesson, applied here before there is
+ * anything to re-learn it on.
+ *
+ * Header-only by design; there is no `src/medui/Schema.cpp`. Everything is `constexpr`, because
+ * ADR-012 decision 3 puts `static_assert(package.validate().has_value())` in the generated source:
+ * a malformed screen has to be a compile error on the device build, not a startup failure in a
+ * theatre. `mdux.ml.schema` is the model followed here. `mdux.text.schema`'s `TextPackage`
+ * deliberately is not - it owns `std::string` and `std::vector`, so it could not appear in a
+ * `static_assert` at all.
+ *
+ * ## Non-owning, and what that costs the caller
+ *
+ * Every string is a `std::string_view` and the node list is a `std::span`. The generated
+ * translation unit owns the storage, statically, so a `ScreenPackage` is a handful of pointers that
+ * costs nothing to copy and needs no lifetime management. The cost is that a host tool assembling a
+ * screen cannot use this type as its accumulator - it builds an owning form and takes a view of it.
+ * That is the same split `mdux.ml.schema` makes with `mdux-mlbake`, and it is the price of a type a
+ * device can hold in `.rodata`.
+ *
+ * ## The package is locale-free, and that is load-bearing
+ *
+ * ADR-011, as amended by #203, carries `textKey` and `colorToken` as **validated names** rather than
+ * as glyph runs and RGBA8. The device resolves each against a governed table for the locale it is
+ * running - a bounded lookup, not a parse - and the per-locale glyph runs stay in the text package
+ * where ADR-010 put them.
+ *
+ * The consequence that decides the file layout: **adding an approved locale rewrites no screen
+ * artifact.** Translations change far more often than layouts, and a package carrying runs would
+ * make the frequent change rewrite the stable artifact - and its digest, and its review.
+ *
+ * The cost, stated as a cost: one rectangle serves every locale, so it must be the one that
+ * survives the widest approved translation. That is what #195 measures, and why the budget below
+ * cannot be derived from the node count.
+ *
+ * ## What `validate()` checks, and what it deliberately does not
+ *
+ * It checks what a consumer is entitled to assume without looking: an identified screen, a positive
+ * surface, nodes with unique ids and rectangles that lie inside that surface, colour tokens that are
+ * names rather than values, and a budget the index width can address.
+ *
+ * It does **not** check that the budget is large enough for what the screen draws. That number is
+ * not derivable from anything here: a `Label` draws one rectangle per glyph of the widest approved
+ * translation, and this package carries no glyph runs by design. The compiler computes the budget
+ * from the text packages it measured (#195) and the components' own draw shapes (#17); a rule
+ * invented here would be a second, weaker opinion about a number this type only carries. What it
+ * *can* say is that a screen with nodes and an empty budget draws nothing, and that a budget past
+ * `mdux::draw::maxIndexableVertices` cannot be indexed - both are refused.
+ */
+module;
+
+export module mdux.medui.schema;
+
+import std;
+import mdux.core.result;
+import mdux.draw;
+import mdux.evidence.report;
+
+export namespace mdux::medui {
+
+/// The `<kind>` component of `generated/<kind>/<id>/`, and the value of a package's `kind` member.
+inline constexpr std::string_view packageKind = "screen";
+
+/// The prefix every colour a node draws with must carry. The package holds names, never values.
+inline constexpr std::string_view colorTokenPrefix = "Theme.Colors.";
+
+enum class SchemaError : std::uint8_t {
+    UnsupportedSchemaVersion,  ///< the package declares a version this module does not read
+    EmptyId,                   ///< the screen has no id, so no directory and no evidence entry
+    NonPositiveSurface,        ///< a surface with no extent cannot contain a rectangle
+    EmptyNodeId,               ///< a node with no id cannot be named by a golden or a requirement
+    DuplicateNodeId,           ///< two nodes share an id, so a golden could name either
+    DegenerateBounds,          ///< a rectangle with no extent, which `DrawList` refuses to record
+    BoundsOutsideSurface,      ///< a rectangle the declared surface does not contain
+    MalformedColorToken,       ///< a colour that is not a `Theme.Colors.<Token>` name
+    EmptyBudget,               ///< a screen with nodes whose budget can hold no primitive
+    BudgetExceedsIndexWidth,   ///< more vertices than a 16-bit index can address
+};
+
+[[nodiscard]] constexpr std::string_view describe(SchemaError error) noexcept {
+    switch (error) {
+        case SchemaError::UnsupportedSchemaVersion:
+            return "the package declares an unsupported schemaVersion";
+        case SchemaError::EmptyId:
+            return "the screen has no id";
+        case SchemaError::NonPositiveSurface:
+            return "the surface has no extent";
+        case SchemaError::EmptyNodeId:
+            return "a node has no id";
+        case SchemaError::DuplicateNodeId:
+            return "two nodes share an id";
+        case SchemaError::DegenerateBounds:
+            return "a node's rectangle has no extent";
+        case SchemaError::BoundsOutsideSurface:
+            return "a node's rectangle leaves the declared surface";
+        case SchemaError::MalformedColorToken:
+            return "a colour is not a Theme.Colors.<Token> name";
+        case SchemaError::EmptyBudget:
+            return "the screen has nodes and a budget that can hold no primitive";
+        case SchemaError::BudgetExceedsIndexWidth:
+            return "the vertex budget exceeds what a 16-bit index can address";
+    }
+    return "unknown schema error";
+}
+
+/**
+ * @brief One node's absolute rectangle, in integer surface pixels.
+ *
+ * Integer throughout, as ADR-011 decision 5 requires: the solver never divides into a fraction, so
+ * two toolchains cannot disagree about where a rectangle is. Signed rather than unsigned because
+ * `mdux::core::Px` is signed and a mixed-signedness comparison is a defect waiting for a reviewer.
+ */
+struct NodeRect {
+    std::int32_t x{0};
+    std::int32_t y{0};
+    std::int32_t width{0};
+    std::int32_t height{0};
+
+    [[nodiscard]] constexpr bool operator==(const NodeRect&) const noexcept = default;
+};
+
+/**
+ * @brief One compiled node: what it draws, where, and what it is traced to.
+ *
+ * `textKey` and `colorToken` are the validated *names* ADR-011 carries rather than the values they
+ * resolve to - the compiler has already proved the key exists in every approved locale (#193) and
+ * that the token is in the governed table, so the device performs a bounded lookup and no parse.
+ *
+ * `requirement` is empty for a node that declares none, and non-empty for every node that is
+ * safety-critical, because #196 refuses the annotation without it. Carrying it here is what makes
+ * the requirement-to-node mapping diffable in a committed artifact.
+ */
+struct CompiledNode {
+    std::string_view id;
+    std::string_view component;    ///< the dictionary name, e.g. `Label`
+    NodeRect         bounds{};
+    std::string_view textKey;      ///< empty when the node draws no static text
+    std::string_view colorToken;   ///< empty when the node declares no tint
+    std::string_view requirement;  ///< empty when the node declares none
+
+    [[nodiscard]] constexpr bool operator==(const CompiledNode&) const noexcept = default;
+};
+
+/**
+ * @brief A whole compiled screen as generated code exposes it and the runtime consumes it.
+ *
+ * Non-owning and `constexpr`-constructible throughout, so a generated translation unit can place one
+ * in read-only memory and `static_assert` that it validates.
+ */
+struct ScreenPackage {
+    std::string_view              id;
+    std::uint64_t                 schemaVersion{evidence::kSchemaVersion};
+    std::int32_t                  surfaceWidth{0};
+    std::int32_t                  surfaceHeight{0};
+    std::span<const CompiledNode> nodes;
+    mdux::draw::DrawBudget        budget{};
+
+    /// Checks every invariant a consumer is entitled to assume. See the module comment for the one
+    /// invariant it deliberately leaves to the compiler: whether the budget is *large enough*.
+    [[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> validate() const noexcept;
+
+    /// The node with this id, or nullptr. Linear: a screen holds tens of nodes, and a map would
+    /// cost more to build than every lookup it could serve - and could not be `constexpr` data.
+    [[nodiscard]] constexpr const CompiledNode* find(std::string_view nodeId) const noexcept {
+        for (const CompiledNode& node : nodes) {
+            if (node.id == nodeId) {
+                return &node;
+            }
+        }
+        return nullptr;
+    }
+};
+
+/// Whether `bounds` lies wholly inside a `width` x `height` surface.
+///
+/// Computed in 64-bit arithmetic: `x + width` on two `std::int32_t` at their extremes overflows,
+/// and an overflowed comparison would admit exactly the rectangle this is written to refuse.
+[[nodiscard]] constexpr bool containedBy(NodeRect bounds, std::int32_t width, std::int32_t height) noexcept {
+    if (bounds.x < 0 || bounds.y < 0) {
+        return false;
+    }
+    const std::int64_t right  = static_cast<std::int64_t>(bounds.x) + bounds.width;
+    const std::int64_t bottom = static_cast<std::int64_t>(bounds.y) + bounds.height;
+    return right <= width && bottom <= height;
+}
+
+constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const noexcept {
+    using mdux::core::err;
+
+    if (schemaVersion != evidence::kSchemaVersion) {
+        return err(SchemaError::UnsupportedSchemaVersion);
+    }
+    if (id.empty()) {
+        return err(SchemaError::EmptyId);
+    }
+    if (surfaceWidth <= 0 || surfaceHeight <= 0) {
+        return err(SchemaError::NonPositiveSurface);
+    }
+
+    for (std::size_t index = 0; index < nodes.size(); ++index) {
+        const CompiledNode& node = nodes[index];
+
+        if (node.id.empty()) {
+            return err(SchemaError::EmptyNodeId);
+        }
+        // Quadratic, and deliberately so: a screen holds tens of nodes, `constexpr` evaluation has
+        // no allocator, and a sorted copy would need one. The alternative is not checking.
+        for (std::size_t earlier = 0; earlier < index; ++earlier) {
+            if (nodes[earlier].id == node.id) {
+                return err(SchemaError::DuplicateNodeId);
+            }
+        }
+        if (node.bounds.width <= 0 || node.bounds.height <= 0) {
+            return err(SchemaError::DegenerateBounds);
+        }
+        if (!containedBy(node.bounds, surfaceWidth, surfaceHeight)) {
+            return err(SchemaError::BoundsOutsideSurface);
+        }
+        if (!node.colorToken.empty() && !node.colorToken.starts_with(colorTokenPrefix)) {
+            return err(SchemaError::MalformedColorToken);
+        }
+    }
+
+    if (budget.maxVertices > mdux::draw::maxIndexableVertices) {
+        return err(SchemaError::BudgetExceedsIndexWidth);
+    }
+    // A screen with nothing to draw may carry an empty budget; one with nodes may not, because the
+    // first rectangle it records would be refused and the frame would silently be blank.
+    if (!nodes.empty() && (budget.maxVertices == 0 || budget.maxIndices == 0 || budget.maxCommands == 0)) {
+        return err(SchemaError::EmptyBudget);
+    }
+
+    return {};
+}
+
+}  // namespace mdux::medui

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -46,6 +46,19 @@
  * survives the widest approved translation. That is what #195 measures, and why the budget below
  * cannot be derived from the node count.
  *
+ * ## The colour table lives here, and its contents do not
+ *
+ * ADR-011 puts the *resolution* of `Theme.Colors.<Token>` on the device, as a bounded scan of a
+ * governed table - TrustSC's `THEME_COLORS` and `resolve_color_token()` are the reference, and both
+ * live in its governed crate. So `ThemeColor` and `resolveColorToken()` are here, beside the package
+ * that carries the names: a consumer holding this schema holds the whole device-side contract, and
+ * #199 inherits a resolver rather than writing a second one.
+ *
+ * What is deliberately *not* here is a palette. Which colours a device shows is a clinical and
+ * regulatory decision belonging to the product, exactly as the theme names semantic analysis
+ * validates against are an input rather than a constant (#193). MduX owns the representation and the
+ * lookup; the table is supplied.
+ *
  * ## What `validate()` checks, and what it deliberately does not
  *
  * It checks what a consumer is entitled to assume without looking: an identified screen, a positive
@@ -66,6 +79,7 @@ export module mdux.medui.schema;
 
 import std;
 import mdux.core.result;
+import mdux.core.units;
 import mdux.draw;
 import mdux.evidence.report;
 
@@ -115,6 +129,102 @@ enum class SchemaError : std::uint8_t {
             return "the vertex budget exceeds what a 16-bit index can address";
     }
     return "unknown schema error";
+}
+
+/**
+ * @brief One entry of the governed colour table: a name a screen may carry, and what it resolves to.
+ *
+ * The device side of ADR-011's boundary. A compiled screen carries `Theme.Colors.<Token>` as a
+ * *name*, and the runtime turns it into a colour by scanning a table like this one - a bounded scan
+ * over fixed data, which is neither parsing nor unbounded work, and therefore not what the compile
+ * boundary exists to keep off a device. TrustSC reached this arrangement first: `THEME_COLORS` and
+ * `resolve_color_token()` live in its governed `trustsc-ui` crate, and this is the same shape.
+ */
+struct ThemeColor {
+    std::string_view       token;  ///< the full name, e.g. `Theme.Colors.ScoreDigits`
+    mdux::core::ColorRgba8 value{};
+
+    [[nodiscard]] constexpr bool operator==(const ThemeColor&) const noexcept = default;
+};
+
+enum class ThemeError : std::uint8_t {
+    MalformedToken,  ///< the name is not of the form `Theme.Colors.<Token>`
+    UnknownToken,    ///< well-formed, but the governed table does not define it
+};
+
+[[nodiscard]] constexpr std::string_view describe(ThemeError error) noexcept {
+    switch (error) {
+        case ThemeError::MalformedToken:
+            return "the colour is not a Theme.Colors.<Token> name";
+        case ThemeError::UnknownToken:
+            return "the governed colour table does not define this token";
+    }
+    return "unknown theme error";
+}
+
+/**
+ * @brief Whether `token` has the shape a colour name must have.
+ *
+ * The prefix, then a non-empty suffix of the characters an identifier may contain - ASCII letters,
+ * digits, `_` and `-` - with `.` admitted between segments, because the parser builds a dotted path
+ * and a product may legitimately name `Theme.Colors.Status.Ok`. No empty segment: a trailing dot or
+ * a `..` names nothing.
+ *
+ * Shape is not existence. A well-formed token may still be absent from a product's table, which is
+ * what `resolveColorToken()` reports and what the compiler already checks against the theme names it
+ * was given (#193). Keeping the two separate is what lets `validate()` reject a malformed name
+ * without holding a table it was never handed.
+ */
+[[nodiscard]] constexpr bool isColorToken(std::string_view token) noexcept {
+    if (!token.starts_with(colorTokenPrefix) || token.size() == colorTokenPrefix.size()) {
+        return false;
+    }
+
+    bool segmentEmpty = true;
+    for (const char character : token.substr(colorTokenPrefix.size())) {
+        if (character == '.') {
+            if (segmentEmpty) {
+                return false;
+            }
+            segmentEmpty = true;
+            continue;
+        }
+        const bool admitted = (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')
+                              || character == '_' || character == '-';
+        if (!admitted) {
+            return false;
+        }
+        segmentEmpty = false;
+    }
+    return !segmentEmpty;
+}
+
+/**
+ * @brief Resolves a name a compiled screen carries against a product's governed colour table.
+ *
+ * A bounded scan with a `Result` on miss - never an allocation, never a throw, as ADR-011 requires
+ * and as `mdux-governed-lint` and `governed.noThrow.symbolScan` hold this module to. Linear rather
+ * than a binary search: a palette holds tens of entries, and requiring the table to be sorted would
+ * add an invariant a product's generated table could silently break, in exchange for a saving no
+ * frame would notice.
+ *
+ * **The table's contents are the product's, not this library's.** MduX defines the representation
+ * and the lookup; a palette is a clinical and regulatory decision belonging to the device it ships
+ * on, exactly as the theme names semantic analysis validates against are an input rather than a
+ * constant (#193). So there is no default table here to inherit, and a caller supplying an empty one
+ * gets `UnknownToken` for every name rather than a colour nobody approved.
+ */
+[[nodiscard]] constexpr mdux::core::Result<mdux::core::ColorRgba8, ThemeError> resolveColorToken(std::span<const ThemeColor> table,
+                                                                                                 std::string_view            token) noexcept {
+    if (!isColorToken(token)) {
+        return mdux::core::err(ThemeError::MalformedToken);
+    }
+    for (const ThemeColor& entry : table) {
+        if (entry.token == token) {
+            return entry.value;
+        }
+    }
+    return mdux::core::err(ThemeError::UnknownToken);
 }
 
 /**
@@ -230,10 +340,11 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
         if (!containedBy(node.bounds, surfaceWidth, surfaceHeight)) {
             return err(SchemaError::BoundsOutsideSurface);
         }
-        // The prefix alone is not a name: `Theme.Colors.` names nothing the governed table could
-        // resolve, so a screen carrying it would validate here and fail its colour lookup on the
-        // device - which is the one direction this check exists to prevent.
-        if (!node.colorToken.empty() && (!node.colorToken.starts_with(colorTokenPrefix) || node.colorToken.size() == colorTokenPrefix.size())) {
+        // The same shape rule the resolver applies, so a screen that validates here cannot fail the
+        // device lookup for a reason `validate()` could have seen. `Theme.Colors.` names nothing and
+        // `Theme.Colors.#` is not a name at all; both would otherwise pass the generated
+        // `static_assert` and fail only where nobody is watching.
+        if (!node.colorToken.empty() && !isColorToken(node.colorToken)) {
             return err(SchemaError::MalformedColorToken);
         }
     }

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -74,7 +74,8 @@ export namespace mdux::medui {
 /// The `<kind>` component of `generated/<kind>/<id>/`, and the value of a package's `kind` member.
 inline constexpr std::string_view packageKind = "screen";
 
-/// The prefix every colour a node draws with must carry. The package holds names, never values.
+/// The prefix every colour a node draws with must carry, and which it must carry *something* after:
+/// the package holds names, never values, and `Theme.Colors.` on its own is not a name.
 inline constexpr std::string_view colorTokenPrefix = "Theme.Colors.";
 
 enum class SchemaError : std::uint8_t {
@@ -229,7 +230,10 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
         if (!containedBy(node.bounds, surfaceWidth, surfaceHeight)) {
             return err(SchemaError::BoundsOutsideSurface);
         }
-        if (!node.colorToken.empty() && !node.colorToken.starts_with(colorTokenPrefix)) {
+        // The prefix alone is not a name: `Theme.Colors.` names nothing the governed table could
+        // resolve, so a screen carrying it would validate here and fail its colour lookup on the
+        // device - which is the one direction this check exists to prevent.
+        if (!node.colorToken.empty() && (!node.colorToken.starts_with(colorTokenPrefix) || node.colorToken.size() == colorTokenPrefix.size())) {
             return err(SchemaError::MalformedColorToken);
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,6 +674,41 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
+# Governed compiled-screen schema (issue #197)
+#
+# Links MduX::Core only, and deliberately not MduX::MeduiLib. `mdux.medui.schema` is the one type a
+# device holds, so a scenario that needed the parser or the solver to build one would mean the
+# trust-zone boundary had moved - the same argument that keeps ml_spec apart from ml_tools_spec.
+#
+# The file's centre of gravity is a namespace-scope static_assert rather than a scenario: ADR-012
+# decision 3 puts `static_assert(package.validate().has_value())` in every generated screen, so
+# compile-time validation is a promise the device build depends on, and one no runtime test can
+# make on its behalf.
+add_executable(medui_spec
+    medui/MeduiSpecMain.cpp
+    medui/SchemaTests.cpp
+)
+
+target_link_libraries(medui_spec PRIVATE MduX::Core speclab::speclab)
+target_include_directories(medui_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(medui_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(medui_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(medui_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(medui_spec)
+
 # .medui compiler host-tools suite (issues #191, #192, #193, #194, #195, #196)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -

--- a/tests/medui/MeduiSpecMain.cpp
+++ b/tests/medui/MeduiSpecMain.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file MeduiSpecMain.cpp
+ * @brief Entry point for the governed `mdux.medui` SpecLab BDD executable.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Deliberately a separate binary from `medui_tools_spec`, which links the host-tools compiler.
+ * This one links MduX::Core only, so it is standing evidence that the compiled-screen schema - the
+ * one type a device holds - reaches nothing but `std`. A scenario here that needed the parser or
+ * the layout solver would mean the boundary had moved.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX MedUI Schema Spec");
+}

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -350,8 +350,13 @@ const mdux::spec::Register colourTokensResolveAgainstAGovernedTable{
                       const auto value = ms::resolveColorToken(constTheme, "#21B86B");
                       checks.expect(!value.has_value() && value.error() == ms::ThemeError::MalformedToken, "a colour value is refused where a name belongs");
 
-                      checks.expect(!ms::resolveColorToken({}, "Theme.Colors.Title").has_value(),
-                                    "an empty table answers every name with a miss rather than a colour nobody approved");
+                      // The error matters as much as the failure: a well-formed name against an
+                      // empty table is *absent*, not malformed. Asserting only `!has_value()` would
+                      // pass if the resolver ever confused the two, which is the distinction this
+                      // scenario exists to draw.
+                      const auto emptyTable = ms::resolveColorToken({}, "Theme.Colors.Title");
+                      checks.expect(!emptyTable.has_value() && emptyTable.error() == ms::ThemeError::UnknownToken,
+                                    "an empty table answers a well-formed name with a miss, not a colour nobody approved");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -1,0 +1,300 @@
+/**
+ * @brief Scenarios for the governed compiled-screen schema (issue #197).
+ * @file SchemaTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * The `static_assert` below is the point of the file. ADR-012 decision 3 puts
+ * `static_assert(package.validate().has_value())` in every generated screen, so "this type can be
+ * validated at compile time" is a promise the device build depends on rather than a nicety - and a
+ * promise a runtime test cannot check, because a runtime test proves only that it also works at
+ * run time. The scenarios that follow cover the rejections, which a `static_assert` cannot express.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.draw;
+import mdux.evidence.report;
+import mdux.medui.schema;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+
+// ---------------------------------------------------------------------------
+// Compile-time evidence for the constexpr claim
+// ---------------------------------------------------------------------------
+
+constexpr std::array<ms::CompiledNode, 3> constNodes{
+    ms::CompiledNode{.id          = "topbar-background",
+                     .component   = "Panel",
+                     .bounds      = {0, 0, 400, 40},
+                     .textKey     = {},
+                     .colorToken  = "Theme.Colors.Surface",
+                     .requirement = {}          },
+    ms::CompiledNode{            .id          = "title",
+                     .component   = "Label",
+                     .bounds      = {8, 8, 200, 24},
+                     .textKey     = "STR-TITLE",
+                     .colorToken  = "Theme.Colors.Title",
+                     .requirement = {}          },
+    ms::CompiledNode{            .id          = "score",
+                     .component   = "NumericDisplay",
+                     .bounds      = {250, 60, 120, 60},
+                     .textKey     = {},
+                     .colorToken  = "Theme.Colors.ScoreDigits",
+                     .requirement = "REQ-NS-001"}
+};
+
+constexpr ms::ScreenPackage constPackage{
+    .id            = "neurosense",
+    .schemaVersion = mdux::evidence::kSchemaVersion,
+    .surfaceWidth  = 400,
+    .surfaceHeight = 300,
+    .nodes         = constNodes,
+    .budget        = mdux::draw::DrawBudget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16}
+};
+
+// The module promises a generated screen can be validated at compile time and placed in read-only
+// memory. This is that promise, mechanically checked - and it is what ADR-012's generated
+// `static_assert` rests on.
+static_assert(constPackage.validate().has_value(), "the reference screen must validate at compile time");
+static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
+static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
+
+// ---------------------------------------------------------------------------
+// A mutable equivalent, so each rejection can change exactly one field
+// ---------------------------------------------------------------------------
+
+/// Owns what the package's spans point at, so a mutated fixture stays self-consistent.
+struct Fixture {
+    std::vector<ms::CompiledNode> nodes{constNodes.begin(), constNodes.end()};
+    std::string                   id{"neurosense"};
+    std::uint64_t                 schemaVersion{mdux::evidence::kSchemaVersion};
+    std::int32_t                  surfaceWidth{400};
+    std::int32_t                  surfaceHeight{300};
+    mdux::draw::DrawBudget        budget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
+
+    [[nodiscard]] ms::ScreenPackage package() const noexcept {
+        return ms::ScreenPackage{.id            = id,
+                                 .schemaVersion = schemaVersion,
+                                 .surfaceWidth  = surfaceWidth,
+                                 .surfaceHeight = surfaceHeight,
+                                 .nodes         = nodes,
+                                 .budget        = budget};
+    }
+};
+
+/// The error a mutated fixture reports, or nothing when it validates.
+[[nodiscard]] std::optional<ms::SchemaError> errorOf(const Fixture& fixture) {
+    const auto result = fixture.package().validate();
+    return result.has_value() ? std::nullopt : std::optional{result.error()};
+}
+
+[[nodiscard]] std::string describe(std::optional<ms::SchemaError> error) {
+    return error.has_value() ? std::string{ms::describe(*error)} : std::string{"accepted"};
+}
+
+}  // namespace
+
+const mdux::spec::Register referenceScreenValidates{"The reference screen validates, so every rejection below changes exactly one thing", "evidence-unit", [] {
+                                                        return speclab::Test("medui-schema-reference-validates")
+                                                            .Given("a three-node screen on a 400x300 surface", [] {})
+                                                            .When("it is validated", [] {})
+                                                            .Then("it is accepted, at run time as well as at compile time",
+                                                                  [] {
+                                                                      mdux::spec::Checks checks;
+                                                                      checks.expect(!errorOf(Fixture{}).has_value(),
+                                                                                    std::format("the fixture validates, got {}", describe(errorOf(Fixture{}))));
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register identityIsRequired{"A screen with no id and one with an unreadable version are both refused", "evidence-unit", [] {
+                                                  return speclab::Test("medui-schema-identity")
+                                                      .Given("the reference screen", [] {})
+                                                      .When("its id is emptied, and its schemaVersion moved past what this module reads", [] {})
+                                                      .Then("each is refused with the error that names it",
+                                                            [] {
+                                                                mdux::spec::Checks checks;
+
+                                                                Fixture unnamed;
+                                                                unnamed.id.clear();
+                                                                checks.expect(errorOf(unnamed) == ms::SchemaError::EmptyId,
+                                                                              std::format("an unnamed screen is refused, got {}", describe(errorOf(unnamed))));
+
+                                                                Fixture future;
+                                                                future.schemaVersion = mdux::evidence::kSchemaVersion + 1;
+                                                                checks.expect(
+                                                                    errorOf(future) == ms::SchemaError::UnsupportedSchemaVersion,
+                                                                    std::format("a version this module cannot read is refused rather than guessed at, got {}",
+                                                                                describe(errorOf(future))));
+                                                                checks.raise();
+                                                            })
+                                                      .Execute();
+                                              }};
+
+const mdux::spec::Register nodesAreAddressable{"Every node must be addressable, and addressable by exactly one id", "evidence-unit", [] {
+                                                   return speclab::Test("medui-schema-node-ids")
+                                                       .Given("the reference screen", [] {})
+                                                       .When("a node loses its id, and two nodes share one", [] {})
+                                                       .Then("both are refused, because a golden or a requirement could name either",
+                                                             [] {
+                                                                 mdux::spec::Checks checks;
+
+                                                                 Fixture anonymous;
+                                                                 anonymous.nodes[1].id = {};
+                                                                 checks.expect(errorOf(anonymous) == ms::SchemaError::EmptyNodeId,
+                                                                               std::format("an unnamed node is refused, got {}", describe(errorOf(anonymous))));
+
+                                                                 Fixture duplicated;
+                                                                 duplicated.nodes[2].id = duplicated.nodes[1].id;
+                                                                 checks.expect(errorOf(duplicated) == ms::SchemaError::DuplicateNodeId,
+                                                                               std::format("a shared id is refused, got {}", describe(errorOf(duplicated))));
+                                                                 checks.raise();
+                                                             })
+                                                       .Execute();
+                                               }};
+
+const mdux::spec::Register rectanglesStayInsideTheSurface{
+    "A rectangle with no extent, or one that leaves the surface, is refused",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-bounds")
+            .Given("the reference screen", [] {})
+            .When("a node is collapsed, moved past the right edge, and given a negative origin", [] {})
+            .Then("each is refused rather than clamped",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Fixture collapsed;
+                      collapsed.nodes[1].bounds.width = 0;
+                      checks.expect(errorOf(collapsed) == ms::SchemaError::DegenerateBounds,
+                                    std::format("a zero-width rectangle is refused, got {}", describe(errorOf(collapsed))));
+
+                      Fixture overflowing;
+                      overflowing.nodes[1].bounds.x = 201;  // 201 + 200 > 400
+                      checks.expect(errorOf(overflowing) == ms::SchemaError::BoundsOutsideSurface,
+                                    std::format("a rectangle past the right edge is refused, got {}", describe(errorOf(overflowing))));
+
+                      Fixture negative;
+                      negative.nodes[1].bounds.y = -1;
+                      checks.expect(errorOf(negative) == ms::SchemaError::BoundsOutsideSurface,
+                                    std::format("a negative origin is refused, got {}", describe(errorOf(negative))));
+
+                      // The containment arithmetic is 64-bit on purpose: at the type's extreme,
+                      // x + width wraps, and a wrapped comparison would admit exactly this.
+                      Fixture wrapping;
+                      wrapping.nodes[1].bounds.x     = std::numeric_limits<std::int32_t>::max();
+                      wrapping.nodes[1].bounds.width = 16;
+                      checks.expect(errorOf(wrapping) == ms::SchemaError::BoundsOutsideSurface,
+                                    std::format("a rectangle whose right edge overflows int32 is refused, got {}", describe(errorOf(wrapping))));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register surfaceMustHaveExtent{"A surface with no extent contains nothing", "evidence-unit", [] {
+                                                     return speclab::Test("medui-schema-surface")
+                                                         .Given("the reference screen", [] {})
+                                                         .When("its surface height is zeroed", [] {})
+                                                         .Then("the screen is refused before any rectangle is considered",
+                                                               [] {
+                                                                   mdux::spec::Checks checks;
+
+                                                                   Fixture flat;
+                                                                   flat.surfaceHeight = 0;
+                                                                   checks.expect(
+                                                                       errorOf(flat) == ms::SchemaError::NonPositiveSurface,
+                                                                       std::format("a surface with no extent is refused, got {}", describe(errorOf(flat))));
+                                                                   checks.raise();
+                                                               })
+                                                         .Execute();
+                                                 }};
+
+const mdux::spec::Register coloursAreNamesNotValues{"A colour a node draws with is a governed name, never a value", "evidence-unit", [] {
+                                                        return speclab::Test("medui-schema-colour-tokens")
+                                                            .Given("the reference screen", [] {})
+                                                            .When("a node carries an RGBA literal where its token belongs, and another carries none", [] {})
+                                                            .Then("the literal is refused and the absent one is not",
+                                                                  [] {
+                                                                      mdux::spec::Checks checks;
+
+                                                                      // ADR-011 keeps values off the device side of the boundary: a package that
+                                                                      // carried `[33, 184, 107, 255]` would have performed the substitution the
+                                                                      // governed table exists to perform, and a reviewer would read numbers.
+                                                                      Fixture literal;
+                                                                      literal.nodes[1].colorToken = "#21B86B";
+                                                                      checks.expect(
+                                                                          errorOf(literal) == ms::SchemaError::MalformedColorToken,
+                                                                          std::format("a colour value is refused, got {}", describe(errorOf(literal))));
+
+                                                                      Fixture untinted;
+                                                                      untinted.nodes[1].colorToken = {};
+                                                                      checks.expect(!errorOf(untinted).has_value(), "a node that declares no tint is legal");
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register budgetMustBeIndexableAndNonEmpty{
+    "The budget must be addressable, and must not be empty for a screen that draws",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-budget")
+            .Given("the reference screen", [] {})
+            .When("its budget is emptied, and then set past the 16-bit index width", [] {})
+            .Then("both are refused, while an empty screen with an empty budget is not",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Fixture empty;
+                      empty.budget = mdux::draw::DrawBudget{};
+                      checks.expect(errorOf(empty) == ms::SchemaError::EmptyBudget,
+                                    std::format("a screen with nodes and no budget draws nothing, got {}", describe(errorOf(empty))));
+
+                      Fixture unindexable;
+                      unindexable.budget.maxVertices = mdux::draw::maxIndexableVertices + 1;
+                      checks.expect(errorOf(unindexable) == ms::SchemaError::BudgetExceedsIndexWidth,
+                                    std::format("more vertices than a 16-bit index can address is refused, got {}", describe(errorOf(unindexable))));
+
+                      // The one screen for which an empty budget is honest: it draws nothing.
+                      Fixture blank;
+                      blank.nodes.clear();
+                      blank.budget = mdux::draw::DrawBudget{};
+                      checks.expect(!errorOf(blank).has_value(), std::format("a screen with no nodes is legal, got {}", describe(errorOf(blank))));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register sizingIsNotThisModulesClaim{
+    "The schema carries the budget without claiming it is large enough",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-budget-sizing")
+            .Given("a three-node screen whose budget holds one rectangle", [] {})
+            .When("it is validated", [] {})
+            .Then("it is accepted, because sizing is the compiler's claim and not this type's",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Not an oversight, and worth a scenario so that nobody later "fixes" it into
+                      // a rule: the number of rectangles a screen draws depends on the widest
+                      // approved translation and on what each component draws, and this package
+                      // carries neither by design. A rule invented here would be a second, weaker
+                      // opinion about a number the compiler computes from the text packages (#195).
+                      Fixture tiny;
+                      tiny.budget = mdux::draw::DrawBudget{.maxVertices = 4, .maxIndices = 6, .maxCommands = 1};
+                      checks.expect(!errorOf(tiny).has_value(),
+                                    std::format("an undersized budget is not this module's to refuse, got {}", describe(errorOf(tiny))));
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -218,30 +218,40 @@ const mdux::spec::Register surfaceMustHaveExtent{"A surface with no extent conta
                                                          .Execute();
                                                  }};
 
-const mdux::spec::Register coloursAreNamesNotValues{"A colour a node draws with is a governed name, never a value", "evidence-unit", [] {
-                                                        return speclab::Test("medui-schema-colour-tokens")
-                                                            .Given("the reference screen", [] {})
-                                                            .When("a node carries an RGBA literal where its token belongs, and another carries none", [] {})
-                                                            .Then("the literal is refused and the absent one is not",
-                                                                  [] {
-                                                                      mdux::spec::Checks checks;
+const mdux::spec::Register coloursAreNamesNotValues{
+    "A colour a node draws with is a governed name, never a value",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-colour-tokens")
+            .Given("the reference screen", [] {})
+            .When("a node carries an RGBA literal where its token belongs, and another carries none", [] {})
+            .Then("the literal is refused and the absent one is not",
+                  [] {
+                      mdux::spec::Checks checks;
 
-                                                                      // ADR-011 keeps values off the device side of the boundary: a package that
-                                                                      // carried `[33, 184, 107, 255]` would have performed the substitution the
-                                                                      // governed table exists to perform, and a reviewer would read numbers.
-                                                                      Fixture literal;
-                                                                      literal.nodes[1].colorToken = "#21B86B";
-                                                                      checks.expect(
-                                                                          errorOf(literal) == ms::SchemaError::MalformedColorToken,
-                                                                          std::format("a colour value is refused, got {}", describe(errorOf(literal))));
+                      // ADR-011 keeps values off the device side of the boundary: a package that
+                      // carried `[33, 184, 107, 255]` would have performed the substitution the
+                      // governed table exists to perform, and a reviewer would read numbers.
+                      Fixture literal;
+                      literal.nodes[1].colorToken = "#21B86B";
+                      checks.expect(errorOf(literal) == ms::SchemaError::MalformedColorToken,
+                                    std::format("a colour value is refused, got {}", describe(errorOf(literal))));
 
-                                                                      Fixture untinted;
-                                                                      untinted.nodes[1].colorToken = {};
-                                                                      checks.expect(!errorOf(untinted).has_value(), "a node that declares no tint is legal");
-                                                                      checks.raise();
-                                                                  })
-                                                            .Execute();
-                                                    }};
+                      // The prefix on its own resolves to nothing in the
+                      // governed table, so a screen carrying it would validate
+                      // at compile time and fail its lookup on the device.
+                      Fixture bare;
+                      bare.nodes[1].colorToken = ms::colorTokenPrefix;
+                      checks.expect(errorOf(bare) == ms::SchemaError::MalformedColorToken,
+                                    std::format("a bare Theme.Colors. prefix names nothing and is refused, got {}", describe(errorOf(bare))));
+
+                      Fixture untinted;
+                      untinted.nodes[1].colorToken = {};
+                      checks.expect(!errorOf(untinted).has_value(), "a node that declares no tint is legal");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
 
 const mdux::spec::Register budgetMustBeIndexableAndNonEmpty{
     "The budget must be addressable, and must not be empty for a screen that draws",

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -16,6 +16,7 @@
 import std;
 import speclab;
 import mdux.core.result;
+import mdux.core.units;
 import mdux.draw;
 import mdux.evidence.report;
 import mdux.medui.schema;
@@ -66,6 +67,17 @@ constexpr ms::ScreenPackage constPackage{
 static_assert(constPackage.validate().has_value(), "the reference screen must validate at compile time");
 static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
 static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
+
+// The governed table a product supplies. Two entries are enough to tell a hit from a miss, and
+// `constexpr` so the resolution below happens at compile time rather than at start-up.
+constexpr std::array<ms::ThemeColor, 2> constTheme{
+    ms::ThemeColor{      .token = "Theme.Colors.Title",   .value = {.r = 12, .g = 24, .b = 36, .a = 255}},
+    ms::ThemeColor{.token = "Theme.Colors.ScoreDigits", .value = {.r = 33, .g = 184, .b = 107, .a = 255}}
+};
+
+static_assert(ms::resolveColorToken(constTheme, "Theme.Colors.ScoreDigits").has_value(), "a name the table defines resolves at compile time");
+static_assert(ms::resolveColorToken(constTheme, "Theme.Colors.ScoreDigits").value() == mdux::core::ColorRgba8{.r = 33, .g = 184, .b = 107, .a = 255},
+              "and resolves to the colour the table carries");
 
 // ---------------------------------------------------------------------------
 // A mutable equivalent, so each rejection can change exactly one field
@@ -304,6 +316,72 @@ const mdux::spec::Register sizingIsNotThisModulesClaim{
                       tiny.budget = mdux::draw::DrawBudget{.maxVertices = 4, .maxIndices = 6, .maxCommands = 1};
                       checks.expect(!errorOf(tiny).has_value(),
                                     std::format("an undersized budget is not this module's to refuse, got {}", describe(errorOf(tiny))));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register colourTokensResolveAgainstAGovernedTable{
+    "A carried name resolves against the product's table, and a miss is a Result rather than a guess",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-colour-resolution")
+            .Given("a two-entry governed colour table", [] {})
+            .When("a defined name, an undefined one, and two malformed ones are resolved", [] {})
+            .Then("each answers with the colour or with the error that says which kind of failure it is",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const auto hit = ms::resolveColorToken(constTheme, "Theme.Colors.Title");
+                      checks.expect(hit.has_value() && *hit == mdux::core::ColorRgba8{.r = 12, .g = 24, .b = 36, .a = 255},
+                                    "a defined name resolves to its colour");
+
+                      // A miss is not a colour. ADR-011 keeps the lookup bounded and fallible on
+                      // purpose: a fallback tint would render something nobody approved, which is
+                      // the failure mode a governed table exists to prevent.
+                      const auto miss = ms::resolveColorToken(constTheme, "Theme.Colors.Undefined");
+                      checks.expect(!miss.has_value() && miss.error() == ms::ThemeError::UnknownToken,
+                                    "a name the table does not define is a miss, not a default");
+
+                      const auto malformed = ms::resolveColorToken(constTheme, "Theme.Colors.#");
+                      checks.expect(!malformed.has_value() && malformed.error() == ms::ThemeError::MalformedToken,
+                                    "a name that is not a name is distinguished from one that is merely absent");
+
+                      const auto value = ms::resolveColorToken(constTheme, "#21B86B");
+                      checks.expect(!value.has_value() && value.error() == ms::ThemeError::MalformedToken, "a colour value is refused where a name belongs");
+
+                      checks.expect(!ms::resolveColorToken({}, "Theme.Colors.Title").has_value(),
+                                    "an empty table answers every name with a miss rather than a colour nobody approved");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register tokenShapeMatchesWhatTheParserAccepts{
+    "The shape rule admits what the language can write, and refuses what it cannot",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-colour-shape")
+            .Given("names the parser produces and names it cannot", [] {})
+            .When("each is checked for shape", [] {})
+            .Then("the rule tracks the grammar rather than a stricter guess at it",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The parser builds a dotted path from identifier tokens, and an identifier
+                      // may contain digits, `_` and `-`. A stricter rule here would reject screens
+                      // the compiler accepted, which is the worse direction to be wrong in.
+                      checks.expect(ms::isColorToken("Theme.Colors.ScoreDigits"), "the ordinary form");
+                      checks.expect(ms::isColorToken("Theme.Colors.Status-Ok"), "a hyphenated name");
+                      checks.expect(ms::isColorToken("Theme.Colors.Alarm_2"), "digits and an underscore");
+                      checks.expect(ms::isColorToken("Theme.Colors.Status.Ok"), "a nested path, which the parser can produce");
+
+                      checks.expect(!ms::isColorToken("Theme.Colors."), "the bare prefix names nothing");
+                      checks.expect(!ms::isColorToken("Theme.Colors.Status."), "a trailing dot leaves an empty segment");
+                      checks.expect(!ms::isColorToken("Theme.Colors..Ok"), "so does a doubled one");
+                      checks.expect(!ms::isColorToken("Theme.Colors.#"), "punctuation is not an identifier character");
+                      checks.expect(!ms::isColorToken("Palette.Title"), "another prefix is another table");
+                      checks.expect(!ms::isColorToken(""), "and nothing at all is not a name");
                       checks.raise();
                   })
             .Execute();


### PR DESCRIPTION
## Summary

First of two PRs for S8. This one lands `mdux.medui.schema` — the canonical compiled-screen type —
and nothing that consumes it, because AGENTS.md § "Stacked delivery" asks for canonical types and
schemas to land before their consumers, and because the emitters are only reviewable once the shape
they render is settled.

**What the type is.** A `.medui` screen after the compiler has resolved it, in the form a device
holds it: an identified screen, a surface, compiled nodes carrying absolute rectangles and the
validated `text_key`, `color_token` and `requirement` names each draws with, plus the `DrawBudget`
the compiler computed. `mdux::draw::DrawBudget` is reused rather than restated — a second budget
type is exactly the drift ADR-008 decision 1 warns about.

**Header-only and `constexpr` throughout**, following `mdux.ml.schema`. ADR-012 decision 3 puts
`static_assert(package.validate().has_value())` in every generated screen, so compile-time
validation is a promise the device build depends on. `mdux.text.schema`'s `TextPackage` is
explicitly *not* the model: it owns `std::string` and `std::vector` and could not appear in a
`static_assert` at all. The evidence is a namespace-scope `static_assert` in the new suite rather
than a scenario — a runtime test could only prove that validation *also* works at run time.

**The package is locale-free**, per ADR-011 as amended by #203 and the decision recorded on #197
today: one screen, one directory, whatever the approved locale count. Adding an approved locale
rewrites no screen artifact; the cost, stated in the module, is that one rectangle must survive the
widest approved translation, which is what #195 measures.

**What `validate()` deliberately does not check: whether the budget is large enough.** That number
depends on the widest approved translation and on what each component draws, and this package
carries neither by design — a rule invented here would be a second, weaker opinion about a number
the compiler computes from the text packages it measured. What it *does* refuse is a screen with
nodes and an empty budget (it would draw nothing, silently) and a vertex budget a 16-bit index
cannot address. `medui-schema-budget-sizing` pins the omission so that nobody later promotes it to a
rule.

`medui_spec` links `MduX::Core` only, deliberately apart from `medui_tools_spec`. The schema is the
one part of the compiler a device holds, so a scenario that needed the parser to build one would
mean the trust-zone boundary had moved — the same argument that keeps `ml_spec` apart from
`ml_tools_spec`.

Part of #197. **Does not close it**: the canonical JSON, the `.cppm`/`.hpp` emitters, the emitter
executable and the dual-form parity test follow in the stacked PR.

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change.
- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: none — maintainer-authored, so neither box applies.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked — #214 (S7) merged as `70d6d7a`, and its post-merge `develop` run
  was green before this branch was cut
- **Merge order:** mergeable now. The S8 successor targets *this* branch and must not merge before it.

## Shared registries touched

- [x] `CMakeLists.txt` (root) — `include/mdux/medui/Schema.cppm` joins MduXCore's module file set
- [x] `FILE_SET CXX_MODULES` lists — as above
- [x] `tests/CMakeLists.txt` — new `medui_spec` target
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`

## Rebase state

- **Rebased onto:** `70d6d7a` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run locally; the macOS toolchain
      cannot build the `std` module (GCC's scan of `bits/std.cc` reports no module interface unit,
      before any MduX source compiles).
- [ ] `ctest --test-dir build-gcc` — not run locally, for the same reason.
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — `OK (80 files checked, 0 findings)`
- [x] `clang-format` applied with the repository's `.clang-format`.

The eight scenarios and the three `static_assert`s are **unverified until this PR's CI legs run**.
The one worth watching is the `static_assert` itself: if `validate()` is not usable in a constant
expression, `medui_spec` fails to compile rather than failing a test, which is the outcome ADR-012's
generated code depends on.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** pending
- [ ] That run is green.

## Regulatory impact

Traceability-relevant rather than safety-behaviour-changing: `requirement` is carried per node, so
the requirement-to-node mapping becomes a property of a committed artifact and shows up in a diff
(ADR-012 § "Traceability"). Nothing here renders, and no device consumes it yet.

Artifacts updated: `docs/architecture.md`'s governed-module table. No ADR changes — ADR-011 and
ADR-012 already decided this shape, and the module cites them rather than restating them. No new
certification or compliance claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a validated schema for compiled MedUI screen data.
  - Supports screen dimensions, node records and lookup, rectangle containment checks, named color tokens, and draw-budget constraints.
  - Provides clear diagnostics for invalid screen packages.
  - Detects invalid identifiers, duplicate nodes, unsupported versions, out-of-bounds content, and malformed color tokens.
  - Supports empty screens and bounded color-token lookup.

- **Tests**
  - Added comprehensive compile-time and runtime coverage for schema validation and related constraints.
  - Added the schema test suite to automated test discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->