### PR TITLE
Give each component its own compiled payload [#197]

### DIFF
--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -129,6 +129,13 @@ is, *how much* it may draw, and *which* validated token and key it draws with. T
 vertices is a bounded table lookup followed by arithmetic over a known bound, which is exactly what
 a governed, allocation-free runtime can do.
 
+**A node's payload is typed per component.** The package carries one spec type per dictionary entry
+behind a `std::variant`, not a single record with every field on it. The flat form was tried first
+and was lossy: it had nowhere to put a `Clock`'s format, a `NumericDisplay`'s template and source, a
+`StatusIndicator`'s state keys and per-state tints, a `CriticalButton`'s `on_press`, or a
+`VulkanViewport`'s stream, so a device could not have rendered four of the eleven components. Every
+field remains a validated *name* rather than a resolved value, which keeps the boundary ADR-011 fixes.
+
 ### 3. Generated C++ is emitted, never committed
 
 `<binary>/mdux_generated/screen/<identifier>.cppm` and `.hpp`, produced from the committed
@@ -151,6 +158,21 @@ They have a different consumer (#16's verifier, not the runtime), a different li
 different review audience — a reviewer checking that a safety-critical node's expected bounds
 changed deliberately should not have to find that hunk inside the whole screen. A separate file also
 gets its own digest in `report.json`, so a goldens-only change is visible as one.
+
+**This is a deliberate divergence from TrustSC, recorded as one.** Its `CompiledScreenPackage`
+carries `golden_references` as a field, and `trustsc-ui-verify::verify_frame()` walks them straight
+out of the compiled screen; the field is not feature-gated, so a shipped binary carries expectations
+only a verifier reads. MduX keeps them outside the package for the reasons above — the runtime never
+reads them, the review audience differs, and the sidecar gets its own digest — and pays for that with
+a verifier that opens two files instead of walking one structure. That is a driver-shaped cost, not
+an evidence-shaped one, and it is the trade this decision accepts knowingly rather than by omission.
+
+**The consistency test is an acceptance criterion for the baker and for #16**, not an aspiration.
+Neither file alone can carry it: applying ADR-011's predicate to the compiled nodes yields exactly
+the id set `goldens.json` must contain, so the check is a set comparison across the pair, and #198 is
+the first place both files exist at once. Until then it has no home — #197's text assigns it to #196,
+this ADR's consequences assign it to #197, and #196 necessarily shipped without it because no package
+existed to compare against.
 
 ### 5. One recipe per screen, under `recipes/screen/<id>.toml`
 

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -167,29 +167,26 @@ reads them, the review audience differs, and the sidecar gets its own digest —
 a verifier that opens two files instead of walking one structure. That is a driver-shaped cost, not
 an evidence-shaped one, and it is the trade this decision accepts knowingly rather than by omission.
 
-**The consistency test is an acceptance criterion for #198's baker**, not an aspiration, and #16
-derives its expectations the same way rather than trusting the sidecar to be complete.
+**Completeness is guaranteed by construction, not by comparing the two files.** The predicate has
+one implementation - `collectGoldens()` (#196) - and the baker applies it once, in the same pass that
+writes the compiled nodes. That is TrustSC's arrangement: its DSL compiler pushes a golden at the
+moment it compiles a selected node, from the AST it already holds, and the guard is a set of unit
+tests over known screens rather than a check over the emitted artifact.
 
-It needs something the package must therefore carry. ADR-011's predicate reads two facts about the
-*source* — whether a node was annotated `@safety_critical`, and whether its `position:` was explicit
-— and compilation erases both: every compiled node has resolved bounds, and `requirement` is
-mandatory on `CriticalButton`, `NumericDisplay` and `StatusIndicator` whether or not anyone
-annotated them, so it is not a proxy for the annotation. Without those two facts a checker can
-confirm that every listed golden resolves to a node and still not see the failure that matters: a
-node that should have a golden and does not.
+An earlier revision of this decision required an artifact-level set comparison instead, and carried
+`NodeProvenance { safetyCritical, positioned }` in every compiled node so the expected id set could be
+re-derived from `package.json`. Both are withdrawn, for two reasons that point the same way:
 
-So each compiled node carries `NodeProvenance { safetyCritical, positioned }` — two booleans the
-runtime never reads, for a check that is otherwise impossible. That is the same trade this decision
-refused for the goldens themselves, and it is granted here because the sizes and the consequences
-differ: an entire expectation list against two bits, and a check that could not be written at all
-against one that would merely have been more convenient.
+- **It could not catch the failure that matters.** Both files come from one AST in one pass, so a
+  comparison between them detects two writers disagreeing, never a predicate that is wrong. The
+  tests that *do* catch a wrong predicate already exist, with the predicate, in #196.
+- **It put data on a device that only a tool reads**, which is what this decision refuses two
+  paragraphs above. Two booleans is a small breach of a rule, and a rule breached for something small
+  is how the next thing gets in.
 
-**One owner: #198.** It is the first stage where both files exist at once, so it is the first place
-the test can run. #197's issue text assigned the cross-check to #196 and an earlier revision of this
-ADR assigned it to #197; #196 necessarily shipped without it, because no package existed to compare
-a golden set against. Three owners for a safety-relevant criterion is how a requirement is lost at a
-handoff, so the other two references are corrected rather than left to be reconciled by whoever
-notices.
+What replaces the check is a constraint on the baker (#198): **it must call `collectGoldens()`, not
+re-apply the predicate.** A second implementation is the only way the two files can disagree once
+they are written in one pass, and it is the thing a reviewer should refuse.
 
 ### 5. One recipe per screen, under `recipes/screen/<id>.toml`
 
@@ -253,28 +250,21 @@ human should read.
   against. The mitigation is host-side — the baker writes both files from one AST, and #198 owns
   the test.
 
-  That test compares **sets, not references**. Applying ADR-011's predicate to the nodes in
-  `package.json` yields exactly the ids `goldens.json` must contain, so the test derives that set
-  and requires equality: an id in the goldens with no node behind it fails, and — the direction
-  that matters more — a node the predicate selects with no golden fails too. Checking only that
-  listed ids resolve would accept the dangerous case silently, since a safety-critical node whose
-  golden was dropped looks exactly like a screen with fewer safety-critical nodes. #16's verifier
-  derives its expectations the same way rather than trusting the file to be complete.
+  The mitigation is structural rather than a comparison: one implementation of ADR-011's predicate,
+  called once, in the pass that writes both files. An earlier revision of this ADR required the baker
+  to derive the expected id set from `package.json` and assert set equality with `goldens.json`, and
+  decision 4 records why that was withdrawn — it cannot see a wrong predicate, and it needed
+  provenance on the device that only a tool would read. #16 derives its expectations from
+  `goldens.json` itself; what it must never do is re-apply the predicate, since a second
+  implementation is precisely what would let the two disagree.
 
 ### Risks
 - **The package grows to carry things the runtime does not need**, because it is the convenient
   place to put them. *Mitigation*: the rule to apply is that `package.json` holds what the runtime
-  reads, plus exactly one named exception; anything else read only by a tool belongs in a sidecar,
-  as the goldens do.
+  reads; anything read only by a tool belongs in a sidecar, as the goldens do. Decision 4 records one
+  attempt to breach this rule - two booleans of golden provenance - and why it was withdrawn rather
+  than granted an exception.
 
-  **The exception is `NodeProvenance`, and it is bounded on purpose.** Decision 4 admits two
-  booleans per node that the runtime never reads, because the golden-completeness check cannot be
-  written without them and no sidecar can carry them — a file cannot supply the input that proves
-  that same file is complete. Naming it here rather than leaving it as an unremarked contradiction
-  is what stops a later reader applying the general rule and deleting the check's only input. The
-  test for a further exception is the one decision 4 applies: it has to be a check that is otherwise
-  *impossible*, not one that would merely be more convenient, and it has to cost bits rather than
-  lists.
 - **A regenerated screen differs on a second toolchain** despite the integer-only layout rule.
   *Mitigation*: `evidence.screen.<id>` runs on both legs, which is the check that would catch it;
   ADR-011's integer-only rule is what makes it expected to pass.

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -264,7 +264,17 @@ human should read.
 ### Risks
 - **The package grows to carry things the runtime does not need**, because it is the convenient
   place to put them. *Mitigation*: the rule to apply is that `package.json` holds what the runtime
-  reads; anything read only by a tool belongs in a sidecar, as the goldens do.
+  reads, plus exactly one named exception; anything else read only by a tool belongs in a sidecar,
+  as the goldens do.
+
+  **The exception is `NodeProvenance`, and it is bounded on purpose.** Decision 4 admits two
+  booleans per node that the runtime never reads, because the golden-completeness check cannot be
+  written without them and no sidecar can carry them — a file cannot supply the input that proves
+  that same file is complete. Naming it here rather than leaving it as an unremarked contradiction
+  is what stops a later reader applying the general rule and deleting the check's only input. The
+  test for a further exception is the one decision 4 applies: it has to be a check that is otherwise
+  *impossible*, not one that would merely be more convenient, and it has to cost bits rather than
+  lists.
 - **A regenerated screen differs on a second toolchain** despite the integer-only layout rule.
   *Mitigation*: `evidence.screen.<id>` runs on both legs, which is the check that would catch it;
   ADR-011's integer-only rule is what makes it expected to pass.

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -167,12 +167,29 @@ reads them, the review audience differs, and the sidecar gets its own digest —
 a verifier that opens two files instead of walking one structure. That is a driver-shaped cost, not
 an evidence-shaped one, and it is the trade this decision accepts knowingly rather than by omission.
 
-**The consistency test is an acceptance criterion for the baker and for #16**, not an aspiration.
-Neither file alone can carry it: applying ADR-011's predicate to the compiled nodes yields exactly
-the id set `goldens.json` must contain, so the check is a set comparison across the pair, and #198 is
-the first place both files exist at once. Until then it has no home — #197's text assigns it to #196,
-this ADR's consequences assign it to #197, and #196 necessarily shipped without it because no package
-existed to compare against.
+**The consistency test is an acceptance criterion for #198's baker**, not an aspiration, and #16
+derives its expectations the same way rather than trusting the sidecar to be complete.
+
+It needs something the package must therefore carry. ADR-011's predicate reads two facts about the
+*source* — whether a node was annotated `@safety_critical`, and whether its `position:` was explicit
+— and compilation erases both: every compiled node has resolved bounds, and `requirement` is
+mandatory on `CriticalButton`, `NumericDisplay` and `StatusIndicator` whether or not anyone
+annotated them, so it is not a proxy for the annotation. Without those two facts a checker can
+confirm that every listed golden resolves to a node and still not see the failure that matters: a
+node that should have a golden and does not.
+
+So each compiled node carries `NodeProvenance { safetyCritical, positioned }` — two booleans the
+runtime never reads, for a check that is otherwise impossible. That is the same trade this decision
+refused for the goldens themselves, and it is granted here because the sizes and the consequences
+differ: an entire expectation list against two bits, and a check that could not be written at all
+against one that would merely have been more convenient.
+
+**One owner: #198.** It is the first stage where both files exist at once, so it is the first place
+the test can run. #197's issue text assigned the cross-check to #196 and an earlier revision of this
+ADR assigned it to #197; #196 necessarily shipped without it, because no package existed to compare
+a golden set against. Three owners for a safety-relevant criterion is how a requirement is lost at a
+handoff, so the other two references are corrected rather than left to be reconciled by whoever
+notices.
 
 ### 5. One recipe per screen, under `recipes/screen/<id>.toml`
 
@@ -233,7 +250,7 @@ human should read.
   nothing in the format prevents them diverging. The check cannot live in the governed
   `validate()`: decision 4 puts the goldens outside the schema precisely because the runtime never
   reads them, so the `static_assert` in §3 sees only `package.json` and has no ids to compare
-  against. The mitigation is host-side — the baker writes both files from one AST, and #197 owns
+  against. The mitigation is host-side — the baker writes both files from one AST, and #198 owns
   the test.
 
   That test compares **sets, not references**. Applying ADR-011's predicate to the nodes in

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -314,6 +314,70 @@ struct NodeRect {
  * over a set it does not own. The package therefore carries names throughout, which is also the one
  * rule a reader has to remember about it.
  */
+/**
+ * @brief The wall-clock renderings a screen may ask a `Clock` for.
+ *
+ * Closed, and this library's to own, which is a deliberate exception to the rule that named values
+ * resolve against tables a product supplies (#195). TrustSC closes the same set in its governed
+ * crate, and the parity criterion decides it; what makes the exception defensible on its own terms
+ * is that a closed set lets the *compiler* know what a clock renders - `TimeSeconds` is `HH:MM:SS`,
+ * eight glyphs of known width - and therefore lets it measure a clock against its bounds. An open
+ * name cannot be measured, only looked up.
+ *
+ * `charset` on a `TextInput` deliberately stays a name: TrustSC leaves its equivalent
+ * (`glyph_set_id`) open too, because a glyph set is a product's to define.
+ */
+enum class ClockFormat : std::uint8_t {
+    TimeSeconds,      ///< `HH:MM:SS`
+    DateTimeSeconds,  ///< `YYYY-MM-DD HH:MM:SS`
+};
+
+/**
+ * @brief What a `CriticalButton` asks the platform to do when it is pressed.
+ *
+ * Two members, and deliberately not a product's list of actions: a screen that could name any event
+ * could name one nothing implements, and the press of a critical button is the worst place to find
+ * that out. A product's own actions reach the device through `source:` and the realtime path, not
+ * through this.
+ */
+enum class SystemEvent : std::uint8_t {
+    NoOp,
+    TriggerHalt,
+};
+
+/// The spelling the emitter writes and a reader recognises, e.g. `TimeSeconds`.
+[[nodiscard]] constexpr std::string_view spell(ClockFormat format) noexcept {
+    return format == ClockFormat::TimeSeconds ? "TimeSeconds" : "DateTimeSeconds";
+}
+
+/// The spelling the emitter writes, e.g. `NoOp`. A `.medui` source writes `SystemEvent.NoOp`; that
+/// mapping is the compiler's, and the package carries the bare enumerator.
+[[nodiscard]] constexpr std::string_view spell(SystemEvent event) noexcept {
+    return event == SystemEvent::NoOp ? "NoOp" : "TriggerHalt";
+}
+
+/// The format `name` spells, or nothing when it is not one of the closed set.
+[[nodiscard]] constexpr std::optional<ClockFormat> parseClockFormat(std::string_view name) noexcept {
+    if (name == spell(ClockFormat::TimeSeconds)) {
+        return ClockFormat::TimeSeconds;
+    }
+    if (name == spell(ClockFormat::DateTimeSeconds)) {
+        return ClockFormat::DateTimeSeconds;
+    }
+    return std::nullopt;
+}
+
+/// The event `name` spells, or nothing when it is not one of the closed set.
+[[nodiscard]] constexpr std::optional<SystemEvent> parseSystemEvent(std::string_view name) noexcept {
+    if (name == spell(SystemEvent::NoOp)) {
+        return SystemEvent::NoOp;
+    }
+    if (name == spell(SystemEvent::TriggerHalt)) {
+        return SystemEvent::TriggerHalt;
+    }
+    return std::nullopt;
+}
+
 // Every spec member carries a default initialiser. `-Wmissing-field-initializers` is an error in
 // this tree, and the emitter (#197) writes these initialisers from a screen - a type whose optional
 // fields still have to be spelled out at every site is a trap for generated code, and an empty name
@@ -332,7 +396,7 @@ struct LabelSpec {
 };
 
 struct ClockSpec {
-    std::string_view format{};  ///< a named value the build's governed table defines
+    ClockFormat format{};
 
     [[nodiscard]] constexpr bool operator==(const ClockSpec&) const noexcept = default;
 };
@@ -369,7 +433,7 @@ struct CriticalButtonSpec {
     std::string_view requirement{};  ///< required by the dictionary, and by #196's annotation rule
     std::string_view labelKey{};
     std::string_view colorToken{};
-    std::string_view onPress{};
+    SystemEvent      onPress{};
 
     [[nodiscard]] constexpr bool operator==(const CriticalButtonSpec&) const noexcept = default;
 };
@@ -638,8 +702,10 @@ struct ScreenPackage {
         }
         return requireColor(spec->colorToken);
     }
-    if (const auto* spec = std::get_if<ClockSpec>(&payload)) {
-        return require(spec->format);
+    if (std::holds_alternative<ClockSpec>(payload)) {
+        // Nothing to check. `format` is a closed enumeration, so an unrepresentable value cannot be
+        // built - which is most of the argument for closing it rather than carrying a name.
+        return {};
     }
     if (const auto* spec = std::get_if<ImageSpec>(&payload)) {
         return require(spec->source);
@@ -663,7 +729,7 @@ struct ScreenPackage {
         return requireColor(spec->colorToken);
     }
     if (const auto* spec = std::get_if<CriticalButtonSpec>(&payload)) {
-        for (const std::string_view name : {spec->requirement, spec->labelKey, spec->onPress}) {
+        for (const std::string_view name : {spec->requirement, spec->labelKey}) {
             if (const auto named = require(name); !named.has_value()) {
                 return named;
             }

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -308,76 +308,20 @@ struct NodeRect {
  * the device performs bounded lookups and no parsing.
  *
  * One consequence worth stating because it diverges from the sibling: `format`, `charset` and
- * `onPress` stay `std::string_view` rather than becoming enumerations. TrustSC closes those sets in
- * its own crate (`ClockFormat`, `SystemEvent`); MduX settled in #195 that such named values resolve
- * against tables a *product* supplies, so closing them here would make this library authoritative
- * over a set it does not own. The package therefore carries names throughout, which is also the one
- * rule a reader has to remember about it.
- */
-/**
- * @brief The wall-clock renderings a screen may ask a `Clock` for.
+ * `onPress` stay `std::string_view` rather than becoming enumerations. TrustSC closes two of those
+ * three in its own crate (`ClockFormat`, `SystemEvent`) and leaves the third - a text input's glyph
+ * set - open, so the divergence is real and narrower than it looks.
  *
- * Closed, and this library's to own, which is a deliberate exception to the rule that named values
- * resolve against tables a product supplies (#195). TrustSC closes the same set in its governed
- * crate, and the parity criterion decides it; what makes the exception defensible on its own terms
- * is that a closed set lets the *compiler* know what a clock renders - `TimeSeconds` is `HH:MM:SS`,
- * eight glyphs of known width - and therefore lets it measure a clock against its bounds. An open
- * name cannot be measured, only looked up.
- *
- * `charset` on a `TextInput` deliberately stays a name: TrustSC leaves its equivalent
- * (`glyph_set_id`) open too, because a glyph set is a product's to define.
+ * Closing them here was tried and withdrawn, and the reason is worth recording so the next attempt
+ * starts from it: the implemented front end accepts any identifier for `format:` and `on_press:`,
+ * #195's budget stage resolves a clock format through a product-supplied table, and the fixtures
+ * across three suites write names no two-value enumeration can hold. Closing the set in this module
+ * alone would leave the canonical type unable to represent a screen the compiler accepts. Doing it
+ * properly needs the semantic domains, the budget rule, the fixtures, the authoring skill and a
+ * diagnostic code for "a named value outside a closed set" - which the shared contract does not
+ * define today - to move together. That is a coordinated change with its own issue, not a paragraph
+ * of this one.
  */
-enum class ClockFormat : std::uint8_t {
-    TimeSeconds,      ///< `HH:MM:SS`
-    DateTimeSeconds,  ///< `YYYY-MM-DD HH:MM:SS`
-};
-
-/**
- * @brief What a `CriticalButton` asks the platform to do when it is pressed.
- *
- * Two members, and deliberately not a product's list of actions: a screen that could name any event
- * could name one nothing implements, and the press of a critical button is the worst place to find
- * that out. A product's own actions reach the device through `source:` and the realtime path, not
- * through this.
- */
-enum class SystemEvent : std::uint8_t {
-    NoOp,
-    TriggerHalt,
-};
-
-/// The spelling the emitter writes and a reader recognises, e.g. `TimeSeconds`.
-[[nodiscard]] constexpr std::string_view spell(ClockFormat format) noexcept {
-    return format == ClockFormat::TimeSeconds ? "TimeSeconds" : "DateTimeSeconds";
-}
-
-/// The spelling the emitter writes, e.g. `NoOp`. A `.medui` source writes `SystemEvent.NoOp`; that
-/// mapping is the compiler's, and the package carries the bare enumerator.
-[[nodiscard]] constexpr std::string_view spell(SystemEvent event) noexcept {
-    return event == SystemEvent::NoOp ? "NoOp" : "TriggerHalt";
-}
-
-/// The format `name` spells, or nothing when it is not one of the closed set.
-[[nodiscard]] constexpr std::optional<ClockFormat> parseClockFormat(std::string_view name) noexcept {
-    if (name == spell(ClockFormat::TimeSeconds)) {
-        return ClockFormat::TimeSeconds;
-    }
-    if (name == spell(ClockFormat::DateTimeSeconds)) {
-        return ClockFormat::DateTimeSeconds;
-    }
-    return std::nullopt;
-}
-
-/// The event `name` spells, or nothing when it is not one of the closed set.
-[[nodiscard]] constexpr std::optional<SystemEvent> parseSystemEvent(std::string_view name) noexcept {
-    if (name == spell(SystemEvent::NoOp)) {
-        return SystemEvent::NoOp;
-    }
-    if (name == spell(SystemEvent::TriggerHalt)) {
-        return SystemEvent::TriggerHalt;
-    }
-    return std::nullopt;
-}
-
 // Every spec member carries a default initialiser. `-Wmissing-field-initializers` is an error in
 // this tree, and the emitter (#197) writes these initialisers from a screen - a type whose optional
 // fields still have to be spelled out at every site is a trap for generated code, and an empty name
@@ -396,7 +340,7 @@ struct LabelSpec {
 };
 
 struct ClockSpec {
-    ClockFormat format{};
+    std::string_view format{};  ///< a named value the build's governed table defines
 
     [[nodiscard]] constexpr bool operator==(const ClockSpec&) const noexcept = default;
 };
@@ -433,7 +377,7 @@ struct CriticalButtonSpec {
     std::string_view requirement{};  ///< required by the dictionary, and by #196's annotation rule
     std::string_view labelKey{};
     std::string_view colorToken{};
-    SystemEvent      onPress{};
+    std::string_view onPress{};
 
     [[nodiscard]] constexpr bool operator==(const CriticalButtonSpec&) const noexcept = default;
 };
@@ -702,10 +646,8 @@ struct ScreenPackage {
         }
         return requireColor(spec->colorToken);
     }
-    if (std::holds_alternative<ClockSpec>(payload)) {
-        // Nothing to check. `format` is a closed enumeration, so an unrepresentable value cannot be
-        // built - which is most of the argument for closing it rather than carrying a name.
-        return {};
+    if (const auto* spec = std::get_if<ClockSpec>(&payload)) {
+        return require(spec->format);
     }
     if (const auto* spec = std::get_if<ImageSpec>(&payload)) {
         return require(spec->source);
@@ -729,7 +671,7 @@ struct ScreenPackage {
         return requireColor(spec->colorToken);
     }
     if (const auto* spec = std::get_if<CriticalButtonSpec>(&payload)) {
-        for (const std::string_view name : {spec->requirement, spec->labelKey}) {
+        for (const std::string_view name : {spec->requirement, spec->labelKey, spec->onPress}) {
             if (const auto named = require(name); !named.has_value()) {
                 return named;
             }

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -314,67 +314,71 @@ struct NodeRect {
  * over a set it does not own. The package therefore carries names throughout, which is also the one
  * rule a reader has to remember about it.
  */
+// Every spec member carries a default initialiser. `-Wmissing-field-initializers` is an error in
+// this tree, and the emitter (#197) writes these initialisers from a screen - a type whose optional
+// fields still have to be spelled out at every site is a trap for generated code, and an empty name
+// is what "absent" means for all of them anyway.
 struct PanelSpec {
-    std::string_view colorToken;  ///< the Row background that produced this synthetic node
+    std::string_view colorToken{};  ///< the Row background that produced this synthetic node
 
     [[nodiscard]] constexpr bool operator==(const PanelSpec&) const noexcept = default;
 };
 
 struct LabelSpec {
-    std::string_view textKey;
-    std::string_view colorToken;
+    std::string_view textKey{};
+    std::string_view colorToken{};
 
     [[nodiscard]] constexpr bool operator==(const LabelSpec&) const noexcept = default;
 };
 
 struct ClockSpec {
-    std::string_view format;  ///< a named value the build's governed table defines
+    std::string_view format{};  ///< a named value the build's governed table defines
 
     [[nodiscard]] constexpr bool operator==(const ClockSpec&) const noexcept = default;
 };
 
 struct ImageSpec {
-    std::string_view source;  ///< the baked image package's id, from `img("ID")`
+    std::string_view source{};  ///< the baked image package's id, from `img("ID")`
 
     [[nodiscard]] constexpr bool operator==(const ImageSpec&) const noexcept = default;
 };
 
 struct VulkanViewportSpec {
-    std::string_view streamSource;
+    std::string_view streamSource{};
 
     [[nodiscard]] constexpr bool operator==(const VulkanViewportSpec&) const noexcept = default;
 };
 
 struct SignalTraceSpec {
-    std::string_view streamSource;
-    std::string_view colorToken;
+    std::string_view streamSource{};
+    std::string_view colorToken{};
 
     [[nodiscard]] constexpr bool operator==(const SignalTraceSpec&) const noexcept = default;
 };
 
 struct ButtonSpec {
-    std::string_view labelKey;
-    std::string_view colorToken;
-    std::string_view source;
-    std::string_view requirement;  ///< optional on a Button; empty when it declares none
+    std::string_view labelKey{};
+    std::string_view colorToken{};
+    std::string_view source{};
+    std::string_view requirement{};  ///< optional on a Button; empty when it declares none
 
     [[nodiscard]] constexpr bool operator==(const ButtonSpec&) const noexcept = default;
 };
 
 struct CriticalButtonSpec {
-    std::string_view requirement;  ///< required by the dictionary, and by #196's annotation rule
-    std::string_view labelKey;
-    std::string_view colorToken;
-    std::string_view onPress;
+    std::string_view requirement{};  ///< required by the dictionary, and by #196's annotation rule
+    std::string_view labelKey{};
+    std::string_view colorToken{};
+    std::string_view onPress{};
 
     [[nodiscard]] constexpr bool operator==(const CriticalButtonSpec&) const noexcept = default;
 };
 
 struct NumericDisplaySpec {
-    std::string_view requirement;
-    std::string_view templateId;  ///< `template:` in the source; `template` is a keyword here
-    std::string_view source;
-    std::string_view colorToken;
+    std::string_view requirement{};
+    std::string_view templateId{};  ///< `template:` in the source; `template` is a keyword here
+    std::string_view source{};
+    std::string_view colorToken{};
 
     [[nodiscard]] constexpr bool operator==(const NumericDisplaySpec&) const noexcept = default;
 };
@@ -392,10 +396,10 @@ struct NumericDisplaySpec {
  * variation lives in the node, not in the expectation.
  */
 struct StatusIndicatorSpec {
-    std::string_view                  requirement;
-    std::string_view                  source;
-    std::span<const std::string_view> stateKeys;
-    std::span<const std::string_view> colorTokens;
+    std::string_view                  requirement{};
+    std::string_view                  source{};
+    std::span<const std::string_view> stateKeys{};
+    std::span<const std::string_view> colorTokens{};
 
     [[nodiscard]] constexpr bool operator==(const StatusIndicatorSpec& other) const noexcept {
         return requirement == other.requirement && source == other.source && std::ranges::equal(stateKeys, other.stateKeys)
@@ -404,11 +408,11 @@ struct StatusIndicatorSpec {
 };
 
 struct TextInputSpec {
-    std::string_view source;
-    std::string_view colorToken;
+    std::string_view source{};
+    std::string_view colorToken{};
     std::int64_t     maxLength{0};
-    std::string_view charset;      ///< empty when the component narrows nothing
-    std::string_view requirement;  ///< optional on a TextInput
+    std::string_view charset{};      ///< empty when the component narrows nothing
+    std::string_view requirement{};  ///< optional on a TextInput
 
     [[nodiscard]] constexpr bool operator==(const TextInputSpec&) const noexcept = default;
 };
@@ -477,7 +481,7 @@ struct NodeProvenance {
  * the provenance is what the golden predicate needs and resolution would otherwise have thrown away.
  */
 struct CompiledNode {
-    std::string_view id;
+    std::string_view id{};
     NodeRect         bounds{};
     NodePayload      payload{PanelSpec{}};
     NodeProvenance   provenance{};

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -104,6 +104,10 @@ enum class SchemaError : std::uint8_t {
     BoundsOutsideSurface,      ///< a rectangle the declared surface does not contain
     MalformedColorToken,       ///< a colour that is not a `Theme.Colors.<Token>` name
     UnknownColorToken,         ///< a well-formed name the governed table does not define
+    EmptyRequiredName,         ///< a spec field the component dictionary requires is empty
+    NoStates,                  ///< a status indicator that can show nothing
+    StateColorCountMismatch,   ///< per-state tints that do not pair one-to-one with the states
+    NonPositiveMaxLength,      ///< a text input that can hold no character
     EmptyBudget,               ///< a screen with nodes whose budget can hold no primitive
     BudgetExceedsIndexWidth,   ///< more vertices than a 16-bit index can address
 };
@@ -128,6 +132,14 @@ enum class SchemaError : std::uint8_t {
             return "a colour is not a Theme.Colors.<Token> name";
         case SchemaError::UnknownColorToken:
             return "a colour names a token the governed table does not define";
+        case SchemaError::EmptyRequiredName:
+            return "a name the component dictionary requires is empty";
+        case SchemaError::NoStates:
+            return "a status indicator declares no state to show";
+        case SchemaError::StateColorCountMismatch:
+            return "per-state colours do not pair one-to-one with the states";
+        case SchemaError::NonPositiveMaxLength:
+            return "a text input accepts no character";
         case SchemaError::EmptyBudget:
             return "the screen has nodes and a budget that can hold no primitive";
         case SchemaError::BudgetExceedsIndexWidth:
@@ -277,26 +289,225 @@ struct NodeRect {
 };
 
 /**
- * @brief One compiled node: what it draws, where, and what it is traced to.
+ * @brief What one component needs the device to know about it, one type per component.
  *
- * `textKey` and `colorToken` are the validated *names* ADR-011 carries rather than the values they
- * resolve to - the compiler has already proved the key exists in every approved locale (#193) and
- * that the token is in the governed table, so the device performs a bounded lookup and no parse.
+ * The dictionary is closed and each entry admits a different set of fields, so a single record with
+ * every field on it would carry a `format` for a `Label` and a `stateKeys` for a `Clock`. An earlier
+ * revision of this module did exactly that, and it was worse than untidy: it was **lossy**. A flat
+ * node had nowhere to put a `Clock`'s format, a `NumericDisplay`'s template and source, a
+ * `StatusIndicator`'s state keys and per-state tints, a `CriticalButton`'s `on_press`, or a
+ * `VulkanViewport`'s stream - so a device holding the package could not have rendered four of the
+ * eleven components at all.
  *
- * `requirement` is empty for a node that declares none, and non-empty for every node that is
- * safety-critical, because #196 refuses the annotation without it. Carrying it here is what makes
- * the requirement-to-node mapping diffable in a committed artifact.
+ * Every field is a **validated name**, never a resolved value, exactly as `colorToken` is. The
+ * compiler has already proved each one resolves - keys against every approved locale (#193), colour
+ * tokens against the governed table, named values against the tables a build supplies (#195) - so
+ * the device performs bounded lookups and no parsing.
+ *
+ * One consequence worth stating because it diverges from the sibling: `format`, `charset` and
+ * `onPress` stay `std::string_view` rather than becoming enumerations. TrustSC closes those sets in
+ * its own crate (`ClockFormat`, `SystemEvent`); MduX settled in #195 that such named values resolve
+ * against tables a *product* supplies, so closing them here would make this library authoritative
+ * over a set it does not own. The package therefore carries names throughout, which is also the one
+ * rule a reader has to remember about it.
+ */
+struct PanelSpec {
+    std::string_view colorToken;  ///< the Row background that produced this synthetic node
+
+    [[nodiscard]] constexpr bool operator==(const PanelSpec&) const noexcept = default;
+};
+
+struct LabelSpec {
+    std::string_view textKey;
+    std::string_view colorToken;
+
+    [[nodiscard]] constexpr bool operator==(const LabelSpec&) const noexcept = default;
+};
+
+struct ClockSpec {
+    std::string_view format;  ///< a named value the build's governed table defines
+
+    [[nodiscard]] constexpr bool operator==(const ClockSpec&) const noexcept = default;
+};
+
+struct ImageSpec {
+    std::string_view source;  ///< the baked image package's id, from `img("ID")`
+
+    [[nodiscard]] constexpr bool operator==(const ImageSpec&) const noexcept = default;
+};
+
+struct VulkanViewportSpec {
+    std::string_view streamSource;
+
+    [[nodiscard]] constexpr bool operator==(const VulkanViewportSpec&) const noexcept = default;
+};
+
+struct SignalTraceSpec {
+    std::string_view streamSource;
+    std::string_view colorToken;
+
+    [[nodiscard]] constexpr bool operator==(const SignalTraceSpec&) const noexcept = default;
+};
+
+struct ButtonSpec {
+    std::string_view labelKey;
+    std::string_view colorToken;
+    std::string_view source;
+    std::string_view requirement;  ///< optional on a Button; empty when it declares none
+
+    [[nodiscard]] constexpr bool operator==(const ButtonSpec&) const noexcept = default;
+};
+
+struct CriticalButtonSpec {
+    std::string_view requirement;  ///< required by the dictionary, and by #196's annotation rule
+    std::string_view labelKey;
+    std::string_view colorToken;
+    std::string_view onPress;
+
+    [[nodiscard]] constexpr bool operator==(const CriticalButtonSpec&) const noexcept = default;
+};
+
+struct NumericDisplaySpec {
+    std::string_view requirement;
+    std::string_view templateId;  ///< `template:` in the source; `template` is a keyword here
+    std::string_view source;
+    std::string_view colorToken;
+
+    [[nodiscard]] constexpr bool operator==(const NumericDisplaySpec&) const noexcept = default;
+};
+
+/**
+ * @brief A status indicator's states, and the tint each one shows.
+ *
+ * `stateKeys` and `colorTokens` are parallel spans over storage the generated translation unit owns.
+ * `colorTokens` is either empty - the component declares no per-state tint - or exactly as long as
+ * `stateKeys`, which `validate()` enforces, because a shorter list would leave a state with no tint
+ * and no way to say which.
+ *
+ * This is where per-state colour belongs, and settling it here answers the question #196 left open:
+ * a golden reference pins one tint, so it refuses `ColorHash` on a node whose tint varies. The
+ * variation lives in the node, not in the expectation.
+ */
+struct StatusIndicatorSpec {
+    std::string_view                  requirement;
+    std::string_view                  source;
+    std::span<const std::string_view> stateKeys;
+    std::span<const std::string_view> colorTokens;
+
+    [[nodiscard]] constexpr bool operator==(const StatusIndicatorSpec& other) const noexcept {
+        return requirement == other.requirement && source == other.source && std::ranges::equal(stateKeys, other.stateKeys)
+               && std::ranges::equal(colorTokens, other.colorTokens);
+    }
+};
+
+struct TextInputSpec {
+    std::string_view source;
+    std::string_view colorToken;
+    std::int64_t     maxLength{0};
+    std::string_view charset;      ///< empty when the component narrows nothing
+    std::string_view requirement;  ///< optional on a TextInput
+
+    [[nodiscard]] constexpr bool operator==(const TextInputSpec&) const noexcept = default;
+};
+
+/**
+ * @brief The payload of one compiled node: exactly one component's spec.
+ *
+ * `std::variant` rather than a hand-rolled union, and accessed only through `std::holds_alternative`
+ * and `std::get_if`. Both are `noexcept` and `constexpr`; `std::get` is deliberately never used
+ * anywhere in this module or its consumers, because it throws on the wrong alternative and ADR-005
+ * does not allow a governed type to have a throwing accessor as its natural spelling.
+ *
+ * The alternative order is *not* a wire contract. Nothing serialises the index: the emitter writes
+ * the component's dictionary name, which `kindName()` returns, so an alternative may be added
+ * without renumbering an artifact.
+ */
+using NodePayload = std::variant<PanelSpec,
+                                 LabelSpec,
+                                 ClockSpec,
+                                 ImageSpec,
+                                 VulkanViewportSpec,
+                                 SignalTraceSpec,
+                                 ButtonSpec,
+                                 CriticalButtonSpec,
+                                 NumericDisplaySpec,
+                                 StatusIndicatorSpec,
+                                 TextInputSpec>;
+
+/**
+ * @brief One compiled node: where it is, and everything the device needs to draw it.
+ *
+ * `id` and `bounds` are common to every component because a golden reference, a requirement trace
+ * and the layout solver all address a node the same way. Everything else is the component's own.
  */
 struct CompiledNode {
     std::string_view id;
-    std::string_view component;    ///< the dictionary name, e.g. `Label`
     NodeRect         bounds{};
-    std::string_view textKey;      ///< empty when the node draws no static text
-    std::string_view colorToken;   ///< empty when the node declares no tint
-    std::string_view requirement;  ///< empty when the node declares none
+    NodePayload      payload{PanelSpec{}};
 
     [[nodiscard]] constexpr bool operator==(const CompiledNode&) const noexcept = default;
 };
+
+/// The dictionary name of a node's component, e.g. `Label`. The spelling an emitter writes and a
+/// reader recognises; see `NodePayload` for why the variant's index is not that spelling.
+[[nodiscard]] constexpr std::string_view kindName(const CompiledNode& node) noexcept {
+    if (std::holds_alternative<PanelSpec>(node.payload)) {
+        return "Panel";
+    }
+    if (std::holds_alternative<LabelSpec>(node.payload)) {
+        return "Label";
+    }
+    if (std::holds_alternative<ClockSpec>(node.payload)) {
+        return "Clock";
+    }
+    if (std::holds_alternative<ImageSpec>(node.payload)) {
+        return "Image";
+    }
+    if (std::holds_alternative<VulkanViewportSpec>(node.payload)) {
+        return "VulkanViewport";
+    }
+    if (std::holds_alternative<SignalTraceSpec>(node.payload)) {
+        return "SignalTrace";
+    }
+    if (std::holds_alternative<ButtonSpec>(node.payload)) {
+        return "Button";
+    }
+    if (std::holds_alternative<CriticalButtonSpec>(node.payload)) {
+        return "CriticalButton";
+    }
+    if (std::holds_alternative<NumericDisplaySpec>(node.payload)) {
+        return "NumericDisplay";
+    }
+    if (std::holds_alternative<StatusIndicatorSpec>(node.payload)) {
+        return "StatusIndicator";
+    }
+    return "TextInput";
+}
+
+/**
+ * @brief The requirement a node is traced to, or empty when it declares none.
+ *
+ * Five components can carry one, and #196 refuses `@safety_critical` without it - so this is the
+ * function a traceability export walks rather than a field every node pretends to have.
+ */
+[[nodiscard]] constexpr std::string_view requirementOf(const CompiledNode& node) noexcept {
+    if (const auto* spec = std::get_if<ButtonSpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    if (const auto* spec = std::get_if<CriticalButtonSpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    if (const auto* spec = std::get_if<NumericDisplaySpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    if (const auto* spec = std::get_if<StatusIndicatorSpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    if (const auto* spec = std::get_if<TextInputSpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    return {};
+}
 
 /**
  * @brief A whole compiled screen as generated code exposes it and the runtime consumes it.
@@ -341,6 +552,147 @@ struct ScreenPackage {
     return right <= width && bottom <= height;
 }
 
+/**
+ * @brief Checks one colour name through the resolver the device will use.
+ *
+ * The resolver rather than the shape rule alone, so a screen that validates cannot fail the device
+ * lookup for any reason `validate()` could have seen. The two errors stay apart because they are
+ * different people's defects: a malformed name is the emitter's, and an unknown one is a screen
+ * compiled against a palette this build does not have.
+ */
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> checkColor(std::string_view token) noexcept {
+    if (token.empty()) {
+        return {};
+    }
+    const auto resolved = resolveColorToken(token);
+    if (resolved.has_value()) {
+        return {};
+    }
+    return mdux::core::err(resolved.error() == ThemeError::MalformedToken ? SchemaError::MalformedColorToken : SchemaError::UnknownColorToken);
+}
+
+/// Requires a colour the dictionary marks required: present, and resolving through the table.
+///
+/// Worth separating from `checkColor()`, which permits an absent one. The dictionary makes `color`
+/// required on `Label`, `Button`, `CriticalButton`, `SignalTrace`, `NumericDisplay` and `TextInput`,
+/// and optional nowhere except `StatusIndicator`'s per-state list - a distinction the flat node this
+/// replaces could not express, since one shared field cannot be required for some components and
+/// absent for others.
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> requireColor(std::string_view token) noexcept;
+
+/// Requires a name the dictionary marks required.
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> require(std::string_view name) noexcept {
+    return name.empty() ? mdux::core::ResultVoid<SchemaError>{mdux::core::err(SchemaError::EmptyRequiredName)} : mdux::core::ResultVoid<SchemaError>{};
+}
+
+/**
+ * @brief Checks one node's payload against what its component's dictionary entry requires.
+ *
+ * Only what the dictionary already fixes, and nothing this module invents on its own: a name a
+ * component must declare is non-empty, every colour resolves, a status indicator has states to show,
+ * and its per-state tints - if it declares any - pair one-to-one with them.
+ *
+ * Optional fields are checked when present and ignored when empty, because "absent" is a legal
+ * value the dictionary allows for `requirement` on a `Button` or `charset` on a `TextInput`.
+ */
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> requireColor(std::string_view token) noexcept {
+    if (const auto named = require(token); !named.has_value()) {
+        return named;
+    }
+    return checkColor(token);
+}
+
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> validatePayload(const NodePayload& payload) noexcept {
+    if (const auto* spec = std::get_if<PanelSpec>(&payload)) {
+        // A Panel exists because a Row declared a background, so it always has one.
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<LabelSpec>(&payload)) {
+        if (const auto named = require(spec->textKey); !named.has_value()) {
+            return named;
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<ClockSpec>(&payload)) {
+        return require(spec->format);
+    }
+    if (const auto* spec = std::get_if<ImageSpec>(&payload)) {
+        return require(spec->source);
+    }
+    if (const auto* spec = std::get_if<VulkanViewportSpec>(&payload)) {
+        return require(spec->streamSource);
+    }
+    if (const auto* spec = std::get_if<SignalTraceSpec>(&payload)) {
+        if (const auto named = require(spec->streamSource); !named.has_value()) {
+            return named;
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<ButtonSpec>(&payload)) {
+        if (const auto named = require(spec->labelKey); !named.has_value()) {
+            return named;
+        }
+        if (const auto named = require(spec->source); !named.has_value()) {
+            return named;
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<CriticalButtonSpec>(&payload)) {
+        for (const std::string_view name : {spec->requirement, spec->labelKey, spec->onPress}) {
+            if (const auto named = require(name); !named.has_value()) {
+                return named;
+            }
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<NumericDisplaySpec>(&payload)) {
+        for (const std::string_view name : {spec->requirement, spec->templateId, spec->source}) {
+            if (const auto named = require(name); !named.has_value()) {
+                return named;
+            }
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<StatusIndicatorSpec>(&payload)) {
+        for (const std::string_view name : {spec->requirement, spec->source}) {
+            if (const auto named = require(name); !named.has_value()) {
+                return named;
+            }
+        }
+        if (spec->stateKeys.empty()) {
+            return mdux::core::err(SchemaError::NoStates);
+        }
+        for (const std::string_view key : spec->stateKeys) {
+            if (const auto named = require(key); !named.has_value()) {
+                return named;
+            }
+        }
+        // Empty is legal - the component declares no per-state tint. Anything else has to pair with
+        // the states one for one, because a shorter list leaves a state with no tint and no way to
+        // say which state that is.
+        if (!spec->colorTokens.empty() && spec->colorTokens.size() != spec->stateKeys.size()) {
+            return mdux::core::err(SchemaError::StateColorCountMismatch);
+        }
+        for (const std::string_view token : spec->colorTokens) {
+            if (const auto colour = requireColor(token); !colour.has_value()) {
+                return colour;
+            }
+        }
+        return {};
+    }
+    const auto* spec = std::get_if<TextInputSpec>(&payload);
+    if (spec == nullptr) {
+        return {};
+    }
+    if (const auto named = require(spec->source); !named.has_value()) {
+        return named;
+    }
+    if (spec->maxLength <= 0) {
+        return mdux::core::err(SchemaError::NonPositiveMaxLength);
+    }
+    return requireColor(spec->colorToken);
+}
+
 constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const noexcept {
     using mdux::core::err;
 
@@ -373,21 +725,8 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
         if (!containedBy(node.bounds, surfaceWidth, surfaceHeight)) {
             return err(SchemaError::BoundsOutsideSurface);
         }
-        // The resolver itself, rather than the shape rule alone, so a screen that validates here
-        // cannot fail the device lookup for any reason `validate()` could have seen. Shape was all
-        // this could check while the palette was a caller's input; now that the governed table is
-        // the approved source of token existence, a name absent from it is as certain a defect as a
-        // name that is not a name - and both would otherwise pass the generated `static_assert` and
-        // fail where nobody is watching.
-        //
-        // The two are kept apart because they are different people's defects: a malformed name is
-        // the emitter's, and an unknown one is a screen compiled against a palette this build does
-        // not have.
-        if (!node.colorToken.empty()) {
-            const auto resolved = resolveColorToken(node.colorToken);
-            if (!resolved.has_value()) {
-                return err(resolved.error() == ThemeError::MalformedToken ? SchemaError::MalformedColorToken : SchemaError::UnknownColorToken);
-            }
+        if (const auto payload = validatePayload(node.payload); !payload.has_value()) {
+            return payload;
         }
     }
 

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -104,6 +104,7 @@ enum class SchemaError : std::uint8_t {
     BoundsOutsideSurface,      ///< a rectangle the declared surface does not contain
     MalformedColorToken,       ///< a colour that is not a `Theme.Colors.<Token>` name
     UnknownColorToken,         ///< a well-formed name the governed table does not define
+    UnknownPayload,            ///< a payload this module cannot name, or one left valueless
     EmptyRequiredName,         ///< a spec field the component dictionary requires is empty
     NoStates,                  ///< a status indicator that can show nothing
     StateColorCountMismatch,   ///< per-state tints that do not pair one-to-one with the states
@@ -132,6 +133,8 @@ enum class SchemaError : std::uint8_t {
             return "a colour is not a Theme.Colors.<Token> name";
         case SchemaError::UnknownColorToken:
             return "a colour names a token the governed table does not define";
+        case SchemaError::UnknownPayload:
+            return "a node carries a payload this module cannot name";
         case SchemaError::EmptyRequiredName:
             return "a name the component dictionary requires is empty";
         case SchemaError::NoStates:
@@ -435,15 +438,49 @@ using NodePayload = std::variant<PanelSpec,
                                  TextInputSpec>;
 
 /**
- * @brief One compiled node: where it is, and everything the device needs to draw it.
+ * @brief Why ADR-011's golden predicate selects a node, carried because compilation erases it.
+ *
+ * The predicate reads two facts about the *source*: whether the node carried `@safety_critical`,
+ * and whether its `position:` was written explicitly. Resolution destroys both - every compiled
+ * node ends up with bounds, and `requirement` is mandatory on `CriticalButton`, `NumericDisplay`
+ * and `StatusIndicator` whether or not anyone annotated them, so it is not a proxy for the
+ * annotation either.
+ *
+ * Without these two bits, the consistency check ADR-012 requires cannot be performed: a reader
+ * holding `package.json` and `goldens.json` could see that every listed golden resolves to a node,
+ * and still not know whether a node that *should* have a golden is missing one - the dangerous
+ * direction, and the whole reason that check compares sets rather than resolving references.
+ *
+ * Two booleans of device storage for a property the runtime never reads is a real cost, and it is
+ * the same trade ADR-012 decision 4 refused for the goldens themselves. The difference is size and
+ * consequence: an entire expectation list against two bits, and a check that is otherwise
+ * impossible against one that is merely more convenient.
+ */
+struct NodeProvenance {
+    bool safetyCritical{false};  ///< the source carried `@safety_critical`
+    bool positioned{false};      ///< the source wrote an explicit `position:`
+
+    [[nodiscard]] constexpr bool operator==(const NodeProvenance&) const noexcept = default;
+
+    /// Whether ADR-011's predicate selects this node for a golden reference.
+    [[nodiscard]] constexpr bool selectsGolden() const noexcept {
+        return safetyCritical || positioned;
+    }
+};
+
+/**
+ * @brief One compiled node: where it is, everything the device needs to draw it, and why a verifier
+ *        would look at it.
  *
  * `id` and `bounds` are common to every component because a golden reference, a requirement trace
- * and the layout solver all address a node the same way. Everything else is the component's own.
+ * and the layout solver all address a node the same way. The payload is the component's own, and
+ * the provenance is what the golden predicate needs and resolution would otherwise have thrown away.
  */
 struct CompiledNode {
     std::string_view id;
     NodeRect         bounds{};
     NodePayload      payload{PanelSpec{}};
+    NodeProvenance   provenance{};
 
     [[nodiscard]] constexpr bool operator==(const CompiledNode&) const noexcept = default;
 };
@@ -481,8 +518,19 @@ struct CompiledNode {
     if (std::holds_alternative<StatusIndicatorSpec>(node.payload)) {
         return "StatusIndicator";
     }
-    return "TextInput";
+    if (std::holds_alternative<TextInputSpec>(node.payload)) {
+        return "TextInput";
+    }
+    // An alternative this function does not know, or a valueless payload. Named as nothing rather
+    // than as the last kind checked: labelling an unknown component `TextInput` is how a package
+    // acquires a plausible wrong answer, and `validate()` refuses the same case outright.
+    return {};
 }
+
+// Adding an alternative to `NodePayload` without teaching `kindName()` and `validatePayload()` about
+// it would leave a node that names itself nothing and fails validation - which is fail-closed, but
+// only discovered at run time. This makes it a build failure at the point of the change instead.
+static_assert(std::variant_size_v<NodePayload> == 11, "an alternative was added or removed: update kindName() and validatePayload() to match");
 
 /**
  * @brief The requirement a node is traced to, or empty when it declares none.
@@ -680,9 +728,15 @@ struct ScreenPackage {
         }
         return {};
     }
+    // Fail closed. An earlier revision returned success here, which made this a fail-open contract:
+    // a payload left valueless by an exceptional emplacement, or an alternative added without
+    // teaching this function about it, would have been accepted as a valid node by the one function
+    // consumers are entitled to trust. `std::visit` would give exhaustiveness, but it throws on a
+    // valueless variant, which ADR-005 does not allow here - so the residual case is named instead,
+    // and the `static_assert` above turns "an alternative was added" into a build failure.
     const auto* spec = std::get_if<TextInputSpec>(&payload);
     if (spec == nullptr) {
-        return {};
+        return mdux::core::err(SchemaError::UnknownPayload);
     }
     if (const auto named = require(spec->source); !named.has_value()) {
         return named;

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -442,49 +442,22 @@ using NodePayload = std::variant<PanelSpec,
                                  TextInputSpec>;
 
 /**
- * @brief Why ADR-011's golden predicate selects a node, carried because compilation erases it.
- *
- * The predicate reads two facts about the *source*: whether the node carried `@safety_critical`,
- * and whether its `position:` was written explicitly. Resolution destroys both - every compiled
- * node ends up with bounds, and `requirement` is mandatory on `CriticalButton`, `NumericDisplay`
- * and `StatusIndicator` whether or not anyone annotated them, so it is not a proxy for the
- * annotation either.
- *
- * Without these two bits, the consistency check ADR-012 requires cannot be performed: a reader
- * holding `package.json` and `goldens.json` could see that every listed golden resolves to a node,
- * and still not know whether a node that *should* have a golden is missing one - the dangerous
- * direction, and the whole reason that check compares sets rather than resolving references.
- *
- * Two booleans of device storage for a property the runtime never reads is a real cost, and it is
- * the same trade ADR-012 decision 4 refused for the goldens themselves. The difference is size and
- * consequence: an entire expectation list against two bits, and a check that is otherwise
- * impossible against one that is merely more convenient.
- */
-struct NodeProvenance {
-    bool safetyCritical{false};  ///< the source carried `@safety_critical`
-    bool positioned{false};      ///< the source wrote an explicit `position:`
-
-    [[nodiscard]] constexpr bool operator==(const NodeProvenance&) const noexcept = default;
-
-    /// Whether ADR-011's predicate selects this node for a golden reference.
-    [[nodiscard]] constexpr bool selectsGolden() const noexcept {
-        return safetyCritical || positioned;
-    }
-};
-
-/**
- * @brief One compiled node: where it is, everything the device needs to draw it, and why a verifier
- *        would look at it.
+ * @brief One compiled node: where it is, and everything the device needs to draw it.
  *
  * `id` and `bounds` are common to every component because a golden reference, a requirement trace
- * and the layout solver all address a node the same way. The payload is the component's own, and
- * the provenance is what the golden predicate needs and resolution would otherwise have thrown away.
+ * and the layout solver all address a node the same way. Everything else is the component's own.
+ *
+ * Deliberately *not* here: whether the source carried `@safety_critical` or an explicit `position:`.
+ * A revision of this module carried both so that golden completeness could be re-derived from the
+ * committed package; ADR-012 decision 4 now takes TrustSC's arrangement instead - one pass applies
+ * the predicate once, and the tests that guard it live with the predicate (#196) rather than with the
+ * artifact. A device therefore carries nothing a verifier reads, which is what decision 4 said in the
+ * first place.
  */
 struct CompiledNode {
     std::string_view id{};
     NodeRect         bounds{};
     NodePayload      payload{PanelSpec{}};
-    NodeProvenance   provenance{};
 
     [[nodiscard]] constexpr bool operator==(const CompiledNode&) const noexcept = default;
 };

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -490,7 +490,7 @@ const mdux::spec::Register everyComponentNamesItself{
                       const ms::CompiledNode untraced{
                           .id      = "now",
                           .bounds  = {0, 0, 1, 1},
-                          .payload = ms::ClockSpec{.format = "HH_MM"}
+                          .payload = ms::ClockSpec{.format = ms::ClockFormat::TimeSeconds}
                       };
                       checks.expect(ms::requirementOf(traced) == "REQ-1", "a status indicator yields its requirement");
                       checks.expect(ms::requirementOf(untraced).empty(), "a clock has none to yield");
@@ -595,6 +595,38 @@ const mdux::spec::Register unknownPayloadsAreRefused{
                       const auto result = package.validate();
                       checks.expect(!result.has_value() && result.error() == ms::SchemaError::EmptyRequiredName,
                                     "and a required name it does declare is still enforced");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register closedSetsCannotHoldAnUnknownValue{
+    "A clock format and a system event are closed sets, spelled one way",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-closed-sets")
+            .Given("the two sets this library owns rather than resolves", [] {})
+            .When("each value is spelled and read back, and an unknown name is read", [] {})
+            .Then("the round trip is exact and the unknown name is refused",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Closed here rather than resolved against a product table, unlike `charset` -
+                      // which TrustSC leaves open too. The gain is not type safety alone: a closed
+                      // format is one the compiler can *measure*, because it knows `TimeSeconds`
+                      // renders `HH:MM:SS`, where an open name could only be looked up.
+                      for (const ms::ClockFormat format : {ms::ClockFormat::TimeSeconds, ms::ClockFormat::DateTimeSeconds}) {
+                          checks.expect(ms::parseClockFormat(ms::spell(format)) == format, std::format("'{}' reads back as itself", ms::spell(format)));
+                      }
+                      for (const ms::SystemEvent event : {ms::SystemEvent::NoOp, ms::SystemEvent::TriggerHalt}) {
+                          checks.expect(ms::parseSystemEvent(ms::spell(event)) == event, std::format("'{}' reads back as itself", ms::spell(event)));
+                      }
+
+                      checks.expect(!ms::parseClockFormat("HH_MM").has_value(), "a spelling the set does not define is refused rather than guessed at");
+                      checks.expect(!ms::parseSystemEvent("SystemEvent.NoOp").has_value(),
+                                    "and the package carries the bare enumerator, not the source's dotted path");
+                      checks.expect(ms::spell(ms::ClockFormat::TimeSeconds) != ms::spell(ms::ClockFormat::DateTimeSeconds),
+                                    "the two formats are distinguishable in an artifact");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -490,7 +490,7 @@ const mdux::spec::Register everyComponentNamesItself{
                       const ms::CompiledNode untraced{
                           .id      = "now",
                           .bounds  = {0, 0, 1, 1},
-                          .payload = ms::ClockSpec{.format = ms::ClockFormat::TimeSeconds}
+                          .payload = ms::ClockSpec{.format = "HH_MM"}
                       };
                       checks.expect(ms::requirementOf(traced) == "REQ-1", "a status indicator yields its requirement");
                       checks.expect(ms::requirementOf(untraced).empty(), "a clock has none to yield");
@@ -595,38 +595,6 @@ const mdux::spec::Register unknownPayloadsAreRefused{
                       const auto result = package.validate();
                       checks.expect(!result.has_value() && result.error() == ms::SchemaError::EmptyRequiredName,
                                     "and a required name it does declare is still enforced");
-                      checks.raise();
-                  })
-            .Execute();
-    }};
-
-const mdux::spec::Register closedSetsCannotHoldAnUnknownValue{
-    "A clock format and a system event are closed sets, spelled one way",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-schema-closed-sets")
-            .Given("the two sets this library owns rather than resolves", [] {})
-            .When("each value is spelled and read back, and an unknown name is read", [] {})
-            .Then("the round trip is exact and the unknown name is refused",
-                  [] {
-                      mdux::spec::Checks checks;
-
-                      // Closed here rather than resolved against a product table, unlike `charset` -
-                      // which TrustSC leaves open too. The gain is not type safety alone: a closed
-                      // format is one the compiler can *measure*, because it knows `TimeSeconds`
-                      // renders `HH:MM:SS`, where an open name could only be looked up.
-                      for (const ms::ClockFormat format : {ms::ClockFormat::TimeSeconds, ms::ClockFormat::DateTimeSeconds}) {
-                          checks.expect(ms::parseClockFormat(ms::spell(format)) == format, std::format("'{}' reads back as itself", ms::spell(format)));
-                      }
-                      for (const ms::SystemEvent event : {ms::SystemEvent::NoOp, ms::SystemEvent::TriggerHalt}) {
-                          checks.expect(ms::parseSystemEvent(ms::spell(event)) == event, std::format("'{}' reads back as itself", ms::spell(event)));
-                      }
-
-                      checks.expect(!ms::parseClockFormat("HH_MM").has_value(), "a spelling the set does not define is refused rather than guessed at");
-                      checks.expect(!ms::parseSystemEvent("SystemEvent.NoOp").has_value(),
-                                    "and the package carries the bare enumerator, not the source's dotted path");
-                      checks.expect(ms::spell(ms::ClockFormat::TimeSeconds) != ms::spell(ms::ClockFormat::DateTimeSeconds),
-                                    "the two formats are distinguishable in an artifact");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -42,9 +42,9 @@ constexpr ms::NumericDisplaySpec scoreDisplay{.requirement = "REQ-NS-001",
                                               .colorToken  = "Theme.Colors.ScoreDigits"};
 
 constexpr std::array<ms::CompiledNode, 3> constNodes{
-    ms::CompiledNode{.id = "topbar-background", .bounds = {0, 0, 400, 40}, .payload = topbarPanel},
-    ms::CompiledNode{.id = "title", .bounds = {8, 8, 200, 24}, .payload = titleLabel},
-    ms::CompiledNode{.id = "score", .bounds = {250, 60, 120, 60}, .payload = scoreDisplay, .provenance = {.safetyCritical = true, .positioned = true}}
+    ms::CompiledNode{.id = "topbar-background",    .bounds = {0, 0, 400, 40},  .payload = topbarPanel},
+    ms::CompiledNode{            .id = "title",    .bounds = {8, 8, 200, 24},   .payload = titleLabel},
+    ms::CompiledNode{            .id = "score", .bounds = {250, 60, 120, 60}, .payload = scoreDisplay}
 };
 
 constexpr ms::ScreenPackage constPackage{
@@ -548,34 +548,6 @@ const mdux::spec::Register statesAndTheirTintsPairUp{
                       checks.expect(errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = states, .colorTokens = oneTint})
                                         == ms::SchemaError::StateColorCountMismatch,
                                     "a short tint list is refused rather than padded");
-                      checks.raise();
-                  })
-            .Execute();
-    }};
-
-const mdux::spec::Register provenanceSurvivesCompilation{
-    "A node keeps why a verifier would look at it, which resolution would otherwise erase",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-schema-golden-provenance")
-            .Given("an annotated and positioned node, and one that is neither", [] {})
-            .When("the golden predicate is applied to the compiled nodes", [] {})
-            .Then("the set it selects is derivable from the package alone",
-                  [] {
-                      mdux::spec::Checks checks;
-
-                      // The check ADR-012 requires needs both facts, and neither survives layout on
-                      // its own: every compiled node has bounds, and `requirement` is mandatory on
-                      // three components whether or not anyone annotated them - so it cannot stand
-                      // in for the annotation.
-                      checks.expect(constNodes[2].provenance.selectsGolden(), "an annotated, positioned node is selected");
-                      checks.expect(!constNodes[1].provenance.selectsGolden(), "a plain label is not");
-                      checks.expect(!ms::requirementOf(constNodes[2]).empty() && !constNodes[1].provenance.safetyCritical,
-                                    "and a requirement is not a proxy for the annotation");
-
-                      const ms::NodeProvenance positionedOnly{.safetyCritical = false, .positioned = true};
-                      const ms::NodeProvenance annotatedOnly{.safetyCritical = true, .positioned = false};
-                      checks.expect(positionedOnly.selectsGolden() && annotatedOnly.selectsGolden(), "either rule alone selects a node, as ADR-011 says");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -30,15 +30,21 @@ namespace ms = mdux::medui;
 // Compile-time evidence for the constexpr claim
 // ---------------------------------------------------------------------------
 
+// Payloads named separately, so the node list stays one line per node. Inline, clang-format's
+// alignment of long designated initialisers pads the block into something no reviewer can scan -
+// the formatter is satisfied and the reader is not, which is the wrong trade in a fixture whose
+// job is to be read.
+constexpr ms::PanelSpec          topbarPanel{.colorToken = "Theme.Colors.TopbarBackground"};
+constexpr ms::LabelSpec          titleLabel{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"};
+constexpr ms::NumericDisplaySpec scoreDisplay{.requirement = "REQ-NS-001",
+                                              .templateId  = "TPL-SEDATION-INDEX-160",
+                                              .source      = "SEDATION_INDEX",
+                                              .colorToken  = "Theme.Colors.ScoreDigits"};
+
 constexpr std::array<ms::CompiledNode, 3> constNodes{
-    ms::CompiledNode{.id = "topbar-background",.bounds = {0, 0, 400, 40},.payload = ms::PanelSpec{.colorToken = "Theme.Colors.TopbarBackground"}                                                                          },
-    ms::CompiledNode{            .id = "title", .bounds = {8, 8, 200, 24}, .payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"}},
-    ms::CompiledNode{       .id      = "score",
-                     .bounds  = {250, 60, 120, 60},
-                     .payload = ms::NumericDisplaySpec{.requirement = "REQ-NS-001",
-                     .templateId  = "TPL-SEDATION-INDEX-160",
-                     .source      = "SEDATION_INDEX",
-                     .colorToken  = "Theme.Colors.ScoreDigits"}                                                                                                }
+    ms::CompiledNode{.id = "topbar-background", .bounds = {0, 0, 400, 40}, .payload = topbarPanel},
+    ms::CompiledNode{.id = "title", .bounds = {8, 8, 200, 24}, .payload = titleLabel},
+    ms::CompiledNode{.id = "score", .bounds = {250, 60, 120, 60}, .payload = scoreDisplay, .provenance = {.safetyCritical = true, .positioned = true}}
 };
 
 constexpr ms::ScreenPackage constPackage{
@@ -542,6 +548,81 @@ const mdux::spec::Register statesAndTheirTintsPairUp{
                       checks.expect(errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = states, .colorTokens = oneTint})
                                         == ms::SchemaError::StateColorCountMismatch,
                                     "a short tint list is refused rather than padded");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register provenanceSurvivesCompilation{
+    "A node keeps why a verifier would look at it, which resolution would otherwise erase",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-golden-provenance")
+            .Given("an annotated and positioned node, and one that is neither", [] {})
+            .When("the golden predicate is applied to the compiled nodes", [] {})
+            .Then("the set it selects is derivable from the package alone",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The check ADR-012 requires needs both facts, and neither survives layout on
+                      // its own: every compiled node has bounds, and `requirement` is mandatory on
+                      // three components whether or not anyone annotated them - so it cannot stand
+                      // in for the annotation.
+                      checks.expect(constNodes[2].provenance.selectsGolden(), "an annotated, positioned node is selected");
+                      checks.expect(!constNodes[1].provenance.selectsGolden(), "a plain label is not");
+                      checks.expect(!ms::requirementOf(constNodes[2]).empty() && !constNodes[1].provenance.safetyCritical,
+                                    "and a requirement is not a proxy for the annotation");
+
+                      const ms::NodeProvenance positionedOnly{.safetyCritical = false, .positioned = true};
+                      const ms::NodeProvenance annotatedOnly{.safetyCritical = true, .positioned = false};
+                      checks.expect(positionedOnly.selectsGolden() && annotatedOnly.selectsGolden(), "either rule alone selects a node, as ADR-011 says");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unknownPayloadsAreRefused{
+    "A payload this module cannot name is refused rather than accepted",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-unknown-payload")
+            .Given("the closed set of payload alternatives", [] {})
+            .When("a node is validated and asked for its component name", [] {})
+            .Then("every alternative names itself, and the residual case fails closed",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Exhaustiveness is a build failure rather than a test: `variant_size_v` is
+                      // static_asserted in the module, so an alternative added without teaching
+                      // kindName() and validatePayload() about it stops the build at the change.
+                      // What a test can still show is that no alternative is silently misnamed.
+                      checks.expect(std::variant_size_v<ms::NodePayload> == 11, "the alternative set is the eleven components");
+
+                      const ms::CompiledNode textInput{
+                          .id      = "entry",
+                          .bounds  = {0, 0, 100, 20},
+                          .payload = ms::TextInputSpec{.source = "NOTE", .colorToken = "Theme.Colors.Title", .maxLength = 16}
+                      };
+                      checks.expect(ms::kindName(textInput) == "TextInput",
+                                    "the last alternative is named because it is that alternative, not because it is last");
+
+                      const ms::CompiledNode noSource{
+                          .id      = "entry",
+                          .bounds  = {0, 0, 100, 20},
+                          .payload = ms::TextInputSpec{.source = {}, .colorToken = "Theme.Colors.Title", .maxLength = 16}
+                      };
+                      const std::array<ms::CompiledNode, 1> nodes{noSource};
+                      const ms::ScreenPackage               package{
+                                        .id            = "screen",
+                                        .schemaVersion = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth  = 400,
+                                        .surfaceHeight = 300,
+                                        .nodes         = nodes,
+                                        .budget        = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+                      };
+                      const auto result = package.validate();
+                      checks.expect(!result.has_value() && result.error() == ms::SchemaError::EmptyRequiredName,
+                                    "and a required name it does declare is still enforced");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -57,7 +57,12 @@ static_assert(constPackage.validate().has_value(), "the reference screen must va
 static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
 static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
 static_assert(ms::kindName(constNodes[1]) == "Label", "a node names its component at compile time");
-static_assert(std::get_if<ms::LabelSpec>(&constNodes[1].payload) != nullptr, "and its payload is reachable without std::get");
+// `holds_alternative` for the claim, and a field read for the value. An earlier revision asserted
+// `get_if(...) != nullptr`, which GCC rejected under -Waddress and was right to: for a variant whose
+// alternative is known at compile time, the pointer can never be null, so the assertion asserted
+// nothing.
+static_assert(std::holds_alternative<ms::LabelSpec>(constNodes[1].payload), "a node's payload is its own component's type");
+static_assert(std::get_if<ms::LabelSpec>(&constNodes[1].payload)->textKey == "STR-TITLE", "and its fields are readable at compile time, without std::get");
 static_assert(ms::requirementOf(constNodes[2]) == "REQ-NS-001", "a traced node yields its requirement");
 static_assert(ms::requirementOf(constNodes[1]).empty(), "and an untraced one yields nothing rather than a placeholder");
 

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -31,24 +31,14 @@ namespace ms = mdux::medui;
 // ---------------------------------------------------------------------------
 
 constexpr std::array<ms::CompiledNode, 3> constNodes{
-    ms::CompiledNode{.id          = "topbar-background",
-                     .component   = "Panel",
-                     .bounds      = {0, 0, 400, 40},
-                     .textKey     = {},
-                     .colorToken  = "Theme.Colors.TopbarBackground",
-                     .requirement = {}          },
-    ms::CompiledNode{            .id          = "title",
-                     .component   = "Label",
-                     .bounds      = {8, 8, 200, 24},
-                     .textKey     = "STR-TITLE",
-                     .colorToken  = "Theme.Colors.Title",
-                     .requirement = {}          },
-    ms::CompiledNode{            .id          = "score",
-                     .component   = "NumericDisplay",
-                     .bounds      = {250, 60, 120, 60},
-                     .textKey     = {},
-                     .colorToken  = "Theme.Colors.ScoreDigits",
-                     .requirement = "REQ-NS-001"}
+    ms::CompiledNode{.id = "topbar-background",.bounds = {0, 0, 400, 40},.payload = ms::PanelSpec{.colorToken = "Theme.Colors.TopbarBackground"}                                                                          },
+    ms::CompiledNode{            .id = "title", .bounds = {8, 8, 200, 24}, .payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"}},
+    ms::CompiledNode{       .id      = "score",
+                     .bounds  = {250, 60, 120, 60},
+                     .payload = ms::NumericDisplaySpec{.requirement = "REQ-NS-001",
+                     .templateId  = "TPL-SEDATION-INDEX-160",
+                     .source      = "SEDATION_INDEX",
+                     .colorToken  = "Theme.Colors.ScoreDigits"}                                                                                                }
 };
 
 constexpr ms::ScreenPackage constPackage{
@@ -66,6 +56,10 @@ constexpr ms::ScreenPackage constPackage{
 static_assert(constPackage.validate().has_value(), "the reference screen must validate at compile time");
 static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
 static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
+static_assert(ms::kindName(constNodes[1]) == "Label", "a node names its component at compile time");
+static_assert(std::get_if<ms::LabelSpec>(&constNodes[1].payload) != nullptr, "and its payload is reachable without std::get");
+static_assert(ms::requirementOf(constNodes[2]) == "REQ-NS-001", "a traced node yields its requirement");
+static_assert(ms::requirementOf(constNodes[1]).empty(), "and an untraced one yields nothing rather than a placeholder");
 
 /**
  * @brief The palette transcribed from TrustSC's `THEME_COLORS`, by hand and independently.
@@ -259,7 +253,7 @@ const mdux::spec::Register coloursAreNamesNotValues{
                       // carried `[33, 184, 107, 255]` would have performed the substitution the
                       // governed table exists to perform, and a reviewer would read numbers.
                       Fixture literal;
-                      literal.nodes[1].colorToken = "#21B86B";
+                      literal.nodes[1].payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = "#21B86B"};
                       checks.expect(errorOf(literal) == ms::SchemaError::MalformedColorToken,
                                     std::format("a colour value is refused, got {}", describe(errorOf(literal))));
 
@@ -267,7 +261,7 @@ const mdux::spec::Register coloursAreNamesNotValues{
                       // governed table, so a screen carrying it would validate
                       // at compile time and fail its lookup on the device.
                       Fixture bare;
-                      bare.nodes[1].colorToken = ms::colorTokenPrefix;
+                      bare.nodes[1].payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = ms::colorTokenPrefix};
                       checks.expect(errorOf(bare) == ms::SchemaError::MalformedColorToken,
                                     std::format("a bare Theme.Colors. prefix names nothing and is refused, got {}", describe(errorOf(bare))));
 
@@ -276,13 +270,17 @@ const mdux::spec::Register coloursAreNamesNotValues{
                       // shape alone accepted it, and the generated `static_assert` would have
                       // certified a screen whose colour lookup then fails on the device.
                       Fixture undefined;
-                      undefined.nodes[1].colorToken = "Theme.Colors.DoesNotExist";
+                      undefined.nodes[1].payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.DoesNotExist"};
                       checks.expect(errorOf(undefined) == ms::SchemaError::UnknownColorToken,
                                     std::format("a name the governed table does not define is refused, got {}", describe(errorOf(undefined))));
 
+                      // The typed payload makes this checkable where the flat node could not: the
+                      // dictionary makes `color` required on a Label, and one shared field cannot be
+                      // required for some components and absent for others.
                       Fixture untinted;
-                      untinted.nodes[1].colorToken = {};
-                      checks.expect(!errorOf(untinted).has_value(), "a node that declares no tint is legal");
+                      untinted.nodes[1].payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = {}};
+                      checks.expect(errorOf(untinted) == ms::SchemaError::EmptyRequiredName,
+                                    std::format("a Label with no tint is refused, got {}", describe(errorOf(untinted))));
                       checks.raise();
                   })
             .Execute();
@@ -427,6 +425,118 @@ const mdux::spec::Register tokenShapeMatchesWhatTheParserAccepts{
                       checks.expect(!ms::isColorToken("Theme.Colors.#"), "punctuation is not an identifier character");
                       checks.expect(!ms::isColorToken("Palette.Title"), "another prefix is another table");
                       checks.expect(!ms::isColorToken(""), "and nothing at all is not a name");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyComponentNamesItself{
+    "Every payload names its component, and only the traced ones carry a requirement",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-payload-kinds")
+            .Given("one node of each of the eleven kinds", [] {})
+            .When("each is asked for its component name and its requirement", [] {})
+            .Then("the names are the dictionary's, and an untraced component yields nothing",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const std::array<std::string_view, 2>                              states{"STR-OK", "STR-ALARM"};
+                      const std::array<std::pair<ms::NodePayload, std::string_view>, 11> cases{
+                          std::pair{          ms::NodePayload{ms::PanelSpec{}},           std::string_view{"Panel"}},
+                          std::pair{          ms::NodePayload{ms::LabelSpec{}},           std::string_view{"Label"}},
+                          std::pair{          ms::NodePayload{ms::ClockSpec{}},           std::string_view{"Clock"}},
+                          std::pair{          ms::NodePayload{ms::ImageSpec{}},           std::string_view{"Image"}},
+                          std::pair{ ms::NodePayload{ms::VulkanViewportSpec{}},  std::string_view{"VulkanViewport"}},
+                          std::pair{    ms::NodePayload{ms::SignalTraceSpec{}},     std::string_view{"SignalTrace"}},
+                          std::pair{         ms::NodePayload{ms::ButtonSpec{}},          std::string_view{"Button"}},
+                          std::pair{ ms::NodePayload{ms::CriticalButtonSpec{}},  std::string_view{"CriticalButton"}},
+                          std::pair{ ms::NodePayload{ms::NumericDisplaySpec{}},  std::string_view{"NumericDisplay"}},
+                          std::pair{ms::NodePayload{ms::StatusIndicatorSpec{}}, std::string_view{"StatusIndicator"}},
+                          std::pair{      ms::NodePayload{ms::TextInputSpec{}},       std::string_view{"TextInput"}}
+                      };
+
+                      bool everyKindNamed = true;
+                      for (const auto& [payload, expected] : cases) {
+                          const ms::CompiledNode node{
+                              .id      = "n",
+                              .bounds  = {0, 0, 1, 1},
+                              .payload = payload
+                          };
+                          everyKindNamed = everyKindNamed && ms::kindName(node) == expected;
+                      }
+                      checks.expect(everyKindNamed, "every alternative names its component");
+                      checks.expect(cases.size() == std::variant_size_v<ms::NodePayload>,
+                                    "and the case list covers every alternative, so a new one cannot be added unnoticed");
+
+                      // Five components can be traced; the rest carry no requirement field at all,
+                      // which is the distinction the flat node had to fake with an empty string.
+                      const ms::CompiledNode traced{
+                          .id      = "score",
+                          .bounds  = {                     0,                 0,                   1,                 1},
+                          .payload = ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "STATE", .stateKeys = states, .colorTokens = {}}
+                      };
+                      const ms::CompiledNode untraced{
+                          .id      = "now",
+                          .bounds  = {0, 0, 1, 1},
+                          .payload = ms::ClockSpec{.format = "HH_MM"}
+                      };
+                      checks.expect(ms::requirementOf(traced) == "REQ-1", "a status indicator yields its requirement");
+                      checks.expect(ms::requirementOf(untraced).empty(), "a clock has none to yield");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register statesAndTheirTintsPairUp{
+    "A status indicator must have states, and per-state tints must pair with them",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-status-states")
+            .Given("a status indicator with two states", [] {})
+            .When("its states are emptied, and its tint list given the wrong length", [] {})
+            .Then("each is refused, while no tints at all is legal",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const std::array<std::string_view, 2> states{"STR-OK", "STR-ALARM"};
+                      const std::array<std::string_view, 2> tints{"Theme.Colors.Nominal", "Theme.Colors.Fault"};
+                      const std::array<std::string_view, 1> oneTint{"Theme.Colors.Nominal"};
+
+                      const auto packageWith = [](std::span<const ms::CompiledNode> storage) {
+                          return ms::ScreenPackage{
+                              .id            = "screen",
+                              .schemaVersion = mdux::evidence::kSchemaVersion,
+                              .surfaceWidth  = 400,
+                              .surfaceHeight = 300,
+                              .nodes         = storage,
+                              .budget        = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+                          };
+                      };
+
+                      const auto errorFor = [&](ms::NodePayload payload) -> std::optional<ms::SchemaError> {
+                          const std::array<ms::CompiledNode, 1> nodes{
+                              ms::CompiledNode{.id = "state", .bounds = {0, 0, 120, 40}, .payload = std::move(payload)}
+                          };
+                          const auto result = packageWith(nodes).validate();
+                          return result.has_value() ? std::nullopt : std::optional{result.error()};
+                      };
+
+                      checks.expect(
+                          !errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = states, .colorTokens = tints}).has_value(),
+                          "two states and two tints validate");
+                      checks.expect(
+                          !errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = states, .colorTokens = {}}).has_value(),
+                          "and declaring no tint at all is legal");
+                      checks.expect(errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = {}, .colorTokens = {}})
+                                        == ms::SchemaError::NoStates,
+                                    "an indicator that can show nothing is refused");
+
+                      // The failure this pairing rule exists for: one tint short leaves a state with
+                      // no colour and no way to say which state that is.
+                      checks.expect(errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = states, .colorTokens = oneTint})
+                                        == ms::SchemaError::StateColorCountMismatch,
+                                    "a short tint list is refused rather than padded");
                       checks.raise();
                   })
             .Execute();


### PR DESCRIPTION
## Summary

Replaces the compiled node's flat record with **one typed payload per component**, before anything
serialises or bakes it. This is the S8 blocker identified in the parity note: the flat node was not
merely unlike TrustSC's, it was **lossy**.

A flat `CompiledNode { id, component, bounds, textKey, colorToken, requirement }` had nowhere to put

- a `Clock`'s `format`,
- a `NumericDisplay`'s `template` and `source`,
- a `StatusIndicator`'s state keys and per-state tints,
- a `CriticalButton`'s `on_press`,
- a `VulkanViewport`'s `stream_source`,
- a `TextInput`'s `max_length` and `charset`,

so a device holding the package could not have rendered four of the eleven components in the closed
dictionary. Nothing consumes the schema yet, which is exactly why this is cheap today and a
`schemaVersion` bump plus a rebake of every screen after #198.

**Semantics preserved from TrustSC, representation not copied.** Rust's enum carries payloads for
free; this had to be built for `constexpr` construction, for storage the generated translation unit
owns, and for the governed no-allocation rules. `std::variant` reached only through
`holds_alternative` and `get_if` — **`std::get` is deliberately never used**, because it throws on
the wrong alternative and ADR-005 does not allow a governed type whose natural accessor throws. The
alternative order is not a wire contract: the emitter writes the dictionary name `kindName()`
returns, so an alternative can be added without renumbering an artifact.

**One deliberate difference from the sibling.** `format`, `charset` and `onPress` stay
`std::string_view` names rather than becoming enumerations as TrustSC's `ClockFormat` and
`SystemEvent` do. Closing two of them was tried on this branch and withdrawn — see the review round
below — and the coordinated change is #219.

> ### What changed while this PR was in review
>
> The description above is what the PR does *now*. Two mechanisms were added and then removed
> during review, and a reader comparing the diff to an earlier version of this text deserves to
> know why rather than to reconstruct it:
>
> - **`NodeProvenance`** — two booleans per node so golden completeness could be re-derived from
>   `package.json`. Withdrawn (`52b370b`) once TrustSC's compiler showed the property is guaranteed
>   by construction: one implementation of the predicate, applied once, guarded by the tests that
>   live with it. The comparison it enabled could only ever have detected two writers disagreeing,
>   never a wrong predicate.
> - **`ClockFormat` and `SystemEvent` as closed enums** — withdrawn (`9b4e4d6`), because the
>   implemented front end accepts any identifier for those fields and #195's budget resolves a clock
>   format through a product table, so closing the set here alone left the canonical type unable to
>   represent a screen the compiler accepts. #219 carries the coordinated change, and opens with the
>   question that blocks it: no registered diagnostic reports a named value outside a closed set.

**Two rules the typed payload makes checkable, that a shared field could not express:**

- `color` is required by the dictionary on six components and optional only inside
  `StatusIndicator`'s per-state list. One common field cannot be required for some components and
  absent for others, so the flat node could only ever permit an empty tint everywhere.
- Per-state tints must pair one-to-one with the states. A short list leaves a state with no colour
  and no way to say which state that is.

`validate()` enforces both, plus the required names each dictionary entry declares.

Also lands two ADR-012 paragraphs the review asked for: the typed payload, and the goldens sidecar
named explicitly as a **deliberate divergence** from TrustSC's package-field arrangement — with the
package-versus-goldens cross-check made an acceptance criterion for the baker and #16. That check
currently has no owner at all: #197's text assigns it to #196, ADR-012's consequences assign it to
#197, and #196 necessarily shipped without it because no package existed to compare against.

Part of #197.

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change.
- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: none — maintainer-authored, so neither box applies.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked — #217 merged as `72edb1f`
- **Merge order:** mergeable now, and before the S8 emitters, which should be written against this shape

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — module already registered by #215
- [ ] `FILE_SET CXX_MODULES` lists — no module added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] `tests/CMakeLists.txt` — suite membership unchanged
- [ ] Schemas under `docs/*/schemas/`
- [ ] Generated indexes
- [ ] Committed artifacts under `generated/` — none exists for screens, which is the point
- [x] None of the above

## Rebase state

- **Rebased onto:** `72edb1f` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — `OK (80 files checked, 0 findings)`
- [x] `clang-format` applied to both touched sources.
- [ ] `cmake --preset ninja-gcc && ctest` — not run locally; the macOS toolchain cannot build the
      `std` module.

**CI is the prototype here, and deliberately so.** The parity note said `std::variant` was worth
proving on both toolchains before committing to it, and with no local module build the honest way to
do that is to let the compile legs answer. Two things to watch:

- the namespace-scope `static_assert`s, which now include `kindName()` and `get_if` on a
  `constexpr` node — if `std::variant` is not usable in a constant expression on either toolchain,
  `medui_spec` fails to compile rather than failing a test;
- `governed-throw` on MduXCore. `std::get` is never called, so `__throw_bad_variant_access` should
  not be emitted; the profile forbids `__cxa_throw` and reports library helpers, so a surprise here
  would show up as a report rather than a silent pass.

If either objects, the fallback is an explicit tagged union — a contained change, and not a lesser
design.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** pending
- [ ] That run is green.

## Regulatory impact

Traceability improves, and no rule about what a screen may say changes: the set of named values the
compiler accepts is exactly what it was before this PR, since the two closed sets were withdrawn.
`requirementOf()` replaces a field every node pretended to have with a function over the five
components that can actually carry one, so a traceability export walks what the dictionary permits
rather than what the record shape allowed.

The safety-relevant rule this unblocks is #17's and #199's: a device can now be given what it needs
to render every component, which the previous shape could not express for four of them. Two
safety-adjacent defects were found in review and are recorded rather than quietly dropped — a
required field that value-initialised to a plausible valid value, and a spelling that named every
out-of-range `SystemEvent` `TriggerHalt`. Both belonged to the withdrawn enums; both are requirements
on #219 so the next attempt cannot reintroduce them.

ADR-012 carries both new decisions. No ADR is contradicted; no certification or compliance claim is
added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed specifications for supported screen components, including component-specific settings and source properties.
  * Added tracking for safety-critical and explicitly positioned components.

* **Bug Fixes**
  * Screen packages now reject invalid, incomplete, or unknown component data with clearer validation errors.
  * Golden-reference selection consistently reflects safety-critical and positioned components.

* **Documentation**
  * Documented compiled screen artifact structure and golden-reference acceptance requirements.

* **Tests**
  * Expanded coverage for component types, provenance-based selection, colors, and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
