### PR TITLE
Settle the compiled-screen JSON member casing [#197]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -97,7 +97,7 @@ Screen NeuroSense500 {
 ## `@safety_critical` — when it's mandatory, and when it's automatic
 
 `@safety_critical(cv_check: [Bounds, ColorHash])` on the line before a component emits a golden
-reference (`node_id`, `bounds`, `text_key?`, `color_token?`, `cv_checks`) that the rendered-truth
+reference (`nodeId`, `bounds`, `textKey?`, `colorToken?`, `cvChecks`) that the rendered-truth
 verifier checks against. Rules:
 
 - **A safety-critical component must carry an explicit `requirement:`.** If you're annotating a
@@ -105,7 +105,7 @@ verifier checks against. Rules:
   annotation or the missing requirement.
 - **Any node with an explicit `position:` gets an automatic `Bounds` golden reference**, even
   without `@safety_critical` — a declared position is a safety-relevant claim by itself.
-- **A node with both gets exactly one merged entry** (deduplicated `cv_checks`), never two.
+- **A node with both gets exactly one merged entry** (deduplicated `cvChecks`), never two.
 - Dynamic content (`NumericDisplay`, `StatusIndicator`, `Clock`, `SignalTrace`) pins its *bounds*
   and *color* but never its varying value — the golden reference says **where** critical content
   must appear and in what tint, not what the live number is.

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -150,8 +150,11 @@ format. Two facts settle it the other way, and both were checked rather than ass
   a compiled screen there is generated Rust source. There is therefore no sibling file for these
   member names to match, and no parity is given up by choosing them freely.
 - **Every committed MduX package is camelCase** — `byteLength`, `occupancyPercent`, `advanceWidth`,
-  `codePoint` — across the font, text, shader and model kinds, and so is the repository's own
-  tooling schema (`fixHint`, `filesChecked`). A screen directory holding `package.json`,
+  `codePoint` — across the three kinds that have committed artifacts today: font, shader and model
+  (`generated/font/`, `generated/shader/`, `generated/model/`). The text pipeline uses the same
+  convention in `mdux.text.schema` and `mdux-textbake`, but commits no package, so it is implemented
+  machinery rather than evidence and is named here as such. The repository's own tooling schema
+  (`fixHint`, `filesChecked`) is camelCase too. A screen directory holding `package.json`,
   `report.json` and `goldens.json` in two conventions would make #16's verifier, which reads two of
   the three, carry two vocabularies for no gain.
 

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -111,7 +111,7 @@ parity programme's direction is MduX moving toward it.
 
 **A compiled screen is locale-free.** It carries no locale field and no glyph runs. Per-locale
 glyph runs stay in the text package where ADR-010 already put them, and the two are joined on device
-by looking each node's `text_key` up for the running locale. TrustSC does exactly this in
+by looking each node's `textKey` up for the running locale. TrustSC does exactly this in
 `ScreenTextLayout::from_screen(screen, package, locale)`.
 
 The consequence that decides it: **adding an approved locale touches no screen artifact at all.**
@@ -137,8 +137,29 @@ and `governed.noThrow.symbolScan` hold the runtime to that.
 the `medui-authoring` skill, stated here because ADR-012 depends on the same predicate: a
 `@safety_critical` node emits an entry, and **any** node with an explicit `position:` emits a
 `Bounds` entry whether annotated or not, because a declared position is a safety-relevant claim by
-itself. A node matching both rules emits exactly one merged entry with deduplicated `cv_checks`,
+itself. A node matching both rules emits exactly one merged entry with deduplicated `cvChecks`,
 never two. #196 implements this and ADR-012's `goldens.json` carries the result.
+
+**Amended: the emitted members are `nodeId`, `bounds`, `textKey`, `colorToken`, `cvChecks`.** An
+earlier revision of this ADR spelled them `node_id`, `text_key`, `color_token` and `cv_checks`, and
+that spelling was a transcription of TrustSC's *Rust identifiers* rather than a decision about a file
+format. Two facts settle it the other way, and both were checked rather than assumed:
+
+- **TrustSC emits no screen JSON at all.** Its `CompiledScreenPackage` derives `Clone, Copy, Debug,
+  Eq, PartialEq` and no `Serialize`, and its repository holds no `generated/screens/*/package.json` —
+  a compiled screen there is generated Rust source. There is therefore no sibling file for these
+  member names to match, and no parity is given up by choosing them freely.
+- **Every committed MduX package is camelCase** — `byteLength`, `occupancyPercent`, `advanceWidth`,
+  `codePoint` — across the font, text, shader and model kinds, and so is the repository's own
+  tooling schema (`fixHint`, `filesChecked`). A screen directory holding `package.json`,
+  `report.json` and `goldens.json` in two conventions would make #16's verifier, which reads two of
+  the three, carry two vocabularies for no gain.
+
+The parity that *is* achievable here is the field vocabulary and the file structure, and both are
+unaffected: the same five facts per entry, under names a C++ reader spells the way this repository
+spells every other artifact. Decided before the first bake deliberately, because renaming a member
+of a committed, byte-compared artifact afterwards is a `schemaVersion` bump and a rebake of every
+screen.
 
 Concretely:
 

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -81,8 +81,8 @@ device performs the substitution by a bounded lookup in a governed table. Carryi
 values is also what makes the package readable in a diff: a reviewer sees
 `Theme.Colors.ScoreDigits`, not `[33, 184, 107, 255]`.
 
-**All three files spell their members in camelCase**, as every other committed MduX package does
-(`byteLength`, `occupancyPercent`, `advanceWidth`). The one file that could have differed is
+**All three files spell their members in camelCase**, as the committed font, shader and model
+packages do (`byteLength`, `occupancyPercent`, `advanceWidth`). The one file that could have differed is
 `goldens.json`, whose entry ADR-011 originally spelled in snake_case; that amendment explains why it
 does not. One directory, one vocabulary, and #16's verifier - which reads two of these three files -
 carries one set of member names rather than two.

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -81,6 +81,12 @@ device performs the substitution by a bounded lookup in a governed table. Carryi
 values is also what makes the package readable in a diff: a reviewer sees
 `Theme.Colors.ScoreDigits`, not `[33, 184, 107, 255]`.
 
+**All three files spell their members in camelCase**, as every other committed MduX package does
+(`byteLength`, `occupancyPercent`, `advanceWidth`). The one file that could have differed is
+`goldens.json`, whose entry ADR-011 originally spelled in snake_case; that amendment explains why it
+does not. One directory, one vocabulary, and #16's verifier - which reads two of these three files -
+carries one set of member names rather than two.
+
 Canonical JSON throughout, written through `mdux.evidence.json`. Registered via
 `mdux_bake_artifact()`, so each screen gets a build-tree bake, an `-update` target and an
 `evidence.screen.<id>` byte-comparison test on both toolchain legs. Two consequences of registering

--- a/tools/medui/Goldens.cpp
+++ b/tools/medui/Goldens.cpp
@@ -251,7 +251,7 @@ private:
     /**
      * @brief Refuses a `ColorHash` check on a node whose expected tint cannot be derived.
      *
-     * `cv_checks` and `color_token` are two halves of one claim: a verifier asked for `ColorHash`
+     * `cvChecks` and `colorToken` are two halves of one claim: a verifier asked for `ColorHash`
      * reads the token to know what tint to expect. A `StatusIndicator` declares `colors:` as a list,
      * one per state, and a `Clock`, `Image` or `VulkanViewport` declares none at all - so a golden
      * over either would ask for a check with nothing to check it against.

--- a/tools/medui/Goldens.cppm
+++ b/tools/medui/Goldens.cppm
@@ -64,19 +64,25 @@
  * one-to-one onto the canonical JSON:
  *
  * ```json
- * { "nodeId": "sedation-index",
- *   "bounds": { "x": 1392, "y": 80, "width": 512, "height": 512 },
- *   "textKey": "STR-SEDATION-LABEL",
+ * { "bounds": { "height": 512, "width": 512, "x": 1392, "y": 80 },
  *   "colorToken": "Theme.Colors.ScoreDigits",
- *   "cvChecks": ["Bounds", "ColorHash"] }
+ *   "cvChecks": ["Bounds", "ColorHash"],
+ *   "nodeId": "sedation-index",
+ *   "textKey": "STR-SEDATION-LABEL" }
  * ```
  *
  * The C++ members and the JSON members are now the same words, which is worth one line because they
  * were not: an earlier revision spelled the file `node_id`, `text_key`, `color_token`, `cv_checks`,
  * transcribed from TrustSC's Rust identifiers. TrustSC emits no screen JSON at all - its compiled
- * screen is generated Rust - so nothing was being matched, while every other committed MduX package
- * is camelCase. ADR-011 records the amendment; the effect here is that a reader has one vocabulary
- * for the struct, the file and the verifier that reads it.
+ * screen is generated Rust - so nothing was being matched, while every package this repository has
+ * committed is camelCase. ADR-011 records the amendment; the effect here is that a reader has one
+ * vocabulary for the struct, the file and the verifier that reads it.
+ *
+ * The example is in the byte order the file actually has. `mdux.evidence.json` sorts every object's
+ * members lexicographically by UTF-8 code unit, nested objects included, so `bounds` reads
+ * `height, width, x, y` rather than the order a reader would write by hand. Object order is
+ * semantically irrelevant in JSON and deliberately relevant here: `goldens.json` is byte-compared
+ * across toolchains, so an example in a different order would be describing a file that cannot exist.
  *
  * `textKey` and `colorToken` are omitted when the node has none. `cvChecks` is sorted and
  * deduplicated so that one screen has one serialisation - `goldens.json` is byte-compared across

--- a/tools/medui/Goldens.cppm
+++ b/tools/medui/Goldens.cppm
@@ -64,20 +64,27 @@
  * one-to-one onto the canonical JSON:
  *
  * ```json
- * { "node_id": "sedation-index",
+ * { "nodeId": "sedation-index",
  *   "bounds": { "x": 1392, "y": 80, "width": 512, "height": 512 },
- *   "text_key": "STR-SEDATION-LABEL",
- *   "color_token": "Theme.Colors.ScoreDigits",
- *   "cv_checks": ["Bounds", "ColorHash"] }
+ *   "textKey": "STR-SEDATION-LABEL",
+ *   "colorToken": "Theme.Colors.ScoreDigits",
+ *   "cvChecks": ["Bounds", "ColorHash"] }
  * ```
  *
- * `text_key` and `color_token` are omitted when the node has none. `cv_checks` is sorted and
+ * The C++ members and the JSON members are now the same words, which is worth one line because they
+ * were not: an earlier revision spelled the file `node_id`, `text_key`, `color_token`, `cv_checks`,
+ * transcribed from TrustSC's Rust identifiers. TrustSC emits no screen JSON at all - its compiled
+ * screen is generated Rust - so nothing was being matched, while every other committed MduX package
+ * is camelCase. ADR-011 records the amendment; the effect here is that a reader has one vocabulary
+ * for the struct, the file and the verifier that reads it.
+ *
+ * `textKey` and `colorToken` are omitted when the node has none. `cvChecks` is sorted and
  * deduplicated so that one screen has one serialisation - `goldens.json` is byte-compared across
  * toolchains like every other committed artifact, and a set whose order depended on which rule
  * selected the node first would not survive that.
  *
  * The two members are halves of one claim, which is why a `ColorHash` check is *refused* for a node
- * with no single declared colour token rather than emitted beside an absent `color_token`. A
+ * with no single declared colour token rather than emitted beside an absent `colorToken`. A
  * verifier asked to compare a tint has to be told which tint; a reference that asked without saying
  * would be one #16 could only skip.
  *
@@ -86,7 +93,7 @@
  * A `NumericDisplay`, `Clock`, `SignalTrace` or `StatusIndicator` shows a value that changes. The
  * golden pins **where** that content appears and **in what tint**, never what the value is: pinning
  * a live number would make the verifier fail whenever the demonstrator changed, which trains a team
- * to ignore it. So `text_key` is filled only from a field whose value is a single static key, and a
+ * to ignore it. So `textKey` is filled only from a field whose value is a single static key, and a
  * list-valued field such as `StatusIndicator`'s `states:` leaves it empty - the state shown is
  * exactly the varying part.
  */
@@ -104,7 +111,7 @@ export namespace mdux::tools::medui {
 /**
  * @brief A verification #16's driver performs against a rendered frame.
  *
- * The closed set the shared language defines. Order is the serialisation order: `cv_checks` is
+ * The closed set the shared language defines. Order is the serialisation order: `cvChecks` is
  * sorted by this enumeration so that a screen has one canonical form.
  */
 enum class CvCheck : std::uint8_t {

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -13,7 +13,7 @@
  *
  * ## Why this stage exists at all
  *
- * A compiled screen is locale-free (ADR-011, as amended by #203): it carries `text_key` rather than
+ * A compiled screen is locale-free (ADR-011, as amended by #203): it carries `textKey` rather than
  * glyph runs, and the device joins the two for the locale it is running. That amendment moved the
  * *substitution* to the device and deliberately left this check behind:
  *


### PR DESCRIPTION
## Summary

Settles one convention per screen directory — **camelCase, in `package.json`, `goldens.json` and
`report.json` alike** — before anything writes a byte of it.

ADR-011's golden entry becomes `nodeId`, `bounds`, `textKey`, `colorToken`, `cvChecks`, with the
amendment recorded in the ADR itself; ADR-012 states the rule for the directory as a whole; the
`medui-authoring` skill and the `mdux.tools.medui.goldens` module comment follow.

**Why the spelling it replaces was never a format decision.** `node_id`, `text_key`, `color_token`
and `cv_checks` were transcribed from TrustSC's *Rust identifiers*. Two facts, both checked rather
than assumed, settle it the other way:

- **TrustSC emits no screen JSON at all.** `CompiledScreenPackage` derives `Clone, Copy, Debug, Eq,
  PartialEq` and no `Serialize`, and the repository holds no `generated/screens/*/package.json` — a
  compiled screen there is generated Rust source. There was no sibling file being matched.
- **Every committed MduX package is camelCase** — `byteLength`, `occupancyPercent`, `advanceWidth`,
  `codePoint` — across four artifact kinds, as is the repository's own tooling schema (`fixHint`,
  `filesChecked`). A directory in two conventions would have made #16's verifier, which reads two of
  these three files, carry two vocabularies to do it.

The parity that *is* achievable here is untouched: the same five facts per entry, the same file
structure, under names spelled the way this repository spells every artifact it commits.

**Why now rather than with the emitters.** Renaming a member of a committed, byte-compared artifact
costs a `schemaVersion` bump and a rebake of every screen. Today it costs a line in a writer that
does not exist yet. #198's first bake is the point of no return, and this lands well before it.

Part of #197. No code changes — nothing serialises these names until the emitters, which is exactly
why the decision is cheap today.

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change.
- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: none — maintainer-authored, so neither box applies.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked — #216 merged as `7cdceb8`, post-merge `develop` green (11/11)
- **Merge order:** mergeable now; the S8 emitters PR should be written against it so it emits these
  names from the start

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] `FILE_SET CXX_MODULES` lists — no module added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/` — none define these members
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/` — no screen artifact exists yet, which is the point
- [x] None of the above

## Rebase state

- **Rebased onto:** `7cdceb8` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — `OK (80 files checked, 0 findings)`
- [x] Swept the tree for the old spelling. What remains is deliberate and was checked line by line:
      ADR-011 quoting TrustSC's own `CompiledScreenPackage` fields, and the two places that record
      what the previous spelling *was*. `resolve_color_token()` and `THEME_COLORS` stay untouched
      throughout — they are the sibling's API, not ours.
- [x] `clang-format` applied to the three touched sources.
- [ ] `cmake --preset ninja-gcc && ctest` — not run locally; the macOS toolchain cannot build the
      `std` module. Comment-only changes to compiled files, so CI is the check that they still parse.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** pending
- [ ] That run is green.

## Regulatory impact

None to the behaviour of any code: no rule changes, no diagnostic changes, and nothing that runs on
a device. It fixes the vocabulary of an artifact that is a configuration item under IEC 62304 before
that artifact exists, which is the cheapest moment for it and the only one where no digest moves.
ADR-011 and ADR-012 carry the reasoning; the skill and the module comment follow them rather than
restating the argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized compiled-screen and safety-reference field names to camelCase.
  * Clarified canonical JSON member names, nested bounds ordering, and byte-order requirements.
  * Documented the naming decision and related schema/versioning implications.
  * Updated guidance for text, color, and visual-check fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->