### PR TITLE
Compile a screen to a canonical JSON package [#197]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -725,6 +725,11 @@ mdux_discover_tests(medui_spec)
 # GoldenTests (#196) reads tests/medui/fixtures/accepted-goldens.medui, which carries every rule
 # ADR-011 fixes for golden references in one screen - including the node that matches both rules and
 # must therefore appear exactly once.
+#
+# PackageTests (#197) reads tests/medui/fixtures/accepted-every-component.medui, a screen carrying
+# all eleven compiled payloads, and round-trips it through canonical JSON. The writer and the reader
+# spell each member name separately, so the scenario executes both directions over one screen rather
+# than asserting either half - the shape of parity check this repository has got wrong before.
 add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
@@ -733,6 +738,7 @@ add_executable(medui_tools_spec
     medui/LayoutTests.cpp
     medui/TextBudgetTests.cpp
     medui/GoldenTests.cpp
+    medui/PackageTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -434,3 +434,45 @@ const mdux::spec::Register aBypassedGateIsARefusalNotADiagnostic{
                   })
             .Execute();
     }};
+
+const mdux::spec::Register aMovedDocumentStillOwnsItsText{
+    "A moved document still owns every name its package views",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-survives-a-move")
+            .Given("a compiled screen whose names are short enough to live inside their strings", [] {})
+            .When("the document is move-constructed and then move-assigned", [] {})
+            .Then("every name reads back unchanged through the package",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The small-string optimisation is the whole hazard: a name short enough to
+                      // live inside its `std::string` moves with the object, so this asserts what
+                      // the deque is chosen for rather than leaving it as an argument in a comment.
+                      // `writePackage()` reads every name and every span, so comparing the bytes
+                      // before and after a move exercises all of them at once.
+                      const std::string before = md::writePackage(everyComponent().package());
+
+                      // Initialising from the helper's return value would elide the move entirely
+                      // and assert nothing, so the source is named first and moved from explicitly.
+                      md::ScreenDocument source = everyComponent();
+                      md::ScreenDocument moved{std::move(source)};
+                      md::ScreenDocument assigned;
+                      assigned = std::move(moved);  // the operation readPackage() performs
+
+                      const ms::ScreenPackage package = assigned.package();
+                      checks.expect(package.validate().has_value(), "the moved screen still satisfies its schema");
+                      checks.expect(md::writePackage(package) == before, "every name and span survives both moves unchanged");
+
+                      // A state key list is a span into storage the document owns separately from
+                      // its text, so it is worth naming rather than trusting the byte comparison.
+                      if (const auto* status = std::get_if<ms::StatusIndicatorSpec>(&node(package, "state").payload)) {
+                          checks.expect(status->stateKeys.size() == 2 && status->stateKeys.front() == "STR-OK",
+                                        "the per-state keys still read back after the move");
+                      } else {
+                          checks.expect(false, "the state node holds a StatusIndicator spec");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -1,0 +1,432 @@
+/**
+ * @brief BDD scenarios for the compiled-screen document and its canonical JSON (issue #197).
+ * @file PackageTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine (canonical form, byte-identity)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Two properties carry most of these scenarios. The first is that the writer and the reader agree:
+ * they are separate code with a member name written on each side, so the round trip runs over a
+ * fixture carrying all eleven payloads and executes both directions rather than asserting one.
+ * The second is that the bytes are exactly determined - one scenario spells a whole small package
+ * out, because a byte-compared artifact's format is worth stating in a form a reviewer can read.
+ */
+
+import std;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.package;
+import mdux.tools.medui.parser;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace ms  = mdux::medui;
+namespace cli = mdux::tools::cli;
+
+/// The budget every scenario compiles with. Declared rather than computed, as `PackageInputs` says.
+constexpr mdux::draw::DrawBudget testBudget{.maxVertices = 4096, .maxIndices = 6144, .maxCommands = 256};
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+    std::ifstream               in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened at {}", name, path.generic_string()),
+                                              std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] md::LayoutResult layoutOf(std::string_view source, std::int64_t width, std::int64_t height) {
+    md::ParseResult parsed = md::parse(source, "package.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("package test source did not parse", std::source_location::current());
+    }
+    md::LayoutResult resolved = md::resolveLayout(*parsed.screen, "package.medui", {.surfaceWidth = width, .surfaceHeight = height});
+    if (!resolved.ok()) {
+        throw speclab::core::AssertionFailure(std::format("package test source did not resolve: {}", resolved.diagnostics.front().message),
+                                              std::source_location::current());
+    }
+    return resolved;
+}
+
+/// The screen carrying all eleven payloads, compiled.
+[[nodiscard]] md::ScreenDocument everyComponent() {
+    return md::buildPackage(layoutOf(fixture("accepted-every-component.medui"), 800, 700), {.id = "every-component", .budget = testBudget});
+}
+
+/// One Label on a small surface: the screen the byte-exact scenario spells out.
+[[nodiscard]] std::string tinyScreen() {
+    return "Screen Tiny {\n"
+           "    layout: Vertical { spacing: 0px; padding: 0px; }\n"
+           "    surface: 200px, 100px;\n"
+           "\n"
+           "    Label {\n"
+           "        id: title;\n"
+           "        width: 200px;\n"
+           "        height: 40px;\n"
+           "        text: t(\"STR-TITLE\");\n"
+           "        color: Theme.Colors.Title;\n"
+           "    }\n"
+           "}\n";
+}
+
+[[nodiscard]] md::ScreenDocument tinyDocument() {
+    return md::buildPackage(layoutOf(tinyScreen(), 200, 100), {.id = "tiny", .budget = testBudget});
+}
+
+[[nodiscard]] const ms::CompiledNode& node(const ms::ScreenPackage& package, std::string_view id) {
+    const ms::CompiledNode* found = package.find(id);
+    if (found == nullptr) {
+        throw speclab::core::AssertionFailure(std::format("the compiled screen has no node '{}'", id), std::source_location::current());
+    }
+    return *found;
+}
+
+/// Replaces the first occurrence of `what`, failing the scenario if the bytes do not contain it -
+/// an edit that silently did nothing would make a rejection scenario pass for the wrong reason.
+[[nodiscard]] std::string editing(std::string text, std::string_view what, std::string_view with) {
+    const std::size_t at = text.find(what);
+    if (at == std::string::npos) {
+        throw speclab::core::AssertionFailure(std::format("the package bytes do not contain '{}'", what), std::source_location::current());
+    }
+    return text.replace(at, what.size(), with);
+}
+
+[[nodiscard]] std::string firstCode(const md::PackageReadResult& result) {
+    return result.diagnostics.empty() ? std::string{"<none>"} : result.diagnostics.front().code;
+}
+
+}  // namespace
+
+const mdux::spec::Register everyComponentCompilesToItsOwnPayload{
+    "Every component in the dictionary compiles to its own typed payload",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-payloads")
+            .Given("a screen carrying all ten authored components and a Row with a background", [] {})
+            .When("it is compiled to a screen package", [] {})
+            .Then("eleven nodes appear, each naming the component it came from",
+                  [] {
+                      mdux::spec::Checks       checks;
+                      const md::ScreenDocument document = everyComponent();
+                      const ms::ScreenPackage  package  = document.package();
+
+                      const std::vector<std::pair<std::string_view, std::string_view>> expected{
+                          {"topbar-background",           "Panel"},
+                          {            "title",           "Label"},
+                          {       "wall-clock",           "Clock"},
+                          {             "logo",           "Image"},
+                          {        "endoscope",  "VulkanViewport"},
+                          {              "ecg",     "SignalTrace"},
+                          {           "freeze",          "Button"},
+                          {             "halt",  "CriticalButton"},
+                          {   "sedation-index",  "NumericDisplay"},
+                          {            "state", "StatusIndicator"},
+                          {       "patient-id",       "TextInput"}
+                      };
+
+                      checks.expect(package.nodes.size() == expected.size(), std::format("eleven compiled nodes, got {}", package.nodes.size()));
+                      for (const auto& [id, kind] : expected) {
+                          const ms::CompiledNode* compiled = package.find(id);
+                          if (compiled == nullptr) {
+                              checks.expect(false, std::format("node '{}' is compiled", id));
+                              continue;
+                          }
+                          checks.expect(ms::kindName(*compiled) == kind, std::format("node '{}' is a {}, got '{}'", id, kind, ms::kindName(*compiled)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register fieldsReachTheirOwnSpecMembers{
+    "A component's fields reach the spec members the dictionary maps them to",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-spec-members")
+            .Given("components whose fields share spellings across different meanings", [] {})
+            .When("the screen is compiled", [] {})
+            .Then("each field lands on its own component's member, and a synthetic Panel carries the Row's background",
+                  [] {
+                      mdux::spec::Checks       checks;
+                      const md::ScreenDocument document = everyComponent();
+                      const ms::ScreenPackage  package  = document.package();
+
+                      // `text` on a Label and `label` on a Button are both a text key; `source` is a
+                      // data stream on one component and an image package on another. That mapping
+                      // is what a table keyed by field name could not express.
+                      if (const auto* label = std::get_if<ms::LabelSpec>(&node(package, "title").payload)) {
+                          checks.expect(label->textKey == "STR-TITLE", std::format("the Label's text key, got '{}'", label->textKey));
+                      } else {
+                          checks.expect(false, "the title node holds a Label spec");
+                      }
+                      if (const auto* button = std::get_if<ms::ButtonSpec>(&node(package, "freeze").payload)) {
+                          checks.expect(button->labelKey == "STR-FREEZE", std::format("the Button's label key, got '{}'", button->labelKey));
+                          checks.expect(button->source == "FREEZE", std::format("the Button's data source, got '{}'", button->source));
+                          checks.expect(button->requirement == "REQ-EC-001", "the Button's optional requirement is carried");
+                      } else {
+                          checks.expect(false, "the freeze node holds a Button spec");
+                      }
+                      if (const auto* image = std::get_if<ms::ImageSpec>(&node(package, "logo").payload)) {
+                          checks.expect(image->source == "IMG-LOGO", std::format("the Image's package id, got '{}'", image->source));
+                      } else {
+                          checks.expect(false, "the logo node holds an Image spec");
+                      }
+                      if (const auto* status = std::get_if<ms::StatusIndicatorSpec>(&node(package, "state").payload)) {
+                          checks.expect(status->stateKeys.size() == 2, std::format("two states, got {}", status->stateKeys.size()));
+                          checks.expect(status->colorTokens.size() == status->stateKeys.size(), "the per-state tints pair with the states");
+                      } else {
+                          checks.expect(false, "the state node holds a StatusIndicator spec");
+                      }
+                      if (const auto* input = std::get_if<ms::TextInputSpec>(&node(package, "patient-id").payload)) {
+                          checks.expect(input->maxLength == 16, std::format("the TextInput's length bound, got {}", input->maxLength));
+                          checks.expect(input->charset == "Ascii", std::format("the TextInput's charset, got '{}'", input->charset));
+                      } else {
+                          checks.expect(false, "the patient-id node holds a TextInput spec");
+                      }
+                      // The one payload no author can write: the solver synthesises it for a Row
+                      // that declares a background, and it carries that background.
+                      if (const auto* panel = std::get_if<ms::PanelSpec>(&node(package, "topbar-background").payload)) {
+                          checks.expect(panel->colorToken == "Theme.Colors.TopbarBackground", std::format("the Row's background, got '{}'", panel->colorToken));
+                      } else {
+                          checks.expect(false, "the synthetic background holds a Panel spec");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register writingAndReadingAgree{
+    "Canonical JSON round-trips every payload without loss",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-round-trip")
+            .Given("a compiled screen carrying all eleven payloads", [] {})
+            .When("it is written as canonical JSON and read back", [] {})
+            .Then("the screen read back equals the screen written, node for node",
+                  [] {
+                      mdux::spec::Checks       checks;
+                      const md::ScreenDocument original = everyComponent();
+                      const std::string        written  = md::writePackage(original.package());
+
+                      const md::PackageReadResult reread = md::readPackage(written, "package.json");
+                      checks.expect(reread.ok(), std::format("the written bytes read back, first diagnostic '{}'", firstCode(reread)));
+                      if (!reread.ok()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      const ms::ScreenPackage before = original.package();
+                      const ms::ScreenPackage after  = reread.document.package();
+                      checks.expect(after.id == before.id, "the package id survives");
+                      checks.expect(after.surfaceWidth == before.surfaceWidth && after.surfaceHeight == before.surfaceHeight, "the surface survives");
+                      checks.expect(after.budget == before.budget, "the draw budget survives");
+                      checks.expect(after.nodes.size() == before.nodes.size(),
+                                    std::format("{} nodes survive, got {}", before.nodes.size(), after.nodes.size()));
+                      for (std::size_t index = 0; index < std::min(before.nodes.size(), after.nodes.size()); ++index) {
+                          checks.expect(after.nodes[index] == before.nodes[index], std::format("node '{}' survives unchanged", before.nodes[index].id));
+                      }
+                      // Writing what was read gives the same bytes: a round trip that lost a member
+                      // would still compare equal if the reader dropped it on both sides.
+                      checks.expect(md::writePackage(after) == written, "writing the screen read back reproduces the bytes");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theBytesAreExactlyDetermined{
+    "A small screen has exactly these bytes",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-canonical-bytes")
+            .Given("a screen with one Label", [] {})
+            .When("it is written as canonical JSON", [] {})
+            .Then("the bytes are sorted, two-space indented, integer-only, and end with a newline",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string  written = md::writePackage(tinyDocument().package());
+
+                      const std::string expected = R"({
+  "budget": {
+    "maxCommands": 256,
+    "maxIndices": 6144,
+    "maxVertices": 4096
+  },
+  "id": "tiny",
+  "kind": "screen",
+  "nodes": [
+    {
+      "bounds": {
+        "height": 40,
+        "width": 200,
+        "x": 0,
+        "y": 0
+      },
+      "id": "title",
+      "kind": "Label",
+      "spec": {
+        "colorToken": "Theme.Colors.Title",
+        "textKey": "STR-TITLE"
+      }
+    }
+  ],
+  "schemaVersion": 1,
+  "surfaceHeight": 100,
+  "surfaceWidth": 200
+}
+)";
+                      checks.expect(written == expected, std::format("the package bytes are exactly as documented, got:\n{}", written));
+                      // A screen package holds no float, so ADR-007's `{"bits": N}` encoding - the
+                      // one thing that makes a float portable - never appears in one.
+                      checks.expect(written.find("\"bits\"") == std::string::npos, "no floating-point value appears in a screen package");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anUndefinedMemberIsRefused{"A member the format does not define is refused rather than ignored", "evidence-unit", [] {
+                                                          return speclab::Test("medui-package-unknown-member")
+                                                              .Given("committed bytes carrying a member no reader knows", [] {})
+                                                              .When("they are read", [] {})
+                                                              .Then("the read fails, naming the member",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+                                                                        const std::string  written = md::writePackage(tinyDocument().package());
+
+                                                                        // A misspelling is the realistic case, and the dangerous one: silently
+                                                                        // ignoring `colourToken` would leave a reviewer believing a tint was pinned.
+                                                                        const std::string edited = editing(written, "\"colorToken\"", "\"colourToken\"");
+                                                                        const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                                                                        checks.expect(!result.ok(), "an undefined member is refused");
+                                                                        checks.expect(firstCode(result) == "SCP003",
+                                                                                      std::format("reported as SCP003, got '{}'", firstCode(result)));
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register anUnknownComponentIsRefused{"A node naming a component outside the dictionary is refused", "evidence-unit", [] {
+                                                           return speclab::Test("medui-package-unknown-kind")
+                                                               .Given("committed bytes naming a component that does not exist", [] {})
+                                                               .When("they are read", [] {})
+                                                               .Then("the read fails with the code for an unknown kind",
+                                                                     [] {
+                                                                         mdux::spec::Checks checks;
+                                                                         const std::string  edited = editing(md::writePackage(tinyDocument().package()),
+                                                                                                            "\"Label\"",
+                                                                                                            "\"Marquee\"");
+                                                                         const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                                                                         checks.expect(!result.ok(), "an unknown component is refused");
+                                                                         checks.expect(firstCode(result) == "SCP004",
+                                                                                       std::format("reported as SCP004, got '{}'", firstCode(result)));
+                                                                         checks.raise();
+                                                                     })
+                                                               .Execute();
+                                                       }};
+
+const mdux::spec::Register aScreenTheSchemaRefusesIsRefused{
+    "A hand-edited screen the schema refuses fails at the read, not at the device",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-schema-refusal")
+            .Given("committed bytes whose surface no longer contains their nodes", [] {})
+            .When("they are read", [] {})
+            .Then("the read fails with the schema's own verdict",
+                  [] {
+                      mdux::spec::Checks checks;
+                      // Shrinking the surface leaves the file canonical and the members known: only
+                      // `validate()` can catch it, which is why the reader runs the same one a
+                      // device would rather than repeating the rules itself.
+                      const std::string edited = editing(md::writePackage(tinyDocument().package()), "\"surfaceWidth\": 200", "\"surfaceWidth\": 100");
+                      const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                      checks.expect(!result.ok(), "a screen the schema refuses is refused here");
+                      checks.expect(firstCode(result) == "SCP005", std::format("reported as SCP005, got '{}'", firstCode(result)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register nonCanonicalBytesAreRefused{"Bytes that are not canonical JSON are refused", "evidence-unit", [] {
+                                                           return speclab::Test("medui-package-non-canonical")
+                                                               .Given("a package whose integer was rewritten as a decimal", [] {})
+                                                               .When("it is read", [] {})
+                                                               .Then("the read fails before any member is interpreted",
+                                                                     [] {
+                                                                         mdux::spec::Checks checks;
+                                                                         // The canonical reader rejects any fraction or exponent outright: a decimal in
+                                                                         // a generated file means it was hand-edited or written by another tool.
+                                                                         const std::string edited = editing(md::writePackage(tinyDocument().package()),
+                                                                                                            "\"height\": 40",
+                                                                                                            "\"height\": 40.0");
+                                                                         const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                                                                         checks.expect(!result.ok(), "non-canonical bytes are refused");
+                                                                         checks.expect(firstCode(result) == "SCP001",
+                                                                                       std::format("reported as SCP001, got '{}'", firstCode(result)));
+                                                                         checks.raise();
+                                                                     })
+                                                               .Execute();
+                                                       }};
+
+const mdux::spec::Register goldensAreWrittenAsTheirOwnSidecar{
+    "The golden references are written as a sidecar, empty array included",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-goldens-sidecar")
+            .Given("a screen that pins safety-critical nodes, and one that pins none", [] {})
+            .When("the sidecar is written for each", [] {})
+            .Then("one carries the agreed member names and the other is an empty array",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const std::string pinned = md::writeGoldens(md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300)));
+                      for (const std::string_view member : {"\"bounds\"", "\"colorToken\"", "\"cvChecks\"", "\"nodeId\"", "\"textKey\""}) {
+                          checks.expect(pinned.find(member) != std::string::npos, std::format("the sidecar spells {}", member));
+                      }
+                      checks.expect(pinned.find("node_id") == std::string::npos, "no snake_case member survives ADR-011's amendment");
+
+                      // ADR-012 makes all three outputs unconditional: a baker that skipped this
+                      // file for a screen with nothing to pin would break the build rather than
+                      // mean "this screen pins nothing".
+                      const std::string none = md::writeGoldens({});
+                      checks.expect(none == "[]\n", std::format("a screen pinning nothing writes an empty array, got '{}'", none));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aBypassedGateIsARefusalNotADiagnostic{
+    "Compiling a screen that did not resolve is a bypassed gate, not a diagnostic",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-bypassed-gate")
+            .Given("a layout result carrying a diagnostic", [] {})
+            .When("it is handed to the package stage anyway", [] {})
+            .Then("the stage throws rather than compiling half a screen",
+                  [] {
+                      mdux::spec::Checks checks;
+                      md::LayoutResult   unresolved;
+                      unresolved.diagnostics.push_back(cli::Diagnostic{.file = "package.medui", .code = "MEDUI-E051"});
+
+                      bool threw = false;
+                      try {
+                          const md::ScreenDocument document = md::buildPackage(unresolved, {.id = "tiny", .budget = testBudget});
+                          checks.expect(document.package().nodes.empty(), "unreachable: the stage compiled a screen that did not resolve");
+                      } catch (const std::logic_error&) {
+                          threw = true;
+                      }
+                      checks.expect(threw, "an unresolved layout is refused as a bypassed gate");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -417,7 +417,10 @@ const mdux::spec::Register aBypassedGateIsARefusalNotADiagnostic{
                   [] {
                       mdux::spec::Checks checks;
                       md::LayoutResult   unresolved;
-                      unresolved.diagnostics.push_back(cli::Diagnostic{.file = "package.medui", .code = "MEDUI-E051"});
+                      cli::Diagnostic    overflow;
+                      overflow.file = "package.medui";
+                      overflow.code = "MEDUI-E051";
+                      unresolved.diagnostics.push_back(std::move(overflow));
 
                       bool threw = false;
                       try {

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -15,6 +15,7 @@
  */
 
 import std;
+import speclab;
 import mdux.draw;
 import mdux.medui.schema;
 import mdux.tools.cli;

--- a/tests/medui/fixtures/accepted-every-component.medui
+++ b/tests/medui/fixtures/accepted-every-component.medui
@@ -1,0 +1,108 @@
+// One screen carrying all eleven compiled payloads, for the package round trip (#197).
+//
+// Every component in the dictionary appears once, and the Row declares a background so the solver
+// synthesises the eleventh payload - a Panel, which an author cannot write. A round trip over this
+// screen therefore executes every branch of the writer and every branch of the reader, which is
+// what keeps the two halves of the file format in step: an assertion on either alone could not.
+//
+// Optional fields are declared where they change the emitted shape: `requirement:` on the Button
+// and the TextInput, `charset:` on the TextInput, and `colors:` on the StatusIndicator, so the
+// round trip covers a spec whose optional names are present as well as one where they are absent.
+Screen EveryComponent {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 800px, 700px;
+
+    Row {
+        id: topbar;
+        height: 64px;
+        background: Theme.Colors.TopbarBackground;
+
+        Label {
+            id: title;
+            width: Fill;
+            height: 64px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+    }
+
+    Clock {
+        id: wall-clock;
+        width: 200px;
+        height: 40px;
+        format: TimeSeconds;
+    }
+
+    Image {
+        id: logo;
+        width: 120px;
+        height: 60px;
+        source: img("IMG-LOGO");
+    }
+
+    VulkanViewport {
+        id: endoscope;
+        width: 640px;
+        height: 200px;
+        stream_source: "ENDOSCOPE";
+    }
+
+    SignalTrace {
+        id: ecg;
+        width: 640px;
+        height: 100px;
+        stream_source: "ECG_LEAD_II";
+        color: Theme.Colors.Nominal;
+    }
+
+    Button {
+        id: freeze;
+        width: 160px;
+        height: 40px;
+        label: t("STR-FREEZE");
+        color: Theme.Colors.PrimaryAction;
+        source: "FREEZE";
+        requirement: "REQ-EC-001";
+    }
+
+    CriticalButton {
+        id: halt;
+        requirement: "REQ-EC-002";
+        width: 160px;
+        height: 40px;
+        label: t("STR-HALT");
+        color: Theme.Colors.Fault;
+        on_press: TriggerHalt;
+    }
+
+    NumericDisplay {
+        id: sedation-index;
+        width: 200px;
+        height: 60px;
+        requirement: "REQ-EC-003";
+        template: "TPL-SEDATION-INDEX-160";
+        source: "SEDATION_INDEX";
+        color: Theme.Colors.ScoreDigits;
+    }
+
+    StatusIndicator {
+        id: state;
+        width: 200px;
+        height: 40px;
+        requirement: "REQ-EC-004";
+        source: "STATE";
+        states: [t("STR-OK"), t("STR-ALARM")];
+        colors: [Theme.Colors.Nominal, Theme.Colors.Alert];
+    }
+
+    TextInput {
+        id: patient-id;
+        width: 240px;
+        height: 40px;
+        source: "PATIENT_ID";
+        max_length: 16;
+        color: Theme.Colors.Neutral;
+        charset: Ascii;
+        requirement: "REQ-EC-005";
+    }
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,12 +271,17 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S7 (#196) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
+# At S8 (#197) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
 # integer-only bounded layout solver, the text-budget check that measures a resolved box against the
-# widest approved translation (#195), and the golden references that say where safety-critical
-# content must appear. The emitters are #197, and the mdux-meduic executable with its
+# widest approved translation (#195), the golden references that say where safety-critical content
+# must appear (#196), and the compiled-screen document with the canonical JSON it is committed as.
+# The C++ emitters are the second half of #197, and the mdux-meduic executable with its
 # mdux_compile_screen() registration is #198 - so there is still no add_executable() here and no
 # bake call site. Every later stage adds sources to this target rather than inventing another.
+#
+# The package stage reaches mdux.evidence.json and mdux.medui.schema through MduX::ToolsCommon's
+# link to MduX::Core, which is what the acceptance criterion on #197 asks for: the host compiler and
+# the device runtime import one definition of a compiled screen rather than two that can drift.
 #
 # The budget stage reaches mdux.text.draw and mdux.font.schema through MduX::ToolsCommon's link to
 # MduX::Core: it decodes committed run records with the same decoder the device draws them with, so
@@ -297,6 +302,7 @@ target_sources(MduXMeduiLib
             medui/Layout.cppm
             medui/TextBudget.cppm
             medui/Goldens.cppm
+            medui/Package.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -305,6 +311,7 @@ target_sources(MduXMeduiLib
         medui/Layout.cpp
         medui/TextBudget.cpp
         medui/Goldens.cpp
+        medui/Package.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -90,7 +90,21 @@ constexpr std::string_view schemaRefused = "SCP005";
         if (element == nullptr) {
             throw std::logic_error(std::format("field '{}' on {} holds an empty list element", name, node.component));
         }
-        names.push_back(element->text);
+        // Checked for the same reason `textOf()` checks: an element of some other domain carries no
+        // text, so taking it silently would put an empty name in a state key and surface as the
+        // schema refusing the package - a confusing report of a bypassed gate rather than a clear one.
+        switch (element->kind) {
+            case ast::ValueKind::String:
+            case ast::ValueKind::TextKey:
+            case ast::ValueKind::ImageRef:
+            case ast::ValueKind::ColorToken:
+            case ast::ValueKind::Identifier:
+                names.push_back(element->text);
+                break;
+            default:
+                throw std::logic_error(
+                    std::format("field '{}' on {} lists a value that is not a name: semantic analysis is a required gate", name, node.component));
+        }
     }
     return names;
 }

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -1,0 +1,847 @@
+/**
+ * @file Package.cpp
+ * @brief Implementation of the compiled-screen document and its canonical JSON form.
+ */
+
+module;
+
+module mdux.tools.medui.package;
+
+import std;
+import mdux.draw;
+import mdux.evidence.json;
+import mdux.evidence.report;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+namespace ms   = mdux::medui;
+namespace json = mdux::evidence::json;
+
+/// Stable diagnostic codes for a malformed committed artifact. Local to this tool, as
+/// `mdux-shaderemit`'s `SHE0NN` are; see the interface comment for why these are not `MEDUI-E0NN`.
+constexpr std::string_view bytesUnparsed = "SCP001";
+constexpr std::string_view memberWrong   = "SCP002";
+constexpr std::string_view memberUnknown = "SCP003";
+constexpr std::string_view kindUnknown   = "SCP004";
+constexpr std::string_view schemaRefused = "SCP005";
+
+// ---------------------------------------------------------------------------
+// Reading the AST a resolved node carries
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
+    const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
+    return found == node.fields.end() ? nullptr : &*found;
+}
+
+/// The text a field carries, or empty when the component did not declare it.
+///
+/// Every name-valued domain - `String`, `TextKey`, `ImageRef`, `ColorToken`, `Identifier` - stores
+/// its characters in the same AST member, so one accessor serves all five. A field holding some
+/// other domain means semantic analysis did not run, which is a bypassed gate rather than a
+/// malformed screen.
+[[nodiscard]] std::string_view textOf(const ast::Node& node, std::string_view name) {
+    const ast::Field* field = fieldFor(node, name);
+    if (field == nullptr || field->value == nullptr) {
+        return {};
+    }
+    switch (field->value->kind) {
+        case ast::ValueKind::String:
+        case ast::ValueKind::TextKey:
+        case ast::ValueKind::ImageRef:
+        case ast::ValueKind::ColorToken:
+        case ast::ValueKind::Identifier:
+            return field->value->text;
+        default:
+            throw std::logic_error(std::format("field '{}' on {} does not hold a name: semantic analysis is a required gate", name, node.component));
+    }
+}
+
+[[nodiscard]] std::int64_t numberOf(const ast::Node& node, std::string_view name) {
+    const ast::Field* field = fieldFor(node, name);
+    if (field == nullptr || field->value == nullptr) {
+        return 0;
+    }
+    if (field->value->kind != ast::ValueKind::Number) {
+        throw std::logic_error(std::format("field '{}' on {} does not hold a number: semantic analysis is a required gate", name, node.component));
+    }
+    return field->value->number;
+}
+
+/// The names in a list-valued field, in source order. Empty when the component declared none.
+[[nodiscard]] std::vector<std::string> listOf(const ast::Node& node, std::string_view name) {
+    const ast::Field* field = fieldFor(node, name);
+    if (field == nullptr || field->value == nullptr) {
+        return {};
+    }
+    if (field->value->kind != ast::ValueKind::List) {
+        throw std::logic_error(std::format("field '{}' on {} does not hold a list: semantic analysis is a required gate", name, node.component));
+    }
+    std::vector<std::string> names;
+    names.reserve(field->value->list.size());
+    for (const std::shared_ptr<ast::Value>& element : field->value->list) {
+        if (element == nullptr) {
+            throw std::logic_error(std::format("field '{}' on {} holds an empty list element", name, node.component));
+        }
+        names.push_back(element->text);
+    }
+    return names;
+}
+
+/**
+ * @brief The typed payload for one resolved node.
+ *
+ * The mapping from a dictionary field to a spec member is the whole content of this function, and
+ * it is spelled once here rather than being derivable: `text` on a `Label` and `label` on a
+ * `Button` are both a `textKey`, while `source` means a data stream on one component and an image
+ * package on another. A table keyed by field name could not express that.
+ */
+[[nodiscard]] ms::NodePayload payloadFor(const ResolvedNode& resolved, ScreenDocument& document) {
+    const ast::Node& source = resolved.source;
+    const auto       name   = [&](std::string_view field) {
+        return document.intern(textOf(source, field));
+    };
+
+    // The only synthetic node the solver produces, and the only way a Panel is ever compiled: an
+    // author cannot write one, because `Panel` is not in the component dictionary.
+    if (resolved.component == "Panel") {
+        return ms::PanelSpec{.colorToken = name("background")};
+    }
+    if (resolved.component == "Label") {
+        return ms::LabelSpec{.textKey = name("text"), .colorToken = name("color")};
+    }
+    if (resolved.component == "Clock") {
+        return ms::ClockSpec{.format = name("format")};
+    }
+    if (resolved.component == "Image") {
+        return ms::ImageSpec{.source = name("source")};
+    }
+    if (resolved.component == "VulkanViewport") {
+        return ms::VulkanViewportSpec{.streamSource = name("stream_source")};
+    }
+    if (resolved.component == "SignalTrace") {
+        return ms::SignalTraceSpec{.streamSource = name("stream_source"), .colorToken = name("color")};
+    }
+    if (resolved.component == "Button") {
+        return ms::ButtonSpec{.labelKey = name("label"), .colorToken = name("color"), .source = name("source"), .requirement = name("requirement")};
+    }
+    if (resolved.component == "CriticalButton") {
+        return ms::CriticalButtonSpec{.requirement = name("requirement"), .labelKey = name("label"), .colorToken = name("color"), .onPress = name("on_press")};
+    }
+    if (resolved.component == "NumericDisplay") {
+        return ms::NumericDisplaySpec{.requirement = name("requirement"),
+                                      .templateId  = name("template"),
+                                      .source      = name("source"),
+                                      .colorToken  = name("color")};
+    }
+    if (resolved.component == "StatusIndicator") {
+        return ms::StatusIndicatorSpec{.requirement = name("requirement"),
+                                       .source      = name("source"),
+                                       .stateKeys   = document.internList(listOf(source, "states")),
+                                       .colorTokens = document.internList(listOf(source, "colors"))};
+    }
+    if (resolved.component == "TextInput") {
+        return ms::TextInputSpec{.source      = name("source"),
+                                 .colorToken  = name("color"),
+                                 .maxLength   = numberOf(source, "max_length"),
+                                 .charset     = name("charset"),
+                                 .requirement = name("requirement")};
+    }
+    // `Row` reaches here only if the solver stopped flattening: a Row contributes its children and
+    // at most one synthetic background, never itself. Anything else is a component semantic
+    // analysis would have refused.
+    throw std::logic_error(std::format("no compiled payload for component '{}': semantic analysis is a required gate", resolved.component));
+}
+
+/// Narrows a solved coordinate to what the compiled schema carries.
+///
+/// The layout solver already refuses a surface wider than `std::int32_t` and every rectangle it
+/// resolves lies inside that surface, so a value out of range here means layout was bypassed.
+[[nodiscard]] std::int32_t narrow(std::int64_t value, std::string_view what) {
+    if (value < std::numeric_limits<std::int32_t>::min() || value > std::numeric_limits<std::int32_t>::max()) {
+        throw std::logic_error(std::format("{} is {}, which a compiled screen cannot carry: layout is a required gate", what, value));
+    }
+    return static_cast<std::int32_t>(value);
+}
+
+// ---------------------------------------------------------------------------
+// Writing
+// ---------------------------------------------------------------------------
+
+/// Inserts a member, turning the writer's `Result` into the exception a host tool may throw.
+void put(json::Value& object, std::string key, json::Value value) {
+    if (const auto inserted = object.set(std::move(key), std::move(value)); !inserted.has_value()) {
+        throw std::logic_error(std::format("canonical JSON refused a member: {}", json::describe(inserted.error().code)));
+    }
+}
+
+void putName(json::Value& object, std::string_view key, std::string_view value) {
+    // An optional name the component did not declare is omitted rather than written empty, as
+    // `goldens.json` omits an absent `textKey`. A required name is never empty in a validated
+    // package, so this cannot drop one.
+    if (value.empty()) {
+        return;
+    }
+    put(object, std::string{key}, json::Value::string(std::string{value}));
+}
+
+/// One rectangle, from the compiled schema's `NodeRect` or from the solver's `LayoutRect`.
+///
+/// A template rather than two overloads: the two types spell their members identically and differ
+/// only in integer width, so two bodies would be two places for the member names of a byte-compared
+/// artifact to drift apart.
+template <typename Rect>
+[[nodiscard]] json::Value writeRect(const Rect& bounds) {
+    json::Value object = json::Value::emptyObject();
+    put(object, "x", json::Value::integer(bounds.x));
+    put(object, "y", json::Value::integer(bounds.y));
+    put(object, "width", json::Value::integer(bounds.width));
+    put(object, "height", json::Value::integer(bounds.height));
+    return object;
+}
+
+[[nodiscard]] json::Value writeNames(std::span<const std::string_view> names) {
+    std::vector<json::Value> elements;
+    elements.reserve(names.size());
+    for (const std::string_view name : names) {
+        elements.push_back(json::Value::string(std::string{name}));
+    }
+    return json::Value::array(std::move(elements));
+}
+
+/// The `spec` object for one payload: the component's own fields, and nothing shared.
+[[nodiscard]] json::Value writeSpec(const ms::NodePayload& payload) {
+    json::Value spec = json::Value::emptyObject();
+
+    if (const auto* panel = std::get_if<ms::PanelSpec>(&payload)) {
+        putName(spec, "colorToken", panel->colorToken);
+    } else if (const auto* label = std::get_if<ms::LabelSpec>(&payload)) {
+        putName(spec, "colorToken", label->colorToken);
+        putName(spec, "textKey", label->textKey);
+    } else if (const auto* clock = std::get_if<ms::ClockSpec>(&payload)) {
+        putName(spec, "format", clock->format);
+    } else if (const auto* image = std::get_if<ms::ImageSpec>(&payload)) {
+        putName(spec, "source", image->source);
+    } else if (const auto* viewport = std::get_if<ms::VulkanViewportSpec>(&payload)) {
+        putName(spec, "streamSource", viewport->streamSource);
+    } else if (const auto* trace = std::get_if<ms::SignalTraceSpec>(&payload)) {
+        putName(spec, "colorToken", trace->colorToken);
+        putName(spec, "streamSource", trace->streamSource);
+    } else if (const auto* button = std::get_if<ms::ButtonSpec>(&payload)) {
+        putName(spec, "colorToken", button->colorToken);
+        putName(spec, "labelKey", button->labelKey);
+        putName(spec, "requirement", button->requirement);
+        putName(spec, "source", button->source);
+    } else if (const auto* critical = std::get_if<ms::CriticalButtonSpec>(&payload)) {
+        putName(spec, "colorToken", critical->colorToken);
+        putName(spec, "labelKey", critical->labelKey);
+        putName(spec, "onPress", critical->onPress);
+        putName(spec, "requirement", critical->requirement);
+    } else if (const auto* numeric = std::get_if<ms::NumericDisplaySpec>(&payload)) {
+        putName(spec, "colorToken", numeric->colorToken);
+        putName(spec, "requirement", numeric->requirement);
+        putName(spec, "source", numeric->source);
+        putName(spec, "templateId", numeric->templateId);
+    } else if (const auto* status = std::get_if<ms::StatusIndicatorSpec>(&payload)) {
+        // Written even when empty, unlike a name: an empty list is the component declaring no
+        // per-state tint, which is a different statement from a name it does not have.
+        put(spec, "colorTokens", writeNames(status->colorTokens));
+        putName(spec, "requirement", status->requirement);
+        putName(spec, "source", status->source);
+        put(spec, "stateKeys", writeNames(status->stateKeys));
+    } else if (const auto* input = std::get_if<ms::TextInputSpec>(&payload)) {
+        putName(spec, "charset", input->charset);
+        putName(spec, "colorToken", input->colorToken);
+        put(spec, "maxLength", json::Value::integer(input->maxLength));
+        putName(spec, "requirement", input->requirement);
+        putName(spec, "source", input->source);
+    } else {
+        // Unreachable for a validated package: `validate()` refuses an unknown payload, and
+        // `writePackage()` validates before rendering.
+        throw std::logic_error("a node carries a payload this writer does not know");
+    }
+    return spec;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// ScreenDocument
+// ---------------------------------------------------------------------------
+
+std::string_view ScreenDocument::intern(std::string_view text) {
+    if (text.empty()) {
+        return {};
+    }
+    return text_.emplace_back(text);
+}
+
+std::span<const std::string_view> ScreenDocument::internList(std::span<const std::string> items) {
+    std::vector<std::string_view>& views = lists_.emplace_back();
+    views.reserve(items.size());
+    for (const std::string& item : items) {
+        views.push_back(intern(item));
+    }
+    return views;
+}
+
+void ScreenDocument::setHeader(std::string_view id, std::int32_t surfaceWidth, std::int32_t surfaceHeight, mdux::draw::DrawBudget budget) {
+    id_            = intern(id);
+    surfaceWidth_  = surfaceWidth;
+    surfaceHeight_ = surfaceHeight;
+    budget_        = budget;
+}
+
+void ScreenDocument::addNode(ms::CompiledNode node) {
+    nodes_.push_back(std::move(node));
+}
+
+ms::ScreenPackage ScreenDocument::package() const noexcept {
+    return ms::ScreenPackage{.id            = id_,
+                             .schemaVersion = mdux::evidence::kSchemaVersion,
+                             .surfaceWidth  = surfaceWidth_,
+                             .surfaceHeight = surfaceHeight_,
+                             .nodes         = nodes_,
+                             .budget        = budget_};
+}
+
+// ---------------------------------------------------------------------------
+// Building from a resolved layout
+// ---------------------------------------------------------------------------
+
+ScreenDocument buildPackage(const LayoutResult& layout, PackageInputs inputs) {
+    if (!layout.ok()) {
+        throw std::logic_error("buildPackage was given a layout that did not resolve: layout is a required gate");
+    }
+
+    ScreenDocument document;
+    document.setHeader(inputs.id, narrow(layout.surfaceWidth, "surface width"), narrow(layout.surfaceHeight, "surface height"), inputs.budget);
+
+    for (const ResolvedNode& resolved : layout.nodes) {
+        document.addNode(ms::CompiledNode{
+            .id      = document.intern(resolved.id),
+            .bounds  = ms::NodeRect{.x      = narrow(resolved.bounds.x, "node x"),
+                                    .y      = narrow(resolved.bounds.y, "node y"),
+                                    .width  = narrow(resolved.bounds.width, "node width"),
+                                    .height = narrow(resolved.bounds.height, "node height")},
+            .payload = payloadFor(resolved, document)
+        });
+    }
+
+    if (const auto valid = document.package().validate(); !valid.has_value()) {
+        throw std::logic_error(std::format("the compiled screen does not satisfy its own schema: {}", ms::describe(valid.error())));
+    }
+    return document;
+}
+
+// ---------------------------------------------------------------------------
+// Writing
+// ---------------------------------------------------------------------------
+
+std::string writePackage(const ms::ScreenPackage& package) {
+    if (const auto valid = package.validate(); !valid.has_value()) {
+        throw std::logic_error(std::format("refusing to write a screen the schema rejects: {}", ms::describe(valid.error())));
+    }
+
+    std::vector<json::Value> nodes;
+    nodes.reserve(package.nodes.size());
+    for (const ms::CompiledNode& node : package.nodes) {
+        json::Value entry = json::Value::emptyObject();
+        put(entry, "bounds", writeRect(node.bounds));
+        put(entry, "id", json::Value::string(std::string{node.id}));
+        put(entry, "kind", json::Value::string(std::string{ms::kindName(node)}));
+        put(entry, "spec", writeSpec(node.payload));
+        nodes.push_back(std::move(entry));
+    }
+
+    json::Value budget = json::Value::emptyObject();
+    put(budget, "maxCommands", json::Value::unsignedInteger(package.budget.maxCommands));
+    put(budget, "maxIndices", json::Value::unsignedInteger(package.budget.maxIndices));
+    put(budget, "maxVertices", json::Value::unsignedInteger(package.budget.maxVertices));
+
+    json::Value root = json::Value::emptyObject();
+    put(root, "budget", std::move(budget));
+    put(root, "id", json::Value::string(std::string{package.id}));
+    put(root, "kind", json::Value::string(std::string{ms::packageKind}));
+    put(root, "nodes", json::Value::array(std::move(nodes)));
+    put(root, "schemaVersion", json::Value::unsignedInteger(package.schemaVersion));
+    put(root, "surfaceHeight", json::Value::integer(package.surfaceHeight));
+    put(root, "surfaceWidth", json::Value::integer(package.surfaceWidth));
+
+    auto written = json::write(root);
+    if (!written.has_value()) {
+        throw std::logic_error(std::format("canonical JSON refused the screen: {}", json::describe(written.error().code)));
+    }
+    return std::move(*written);
+}
+
+std::string writeGoldens(std::span<const GoldenReference> goldens) {
+    std::vector<json::Value> entries;
+    entries.reserve(goldens.size());
+    for (const GoldenReference& golden : goldens) {
+        std::vector<json::Value> checks;
+        checks.reserve(golden.cvChecks.size());
+        for (const CvCheck check : golden.cvChecks) {
+            checks.push_back(json::Value::string(std::string{spell(check)}));
+        }
+
+        json::Value entry = json::Value::emptyObject();
+        put(entry, "bounds", writeRect(golden.bounds));
+        putName(entry, "colorToken", golden.colorToken);
+        put(entry, "cvChecks", json::Value::array(std::move(checks)));
+        put(entry, "nodeId", json::Value::string(golden.nodeId));
+        putName(entry, "textKey", golden.textKey);
+        entries.push_back(std::move(entry));
+    }
+
+    // An empty array rather than no file: ADR-012 makes all three outputs unconditional, because
+    // `mdux_bake_artifact()` declares each as a build output and a skipped one breaks the
+    // byte-comparison test rather than meaning "this screen pins nothing".
+    auto written = json::write(json::Value::array(std::move(entries)));
+    if (!written.has_value()) {
+        throw std::logic_error(std::format("canonical JSON refused the golden references: {}", json::describe(written.error().code)));
+    }
+    return std::move(*written);
+}
+
+
+// ---------------------------------------------------------------------------
+// Reading
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Where a read failure goes, and the file it names.
+///
+/// Every helper returns false or nullopt after reporting, so a caller stops at the first failure.
+/// Deliberately not an accumulating pass like the authoring stages: those report on a source a
+/// human is editing, where a list of problems saves round trips. This reads a generated, reviewed,
+/// byte-compared artifact - if it is malformed at all, the first place it stops being canonical is
+/// the actionable fact.
+class Sink {
+public:
+    Sink(std::string file, std::vector<mdux::tools::cli::Diagnostic>& diagnostics) : file_{std::move(file)}, diagnostics_{&diagnostics} {}
+
+    bool fail(std::string_view code, std::string message, std::string fixHint = {}) const {
+        diagnostics_->push_back(mdux::tools::cli::Diagnostic{.file     = file_,
+                                                             .code     = std::string{code},
+                                                             .severity = mdux::tools::cli::Severity::Error,
+                                                             .message  = std::move(message),
+                                                             .fixHint  = std::move(fixHint)});
+        return false;
+    }
+
+private:
+    std::string                                file_;
+    std::vector<mdux::tools::cli::Diagnostic>* diagnostics_;
+};
+
+/// Checks that `value` is an object and carries no member outside `allowed`.
+///
+/// Rejecting an unknown member is the fail-closed direction for a reviewed artifact: a member this
+/// reader ignored would be one a reviewer believed was doing something.
+[[nodiscard]] bool expectObject(const json::Value& value, std::string_view what, std::span<const std::string_view> allowed, const Sink& sink) {
+    if (value.kind() != json::Value::Kind::Object) {
+        return sink.fail(memberWrong, std::format("{} is not an object", what));
+    }
+    for (const json::Member& member : value.members()) {
+        if (std::ranges::find(allowed, member.key) == allowed.end()) {
+            return sink.fail(memberUnknown,
+                             std::format("{} carries a member '{}' the compiled-screen format does not define", what, member.key),
+                             "the format is fixed by ADR-012; a member that is not in it means the file was hand-edited or written by "
+                             "another tool");
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::optional<std::string> readName(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        return std::string{};
+    }
+    const auto text = member->asString();
+    if (!text.has_value()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not a string", what, key));
+        return std::nullopt;
+    }
+    return std::string{*text};
+}
+
+[[nodiscard]] std::optional<std::int64_t> readInteger(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        sink.fail(memberWrong, std::format("{} is missing the member '{}'", what, key));
+        return std::nullopt;
+    }
+    const auto number = member->asInt();
+    if (!number.has_value()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not an integer", what, key));
+        return std::nullopt;
+    }
+    return *number;
+}
+
+[[nodiscard]] std::optional<std::int32_t> readInt32(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const auto number = readInteger(object, key, what, sink);
+    if (!number.has_value()) {
+        return std::nullopt;
+    }
+    if (*number < std::numeric_limits<std::int32_t>::min() || *number > std::numeric_limits<std::int32_t>::max()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is {}, which a compiled screen cannot carry", what, key, *number));
+        return std::nullopt;
+    }
+    return static_cast<std::int32_t>(*number);
+}
+
+[[nodiscard]] std::optional<std::uint32_t> readUInt32(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const auto number = readInteger(object, key, what, sink);
+    if (!number.has_value()) {
+        return std::nullopt;
+    }
+    if (*number < 0 || *number > std::numeric_limits<std::uint32_t>::max()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is {}, which is outside a draw budget's range", what, key, *number));
+        return std::nullopt;
+    }
+    return static_cast<std::uint32_t>(*number);
+}
+
+/// A list-valued spec member, absent meaning empty.
+[[nodiscard]] std::optional<std::vector<std::string>> readNames(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        return std::vector<std::string>{};
+    }
+    if (member->kind() != json::Value::Kind::Array) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not an array", what, key));
+        return std::nullopt;
+    }
+    std::vector<std::string> names;
+    names.reserve(member->elements().size());
+    for (const json::Value& element : member->elements()) {
+        const auto text = element.asString();
+        if (!text.has_value()) {
+            sink.fail(memberWrong, std::format("{} member '{}' holds a value that is not a string", what, key));
+            return std::nullopt;
+        }
+        names.emplace_back(*text);
+    }
+    return names;
+}
+
+[[nodiscard]] std::optional<ms::NodeRect> readRect(const json::Value& node, std::string_view what, const Sink& sink) {
+    static constexpr std::array<std::string_view, 4> allowed{"height", "width", "x", "y"};
+    const json::Value*                               member = node.find("bounds");
+    if (member == nullptr) {
+        sink.fail(memberWrong, std::format("{} is missing the member 'bounds'", what));
+        return std::nullopt;
+    }
+    if (!expectObject(*member, std::format("{} bounds", what), allowed, sink)) {
+        return std::nullopt;
+    }
+    const auto x      = readInt32(*member, "x", what, sink);
+    const auto y      = readInt32(*member, "y", what, sink);
+    const auto width  = readInt32(*member, "width", what, sink);
+    const auto height = readInt32(*member, "height", what, sink);
+    if (!x.has_value() || !y.has_value() || !width.has_value() || !height.has_value()) {
+        return std::nullopt;
+    }
+    return ms::NodeRect{.x = *x, .y = *y, .width = *width, .height = *height};
+}
+
+/**
+ * @brief Reads one node's `spec` into the payload its `kind` names.
+ *
+ * Every name is read as optional here, and that is not laxity: which names a component *must*
+ * declare is fixed by the dictionary and enforced by `validatePayload()`, which runs over the whole
+ * package a few lines later. Listing the required ones again in this reader would be a second
+ * authority on the same question, free to drift from the first.
+ */
+[[nodiscard]] bool
+readSpec(const json::Value& node, std::string_view kind, std::string_view what, ScreenDocument& document, ms::NodePayload& payload, const Sink& sink) {
+    const json::Value* spec = node.find("spec");
+    if (spec == nullptr) {
+        return sink.fail(memberWrong, std::format("{} is missing the member 'spec'", what));
+    }
+    const std::string where = std::format("{} spec", what);
+
+    // One list per kind, in the order `writeSpec()` writes them. The round-trip scenario in
+    // PackageTests executes both directions over one screen, which is what keeps these in step -
+    // an assertion on either half alone could not.
+    static constexpr std::array<std::string_view, 1> panelMembers{"colorToken"};
+    static constexpr std::array<std::string_view, 2> labelMembers{"colorToken", "textKey"};
+    static constexpr std::array<std::string_view, 1> clockMembers{"format"};
+    static constexpr std::array<std::string_view, 1> imageMembers{"source"};
+    static constexpr std::array<std::string_view, 1> viewportMembers{"streamSource"};
+    static constexpr std::array<std::string_view, 2> traceMembers{"colorToken", "streamSource"};
+    static constexpr std::array<std::string_view, 4> buttonMembers{"colorToken", "labelKey", "requirement", "source"};
+    static constexpr std::array<std::string_view, 4> criticalMembers{"colorToken", "labelKey", "onPress", "requirement"};
+    static constexpr std::array<std::string_view, 4> numericMembers{"colorToken", "requirement", "source", "templateId"};
+    static constexpr std::array<std::string_view, 4> statusMembers{"colorTokens", "requirement", "source", "stateKeys"};
+    static constexpr std::array<std::string_view, 5> inputMembers{"charset", "colorToken", "maxLength", "requirement", "source"};
+
+    // Interns one spec name. The member set has already been checked by `expectObject()` on the
+    // branch that calls this, so what remains is reading the names the kind admits.
+    const auto name = [&](std::string_view key) -> std::optional<std::string_view> {
+        const auto text = readName(*spec, key, where, sink);
+        if (!text.has_value()) {
+            return std::nullopt;
+        }
+        return document.intern(*text);
+    };
+
+    if (kind == "Panel") {
+        if (!expectObject(*spec, where, panelMembers, sink)) {
+            return false;
+        }
+        const auto colorToken = name("colorToken");
+        if (!colorToken.has_value()) {
+            return false;
+        }
+        payload = ms::PanelSpec{.colorToken = *colorToken};
+        return true;
+    }
+    if (kind == "Label") {
+        if (!expectObject(*spec, where, labelMembers, sink)) {
+            return false;
+        }
+        const auto textKey    = name("textKey");
+        const auto colorToken = name("colorToken");
+        if (!textKey.has_value() || !colorToken.has_value()) {
+            return false;
+        }
+        payload = ms::LabelSpec{.textKey = *textKey, .colorToken = *colorToken};
+        return true;
+    }
+    if (kind == "Clock") {
+        if (!expectObject(*spec, where, clockMembers, sink)) {
+            return false;
+        }
+        const auto format = name("format");
+        if (!format.has_value()) {
+            return false;
+        }
+        payload = ms::ClockSpec{.format = *format};
+        return true;
+    }
+    if (kind == "Image") {
+        if (!expectObject(*spec, where, imageMembers, sink)) {
+            return false;
+        }
+        const auto source = name("source");
+        if (!source.has_value()) {
+            return false;
+        }
+        payload = ms::ImageSpec{.source = *source};
+        return true;
+    }
+    if (kind == "VulkanViewport") {
+        if (!expectObject(*spec, where, viewportMembers, sink)) {
+            return false;
+        }
+        const auto streamSource = name("streamSource");
+        if (!streamSource.has_value()) {
+            return false;
+        }
+        payload = ms::VulkanViewportSpec{.streamSource = *streamSource};
+        return true;
+    }
+    if (kind == "SignalTrace") {
+        if (!expectObject(*spec, where, traceMembers, sink)) {
+            return false;
+        }
+        const auto streamSource = name("streamSource");
+        const auto colorToken   = name("colorToken");
+        if (!streamSource.has_value() || !colorToken.has_value()) {
+            return false;
+        }
+        payload = ms::SignalTraceSpec{.streamSource = *streamSource, .colorToken = *colorToken};
+        return true;
+    }
+    if (kind == "Button") {
+        if (!expectObject(*spec, where, buttonMembers, sink)) {
+            return false;
+        }
+        const auto labelKey    = name("labelKey");
+        const auto colorToken  = name("colorToken");
+        const auto source      = name("source");
+        const auto requirement = name("requirement");
+        if (!labelKey.has_value() || !colorToken.has_value() || !source.has_value() || !requirement.has_value()) {
+            return false;
+        }
+        payload = ms::ButtonSpec{.labelKey = *labelKey, .colorToken = *colorToken, .source = *source, .requirement = *requirement};
+        return true;
+    }
+    if (kind == "CriticalButton") {
+        if (!expectObject(*spec, where, criticalMembers, sink)) {
+            return false;
+        }
+        const auto requirement = name("requirement");
+        const auto labelKey    = name("labelKey");
+        const auto colorToken  = name("colorToken");
+        const auto onPress     = name("onPress");
+        if (!requirement.has_value() || !labelKey.has_value() || !colorToken.has_value() || !onPress.has_value()) {
+            return false;
+        }
+        payload = ms::CriticalButtonSpec{.requirement = *requirement, .labelKey = *labelKey, .colorToken = *colorToken, .onPress = *onPress};
+        return true;
+    }
+    if (kind == "NumericDisplay") {
+        if (!expectObject(*spec, where, numericMembers, sink)) {
+            return false;
+        }
+        const auto requirement = name("requirement");
+        const auto templateId  = name("templateId");
+        const auto source      = name("source");
+        const auto colorToken  = name("colorToken");
+        if (!requirement.has_value() || !templateId.has_value() || !source.has_value() || !colorToken.has_value()) {
+            return false;
+        }
+        payload = ms::NumericDisplaySpec{.requirement = *requirement, .templateId = *templateId, .source = *source, .colorToken = *colorToken};
+        return true;
+    }
+    if (kind == "StatusIndicator") {
+        if (!expectObject(*spec, where, statusMembers, sink)) {
+            return false;
+        }
+        const auto requirement = name("requirement");
+        const auto source      = name("source");
+        const auto stateKeys   = readNames(*spec, "stateKeys", where, sink);
+        const auto colorTokens = readNames(*spec, "colorTokens", where, sink);
+        if (!requirement.has_value() || !source.has_value() || !stateKeys.has_value() || !colorTokens.has_value()) {
+            return false;
+        }
+        payload = ms::StatusIndicatorSpec{.requirement = *requirement,
+                                          .source      = *source,
+                                          .stateKeys   = document.internList(*stateKeys),
+                                          .colorTokens = document.internList(*colorTokens)};
+        return true;
+    }
+    if (kind == "TextInput") {
+        if (!expectObject(*spec, where, inputMembers, sink)) {
+            return false;
+        }
+        const auto source      = name("source");
+        const auto colorToken  = name("colorToken");
+        const auto maxLength   = readInteger(*spec, "maxLength", where, sink);
+        const auto charset     = name("charset");
+        const auto requirement = name("requirement");
+        if (!source.has_value() || !colorToken.has_value() || !maxLength.has_value() || !charset.has_value() || !requirement.has_value()) {
+            return false;
+        }
+        payload = ms::TextInputSpec{.source = *source, .colorToken = *colorToken, .maxLength = *maxLength, .charset = *charset, .requirement = *requirement};
+        return true;
+    }
+    return sink.fail(kindUnknown,
+                     std::format("{} names the component '{}', which is not in the dictionary", what, kind),
+                     "a compiled node's kind is one of the eleven ADR-011 fixes");
+}
+
+}  // namespace
+
+PackageReadResult readPackage(std::string_view text, std::string file) {
+    PackageReadResult result;
+    const Sink        sink{std::move(file), result.diagnostics};
+
+    auto parsed = json::parse(text);
+    if (!parsed.has_value()) {
+        sink.fail(bytesUnparsed,
+                  std::format("the file is not canonical JSON: {} at byte {}", json::describe(parsed.error().code), parsed.error().offset),
+                  "canonical form is what mdux.evidence.json writes; re-bake rather than editing the artifact");
+        return result;
+    }
+
+    static constexpr std::array<std::string_view, 7> rootMembers{"budget", "id", "kind", "nodes", "schemaVersion", "surfaceHeight", "surfaceWidth"};
+    static constexpr std::array<std::string_view, 3> budgetMembers{"maxCommands", "maxIndices", "maxVertices"};
+    static constexpr std::array<std::string_view, 4> nodeMembers{"bounds", "id", "kind", "spec"};
+
+    const json::Value& root = *parsed;
+    if (!expectObject(root, "the package", rootMembers, sink)) {
+        return result;
+    }
+
+    const auto id            = readName(root, "id", "the package", sink);
+    const auto kind          = readName(root, "kind", "the package", sink);
+    const auto schemaVersion = readInteger(root, "schemaVersion", "the package", sink);
+    const auto surfaceWidth  = readInt32(root, "surfaceWidth", "the package", sink);
+    const auto surfaceHeight = readInt32(root, "surfaceHeight", "the package", sink);
+    if (!id.has_value() || !kind.has_value() || !schemaVersion.has_value() || !surfaceWidth.has_value() || !surfaceHeight.has_value()) {
+        return result;
+    }
+    if (*kind != ms::packageKind) {
+        sink.fail(memberWrong, std::format("the package names the kind '{}' rather than '{}'", *kind, ms::packageKind));
+        return result;
+    }
+    if (static_cast<std::uint64_t>(*schemaVersion) != mdux::evidence::kSchemaVersion) {
+        sink.fail(memberWrong,
+                  std::format("the package declares schema version {}, and this build reads version {}", *schemaVersion, mdux::evidence::kSchemaVersion));
+        return result;
+    }
+
+    const json::Value* budgetValue = root.find("budget");
+    if (budgetValue == nullptr) {
+        sink.fail(memberWrong, "the package is missing the member 'budget'");
+        return result;
+    }
+    if (!expectObject(*budgetValue, "the budget", budgetMembers, sink)) {
+        return result;
+    }
+    const auto maxVertices = readUInt32(*budgetValue, "maxVertices", "the budget", sink);
+    const auto maxIndices  = readUInt32(*budgetValue, "maxIndices", "the budget", sink);
+    const auto maxCommands = readUInt32(*budgetValue, "maxCommands", "the budget", sink);
+    if (!maxVertices.has_value() || !maxIndices.has_value() || !maxCommands.has_value()) {
+        return result;
+    }
+
+    ScreenDocument document;
+    document.setHeader(*id,
+                       *surfaceWidth,
+                       *surfaceHeight,
+                       mdux::draw::DrawBudget{.maxVertices = *maxVertices, .maxIndices = *maxIndices, .maxCommands = *maxCommands});
+
+    const json::Value* nodes = root.find("nodes");
+    if (nodes == nullptr || nodes->kind() != json::Value::Kind::Array) {
+        sink.fail(memberWrong, "the package member 'nodes' is missing or is not an array");
+        return result;
+    }
+
+    for (std::size_t index = 0; index < nodes->elements().size(); ++index) {
+        const json::Value& entry = nodes->elements()[index];
+        const std::string  what  = std::format("node {}", index);
+        if (!expectObject(entry, what, nodeMembers, sink)) {
+            return result;
+        }
+        const auto nodeId   = readName(entry, "id", what, sink);
+        const auto nodeKind = readName(entry, "kind", what, sink);
+        const auto bounds   = readRect(entry, what, sink);
+        if (!nodeId.has_value() || !nodeKind.has_value() || !bounds.has_value()) {
+            return result;
+        }
+        ms::NodePayload payload;
+        if (!readSpec(entry, *nodeKind, what, document, payload, sink)) {
+            return result;
+        }
+        document.addNode(ms::CompiledNode{.id = document.intern(*nodeId), .bounds = *bounds, .payload = payload});
+    }
+
+    // The same check a device runs, and the reason this reader does not repeat the dictionary's
+    // required-name rules itself: one authority decides what a compiled screen must contain.
+    if (const auto valid = document.package().validate(); !valid.has_value()) {
+        sink.fail(schemaRefused,
+                  std::format("the screen the file describes is not valid: {}", ms::describe(valid.error())),
+                  "re-bake the screen from its source rather than editing the artifact");
+        return result;
+    }
+
+    result.document = std::move(document);
+    return result;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Package.cppm
+++ b/tools/medui/Package.cppm
@@ -1,0 +1,220 @@
+/**
+ * @file Package.cppm
+ * @brief The compiled screen as a document a host tool owns, and as the canonical JSON bytes that
+ *        document is committed as.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine (canonical form, byte-identity)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Host-only, and the stage where the compiler's own types stop and the shared ones begin. Every
+ * earlier stage works on the AST and the layout: types that own their strings, carry positions, and
+ * exist to produce diagnostics. `mdux::medui::ScreenPackage` is none of those things - it is what a
+ * device holds, non-owning and `constexpr`-constructible, so that a generated translation unit can
+ * place one in read-only memory. This module is the join.
+ *
+ * ## Why a document, and not just a package
+ *
+ * `ScreenPackage` is a view: `std::string_view` names and `std::span` nodes, pointing at storage
+ * somebody else owns. That is exactly right for generated code, where the storage is namespace-scope
+ * `constexpr` data with static lifetime, and unusable on the host, where the strings are built at run
+ * time from a file.
+ *
+ * `ScreenDocument` is that missing owner. It holds the text and the nodes, and hands out a
+ * `ScreenPackage` viewing them - so the host compiler and the device runtime share **one** definition
+ * of what a compiled screen is, which is the property #197 exists to deliver. The alternative, a
+ * second host-side screen type with owning members, is two definitions that agree until they do not.
+ *
+ * Text is interned in a `std::deque<std::string>` rather than a `std::vector<std::string>`, and the
+ * reason is not style. A `std::string` short enough for the small-string optimisation stores its
+ * characters inside the object, so moving that object moves the characters and every `string_view`
+ * onto them dangles. A deque never relocates an element it already holds, and the container
+ * requirements keep references valid across the deque's own move - so a document may be returned by
+ * value, which every function here does, without invalidating the package it hands out.
+ *
+ * Copying is deleted for the same reason, stated as a rule rather than left to be discovered: a
+ * copied document would hold copied strings while its nodes still viewed the original's. There is no
+ * correct memberwise copy, so there is none.
+ *
+ * ## What the artifact contains, and what it deliberately does not
+ *
+ * `package.json` carries the compiled nodes, their absolute rectangles, the draw budget, and the
+ * validated names each node draws with. It carries no resolved colour, no glyph run, no locale and
+ * no vertex - ADR-011 fixes that boundary and ADR-012 explains it. One consequence is worth naming
+ * because it is unusual for this repository: **a screen package contains no floating-point number at
+ * all**, so the `{"bits": N}` encoding that ADR-007 requires for a float never appears in one. Every
+ * number here is an integer the layout solver computed in integer arithmetic.
+ *
+ * ## The JSON shape
+ *
+ * Members are camelCase, as ADR-012 decision 1 fixes for all three files in a screen's directory.
+ * A node names its component in `kind` and carries that component's own fields in `spec`:
+ *
+ * ```json
+ * { "bounds": { "height": 60, "width": 120, "x": 250, "y": 60 },
+ *   "id": "score",
+ *   "kind": "NumericDisplay",
+ *   "spec": { "colorToken": "Theme.Colors.ScoreDigits",
+ *             "requirement": "REQ-NS-001",
+ *             "source": "SEDATION_INDEX",
+ *             "templateId": "TPL-SEDATION-INDEX-160" } }
+ * ```
+ *
+ * One member name for the payload rather than eleven named after their components: a reader that
+ * switches on `kind` reads `spec` whatever the answer, and adding a component to the dictionary adds
+ * no member name to the file format. The variant's alternative *index* is never written - `kind`
+ * holds the dictionary spelling, so an alternative may be added to `NodePayload` without renumbering
+ * a committed artifact.
+ *
+ * The example is in the byte order the file actually has, because `mdux.evidence.json` sorts every
+ * object's members lexicographically and these artifacts are byte-compared across toolchains. An
+ * optional name the component did not declare is omitted rather than written empty, matching what
+ * `goldens.json` already does with `textKey` and `colorToken`.
+ *
+ * ## Reading is as strict as writing
+ *
+ * `readPackage()` rejects a member it does not know, in either the package or a spec. That is
+ * deliberate and it is the fail-closed direction: these files are reviewed and byte-compared, so a
+ * member the reader silently ignored would be a member a reviewer believed was doing something. It
+ * also rejects a `kind` outside the dictionary, a spec whose shape does not match its `kind`, and a
+ * package the schema refuses - the same `validate()` a device would run, so a hand-edited artifact
+ * fails here rather than at the `static_assert` in generated code with no file name attached.
+ */
+module;
+
+export module mdux.tools.medui.package;
+
+import std;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief What a compiled screen needs that its source does not carry.
+ *
+ * `id` is the artifact slug - `generated/screen/<id>/` - which ADR-012 requires to match
+ * `^[a-z0-9][a-z0-9-]*$` while a screen's name in the grammar is CamelCase. The mapping is the
+ * recipe's business (#198); this stage records the slug it is given.
+ *
+ * `budget` is **declared, not computed**. Computing it needs a per-component cost model, and that
+ * model is the runtime's: #199 owns how a node becomes vertices, and a bound this stage invented
+ * would be a second answer to a question the runtime has not yet answered once. Until then the
+ * product declares its ceiling in the recipe, the schema refuses an empty one on a screen with
+ * nodes, and `DrawList` fails closed against it at run time.
+ */
+struct PackageInputs {
+    std::string_view       id;
+    mdux::draw::DrawBudget budget{};
+};
+
+/**
+ * @brief A compiled screen with its storage: the owner a `ScreenPackage` view points into.
+ *
+ * Move-only. See the module comment for why copying cannot be written correctly and why the text
+ * lives in a deque.
+ */
+class ScreenDocument {
+public:
+    ScreenDocument() = default;
+
+    ScreenDocument(const ScreenDocument&)            = delete;
+    ScreenDocument& operator=(const ScreenDocument&) = delete;
+    ScreenDocument(ScreenDocument&&)                 = default;
+    ScreenDocument& operator=(ScreenDocument&&)      = default;
+    ~ScreenDocument()                                = default;
+
+    /// The screen, as the device's own type. Views this document; valid while it lives.
+    [[nodiscard]] mdux::medui::ScreenPackage package() const noexcept;
+
+    /// Records the header. Interns `id`, so the caller's storage need not outlive the call.
+    void setHeader(std::string_view id, std::int32_t surfaceWidth, std::int32_t surfaceHeight, mdux::draw::DrawBudget budget);
+
+    /// Appends a node. Its views must already point into this document - `intern()` produces them.
+    ///
+    /// Invalidates any package previously obtained from `package()`, whose node span is a view of a
+    /// vector this grows. Call it again after the last node rather than holding one across a build.
+    void addNode(mdux::medui::CompiledNode node);
+
+    /// Interns text and returns a stable view of the copy this document now owns.
+    ///
+    /// Empty text interns to an empty view without storing anything: "absent" is a legal value for
+    /// every optional name, and it is not worth a deque entry.
+    [[nodiscard]] std::string_view intern(std::string_view text);
+
+    /// Interns a list of names and returns a stable span of the views, for a `StatusIndicator`'s
+    /// parallel `stateKeys` and `colorTokens`.
+    [[nodiscard]] std::span<const std::string_view> internList(std::span<const std::string> items);
+
+private:
+    std::deque<std::string>                   text_;
+    std::deque<std::vector<std::string_view>> lists_;
+    std::vector<mdux::medui::CompiledNode>    nodes_;
+    std::string_view                          id_;
+    std::int32_t                              surfaceWidth_{0};
+    std::int32_t                              surfaceHeight_{0};
+    mdux::draw::DrawBudget                    budget_{};
+};
+
+/**
+ * @brief Builds the compiled screen from a resolved layout.
+ *
+ * Returns a document rather than a result type with a diagnostic list, for the reason
+ * `collectGoldens()` gives: every rule that can reject a screen was decided by an earlier stage, and
+ * a permanently empty diagnostic vector would suggest this one can reject a screen when it cannot.
+ * The component dictionary was checked by semantic analysis, the rectangles by the layout solver,
+ * and - the case #197 raised as an open gap - **compiled** id uniqueness by the layout solver too,
+ * which re-runs it after synthesising a Row's background node (`Layout.cpp`, `validateUniqueIds()`).
+ * That gap is therefore closed upstream, and this stage inherits the guarantee rather than repeating
+ * the check.
+ *
+ * A screen reaching here that breaks any of those means a gate was bypassed - the AST is public and
+ * can be built by hand - and throws, as layout and goldens do for the same reason. So does a budget
+ * the schema refuses: `PackageInputs` documents it as a precondition the recipe reader diagnoses,
+ * because this stage has no diagnostic code for a recipe's value and inventing one is the mistake
+ * #219 exists to avoid repeating.
+ *
+ * @throws std::logic_error if a gate was bypassed, or if the resulting package does not validate.
+ */
+[[nodiscard]] ScreenDocument buildPackage(const LayoutResult& layout, PackageInputs inputs);
+
+/// The canonical `package.json` bytes for a validated screen, trailing newline included.
+///
+/// @throws std::logic_error if the package does not validate, or if a name is not valid UTF-8 - both
+///         of which mean it did not come from `buildPackage()` or `readPackage()`.
+[[nodiscard]] std::string writePackage(const mdux::medui::ScreenPackage& package);
+
+/// The canonical `goldens.json` bytes: ADR-012's sidecar, written as `[]` when a screen pins nothing.
+///
+/// @throws std::logic_error if a reference carries text that is not valid UTF-8.
+[[nodiscard]] std::string writeGoldens(std::span<const GoldenReference> goldens);
+
+/// A screen read back from committed bytes, and any diagnostic that prevented one.
+///
+/// `document` is meaningful only when `diagnostics` is empty; a failed read leaves it empty rather
+/// than partially filled, so a caller cannot consume half a screen.
+struct PackageReadResult {
+    ScreenDocument                            document;
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Parses canonical `package.json` bytes into a document.
+ *
+ * Strict in the ways the module comment describes. Diagnostics carry `SCP0NN` codes, a family local
+ * to this tool in the same sense as `mdux-shaderemit`'s `SHE0NN` - the `MEDUI-E0NN` registry is the
+ * shared contract for what a *screen source* may say, and a malformed committed artifact is not that.
+ *
+ * @param file the path to name in diagnostics, e.g. `generated/screen/neurosense-500/package.json`
+ */
+[[nodiscard]] PackageReadResult readPackage(std::string_view text, std::string file);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Package.cppm
+++ b/tools/medui/Package.cppm
@@ -30,8 +30,15 @@
  * reason is not style. A `std::string` short enough for the small-string optimisation stores its
  * characters inside the object, so moving that object moves the characters and every `string_view`
  * onto them dangles. A deque never relocates an element it already holds, and the container
- * requirements keep references valid across the deque's own move - so a document may be returned by
- * value, which every function here does, without invalidating the package it hands out.
+ * requirements keep references to its elements valid across both the deque's move construction and
+ * its move assignment - the latter because `std::allocator` propagates on move assignment, which
+ * makes that operation an adoption of the existing storage rather than a relocation of elements. So
+ * a document may be returned by value, which every function here does, and move-assigned into a
+ * result, which `readPackage()` does, without invalidating the package it hands out.
+ *
+ * That is the whole justification for the defaulted move operations on a type full of views, so it
+ * is asserted rather than argued: a scenario moves a document both ways and reads every name back
+ * through the package afterwards.
  *
  * Copying is deleted for the same reason, stated as a rule rather than left to be discovered: a
  * copied document would hold copied strings while its nodes still viewed the original's. There is no
@@ -124,9 +131,12 @@ public:
 
     ScreenDocument(const ScreenDocument&)            = delete;
     ScreenDocument& operator=(const ScreenDocument&) = delete;
-    ScreenDocument(ScreenDocument&&)                 = default;
-    ScreenDocument& operator=(ScreenDocument&&)      = default;
-    ~ScreenDocument()                                = default;
+
+    /// Moving is safe, and not by accident: see the module comment for why a deque's elements
+    /// survive both move operations, and `medui-package-survives-a-move` for the assertion of it.
+    ScreenDocument(ScreenDocument&&)            = default;
+    ScreenDocument& operator=(ScreenDocument&&) = default;
+    ~ScreenDocument()                           = default;
 
     /// The screen, as the device's own type. Views this document; valid while it lives.
     [[nodiscard]] mdux::medui::ScreenPackage package() const noexcept;


### PR DESCRIPTION
First of two for S8. This one turns a resolved layout into a compiled screen and into the bytes that
screen is committed as; the C++ emitters, the `mdux-screenemit` executable and the dual-form parity
test follow in the second, which reads what this one writes.

## What it adds

`mdux.tools.medui.package`, in the host-tools zone:

- **`ScreenDocument`** - the owner a `ScreenPackage` view points into. `mdux.medui.schema` is
  deliberately non-owning, which is right for generated code where the storage is namespace-scope
  `constexpr` data, and unusable on a host where the strings are built at run time from a file. The
  document holds the text and the nodes and hands out a package viewing them, which is how the host
  compiler and the device runtime end up importing **one** definition of a compiled screen - the
  acceptance criterion on #197 - rather than a second host-side screen type that agrees until it does
  not.
- **`buildPackage()`** - a `LayoutResult` becomes typed payloads. This is where the dictionary's field
  spellings are mapped to spec members, and the mapping is spelled once because it is not derivable:
  `text` on a `Label` and `label` on a `Button` are both a text key, while `source` names a data
  stream on one component and an image package on another.
- **`writePackage()` / `writeGoldens()` / `readPackage()`** - canonical JSON through
  `mdux.evidence.json`, so float encoding and key ordering follow ADR-007 rather than a second
  convention.

## The shape, and two things worth a reviewer's attention

A node names its component in `kind` and carries that component's own fields in `spec`:

```json
{ "bounds": { "height": 60, "width": 120, "x": 250, "y": 60 },
  "id": "score",
  "kind": "NumericDisplay",
  "spec": { "colorToken": "Theme.Colors.ScoreDigits",
            "requirement": "REQ-NS-001",
            "source": "SEDATION_INDEX",
            "templateId": "TPL-SEDATION-INDEX-160" } }
```

One member name for the payload rather than eleven named after their components: a reader that
switches on `kind` reads `spec` whatever the answer, and adding a component to the dictionary adds no
member name to the file format. The variant's alternative *index* is never written, so an alternative
may be added to `NodePayload` without renumbering a committed artifact.

**A screen package contains no floating-point number at all**, which is unusual here and worth
stating: ADR-007's `{"bits": N}` encoding - the thing that makes a float portable - never appears in
one, because ADR-011 keeps colours as names and the solver works in integers. A scenario asserts it
rather than leaving it as a property nobody checks.

**Reading is as strict as writing.** An undefined member is refused rather than ignored: these files
are reviewed and byte-compared, so a member the reader dropped would be a member a reviewer believed
was doing something. `colourToken` for `colorToken` is the realistic case and the dangerous one.

## One decision you may want to overrule

**The draw budget is declared by the recipe, not computed here.** Computing it needs a per-component
cost model, and that model is the runtime's: #199 owns how a node becomes vertices, and a bound this
stage invented would be a second answer to a question the runtime has not yet answered once. So
`PackageInputs::budget` is a precondition the recipe reader (#198) diagnoses, `validate()` refuses an
empty budget on a screen with nodes, and `DrawList` fails closed against it at run time. If you would
rather the compiler compute it, the place to decide that is #199's cost model, and this field becomes
its output.

Worth knowing while you weigh that: TrustSC's `CompiledScreenPackage` carries **no** budget at all
(`crates/trustsc-ui/src/lib.rs:273` - `screen_id`, `layout`, `nodes`, `golden_references`), so there
is no parity constraint pulling either way here.

## A gap #197 recorded that turns out to be closed

The issue asks this stage to "either re-run the uniqueness check over the emitted node set, or state
in the emitter that no id is synthesized", because a synthesized `<row-id>-background` colliding with
an author's id would be silent. Neither is needed: **#194's solver already re-runs it after
synthesis** (`tools/medui/Layout.cpp`, `validateUniqueIds()`, reporting `MEDUI-E014`). This stage
inherits the guarantee, and `ScreenPackage::validate()` re-checks it as a schema invariant anyway.
Recorded here rather than silently not doing it.

## Tests

`tests/medui/PackageTests.cpp`, ten scenarios in `medui_tools_spec`, over a new fixture
(`accepted-every-component.medui`) carrying all eleven compiled payloads - the ten authored components
plus the synthetic Panel a Row's background produces.

The round trip is deliberately shaped to avoid a defect class this repository has produced before: the
writer and the reader spell each member name separately, so the scenario **executes both directions**
over one screen and compares, rather than asserting one side's return values. It also writes what it
read and compares bytes, since a round trip that lost a member would still compare equal if the reader
dropped it on both sides.

One scenario spells a whole small package out byte for byte. A byte-compared artifact's format is
worth stating in a form a reviewer can read.

## Regulatory impact

No device code changes: everything here is host-tools zone, and `mdux.medui.schema` is untouched. What
improves is where a malformed compiled screen is caught - a hand-edited artifact now fails at the read
with a file name and a code, rather than at a `static_assert` in generated source that names neither.
The requirement trace and the golden sidecar are unaffected in shape; `writeGoldens()` serialises what
#196 settled, `[]` included, since ADR-012 makes all three outputs unconditional.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compiled screen package generation for `.medui` layouts.
  * Added canonical JSON serialization with stable, repeatable output.
  * Added golden-reference output for package verification.
  * Added strict package loading with validation for malformed, unsupported, or non-canonical content.
  * Added diagnostics for invalid package data and unresolved layouts.

* **Documentation**
  * Updated compiler documentation to describe the complete diagnostic, compilation, packaging, and canonical JSON workflow.

* **Tests**
  * Added comprehensive coverage for all supported component types, validation rules, serialization, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->