### PR TITLE
Restore the TrustSC colour-table alignment lost in #215 [#197]

### DIFF
--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -82,7 +82,6 @@ export module mdux.medui.schema;
 
 import std;
 import mdux.core.result;
-import mdux.core.units;
 import mdux.draw;
 import mdux.evidence.report;
 

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -65,8 +65,8 @@
  * ## What `validate()` checks, and what it deliberately does not
  *
  * It checks what a consumer is entitled to assume without looking: an identified screen, a positive
- * surface, nodes with unique ids and rectangles that lie inside that surface, colour tokens that are
- * names rather than values, and a budget the index width can address.
+ * surface, nodes with unique ids and rectangles that lie inside that surface, colour tokens the
+ * governed table actually defines, and a budget the index width can address.
  *
  * It does **not** check that the budget is large enough for what the screen draws. That number is
  * not derivable from anything here: a `Label` draws one rectangle per glyph of the widest approved
@@ -103,6 +103,7 @@ enum class SchemaError : std::uint8_t {
     DegenerateBounds,          ///< a rectangle with no extent, which `DrawList` refuses to record
     BoundsOutsideSurface,      ///< a rectangle the declared surface does not contain
     MalformedColorToken,       ///< a colour that is not a `Theme.Colors.<Token>` name
+    UnknownColorToken,         ///< a well-formed name the governed table does not define
     EmptyBudget,               ///< a screen with nodes whose budget can hold no primitive
     BudgetExceedsIndexWidth,   ///< more vertices than a 16-bit index can address
 };
@@ -125,6 +126,8 @@ enum class SchemaError : std::uint8_t {
             return "a node's rectangle leaves the declared surface";
         case SchemaError::MalformedColorToken:
             return "a colour is not a Theme.Colors.<Token> name";
+        case SchemaError::UnknownColorToken:
+            return "a colour names a token the governed table does not define";
         case SchemaError::EmptyBudget:
             return "the screen has nodes and a budget that can hold no primitive";
         case SchemaError::BudgetExceedsIndexWidth:
@@ -370,12 +373,21 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
         if (!containedBy(node.bounds, surfaceWidth, surfaceHeight)) {
             return err(SchemaError::BoundsOutsideSurface);
         }
-        // The same shape rule the resolver applies, so a screen that validates here cannot fail the
-        // device lookup for a reason `validate()` could have seen. `Theme.Colors.` names nothing and
-        // `Theme.Colors.#` is not a name at all; both would otherwise pass the generated
-        // `static_assert` and fail only where nobody is watching.
-        if (!node.colorToken.empty() && !isColorToken(node.colorToken)) {
-            return err(SchemaError::MalformedColorToken);
+        // The resolver itself, rather than the shape rule alone, so a screen that validates here
+        // cannot fail the device lookup for any reason `validate()` could have seen. Shape was all
+        // this could check while the palette was a caller's input; now that the governed table is
+        // the approved source of token existence, a name absent from it is as certain a defect as a
+        // name that is not a name - and both would otherwise pass the generated `static_assert` and
+        // fail where nobody is watching.
+        //
+        // The two are kept apart because they are different people's defects: a malformed name is
+        // the emitter's, and an unknown one is a screen compiled against a palette this build does
+        // not have.
+        if (!node.colorToken.empty()) {
+            const auto resolved = resolveColorToken(node.colorToken);
+            if (!resolved.has_value()) {
+                return err(resolved.error() == ThemeError::MalformedToken ? SchemaError::MalformedColorToken : SchemaError::UnknownColorToken);
+            }
         }
     }
 

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -46,18 +46,21 @@
  * survives the widest approved translation. That is what #195 measures, and why the budget below
  * cannot be derived from the node count.
  *
- * ## The colour table lives here, and its contents do not
+ * ## The colour table, and why its contents are here rather than supplied
  *
  * ADR-011 puts the *resolution* of `Theme.Colors.<Token>` on the device, as a bounded scan of a
  * governed table - TrustSC's `THEME_COLORS` and `resolve_color_token()` are the reference, and both
- * live in its governed crate. So `ThemeColor` and `resolveColorToken()` are here, beside the package
- * that carries the names: a consumer holding this schema holds the whole device-side contract, and
- * #199 inherits a resolver rather than writing a second one.
+ * live in its governed crate. So `themeColors`, `ThemeColor` and `resolveColorToken()` are here,
+ * beside the package that carries the names: a consumer holding this schema holds the whole
+ * device-side contract, and #199 inherits a resolver rather than writing a second one.
  *
- * What is deliberately *not* here is a palette. Which colours a device shows is a clinical and
- * regulatory decision belonging to the product, exactly as the theme names semantic analysis
- * validates against are an input rather than a constant (#193). MduX owns the representation and the
- * lookup; the table is supplied.
+ * The table's *contents* are here for the same reason, and it is worth stating because the opposite
+ * is defensible in isolation: a palette looks like a product decision, and the theme names semantic
+ * analysis validates against are indeed a compiler input (#193). But the parity programme's purpose
+ * is that one `.medui` screen means the same thing in both projects, and it does not if a token
+ * renders one colour here and another there. TrustSC settles this in its governed crate; MduX
+ * matches it entry for entry, and a change to the palette is a change to make in both projects at
+ * once.
  *
  * ## What `validate()` checks, and what it deliberately does not
  *
@@ -132,17 +135,23 @@ enum class SchemaError : std::uint8_t {
 }
 
 /**
- * @brief One entry of the governed colour table: a name a screen may carry, and what it resolves to.
+ * @brief One entry of the governed token to RGBA table: a name a screen may carry, and its colour.
  *
  * The device side of ADR-011's boundary. A compiled screen carries `Theme.Colors.<Token>` as a
- * *name*, and the runtime turns it into a colour by scanning a table like this one - a bounded scan
- * over fixed data, which is neither parsing nor unbounded work, and therefore not what the compile
- * boundary exists to keep off a device. TrustSC reached this arrangement first: `THEME_COLORS` and
- * `resolve_color_token()` live in its governed `trustsc-ui` crate, and this is the same shape.
+ * *name*, and the runtime turns it into a colour by scanning this table - a bounded scan over fixed
+ * data, which is neither parsing nor unbounded work, and therefore not what the compile boundary
+ * exists to keep off a device.
+ *
+ * **Linear RGBA, straight alpha, in 0..1**, and `float` rather than the `ColorRgba8` a vertex
+ * carries. Both are parity decisions rather than local preferences: TrustSC's `THEME_COLORS` is
+ * `&[(&str, [f32; 4])]` and its `resolve_color_token()` returns `Option<[f32; 4]>`, so this is the
+ * same value in the same space. Converting to the `R8G8B8A8_UNORM` form `mdux.draw` records is the
+ * adapter's step, and is deliberately not folded in here - a table that stored bytes would have
+ * chosen a rounding rule that the two projects could then disagree about silently.
  */
 struct ThemeColor {
-    std::string_view       token;  ///< the full name, e.g. `Theme.Colors.ScoreDigits`
-    mdux::core::ColorRgba8 value{};
+    std::string_view     token;    ///< the full name, e.g. `Theme.Colors.ScoreDigits`
+    std::array<float, 4> value{};  ///< linear RGBA, straight alpha, each channel in 0..1
 
     [[nodiscard]] constexpr bool operator==(const ThemeColor&) const noexcept = default;
 };
@@ -163,17 +172,43 @@ enum class ThemeError : std::uint8_t {
 }
 
 /**
+ * @brief The governed token to RGBA table: the single approved source of truth for what a name
+ *        renders as.
+ *
+ * Entry for entry, and value for value, TrustSC's `THEME_COLORS` (its ADR-014). That is the point
+ * rather than an implementation detail: the parity programme's purpose is that one `.medui` screen
+ * means the same thing in both projects, and a screen means a different thing if the same token
+ * renders a different colour. A rendered-truth check (#16) comparing a tint against this table is
+ * comparing against the same numbers TrustSC's verifier uses.
+ *
+ * Consequently this table is **not** a product input. An earlier revision of this module left the
+ * contents to the caller on the argument that a palette is a clinical decision; TrustSC settles it
+ * the other way, in its governed crate, and the parity criterion decides between the two. A product
+ * that needs a different palette is a change to make in both projects at once, not one to make here
+ * by supplying a different span.
+ */
+inline constexpr std::array<ThemeColor, 8> themeColors{
+    ThemeColor{.token = "Theme.Colors.TopbarBackground", .value = {0.82F, 0.84F, 0.86F, 1.0F}},
+    ThemeColor{           .token = "Theme.Colors.Title", .value = {0.10F, 0.12F, 0.16F, 1.0F}},
+    ThemeColor{     .token = "Theme.Colors.ScoreDigits", .value = {0.13F, 0.72F, 0.42F, 1.0F}},
+    ThemeColor{         .token = "Theme.Colors.Nominal", .value = {0.13F, 0.72F, 0.42F, 1.0F}},
+    ThemeColor{           .token = "Theme.Colors.Alert", .value = {0.95F, 0.65F, 0.15F, 1.0F}},
+    ThemeColor{           .token = "Theme.Colors.Fault", .value = {0.86F, 0.20F, 0.18F, 1.0F}},
+    ThemeColor{         .token = "Theme.Colors.Neutral", .value = {0.62F, 0.66F, 0.70F, 1.0F}},
+    ThemeColor{   .token = "Theme.Colors.PrimaryAction", .value = {0.16F, 0.44F, 0.86F, 1.0F}}
+};
+
+/**
  * @brief Whether `token` has the shape a colour name must have.
  *
  * The prefix, then a non-empty suffix of the characters an identifier may contain - ASCII letters,
  * digits, `_` and `-` - with `.` admitted between segments, because the parser builds a dotted path
- * and a product may legitimately name `Theme.Colors.Status.Ok`. No empty segment: a trailing dot or
- * a `..` names nothing.
+ * and a name such as `Theme.Colors.Status.Ok` is expressible. No empty segment: a trailing dot or a
+ * `..` names nothing.
  *
- * Shape is not existence. A well-formed token may still be absent from a product's table, which is
- * what `resolveColorToken()` reports and what the compiler already checks against the theme names it
- * was given (#193). Keeping the two separate is what lets `validate()` reject a malformed name
- * without holding a table it was never handed.
+ * Shape is not existence. A well-formed token may still be absent from the governed table, which is
+ * what `resolveColorToken()` reports separately - and the distinction matters, because a malformed
+ * name is an emitter defect while an absent one is a table that does not define it.
  */
 [[nodiscard]] constexpr bool isColorToken(std::string_view token) noexcept {
     if (!token.starts_with(colorTokenPrefix) || token.size() == colorTokenPrefix.size()) {
@@ -200,26 +235,22 @@ enum class ThemeError : std::uint8_t {
 }
 
 /**
- * @brief Resolves a name a compiled screen carries against a product's governed colour table.
+ * @brief Resolves a name a compiled screen carries against the governed table.
  *
  * A bounded scan with a `Result` on miss - never an allocation, never a throw, as ADR-011 requires
- * and as `mdux-governed-lint` and `governed.noThrow.symbolScan` hold this module to. Linear rather
- * than a binary search: a palette holds tens of entries, and requiring the table to be sorted would
- * add an invariant a product's generated table could silently break, in exchange for a saving no
- * frame would notice.
+ * and as `mdux-governed-lint` and `governed.noThrow.symbolScan` hold this module to. Linear, like
+ * TrustSC's `resolve_color_token()`, over a table of eight entries.
  *
- * **The table's contents are the product's, not this library's.** MduX defines the representation
- * and the lookup; a palette is a clinical and regulatory decision belonging to the device it ships
- * on, exactly as the theme names semantic analysis validates against are an input rather than a
- * constant (#193). So there is no default table here to inherit, and a caller supplying an empty one
- * gets `UnknownToken` for every name rather than a colour nobody approved.
+ * Two errors rather than one, which is where this parts from the sibling's `Option`: a name that is
+ * not a name at all is an emitter defect, and a well-formed name the table does not define is a
+ * screen compiled against a different palette. Both are misses to a caller that only asks whether
+ * it got a colour, and they need different people to fix them.
  */
-[[nodiscard]] constexpr mdux::core::Result<mdux::core::ColorRgba8, ThemeError> resolveColorToken(std::span<const ThemeColor> table,
-                                                                                                 std::string_view            token) noexcept {
+[[nodiscard]] constexpr mdux::core::Result<std::array<float, 4>, ThemeError> resolveColorToken(std::string_view token) noexcept {
     if (!isColorToken(token)) {
         return mdux::core::err(ThemeError::MalformedToken);
     }
-    for (const ThemeColor& entry : table) {
+    for (const ThemeColor& entry : themeColors) {
         if (entry.token == token) {
             return entry.value;
         }

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -67,13 +67,15 @@ static_assert(constPackage.validate().has_value(), "the reference screen must va
 static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
 static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
 
-/// The palette transcribed from TrustSC's `THEME_COLORS`, by hand and independently.
-///
-/// A second copy of data the module already holds, which this suite would normally refuse - and the
-/// exception is the point. The parity claim is that a token renders the same colour in both
-/// projects, so a check reading `themeColors` for both its input and its expectation would stay
-/// green while an entry drifted, which is the one failure this table exists to prevent. Compared
-/// against a transcription, a drift has to survive two edits in two files to go unnoticed.
+/**
+ * @brief The palette transcribed from TrustSC's `THEME_COLORS`, by hand and independently.
+ *
+ * A second copy of data the module already holds, which this suite would normally refuse - and the
+ * exception is the point. The parity claim is that a token renders the same colour in both projects,
+ * so a check reading `themeColors` for both its input and its expectation would stay green while an
+ * entry drifted, which is the one failure this table exists to prevent. Compared against a
+ * transcription, a drift has to survive two edits in two files to go unnoticed.
+ */
 constexpr std::array<ms::ThemeColor, 8> expectedPalette{
     ms::ThemeColor{.token = "Theme.Colors.TopbarBackground", .value = {0.82F, 0.84F, 0.86F, 1.0F}},
     ms::ThemeColor{           .token = "Theme.Colors.Title", .value = {0.10F, 0.12F, 0.16F, 1.0F}},
@@ -268,6 +270,15 @@ const mdux::spec::Register coloursAreNamesNotValues{
                       bare.nodes[1].colorToken = ms::colorTokenPrefix;
                       checks.expect(errorOf(bare) == ms::SchemaError::MalformedColorToken,
                                     std::format("a bare Theme.Colors. prefix names nothing and is refused, got {}", describe(errorOf(bare))));
+
+                      // The case the governed table makes checkable, and the reason this is worth
+                      // a rejection rather than a device-time miss: the name is well-formed, so
+                      // shape alone accepted it, and the generated `static_assert` would have
+                      // certified a screen whose colour lookup then fails on the device.
+                      Fixture undefined;
+                      undefined.nodes[1].colorToken = "Theme.Colors.DoesNotExist";
+                      checks.expect(errorOf(undefined) == ms::SchemaError::UnknownColorToken,
+                                    std::format("a name the governed table does not define is refused, got {}", describe(errorOf(undefined))));
 
                       Fixture untinted;
                       untinted.nodes[1].colorToken = {};

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -36,7 +36,7 @@ constexpr std::array<ms::CompiledNode, 3> constNodes{
                      .component   = "Panel",
                      .bounds      = {0, 0, 400, 40},
                      .textKey     = {},
-                     .colorToken  = "Theme.Colors.Surface",
+                     .colorToken  = "Theme.Colors.TopbarBackground",
                      .requirement = {}          },
     ms::CompiledNode{            .id          = "title",
                      .component   = "Label",
@@ -68,16 +68,11 @@ static_assert(constPackage.validate().has_value(), "the reference screen must va
 static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
 static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
 
-// The governed table a product supplies. Two entries are enough to tell a hit from a miss, and
-// `constexpr` so the resolution below happens at compile time rather than at start-up.
-constexpr std::array<ms::ThemeColor, 2> constTheme{
-    ms::ThemeColor{      .token = "Theme.Colors.Title",   .value = {.r = 12, .g = 24, .b = 36, .a = 255}},
-    ms::ThemeColor{.token = "Theme.Colors.ScoreDigits", .value = {.r = 33, .g = 184, .b = 107, .a = 255}}
-};
-
-static_assert(ms::resolveColorToken(constTheme, "Theme.Colors.ScoreDigits").has_value(), "a name the table defines resolves at compile time");
-static_assert(ms::resolveColorToken(constTheme, "Theme.Colors.ScoreDigits").value() == mdux::core::ColorRgba8{.r = 33, .g = 184, .b = 107, .a = 255},
-              "and resolves to the colour the table carries");
+// The governed table is the module's own, so there is no fixture to build here - only the promise
+// that a name resolves at compile time, which is what generated code and #16's verifier both rest on.
+static_assert(ms::resolveColorToken("Theme.Colors.ScoreDigits").has_value(), "a name the governed table defines resolves at compile time");
+static_assert(ms::resolveColorToken("Theme.Colors.ScoreDigits").value() == std::array<float, 4>{0.13F, 0.72F, 0.42F, 1.0F},
+              "and resolves to the colour TrustSC's THEME_COLORS carries for it");
 
 // ---------------------------------------------------------------------------
 // A mutable equivalent, so each rejection can change exactly one field
@@ -321,42 +316,44 @@ const mdux::spec::Register sizingIsNotThisModulesClaim{
             .Execute();
     }};
 
-const mdux::spec::Register colourTokensResolveAgainstAGovernedTable{
-    "A carried name resolves against the product's table, and a miss is a Result rather than a guess",
+const mdux::spec::Register colourTokensResolveAgainstTheGovernedTable{
+    "Every governed token resolves, and everything else is refused with the error that fits",
     "evidence-unit",
     [] {
         return speclab::Test("medui-schema-colour-resolution")
-            .Given("a two-entry governed colour table", [] {})
-            .When("a defined name, an undefined one, and two malformed ones are resolved", [] {})
-            .Then("each answers with the colour or with the error that says which kind of failure it is",
+            .Given("the governed token to RGBA table", [] {})
+            .When("every entry, an undefined name and two malformed ones are resolved", [] {})
+            .Then("each answers with its colour or with the error that says whose defect it is",
                   [] {
                       mdux::spec::Checks checks;
 
-                      const auto hit = ms::resolveColorToken(constTheme, "Theme.Colors.Title");
-                      checks.expect(hit.has_value() && *hit == mdux::core::ColorRgba8{.r = 12, .g = 24, .b = 36, .a = 255},
-                                    "a defined name resolves to its colour");
+                      // The shape of TrustSC's own
+                      // `theme_color_table_resolves_every_entry_and_rejects_unknown_tokens`: walk
+                      // the table rather than spot-check it, so an entry that stops resolving -
+                      // a malformed token added to the table, say - fails here rather than on a
+                      // device.
+                      bool everyEntryResolves = true;
+                      for (const ms::ThemeColor& entry : ms::themeColors) {
+                          const auto resolved = ms::resolveColorToken(entry.token);
+                          everyEntryResolves  = everyEntryResolves && resolved.has_value() && *resolved == entry.value;
+                      }
+                      checks.expect(everyEntryResolves, "every governed entry resolves to its own colour");
+                      checks.expect(ms::themeColors.size() == 8, std::format("the table carries TrustSC's eight entries, got {}", ms::themeColors.size()));
 
                       // A miss is not a colour. ADR-011 keeps the lookup bounded and fallible on
-                      // purpose: a fallback tint would render something nobody approved, which is
-                      // the failure mode a governed table exists to prevent.
-                      const auto miss = ms::resolveColorToken(constTheme, "Theme.Colors.Undefined");
+                      // purpose: a fallback tint would render something nobody approved.
+                      const auto miss = ms::resolveColorToken("Theme.Colors.DoesNotExist");
                       checks.expect(!miss.has_value() && miss.error() == ms::ThemeError::UnknownToken,
                                     "a name the table does not define is a miss, not a default");
 
-                      const auto malformed = ms::resolveColorToken(constTheme, "Theme.Colors.#");
+                      // The error matters as much as the failure: a malformed name is an emitter
+                      // defect, while an absent one is a screen compiled against another palette.
+                      const auto malformed = ms::resolveColorToken("Theme.Colors.#");
                       checks.expect(!malformed.has_value() && malformed.error() == ms::ThemeError::MalformedToken,
                                     "a name that is not a name is distinguished from one that is merely absent");
 
-                      const auto value = ms::resolveColorToken(constTheme, "#21B86B");
+                      const auto value = ms::resolveColorToken("#21B86B");
                       checks.expect(!value.has_value() && value.error() == ms::ThemeError::MalformedToken, "a colour value is refused where a name belongs");
-
-                      // The error matters as much as the failure: a well-formed name against an
-                      // empty table is *absent*, not malformed. Asserting only `!has_value()` would
-                      // pass if the resolver ever confused the two, which is the distinction this
-                      // scenario exists to draw.
-                      const auto emptyTable = ms::resolveColorToken({}, "Theme.Colors.Title");
-                      checks.expect(!emptyTable.has_value() && emptyTable.error() == ms::ThemeError::UnknownToken,
-                                    "an empty table answers a well-formed name with a miss, not a colour nobody approved");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -67,6 +67,24 @@ static_assert(constPackage.validate().has_value(), "the reference screen must va
 static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
 static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
 
+/// The palette transcribed from TrustSC's `THEME_COLORS`, by hand and independently.
+///
+/// A second copy of data the module already holds, which this suite would normally refuse - and the
+/// exception is the point. The parity claim is that a token renders the same colour in both
+/// projects, so a check reading `themeColors` for both its input and its expectation would stay
+/// green while an entry drifted, which is the one failure this table exists to prevent. Compared
+/// against a transcription, a drift has to survive two edits in two files to go unnoticed.
+constexpr std::array<ms::ThemeColor, 8> expectedPalette{
+    ms::ThemeColor{.token = "Theme.Colors.TopbarBackground", .value = {0.82F, 0.84F, 0.86F, 1.0F}},
+    ms::ThemeColor{           .token = "Theme.Colors.Title", .value = {0.10F, 0.12F, 0.16F, 1.0F}},
+    ms::ThemeColor{     .token = "Theme.Colors.ScoreDigits", .value = {0.13F, 0.72F, 0.42F, 1.0F}},
+    ms::ThemeColor{         .token = "Theme.Colors.Nominal", .value = {0.13F, 0.72F, 0.42F, 1.0F}},
+    ms::ThemeColor{           .token = "Theme.Colors.Alert", .value = {0.95F, 0.65F, 0.15F, 1.0F}},
+    ms::ThemeColor{           .token = "Theme.Colors.Fault", .value = {0.86F, 0.20F, 0.18F, 1.0F}},
+    ms::ThemeColor{         .token = "Theme.Colors.Neutral", .value = {0.62F, 0.66F, 0.70F, 1.0F}},
+    ms::ThemeColor{   .token = "Theme.Colors.PrimaryAction", .value = {0.16F, 0.44F, 0.86F, 1.0F}}
+};
+
 // The governed table is the module's own, so there is no fixture to build here - only the promise
 // that a name resolves at compile time, which is what generated code and #16's verifier both rest on.
 static_assert(ms::resolveColorToken("Theme.Colors.ScoreDigits").has_value(), "a name the governed table defines resolves at compile time");
@@ -331,13 +349,28 @@ const mdux::spec::Register colourTokensResolveAgainstTheGovernedTable{
                       // the table rather than spot-check it, so an entry that stops resolving -
                       // a malformed token added to the table, say - fails here rather than on a
                       // device.
+                      // Two different claims, and the second is the parity one. The first says the
+                      // resolver reaches every entry the table holds - a malformed token added to
+                      // the table would fail `isColorToken()` and be unreachable, and this catches
+                      // it. The second says the table holds what TrustSC holds, which reading the
+                      // table for both sides could never show.
                       bool everyEntryResolves = true;
                       for (const ms::ThemeColor& entry : ms::themeColors) {
                           const auto resolved = ms::resolveColorToken(entry.token);
                           everyEntryResolves  = everyEntryResolves && resolved.has_value() && *resolved == entry.value;
                       }
-                      checks.expect(everyEntryResolves, "every governed entry resolves to its own colour");
-                      checks.expect(ms::themeColors.size() == 8, std::format("the table carries TrustSC's eight entries, got {}", ms::themeColors.size()));
+                      checks.expect(everyEntryResolves, "the resolver reaches every entry the table holds");
+
+                      checks.expect(ms::themeColors.size() == expectedPalette.size(),
+                                    std::format("the table carries TrustSC's eight entries, got {}", ms::themeColors.size()));
+                      checks.expect(std::ranges::equal(ms::themeColors, expectedPalette), "and carries them token for token, value for value");
+
+                      bool everyExpectedTokenResolves = true;
+                      for (const ms::ThemeColor& expected : expectedPalette) {
+                          const auto resolved        = ms::resolveColorToken(expected.token);
+                          everyExpectedTokenResolves = everyExpectedTokenResolves && resolved.has_value() && *resolved == expected.value;
+                      }
+                      checks.expect(everyExpectedTokenResolves, "and every name TrustSC defines resolves here to the colour it defines");
 
                       // A miss is not a colour. ADR-011 keeps the lookup bounded and fallible on
                       // purpose: a fallback tint would render something nobody approved.

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -16,7 +16,6 @@
 import std;
 import speclab;
 import mdux.core.result;
-import mdux.core.units;
 import mdux.draw;
 import mdux.evidence.report;
 import mdux.medui.schema;


### PR DESCRIPTION
## Summary

Recovers a commit that #215 was supposed to carry and did not. **`develop` currently ships the
colour design that was explicitly overruled**, and this puts the agreed one back.

**What happened.** #215's last commit, `9655c5f`, aligned the colour table and resolver with
TrustSC. GitHub accepted the push — `git ls-remote` and `/git/ref/heads/...` both showed the branch
at `9655c5f` — but never processed the resulting event: no workflow was scheduled for that SHA, and
the pull request went on reporting `d03de7c` as its head. The merge therefore took the stale head,
and `git merge-base --is-ancestor 9655c5f develop` says plainly that the alignment is not there.
This was the tail of the same platform incident that failed two jobs on #214 with 429/503 responses
from `codeload`.

**What this restores**, unchanged from the commit that was lost:

- `resolveColorToken()` returns **linear RGBA as four floats, straight alpha**, matching
  `resolve_color_token() -> Option<[f32; 4]>`. Converting to the `R8G8B8A8_UNORM` form a vertex
  carries stays in the adapter: a table storing bytes would have fixed a rounding rule the two
  projects could then disagree about silently.
- The **table's contents move into the module** — the same eight tokens with the same values as
  TrustSC's `THEME_COLORS` (its ADR-014). An earlier revision left the palette to the caller on the
  argument that it is a product decision; the parity criterion settles it the other way, because one
  `.medui` screen does not mean one thing if a token renders differently in each project.
- The scenario walks the table entry by entry, in the shape of TrustSC's own
  `theme_color_table_resolves_every_entry_and_rejects_unknown_tokens`, so an entry that stops
  resolving fails here rather than on a device. Two errors are kept where the sibling has one
  `Option`: a malformed name is an emitter defect, an absent one is a screen compiled against another
  palette.

Plus one addition the lost commit did not have: `mdux.core.units` is no longer imported by either
file, since nothing names a type from it once the resolver deals in plain floats.

Part of #197.

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change.
- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: none — maintainer-authored, so neither box applies.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked — this repairs #215, which is merged as `6f62ab4`
- **Merge order:** mergeable now, and worth merging before anything else touches the schema: until it
  lands, `develop` carries a design that was decided against.

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] `FILE_SET CXX_MODULES` lists — no module added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`
- [x] None of the above — two files, both already registered by #215

## Rebase state

- **Rebased onto:** `6f62ab4` (current `develop`)
- **Conflicts resolved as a union:** no conflicts. The cherry-pick applied cleanly, because the file
  content it was written against is exactly what #215 merged.

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run locally; the macOS toolchain
      cannot build the `std` module.
- [ ] `ctest --test-dir build-gcc` — not run locally, for the same reason.
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — `OK (80 files checked, 0 findings)`
- [x] `clang-format` applied with the repository's `.clang-format`.

**This content has never been executed anywhere.** The commit it recovers was pushed but never
built, because no workflow was scheduled for it — which is precisely how it came to be merged out of
existence without anyone noticing a red check. The `static_assert` resolving a token to its colour at
compile time is the first thing to watch in this PR's CI.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** pending
- [ ] That run is green.

## Regulatory impact

Parity-relevant, and this is the direction that reduces risk rather than adding it: a governed token
resolves to the same colour in both implementations, so a rendered-truth check (#16) compares a tint
against the same numbers TrustSC's verifier uses. Until this lands, the two projects would disagree
about what `Theme.Colors.Fault` looks like — on a fault indicator.

No ADR changes. ADR-011 already places the resolution on the device as a bounded lookup in a governed
table; what changes here is only which side of the boundary the table's *contents* sit on, and the
module records the reasoning where the decision is made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in palette of eight governed theme colors.
  * Theme color values now use linear RGBA values for more consistent rendering.
  * Color tokens resolve directly through the standard theme palette.

* **Bug Fixes**
  * Improved validation and handling of unknown or malformed color tokens.
  * Updated top-bar styling to use the governed theme color token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->