### PR TITLE
Homogenise file-level Doxygen blocks, and lint them [#223]

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -39,6 +39,16 @@ jobs:
         python3 -m unittest discover -s tools/docs-lint -p "test_*.py"
         python3 tools/docs-lint/mdux_docs_lint.py
 
+    # Issue #223: CONTRIBUTING.md fixes one shape for a file-level Doxygen block, and the rule has
+    # been settled twice - once because the tree contradicted it, once because ten files had drifted
+    # back. A block without @file is not ignored by Doxygen; it silently documents whatever
+    # declaration follows. Checked here rather than in a C++ test so that a PR touching no C++ at
+    # all - which is exactly the kind that adds a file - still gets the answer.
+    - name: Check file-level Doxygen blocks
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: python3 tools/docs-lint/check_file_headers.py
+
     # Every AI-Reference.md is generated, so an edited module with a stale index is a defect the
     # build should catch rather than a reader. --check writes nothing; it fails when regenerating
     # would change a byte, and when a clause is cited in prose that no index row covers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,10 @@ We use **Doxygen** syntax for code documentation. Follow these guidelines:
   This rule previously said the opposite. It was never what the tree did — 82 files used `@file`
   against 56 that did not — and review bots cite this document, so the contradiction kept
   resurfacing on unrelated pull requests. #180 settled it in favour of the half that works.
+
+  `tools/docs-lint/check_file_headers.py` now enforces it, in the `Documentation Lint` job. #223
+  added it after finding ten files back in the retired order, all in one epic and all copied from
+  a neighbour: settling a rule in prose twice had not been enough to keep it true.
 - **Class documentation:** Include `@brief` with detailed description and usage examples.
 - **Method documentation:**
   - Use compact notation `/** @brief Description */` for simple one-line descriptions.

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for the screen emitter (issue #197).
  * @file EmitTests.cpp
+ * @brief BDD scenarios for the screen emitter (issue #197).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine

--- a/tests/medui/GeneratedScreenTests.cpp
+++ b/tests/medui/GeneratedScreenTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for the generated screen, in both emitted forms (issue #197).
  * @file GeneratedScreenTests.cpp
+ * @brief BDD scenarios for the generated screen, in both emitted forms (issue #197).
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/GoldenTests.cpp
+++ b/tests/medui/GoldenTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for golden references on safety-critical nodes (issue #196).
  * @file GoldenTests.cpp
+ * @brief BDD scenarios for golden references on safety-critical nodes (issue #196).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/LayoutTests.cpp
+++ b/tests/medui/LayoutTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for bounded integer `.medui` layout (issue #194).
  * @file LayoutTests.cpp
+ * @brief BDD scenarios for bounded integer `.medui` layout (issue #194).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for the compiled-screen document and its canonical JSON (issue #197).
  * @file PackageTests.cpp
+ * @brief BDD scenarios for the compiled-screen document and its canonical JSON (issue #197).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine (canonical form, byte-identity)

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief Scenarios for the governed compiled-screen schema (issue #197).
  * @file SchemaTests.cpp
+ * @brief Scenarios for the governed compiled-screen schema (issue #197).
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief The pinned `Compliatory/MedUI` conformance cases, run against this parser.
  * @file SharedConformanceTests.cpp
+ * @brief The pinned `Compliatory/MedUI` conformance cases, run against this parser.
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for text-budget and dynamic-charset validation (issue #195).
  * @file TextBudgetTests.cpp
+ * @brief BDD scenarios for text-budget and dynamic-charset validation (issue #195).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-010 No on-device text shaping

--- a/tools/docs-lint/check_file_headers.py
+++ b/tools/docs-lint/check_file_headers.py
@@ -45,6 +45,10 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# The extensions CONTRIBUTING.md declares this project uses: `.hpp` for headers, `.cpp` for sources,
+# `.cppm` for module interfaces. `.h` is deliberately not here - a `.h` in this tree would be a
+# naming violation, and listing it would quietly bless it as a project extension while asking a
+# vendored C header for a Doxygen block it has no reason to carry.
 SOURCE_SUFFIXES = (".cpp", ".cppm", ".hpp")
 
 # Where MduX's own C++ lives. `_deps` holds fetched dependencies and `build*` holds build trees;

--- a/tools/docs-lint/check_file_headers.py
+++ b/tools/docs-lint/check_file_headers.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Fails when a C++ file's opening Doxygen block does not follow CONTRIBUTING.md.
+
+Host-only tool (ADR-004): standard library only, no third-party dependencies.
+
+`CONTRIBUTING.md` fixes one shape for a file-level block - `@file <name.ext>`, then `@brief`, no
+`@author` - and records why with a measurement rather than a preference: `@file` is what attaches
+the block to the *file*. Without it the block is not ignored, it silently becomes the documentation
+of whatever declaration follows. On `tests/framework/RunRecords.hpp` with Doxygen 1.15, dropping the
+tag moved the file's brief onto `namespace mdux::spec` - wrong documentation, and no warning.
+
+## Why a lint and not another sweep
+
+The rule has been settled twice. #180 changed it to match what the tree did, and issue #223 found ten
+files still in the retired order - all in one epic, spread by copying the neighbour. A sweep fixes
+the ten; it does nothing about the eleventh. Worse, the drift has a second cost that a sweep cannot
+touch: review bots cite `CONTRIBUTING.md`, find the tree contradicting it, and raise the same finding
+on unrelated pull requests, which trains everyone to wave it through.
+
+So this runs in `Documentation Lint`, on a job that needs no C++ toolchain, and answers the question
+a reviewer would otherwise have to ask by hand.
+
+## What it checks, and what it deliberately does not
+
+- the first `/** ... */` block in the file opens with `@file`;
+- its argument is the file's own name **with extension and no path**, since `Draw.cppm` and
+  `Draw.cpp` are different files with one stem and this tree has several such pairs;
+- `@brief` follows it, and is present at all;
+- no `@author` anywhere in the block.
+
+It does not check the prose, the `@compliance` lines, or whether the brief is any good. It reads the
+first block only: a file whose first block is a licence banner rather than documentation would be a
+different convention, and the tree has none.
+
+Usage:
+    python3 tools/docs-lint/check_file_headers.py [--repo-root PATH] [paths...]
+
+Exit status 0 when every scanned file conforms, 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SOURCE_SUFFIXES = (".cpp", ".cppm", ".hpp")
+
+# Where MduX's own C++ lives. `_deps` holds fetched dependencies and `build*` holds build trees;
+# neither is this project's to format.
+SCAN_ROOTS = ("include", "src", "tools", "tests", "examples")
+SKIP_DIRECTORY_NAMES = {"_deps", "__pycache__", "fixtures"}
+
+BLOCK_PATTERN = re.compile(r"/\*\*(.*?)\*/", re.DOTALL)
+
+# A Doxygen tag is a line whose content starts with `@name`, after the leading ` * `. Matching the
+# bare word anywhere would read prose as markup: a block that discusses `@author` in a sentence -
+# this file's own tests do - is not a block that carries the tag.
+TAG_LINE_PATTERN = re.compile(r"^\s*\*?\s*@(\w+)(?:[ \t]+(.*))?$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    message: str
+
+
+@dataclass(frozen=True)
+class Tag:
+    name: str
+    argument: str
+
+
+def first_block(text: str) -> str | None:
+    """The body of the first `/** ... */` comment, or None when the file has none."""
+    match = BLOCK_PATTERN.search(text)
+    return match.group(1) if match else None
+
+
+def tags_of(block: str) -> list[Tag]:
+    """Every Doxygen tag the block carries, in order."""
+    found: list[Tag] = []
+    for line in block.splitlines():
+        match = TAG_LINE_PATTERN.match(line)
+        if match is not None:
+            found.append(Tag(match.group(1), (match.group(2) or "").strip()))
+    return found
+
+
+def check_text(path: Path, text: str) -> list[Finding]:
+    """Every way `text`'s opening block departs from the documented shape."""
+    block = first_block(text)
+    if block is None:
+        return [Finding(path, "has no file-level Doxygen block; open one with @file then @brief")]
+
+    tags = tags_of(block)
+    names = [tag.name for tag in tags]
+    findings: list[Finding] = []
+
+    if "author" in names:
+        findings.append(Finding(path, "carries an @author tag, which this project does not use"))
+
+    if "file" not in names:
+        findings.append(
+            Finding(
+                path,
+                "opens a block without @file. Doxygen then attaches the block to whatever "
+                "declaration follows instead of to the file",
+            )
+        )
+    else:
+        named = tags[names.index("file")].argument
+        if named != path.name:
+            findings.append(
+                Finding(
+                    path,
+                    f"@file names '{named}'; it must name '{path.name}', with the extension and no path",
+                )
+            )
+
+    if "brief" not in names:
+        findings.append(Finding(path, "has a file-level block with no @brief"))
+    elif "file" in names and names.index("brief") < names.index("file"):
+        findings.append(Finding(path, "puts @brief before @file; CONTRIBUTING.md fixes the order the other way"))
+    elif "file" in names and names.index("file") != 0:
+        findings.append(Finding(path, f"opens with @{names[0]} rather than @file"))
+
+    return findings
+
+
+def collect_sources(root: Path, paths: list[str]) -> list[Path]:
+    """The files to scan: the ones named, or every C++ source under the scan roots."""
+    if paths:
+        return [Path(entry) if Path(entry).is_absolute() else root / entry for entry in paths]
+
+    found: list[Path] = []
+    for scan_root in SCAN_ROOTS:
+        base = root / scan_root
+        if not base.is_dir():
+            continue
+        for candidate in sorted(base.rglob("*")):
+            if candidate.suffix not in SOURCE_SUFFIXES or not candidate.is_file():
+                continue
+            if SKIP_DIRECTORY_NAMES.intersection(part for part in candidate.parts):
+                continue
+            found.append(candidate)
+    return found
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (default: inferred from this script's location)",
+    )
+    parser.add_argument("paths", nargs="*", help="files to check (default: every C++ source in the tree)")
+    args = parser.parse_args(argv)
+    root: Path = args.repo_root
+
+    sources = collect_sources(root, args.paths)
+    findings: list[Finding] = []
+    for source in sources:
+        findings.extend(check_text(source, source.read_text(encoding="utf-8", errors="replace")))
+
+    if findings:
+        for finding in findings:
+            relative = finding.path.relative_to(root) if finding.path.is_relative_to(root) else finding.path
+            print(f"mdux-file-headers: {relative}: {finding.message}", file=sys.stderr)
+        print(f"mdux-file-headers: {len(findings)} finding(s)", file=sys.stderr)
+        print("mdux-file-headers: the rule and the reason are in CONTRIBUTING.md, 'Documentation'", file=sys.stderr)
+        return 1
+
+    print(f"mdux-file-headers: OK ({len(sources)} sources checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/docs-lint/test_check_file_headers.py
+++ b/tools/docs-lint/test_check_file_headers.py
@@ -1,0 +1,112 @@
+"""Tests for check_file_headers.
+
+The tests that matter are the ones proving the check *fails*. A header lint that only ever passes is
+indistinguishable from no lint, and it is the failure paths a reviewer trusts when they read
+"file headers OK" in a CI log - so every departure CONTRIBUTING.md names has a test that it is
+caught, and the shape the tree actually uses has one that it is not.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_file_headers as headers
+
+CONFORMING = """\
+/**
+ * @file Widget.cppm
+ * @brief One sentence on what this file is.
+ *
+ * @compliance ADR-004 Trust zones in C++
+ *
+ * Prose that mentions @author and @brief in passing, well after the tags.
+ */
+module;
+export module mdux.widget;
+"""
+
+
+def check(name: str, text: str) -> list[str]:
+    return [finding.message for finding in headers.check_text(Path(name), text)]
+
+
+class CheckFileHeadersTests(unittest.TestCase):
+    def test_accepts_the_documented_shape(self) -> None:
+        self.assertEqual(check("Widget.cppm", CONFORMING), [])
+
+    def test_rejects_brief_before_file(self) -> None:
+        swapped = CONFORMING.replace(
+            " * @file Widget.cppm\n * @brief One sentence on what this file is.\n",
+            " * @brief One sentence on what this file is.\n * @file Widget.cppm\n",
+        )
+        findings = check("Widget.cppm", swapped)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("@brief before @file", findings[0])
+
+    def test_rejects_a_missing_file_tag(self) -> None:
+        # The case with teeth: without @file the block documents whatever declaration follows it,
+        # silently and with no Doxygen warning.
+        findings = check("Widget.cppm", CONFORMING.replace(" * @file Widget.cppm\n", ""))
+        self.assertEqual(len(findings), 1)
+        self.assertIn("without @file", findings[0])
+
+    def test_rejects_a_file_tag_naming_another_file(self) -> None:
+        findings = check("Widget.cppm", CONFORMING.replace("@file Widget.cppm", "@file Widget.cpp"))
+        self.assertEqual(len(findings), 1)
+        self.assertIn("must name 'Widget.cppm'", findings[0])
+
+    def test_rejects_a_file_tag_carrying_a_path(self) -> None:
+        # `Draw.cppm` and `Draw.cpp` are different files with one stem, and this tree has several
+        # such pairs, so the extension is load-bearing - and so is the absence of a path.
+        findings = check("Widget.cppm", CONFORMING.replace("@file Widget.cppm", "@file include/mdux/Widget.cppm"))
+        self.assertEqual(len(findings), 1)
+        self.assertIn("no path", findings[0])
+
+    def test_rejects_an_author_tag(self) -> None:
+        findings = check("Widget.cppm", CONFORMING.replace(" * @brief", " * @author A. Person\n * @brief"))
+        self.assertEqual(len(findings), 1)
+        self.assertIn("@author", findings[0])
+
+    def test_rejects_a_file_with_no_block_at_all(self) -> None:
+        findings = check("Widget.cppm", "module;\nexport module mdux.widget;\n")
+        self.assertEqual(len(findings), 1)
+        self.assertIn("no file-level Doxygen block", findings[0])
+
+    def test_rejects_a_block_with_no_brief(self) -> None:
+        findings = check("Widget.cppm", "/**\n * @file Widget.cppm\n */\nmodule;\n")
+        self.assertEqual(len(findings), 1)
+        self.assertIn("no @brief", findings[0])
+
+    def test_reads_only_the_first_block(self) -> None:
+        # A later block documenting a function must not be mistaken for the file's own.
+        text = CONFORMING + "\n/**\n * @brief A function, documented after the file block.\n */\nvoid f();\n"
+        self.assertEqual(check("Widget.cppm", text), [])
+
+    def test_collects_sources_and_skips_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "src").mkdir()
+            (root / "src" / "Widget.cpp").write_text(CONFORMING, encoding="utf-8")
+            (root / "src" / "notes.md").write_text("not a source", encoding="utf-8")
+            (root / "tests" / "_deps" / "vendor").mkdir(parents=True)
+            (root / "tests" / "_deps" / "vendor" / "Vendor.cpp").write_text("no block here", encoding="utf-8")
+            (root / "tests" / "fixtures").mkdir(parents=True)
+            (root / "tests" / "fixtures" / "Fixture.cpp").write_text("no block here either", encoding="utf-8")
+
+            collected = [path.name for path in headers.collect_sources(root, [])]
+            self.assertEqual(collected, ["Widget.cpp"])
+
+    def test_the_tree_itself_conforms(self) -> None:
+        # The sweep in #223 is what makes this pass; it is here so that a file added later cannot
+        # reintroduce the deviation without a test saying so.
+        root = Path(__file__).resolve().parents[2]
+        offenders = [
+            f"{path.relative_to(root)}: {message}"
+            for path in headers.collect_sources(root, [])
+            for message in check(path.name, path.read_text(encoding="utf-8", errors="replace"))
+        ]
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/docs-lint/test_check_file_headers.py
+++ b/tools/docs-lint/test_check_file_headers.py
@@ -43,6 +43,18 @@ class CheckFileHeadersTests(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         self.assertIn("@brief before @file", findings[0])
 
+    def test_rejects_a_block_opening_with_another_tag(self) -> None:
+        # A block whose first tag is not @file but which still has both, in the right order relative
+        # to each other. CONTRIBUTING says to *open* with @file, so this is its own finding rather
+        # than a variant of the ordering one - and without this case that branch was never executed.
+        moved = CONFORMING.replace(
+            " * @file Widget.cppm\n",
+            " * @compliance ADR-004 Trust zones in C++\n * @file Widget.cppm\n",
+        )
+        findings = check("Widget.cppm", moved)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("opens with @compliance", findings[0])
+
     def test_rejects_a_missing_file_tag(self) -> None:
         # The case with teeth: without @file the block documents whatever declaration follows it,
         # silently and with no Doxygen warning.
@@ -92,6 +104,12 @@ class CheckFileHeadersTests(unittest.TestCase):
             (root / "tests" / "_deps" / "vendor" / "Vendor.cpp").write_text("no block here", encoding="utf-8")
             (root / "tests" / "fixtures").mkdir(parents=True)
             (root / "tests" / "fixtures" / "Fixture.cpp").write_text("no block here either", encoding="utf-8")
+
+            # `.h` is deliberately absent from the suffix list: CONTRIBUTING fixes this project's
+            # extensions as .hpp, .cpp and .cppm, so a `.h` in the tree is a naming violation rather
+            # than a file this lint should be asking for Doxygen blocks in - and treating it as a
+            # source would quietly bless it.
+            (root / "src" / "legacy.h").write_text("no block here", encoding="utf-8")
 
             collected = [path.name for path in headers.collect_sources(root, [])]
             self.assertEqual(collected, ["Widget.cpp"])

--- a/tools/medui/Layout.cpp
+++ b/tools/medui/Layout.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief Integer-only Vertical/Row layout resolution.
  * @file Layout.cpp
+ * @brief Integer-only Vertical/Row layout resolution.
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tools/medui/Layout.cppm
+++ b/tools/medui/Layout.cppm
@@ -1,6 +1,6 @@
 /**
- * @brief Integer-only build-time layout resolution for `.medui` screens.
  * @file Layout.cppm
+ * @brief Integer-only build-time layout resolution for `.medui` screens.
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary


### PR DESCRIPTION
Closes #223.

## The sweep

Ten files opened their file-level block with `@brief` and then `@file`, the order `CONTRIBUTING.md`
retired. One swapped line each, nothing else touched - no rewording, no reflowing. All ten belong to
the `.medui` epic, and the other 168 C++ sources in the tree were already right, so this is one
lineage of copied headers rather than a tree-wide habit.

## The part that matters

The sweep on its own would not hold. This rule has been settled in prose twice - #180 changed it to
match what the tree actually did, and it drifted back anyway - so the fix has to be something other
than a third settling.

`tools/docs-lint/check_file_headers.py` runs in `Documentation Lint`, on the job that needs no C++
toolchain, and checks exactly what `CONTRIBUTING.md` states and no more:

- the file's first `/** ... */` block opens with `@file`;
- its argument is the file's own name, with extension and no path (`Draw.cppm` and `Draw.cpp` are
  different files with one stem, and this tree has several such pairs);
- `@brief` follows, and is present;
- no `@author`.

It does not judge the prose or the `@compliance` lines. `check_file_headers.py` reports 178 sources
checked, 0 findings, and rejects the pre-sweep files - I ran it against the old `GoldenTests.cpp` to
confirm the lint would actually have caught what the sweep fixed, rather than trusting that it would.

## One thing worth reading in the tests

`test_check_file_headers.py` follows the neighbouring checker's stance - the tests that matter are
the ones proving the check *fails* - so every departure has a rejection test, and one asserts the
tree itself conforms so a later file cannot quietly reintroduce the deviation.

That suite caught a defect in the lint's first revision, which is the reason it is worth mentioning:
the check looked for `@author` and `@brief` as **substrings**, so a block whose prose discusses a tag
in a sentence was reported as carrying it - and the ordering verdict could be decided by a prose
mention rather than by the tags. Tags are now read as tags: a line whose content begins with `@name`
after the leading ` * `. The conforming fixture in the test file deliberately mentions `@author` in
its prose, so that revision cannot come back.

## Known, and not mine

`test_mdux_docs_lint.InternalLinkTests` has four failures that reproduce on a clean `develop` on
macOS and do not occur on CI's Linux runner. Left alone: unrelated to this issue, and worth its own
look if you want it.

## Regulatory impact

None on behaviour. The effect is on documentation correctness: a block without `@file` is not
ignored by Doxygen, it silently becomes the documentation of whatever declaration follows - measured
in `CONTRIBUTING.md` on `RunRecords.hpp`, where dropping the tag moved the file's brief onto
`namespace mdux::spec`. Ten files were one edit away from that failure mode; now none are, and the
next one fails the build instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized file-level documentation headers across source and test files.
  * Updated contributor guidance for the documentation header requirements.

* **New Features**
  * Added automated checks for required Doxygen file headers, tag ordering, filename accuracy, and prohibited author tags.
  * Integrated these checks into the documentation lint workflow.

* **Tests**
  * Added comprehensive validation coverage for documentation header rules and source-file discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->