### PR TITLE
Compile a screen from a recipe [#198]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -810,6 +810,14 @@ target_include_directories(medui_tools_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 # and a fixture that exists only inside a test cannot be reused by the tool that checks files.
 target_compile_definitions(medui_tools_spec PRIVATE MDUX_REPO_ROOT="${CMAKE_SOURCE_DIR}")
 
+# One scenario spawns the compiler rather than calling into it: `medui-compile-cli` is the only place
+# that can show main() rendering a diagnostic envelope and returning a status, rather than letting an
+# exception reach the terminate handler - which is the behaviour an author meets first when a recipe
+# is wrong. Everything else in this suite drives the calls, because a failing assertion then says
+# what was wrong instead of what the exit status was.
+add_dependencies(medui_tools_spec mdux-meduic)
+target_compile_definitions(medui_tools_spec PRIVATE MDUX_MEDUIC_PATH="$<TARGET_FILE:mdux-meduic>")
+
 # The build's own answers for mdux_screen_identifier(), written where EmitTests can read them and
 # compare against identifierForScreen() in the C++ emitter. Both halves are executed, for the reason
 # the shader pair had to learn: a C++ assertion cannot observe a CMake regex, so asserting one half

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -773,6 +773,10 @@ mdux_discover_tests(medui_spec)
 # ADR-011 fixes for golden references in one screen - including the node that matches both rules and
 # must therefore appear exactly once.
 #
+# CompileTests (#198) drives the compiler driver as calls rather than spawning mdux-meduic: what is
+# under test is the order the stages run in, the recipe being complete for the screen it names, and
+# the three artifacts a compile produces - none of which an exit status could report on.
+#
 # EmitTests (#197) covers everything that has to hold before a compiler sees the generated source:
 # among them the two ways a valid screen used to become invalid C++ - a name carrying a control
 # character the `.medui` lexer decodes, and the empty screen the schema permits, whose node table
@@ -795,6 +799,7 @@ add_executable(medui_tools_spec
     medui/GoldenTests.cpp
     medui/PackageTests.cpp
     medui/EmitTests.cpp
+    medui/CompileTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -1,0 +1,318 @@
+/**
+ * @file CompileTests.cpp
+ * @brief BDD scenarios for the `.medui` compiler driver (issue #198).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * The stages have their own suites; what is under test here is the driver's own contract - the order
+ * they run in, the recipe being complete for the screen it names, and the three artifacts a compile
+ * produces being exactly what the schema, the sidecar rule and the bake report require.
+ *
+ * The scenarios drive `run()`, `write()` and `verify()` as calls rather than spawning `mdux-meduic`,
+ * which is why the tool is split library-and-executable: an assertion on an exit status could only
+ * report that something was wrong, never what.
+ */
+
+import std;
+import speclab;
+import mdux.evidence.report;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.compile;
+import mdux.tools.medui.package;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.textbudget;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace ms  = mdux::medui;
+namespace cli = mdux::tools::cli;
+
+[[nodiscard]] std::filesystem::path repoRoot() {
+    return std::filesystem::path{MDUX_REPO_ROOT};
+}
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    std::ifstream in{repoRoot() / "tests" / "medui" / "fixtures" / name, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened", name), std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string& text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] std::string firstCode(std::span<const cli::Diagnostic> diagnostics) {
+    return diagnostics.empty() ? std::string{"<none>"} : diagnostics.front().code;
+}
+
+/// The fixture recipe, parsed. Every scenario that compiles starts here.
+[[nodiscard]] md::Recipe textlessRecipe(std::vector<cli::Diagnostic>& diagnostics) {
+    const std::optional<md::Recipe> recipe = md::parseRecipe(fixture("textless-screen.toml"), "tests/medui/fixtures/textless-screen.toml", diagnostics);
+    if (!recipe.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("the fixture recipe did not parse: {}", firstCode(diagnostics)), std::source_location::current());
+    }
+    return *recipe;
+}
+
+/// A directory this scenario owns, removed when it is done with it.
+class TemporaryDirectory {
+public:
+    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+        std::filesystem::create_directories(path_, code);
+    }
+
+    TemporaryDirectory(const TemporaryDirectory&)            = delete;
+    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
+
+    ~TemporaryDirectory() {
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
+[[nodiscard]] std::string contentsOf(const std::filesystem::path& path) {
+    std::ifstream in{path, std::ios::binary};
+    if (!in) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+}  // namespace
+
+const mdux::spec::Register everyRecipeKnobIsRequired{
+    "Every recipe knob is required, because a defaulted one would not appear in the report",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-recipe")
+            .Given("the fixture recipe, and copies with one knob removed", [] {})
+            .When("each is parsed", [] {})
+            .Then("the complete one resolves and each incomplete one is refused",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      const md::Recipe recipe = textlessRecipe(diagnostics);
+                      checks.expect(diagnostics.empty(), "the complete recipe parses without diagnostics");
+                      checks.expect(recipe.id == "textless-screen", std::format("the artifact slug, got '{}'", recipe.id));
+                      checks.expect(recipe.surfaceWidth == 400 && recipe.surfaceHeight == 300, "the declared surface");
+                      checks.expect(recipe.budget.maxVertices == 4096 && recipe.budget.maxCommands == 256, "the declared budget");
+                      checks.expect(recipe.fontPackage.empty() && recipe.textPackages.empty(), "a text-free screen names no locale inputs");
+
+                      // ADR-007's rule, checked rather than described: a knob with a default would
+                      // not appear in report.json, so a later change to that default would leave
+                      // every report looking unchanged.
+                      const std::string complete = fixture("textless-screen.toml");
+                      for (const std::string_view knob : {"id ", "source ", "surfaceWidth ", "maxVertices ", "maxIndices "}) {
+                          std::string       broken = complete;
+                          const std::size_t at     = broken.find(knob);
+                          if (at == std::string::npos) {
+                              checks.expect(false, std::format("the fixture declares {}", knob));
+                              continue;
+                          }
+                          const std::size_t lineEnd = broken.find('\n', at);
+                          broken.erase(at, lineEnd - at);
+
+                          std::vector<cli::Diagnostic> refused;
+                          const auto                   parsed = md::parseRecipe(broken, "recipe.toml", refused);
+                          checks.expect(!parsed.has_value(), std::format("a recipe without {}is refused", knob));
+                          checks.expect(firstCode(refused) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(refused)));
+                      }
+
+                      std::vector<cli::Diagnostic> unparsed;
+                      const auto                   broken = md::parseRecipe("this is not TOML {{", "recipe.toml", unparsed);
+                      checks.expect(!broken.has_value(), "a recipe that is not TOML is refused");
+                      checks.expect(firstCode(unparsed) == "MEDUI-E001", std::format("reported as MEDUI-E001, got '{}'", firstCode(unparsed)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aCompileProducesThreeArtifacts{
+    "A compile produces the three artifacts ADR-012 fixes",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-artifacts")
+            .Given("a screen that draws no text", [] {})
+            .When("the compiler runs every stage over it", [] {})
+            .Then("the package validates, the goldens pin the positioned node, and the report records both",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      const md::Recipe  recipe     = textlessRecipe(diagnostics);
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "tests/medui/fixtures/textless-screen.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, std::format("the fixture screen compiles, first diagnostic '{}'", firstCode(diagnostics)));
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(diagnostics.empty(), "a clean compile reports nothing");
+
+                      // The package is read back through the reader rather than inspected as the
+                      // value that produced it, so this exercises the round trip a device's build
+                      // would take.
+                      const md::PackageReadResult read = md::readPackage(outputs->packageJson, "package.json");
+                      checks.expect(read.ok(), std::format("the emitted package reads back, first diagnostic '{}'", firstCode(read.diagnostics)));
+                      if (read.ok()) {
+                          const ms::ScreenPackage package = read.document.package();
+                          checks.expect(package.id == "textless-screen", "the package carries the artifact slug, not the screen name");
+                          checks.expect(package.nodes.size() == 4, std::format("four compiled nodes, got {}", package.nodes.size()));
+                          checks.expect(package.find("topbar-background") != nullptr, "the Row's synthetic background is compiled");
+                          checks.expect(package.validate().has_value(), "the compiled screen satisfies its schema");
+                      }
+
+                      // One golden, for the positioned SignalTrace. An empty array here would have
+                      // meant the sidecar proved nothing.
+                      checks.expect(outputs->goldenCount == 1, std::format("one golden reference, got {}", outputs->goldenCount));
+                      checks.expect(outputs->goldensJson.contains("\"nodeId\": \"ecg\""), "the positioned node is the one pinned");
+
+                      const auto report = mdux::evidence::BakeReport::parse(outputs->reportJson);
+                      checks.expect(report.has_value(), "the bake report parses");
+                      if (report.has_value()) {
+                          checks.expect(report->tool == "mdux-meduic", std::format("the report names the tool, got '{}'", report->tool));
+                          // Two outputs, not three: a file cannot carry its own digest, which is the
+                          // same reason ADR-007 gives for there being no commit SHA in a report.
+                          checks.expect(report->outputs.size() == 2, std::format("package.json and goldens.json are recorded, got {}", report->outputs.size()));
+                          checks.expect(report->inputs.size() == 1, std::format("the .medui source is the only input, got {}", report->inputs.size()));
+                          checks.expect(report->validate().has_value(), "the report satisfies its own schema");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aScreenThatDrawsTextNeedsItsLocales{
+    "A screen that draws text is refused when the recipe declares no locales",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-requires-locales")
+            .Given("a recipe with no [text] table, naming a screen full of text keys", [] {})
+            .When("the compiler runs", [] {})
+            .Then("it refuses rather than compiling a screen whose boxes nobody measured",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      // The hazard this rule closes: skipping the budget stage is safe only for a
+                      // screen with nothing to measure. A screen with text and no approved locale
+                      // would otherwise be certified against a set nobody approved - and the
+                      // omitted translation is exactly the one that overflows.
+                      md::Recipe recipe    = textlessRecipe(diagnostics);
+                      recipe.source        = "tests/medui/fixtures/accepted-every-component.medui";
+                      recipe.surfaceWidth  = 800;
+                      recipe.surfaceHeight = 700;
+
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      checks.expect(!outputs.has_value(), "a text-drawing screen with no locales is refused");
+                      checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
+
+                      // And the predicate that decides it, asked directly: the driver must not be
+                      // the second place that knows what counts as text.
+                      md::ParseResult drawsText = md::parse(fixture("accepted-every-component.medui"), "every.medui");
+                      md::ParseResult drawsNone = md::parse(fixture("accepted-textless.medui"), "textless.medui");
+                      checks.expect(drawsText.screen.has_value() && md::needsTextBudget(*drawsText.screen), "a screen with keys needs the budget stage");
+                      checks.expect(drawsNone.screen.has_value() && !md::needsTextBudget(*drawsNone.screen), "a screen without them does not");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aRejectedStageStopsTheCompile{
+    "A stage that rejects the screen stops the compile",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-stops-at-the-cause")
+            .Given("a recipe whose declared surface is not the one the screen was drawn for", [] {})
+            .When("the compiler runs", [] {})
+            .Then("it reports the disagreement and produces nothing",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      md::Recipe recipe   = textlessRecipe(diagnostics);
+                      recipe.surfaceWidth = 640;
+
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      checks.expect(!outputs.has_value(), "a screen drawn for another panel is refused");
+                      checks.expect(!diagnostics.empty(), "and the refusal is reported");
+                      // Diagnostics are not accumulated across stages: a later stage reading a screen
+                      // an earlier one rejected reports consequences rather than causes.
+                      checks.expect(diagnostics.size() == 1, std::format("one diagnostic, at the cause, got {}", diagnostics.size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register writingAndVerifyingAgree{
+    "What a compile writes is what verifying it accepts",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-write-verify")
+            .Given("a compiled screen", [] {})
+            .When("it is written, verified, and verified again after an edit", [] {})
+            .Then("all three files appear, the untouched ones verify, and the edited one does not",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+                      TemporaryDirectory           scratch{"mdux-meduic-write"};
+
+                      const md::Recipe  recipe     = textlessRecipe(diagnostics);
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, "the fixture screen compiles");
+                          checks.raise();
+                          return;
+                      }
+
+                      checks.expect(md::write(*outputs, scratch.path(), diagnostics), "writing succeeds");
+                      const std::filesystem::path package = scratch.path() / "package.json";
+                      const std::filesystem::path goldens = scratch.path() / "goldens.json";
+                      const std::filesystem::path report  = scratch.path() / "report.json";
+                      // All three unconditionally: ADR-012 declares each a build output, so a
+                      // compiler that skipped one would break the build rather than produce less.
+                      checks.expect(std::filesystem::exists(package) && std::filesystem::exists(goldens) && std::filesystem::exists(report),
+                                    "all three artifacts are written");
+                      checks.expect(contentsOf(goldens) == outputs->goldensJson, "the sidecar holds what the compile produced");
+
+                      std::vector<cli::Diagnostic> verified;
+                      checks.expect(md::verify(*outputs, package, goldens, report, verified), "the freshly written artifacts verify");
+                      checks.expect(verified.empty(), "and verifying reports nothing");
+
+                      std::ofstream tamper{goldens, std::ios::binary | std::ios::trunc};
+                      tamper << "[]\n";
+                      tamper.close();
+
+                      std::vector<cli::Diagnostic> mismatched;
+                      checks.expect(!md::verify(*outputs, package, goldens, report, mismatched), "a hand-edited artifact does not verify");
+                      checks.expect(!mismatched.empty(), "and the mismatch is reported");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -91,6 +91,23 @@ private:
     std::filesystem::path path_;
 };
 
+/// One shell command line, spelled the way the platform's shell will actually read it.
+///
+/// `cmd.exe` strips the outer pair of quotes when a command line begins with one, so a quoted
+/// program path arrives mangled unless the whole line is wrapped in a second pair - and it reads a
+/// leading `/` as a switch, so the path needs native separators. Getting this wrong does not make a
+/// scenario fail honestly: the process never starts, the exit status is non-zero for the wrong
+/// reason, and only an assertion on what the process printed notices.
+[[nodiscard]] std::string shellCommand(std::string_view program, std::string_view arguments) {
+#ifdef _WIN32
+    std::string native{program};
+    std::ranges::replace(native, '/', '\\');
+    return std::format(R"(""{}" {}")", native, arguments);
+#else
+    return std::format(R"("{}" {})", program, arguments);
+#endif
+}
+
 [[nodiscard]] std::string contentsOf(const std::filesystem::path& path) {
     std::ifstream in{path, std::ios::binary};
     if (!in) {
@@ -513,48 +530,51 @@ const mdux::spec::Register anInvertedDynamicRangeIsRefused{
             .Execute();
     }};
 
-const mdux::spec::Register theExecutableFailsLikeATool{"A malformed recipe makes the executable exit with an envelope, not a crash", "evidence-unit", [] {
-                                                           return speclab::Test("medui-compile-cli")
-                                                               .Given("mdux-meduic and a recipe naming a screen that does not exist", [] {})
-                                                               .When("it is run with --format=json", [] {})
-                                                               .Then("it exits non-zero having printed a diagnostic envelope",
-                                                                     [] {
-                                                                         mdux::spec::Checks checks;
-                                                                         TemporaryDirectory scratch{"mdux-meduic-cli"};
+const mdux::spec::Register theExecutableFailsLikeATool{
+    "A malformed recipe makes the executable exit with an envelope, not a crash",
+    "evidence-unit",  // the one scenario here that spawns mdux-meduic rather than calling into it
+    [] {
+        return speclab::Test("medui-compile-cli")
+            .Given("mdux-meduic and a recipe naming a screen that does not exist", [] {})
+            .When("it is run with --format=json", [] {})
+            .Then("it exits non-zero having printed a diagnostic envelope",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TemporaryDirectory scratch{"mdux-meduic-cli"};
 
-                                                                         // The one scenario that spawns the process rather than calling into the
-                                                                         // library. Everything else here drives the calls, which says more when it
-                                                                         // fails - but nothing at call level can show that `main()` renders an envelope
-                                                                         // and returns a status rather than letting an exception reach the terminate
-                                                                         // handler, and that is exactly the behaviour an author sees first.
-                                                                         const std::filesystem::path recipe = scratch.path() / "recipe.toml";
-                                                                         std::ofstream               out{recipe, std::ios::binary | std::ios::trunc};
-                                                                         out << "[package]\n"
-                                                                                "id = \"missing-screen\"\n"
-                                                                                "source = \"tests/medui/fixtures/no-such-screen.medui\"\n"
-                                                                                "surfaceWidth = 400\n"
-                                                                                "surfaceHeight = 300\n"
-                                                                                "[budget]\n"
-                                                                                "maxVertices = 64\n"
-                                                                                "maxIndices = 96\n"
-                                                                                "maxCommands = 8\n";
-                                                                         out.close();
+                      // The one scenario that spawns the process rather than calling into the
+                      // library. Everything else here drives the calls, which says more when it
+                      // fails - but nothing at call level can show that `main()` renders an envelope
+                      // and returns a status rather than letting an exception reach the terminate
+                      // handler, and that is exactly the behaviour an author sees first.
+                      const std::filesystem::path recipe = scratch.path() / "recipe.toml";
+                      std::ofstream               out{recipe, std::ios::binary | std::ios::trunc};
+                      out << "[package]\n"
+                             "id = \"missing-screen\"\n"
+                             "source = \"tests/medui/fixtures/no-such-screen.medui\"\n"
+                             "surfaceWidth = 400\n"
+                             "surfaceHeight = 300\n"
+                             "[budget]\n"
+                             "maxVertices = 64\n"
+                             "maxIndices = 96\n"
+                             "maxCommands = 8\n";
+                      out.close();
 
-                                                                         const std::filesystem::path log = scratch.path() / "stdout.txt";
-                                                                         const std::string command = std::format(R"("{}" bake "{}" "{}" --format=json > "{}")",
-                                                                                                                 MDUX_MEDUIC_PATH,
-                                                                                                                 recipe.generic_string(),
-                                                                                                                 (scratch.path() / "out").generic_string(),
-                                                                                                                 log.generic_string());
-                                                                         const int         status  = std::system(command.c_str());
-                                                                         checks.expect(status != 0, "a malformed recipe exits non-zero");
+                      const std::filesystem::path log       = scratch.path() / "stdout.txt";
+                      const std::string           arguments = std::format(R"(bake "{}" "{}" --format=json > "{}")",
+                                                                recipe.generic_string(),
+                                                                (scratch.path() / "out").generic_string(),
+                                                                log.generic_string());
+                      const int                   status    = std::system(shellCommand(MDUX_MEDUIC_PATH, arguments).c_str());
+                      checks.expect(status != 0, "a malformed recipe exits non-zero");
 
-                                                                         const std::string envelope = contentsOf(log);
-                                                                         checks.expect(envelope.contains("mdux-meduic"), "the envelope names the tool");
-                                                                         checks.expect(
-                                                                             envelope.contains("MEDUI-E003"),
-                                                                             std::format("and carries the unreadable-source code, got:\n{}", envelope));
-                                                                         checks.raise();
-                                                                     })
-                                                               .Execute();
-                                                       }};
+                      const std::string envelope = contentsOf(log);
+                      // Asserted before the contents: an empty log means the process never ran, and the
+                      // status above was non-zero for a reason that has nothing to do with the recipe.
+                      checks.expect(!envelope.empty(), "the compiler ran and printed something");
+                      checks.expect(envelope.contains("mdux-meduic"), "the envelope names the tool");
+                      checks.expect(envelope.contains("MEDUI-E003"), std::format("and carries the unreadable-source code, got:\n{}", envelope));
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -427,11 +427,11 @@ const mdux::spec::Register theSlugAndTheScreenNameAreOneScreen{
                       checks.expect(!outputs.has_value(), "an id naming another screen is refused");
                       checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
 
-                      // Hyphenation is the author's, the word is not: `Textless` may be spelled
-                      // `textless` and nothing else.
+                      // Hyphenation is the author's, the word is not: `TextlessScreen` may be
+                      // spelled `textless-screen` or `textlessscreen`, and nothing else.
                       std::vector<cli::Diagnostic> accepted;
                       md::Recipe                   renamed = textlessRecipe(accepted);
-                      renamed.id                           = "textless";
+                      renamed.id                           = "textlessscreen";
                       const auto compiled                  = md::run(renamed, "recipe.toml", asBytes(recipeText), repoRoot(), accepted);
                       checks.expect(compiled.has_value(), std::format("a differently hyphenated slug compiles, first diagnostic '{}'", firstCode(accepted)));
                       checks.raise();

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -18,6 +18,7 @@
 
 import std;
 import speclab;
+import mdux.draw;
 import mdux.evidence.report;
 import mdux.medui.schema;
 import mdux.tools.cli;

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -387,3 +387,173 @@ const mdux::spec::Register theGovernedDynamicTextTableIsARecipeInput{
                   })
             .Execute();
     }};
+
+const mdux::spec::Register theSlugAndTheScreenNameAreOneScreen{
+    "The artifact slug and the screen name have to be the same screen",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-identity")
+            .Given("recipes whose id is malformed, and whose id names another screen", [] {})
+            .When("each is compiled", [] {})
+            .Then("both are refused before anything is written",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const std::string            recipeText = fixture("textless-screen.toml");
+
+                      // The slug names a directory, an evidence test and a generated C++ identifier.
+                      // `mdux_bake_artifact()` refuses a non-slug at configure time; a compile run
+                      // directly would otherwise write `generated/screen/Textless/`, which no
+                      // registration could ever match.
+                      for (const std::string_view bad : {"Textless", "textless_screen", "-textless"}) {
+                          std::vector<cli::Diagnostic> refused;
+                          const auto                   parsed = md::parseRecipe(std::string{recipeText}.replace(recipeText.find("\"textless-screen\""),
+                                                                                              std::string_view{"\"textless-screen\""}.size(),
+                                                                                              std::format("\"{}\"", bad)),
+                                                              "recipe.toml",
+                                                              refused);
+                          checks.expect(!parsed.has_value(), std::format("the id '{}' is refused", bad));
+                          checks.expect(firstCode(refused) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(refused)));
+                      }
+
+                      // A well-formed slug naming a different screen: the registration would place
+                      // outputs in one directory while the package inside called itself something
+                      // else, and every later consumer would follow one name with nothing to say the
+                      // other exists.
+                      md::Recipe recipe  = textlessRecipe(diagnostics);
+                      recipe.id          = "another-screen";
+                      const auto outputs = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      checks.expect(!outputs.has_value(), "an id naming another screen is refused");
+                      checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
+
+                      // Hyphenation is the author's, the word is not: `Textless` may be spelled
+                      // `textless` and nothing else.
+                      std::vector<cli::Diagnostic> accepted;
+                      md::Recipe                   renamed = textlessRecipe(accepted);
+                      renamed.id                           = "textless";
+                      const auto compiled                  = md::run(renamed, "recipe.toml", asBytes(recipeText), repoRoot(), accepted);
+                      checks.expect(compiled.has_value(), std::format("a differently hyphenated slug compiles, first diagnostic '{}'", firstCode(accepted)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aBudgetTheScreenCannotUseIsRefused{
+    "A budget the screen cannot use is a diagnostic, not a termination",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-budget-bounds")
+            .Given("a budget past the 16-bit index width, and an empty budget on a screen with nodes", [] {})
+            .When("each is compiled", [] {})
+            .Then("each is reported against the recipe that declared it",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string  recipeText = fixture("textless-screen.toml");
+
+                      // Both of these reach `ScreenPackage::validate()` if they are not caught here,
+                      // and `buildPackage()` treats a schema failure as a compiler bug and throws -
+                      // so an author's extra digit would terminate the tool rather than produce a
+                      // report.
+                      std::vector<cli::Diagnostic> tooWide;
+                      const auto                   wide = md::parseRecipe(std::string{recipeText}.replace(recipeText.find("maxVertices = 4096"),
+                                                                                        std::string_view{"maxVertices = 4096"}.size(),
+                                                                                        "maxVertices = 70000"),
+                                                        "recipe.toml",
+                                                        tooWide);
+                      checks.expect(!wide.has_value(), "a budget past the 16-bit index width is refused");
+                      checks.expect(firstCode(tooWide) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(tooWide)));
+
+                      std::vector<cli::Diagnostic> empty;
+                      md::Recipe                   recipe = textlessRecipe(empty);
+                      recipe.budget                       = mdux::draw::DrawBudget{};
+                      const auto outputs                  = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), empty);
+                      checks.expect(!outputs.has_value(), "an empty budget on a screen with nodes is refused");
+                      checks.expect(firstCode(empty) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(empty)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anInvertedDynamicRangeIsRefused{
+    "An inverted dynamic-text range is refused rather than read as empty",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-inverted-range")
+            .Given("a governed table whose entry descends", [] {})
+            .When("the recipe is parsed", [] {})
+            .Then("it is refused, because an empty range would check nothing",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      // Fail-open is the reason this one matters. `checkDynamicText()` deliberately
+                      // skips a range with `last < first`, so an inverted entry does not narrow the
+                      // charset - it removes the check, on the table that is the governed upper bound
+                      // for what a Clock or a TextInput can put on screen.
+                      const std::string recipeText = "[package]\n"
+                                                     "id = \"textless\"\n"
+                                                     "source = \"tests/medui/fixtures/accepted-textless.medui\"\n"
+                                                     "surfaceWidth = 400\n"
+                                                     "surfaceHeight = 300\n"
+                                                     "[budget]\n"
+                                                     "maxVertices = 64\n"
+                                                     "maxIndices = 96\n"
+                                                     "maxCommands = 8\n"
+                                                     "[dynamicText]\n"
+                                                     "names = [\"TimeSeconds\"]\n"
+                                                     "firstCodePoints = [58]\n"
+                                                     "lastCodePoints = [48]\n";
+
+                      const auto parsed = md::parseRecipe(recipeText, "recipe.toml", diagnostics);
+                      checks.expect(!parsed.has_value(), "a descending range is refused");
+                      checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theExecutableFailsLikeATool{"A malformed recipe makes the executable exit with an envelope, not a crash", "evidence-unit", [] {
+                                                           return speclab::Test("medui-compile-cli")
+                                                               .Given("mdux-meduic and a recipe naming a screen that does not exist", [] {})
+                                                               .When("it is run with --format=json", [] {})
+                                                               .Then("it exits non-zero having printed a diagnostic envelope",
+                                                                     [] {
+                                                                         mdux::spec::Checks checks;
+                                                                         TemporaryDirectory scratch{"mdux-meduic-cli"};
+
+                                                                         // The one scenario that spawns the process rather than calling into the
+                                                                         // library. Everything else here drives the calls, which says more when it
+                                                                         // fails - but nothing at call level can show that `main()` renders an envelope
+                                                                         // and returns a status rather than letting an exception reach the terminate
+                                                                         // handler, and that is exactly the behaviour an author sees first.
+                                                                         const std::filesystem::path recipe = scratch.path() / "recipe.toml";
+                                                                         std::ofstream               out{recipe, std::ios::binary | std::ios::trunc};
+                                                                         out << "[package]\n"
+                                                                                "id = \"missing-screen\"\n"
+                                                                                "source = \"tests/medui/fixtures/no-such-screen.medui\"\n"
+                                                                                "surfaceWidth = 400\n"
+                                                                                "surfaceHeight = 300\n"
+                                                                                "[budget]\n"
+                                                                                "maxVertices = 64\n"
+                                                                                "maxIndices = 96\n"
+                                                                                "maxCommands = 8\n";
+                                                                         out.close();
+
+                                                                         const std::filesystem::path log = scratch.path() / "stdout.txt";
+                                                                         const std::string command = std::format(R"("{}" bake "{}" "{}" --format=json > "{}")",
+                                                                                                                 MDUX_MEDUIC_PATH,
+                                                                                                                 recipe.generic_string(),
+                                                                                                                 (scratch.path() / "out").generic_string(),
+                                                                                                                 log.generic_string());
+                                                                         const int         status  = std::system(command.c_str());
+                                                                         checks.expect(status != 0, "a malformed recipe exits non-zero");
+
+                                                                         const std::string envelope = contentsOf(log);
+                                                                         checks.expect(envelope.contains("mdux-meduic"), "the envelope names the tool");
+                                                                         checks.expect(
+                                                                             envelope.contains("MEDUI-E003"),
+                                                                             std::format("and carries the unreadable-source code, got:\n{}", envelope));
+                                                                         checks.raise();
+                                                                     })
+                                                               .Execute();
+                                                       }};

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -316,3 +316,69 @@ const mdux::spec::Register writingAndVerifyingAgree{
                   })
             .Execute();
     }};
+
+const mdux::spec::Register theGovernedDynamicTextTableIsARecipeInput{
+    "The governed dynamic-text table comes from the recipe, not from the compiler",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-dynamic-text")
+            .Given("a recipe declaring what each named dynamic-text source can produce", [] {})
+            .When("it is parsed", [] {})
+            .Then("the rules resolve, and a malformed table is refused rather than half-read",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      // The names belong to a product's governed tables. A compiler shipping its own
+                      // list would be authoritative about a set it does not own - the same argument
+                      // that keeps the theme tokens and the approved locales out of the language.
+                      const std::string recipeText = "[package]\n"
+                                                     "id = \"clock\"\n"
+                                                     "source = \"tests/medui/fixtures/accepted-textless.medui\"\n"
+                                                     "surfaceWidth = 400\n"
+                                                     "surfaceHeight = 300\n"
+                                                     "[budget]\n"
+                                                     "maxVertices = 64\n"
+                                                     "maxIndices = 96\n"
+                                                     "maxCommands = 8\n"
+                                                     "[dynamicText]\n"
+                                                     "names = [\"TimeSeconds\", \"Ascii\"]\n"
+                                                     "firstCodePoints = [48, 32]\n"
+                                                     "lastCodePoints = [58, 126]\n";
+
+                      const auto recipe = md::parseRecipe(recipeText, "recipe.toml", diagnostics);
+                      checks.expect(recipe.has_value(), std::format("the recipe parses, first diagnostic '{}'", firstCode(diagnostics)));
+                      if (recipe.has_value()) {
+                          checks.expect(recipe->dynamicText.size() == 2, std::format("two rules, got {}", recipe->dynamicText.size()));
+                          if (recipe->dynamicText.size() == 2) {
+                              checks.expect(recipe->dynamicText[0].name == "TimeSeconds", "the first rule's name");
+                              checks.expect(recipe->dynamicText[0].produces.size() == 1 && recipe->dynamicText[0].produces[0].first == U'0'
+                                                && recipe->dynamicText[0].produces[0].last == U':',
+                                            "and the range a clock's digits and separator occupy");
+                          }
+                      }
+
+                      // Parallel arrays, so a length mismatch is a diagnostic rather than a silent
+                      // truncation to the shortest - the same rule the font recipe's charset has.
+                      std::vector<cli::Diagnostic> mismatched;
+                      const auto                   ragged = md::parseRecipe(std::string{recipeText}.replace(recipeText.find("lastCodePoints = [58, 126]"),
+                                                                                          std::string_view{"lastCodePoints = [58, 126]"}.size(),
+                                                                                          "lastCodePoints = [58]"),
+                                                          "recipe.toml",
+                                                          mismatched);
+                      checks.expect(!ragged.has_value(), "a ragged dynamic-text table is refused");
+                      checks.expect(firstCode(mismatched) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(mismatched)));
+
+                      // A range outside Unicode is named at the entry rather than left for the
+                      // charset walk to stop on.
+                      std::vector<cli::Diagnostic> outside;
+                      const auto                   beyond = md::parseRecipe(std::string{recipeText}.replace(recipeText.find("lastCodePoints = [58, 126]"),
+                                                                                          std::string_view{"lastCodePoints = [58, 126]"}.size(),
+                                                                                          "lastCodePoints = [58, 2000000]"),
+                                                          "recipe.toml",
+                                                          outside);
+                      checks.expect(!beyond.has_value(), "a range outside Unicode is refused");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -125,19 +125,24 @@ const mdux::spec::Register everyRecipeKnobIsRequired{
                       // not appear in report.json, so a later change to that default would leave
                       // every report looking unchanged.
                       const std::string complete = fixture("textless-screen.toml");
-                      for (const std::string_view knob : {"id ", "source ", "surfaceWidth ", "maxVertices ", "maxIndices "}) {
+                      for (const std::string_view knob : {"id", "source", "surfaceWidth", "maxVertices", "maxIndices"}) {
+                          // Anchored to the start of a line, which is not fussiness: an unanchored
+                          // search for "id" finds "did" in the recipe's own commentary first, and
+                          // then this scenario deletes half a comment and asserts that a recipe
+                          // which is still complete was refused. It passed for four knobs and failed
+                          // for the one where the comment happened to come first.
                           std::string       broken = complete;
-                          const std::size_t at     = broken.find(knob);
+                          const std::size_t at     = broken.find("\n" + std::string{knob});
                           if (at == std::string::npos) {
-                              checks.expect(false, std::format("the fixture declares {}", knob));
+                              checks.expect(false, std::format("the fixture declares {} at the start of a line", knob));
                               continue;
                           }
-                          const std::size_t lineEnd = broken.find('\n', at);
+                          const std::size_t lineEnd = broken.find('\n', at + 1);
                           broken.erase(at, lineEnd - at);
 
                           std::vector<cli::Diagnostic> refused;
                           const auto                   parsed = md::parseRecipe(broken, "recipe.toml", refused);
-                          checks.expect(!parsed.has_value(), std::format("a recipe without {}is refused", knob));
+                          checks.expect(!parsed.has_value(), std::format("a recipe without {} is refused", knob));
                           checks.expect(firstCode(refused) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(refused)));
                       }
 

--- a/tests/medui/fixtures/accepted-textless.medui
+++ b/tests/medui/fixtures/accepted-textless.medui
@@ -1,0 +1,43 @@
+// A screen that draws no text, for the compiler driver's happy path (#198).
+//
+// Every node here is a component that paints pixels rather than characters: a Row background, an
+// Image, a VulkanViewport and a SignalTrace. That is what makes it compilable without a font
+// package and without an approved locale - `needsTextBudget()` answers false for it, so the recipe
+// needs no [text] table and the budget stage has nothing to measure.
+//
+// The SignalTrace is positioned, which is the other half of what this fixture is for: an explicitly
+// positioned node is pinned by a golden reference, so `goldens.json` carries one entry rather than
+// being empty and proving nothing.
+Screen Textless {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 400px, 300px;
+
+    Row {
+        id: topbar;
+        height: 40px;
+        background: Theme.Colors.TopbarBackground;
+
+        Image {
+            id: logo;
+            width: 120px;
+            height: 40px;
+            source: img("IMG-LOGO");
+        }
+    }
+
+    VulkanViewport {
+        id: scope;
+        width: 400px;
+        height: 160px;
+        stream_source: "ENDOSCOPE";
+    }
+
+    SignalTrace {
+        id: ecg;
+        width: 400px;
+        height: 100px;
+        position: 0px, 200px;
+        stream_source: "ECG_LEAD_II";
+        color: Theme.Colors.Nominal;
+    }
+}

--- a/tests/medui/fixtures/accepted-textless.medui
+++ b/tests/medui/fixtures/accepted-textless.medui
@@ -8,7 +8,7 @@
 // The SignalTrace is positioned, which is the other half of what this fixture is for: an explicitly
 // positioned node is pinned by a golden reference, so `goldens.json` carries one entry rather than
 // being empty and proving nothing.
-Screen Textless {
+Screen TextlessScreen {
     layout: Vertical { spacing: 0px; padding: 0px; }
     surface: 400px, 300px;
 

--- a/tests/medui/fixtures/textless-screen.toml
+++ b/tests/medui/fixtures/textless-screen.toml
@@ -1,0 +1,26 @@
+# The recipe the compiler-driver scenarios compile (#198).
+#
+# A fixture rather than a registered artifact: `mdux_compile_screen()` and the first committed screen
+# under generated/screen/ are the second half of #198. What this file is for is the driver's own
+# contract - every knob required, no defaults - so a scenario can point `run()` at something an
+# author could actually have written.
+#
+# There is no [text] table, and that is the interesting part: the screen it names draws no text, so
+# `needsTextBudget()` answers false and the compile does not need a font package or an approved
+# locale. A screen that did draw text and left this table out is refused rather than compiled
+# without the check.
+
+[package]
+id            = "textless-screen"
+source        = "tests/medui/fixtures/accepted-textless.medui"
+# The panel this screen is drawn for. Declared here rather than taken from the source, so a screen
+# drawn for another panel is a diagnostic rather than a silently rescaled frame.
+surfaceWidth  = 400
+surfaceHeight = 300
+
+# What the runtime may draw for this screen. Declared by the product rather than computed: the cost
+# model belongs to the runtime (#199), and DrawList fails closed against these numbers at run time.
+[budget]
+maxVertices = 4096
+maxIndices  = 6144
+maxCommands = 256

--- a/tests/medui/fixtures/textless-screen.toml
+++ b/tests/medui/fixtures/textless-screen.toml
@@ -11,6 +11,9 @@
 # without the check.
 
 [package]
+# The slug and the screen name are the same word: `Screen TextlessScreen` compiles as
+# `textless-screen`. The compiler checks that pairing, because a slug naming one screen while the
+# package inside names another would leave every later consumer following one of the two.
 id            = "textless-screen"
 source        = "tests/medui/fixtures/accepted-textless.medui"
 # The panel this screen is drawn for. Declared here rather than taken from the source, so a screen

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -275,8 +275,9 @@ endif()
 # integer-only bounded layout solver, the text-budget check that measures a resolved box against the
 # widest approved translation (#195), the golden references that say where safety-critical content
 # must appear (#196), and the compiled-screen document with the canonical JSON it is committed as.
-# The mdux-meduic executable with its mdux_compile_screen() registration is #198, so there is still
-# no bake call site. Every later stage adds sources to this target rather than inventing another.
+# At S9 (#198) the compiler driver joins them: one file fixing the order the stages run in, the
+# recipe model, and the bake report. mdux_compile_screen() and the first committed screen artifact
+# are the second half of #198, so there is still no bake call site.
 #
 # The package stage reaches mdux.evidence.json and mdux.medui.schema through MduX::ToolsCommon's
 # link to MduX::Core, which is what the acceptance criterion on #197 asks for: the host compiler and
@@ -303,6 +304,7 @@ target_sources(MduXMeduiLib
             medui/Goldens.cppm
             medui/Package.cppm
             medui/Emit.cppm
+            medui/Compile.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -313,6 +315,7 @@ target_sources(MduXMeduiLib
         medui/Goldens.cpp
         medui/Package.cpp
         medui/Emit.cpp
+        medui/Compile.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)
@@ -332,6 +335,26 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(MduXMeduiLib PRIVATE /experimental:module /std:c++latest)
+endif()
+
+# The compiler (issue #198). Split library-and-executable like every other baker, so tests drive
+# run()/write()/verify() as calls rather than spawning a process and asserting an exit status.
+add_executable(mdux-meduic medui/MeduicMain.cpp)
+target_link_libraries(mdux-meduic PRIVATE MduX::MeduiLib MduX_warnings)
+
+set_target_properties(mdux-meduic
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(mdux-meduic PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(mdux-meduic PRIVATE /experimental:module /std:c++latest)
 endif()
 
 # The screen emitter (issue #197). Its own executable rather than a mode of the compiler, for the

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -36,6 +36,45 @@ void report(std::vector<cli::Diagnostic>& diagnostics, Code code, std::string fi
     diagnostics.push_back(diagnose(code, std::move(file), line, 0, std::move(message), std::move(fixHint)));
 }
 
+/// Whether `id` is the lowercase slug an artifact directory, an evidence test name and a generated
+/// C++ identifier are all derived from. `mdux_bake_artifact()` enforces the same shape at configure
+/// time; this is the half that also holds when the compiler is run directly.
+[[nodiscard]] bool isArtifactSlug(std::string_view id) noexcept {
+    const auto lower = [](char c) {
+        return c >= 'a' && c <= 'z';
+    };
+    const auto digit = [](char c) {
+        return c >= '0' && c <= '9';
+    };
+    if (id.empty() || (!lower(id.front()) && !digit(id.front()))) {
+        return false;
+    }
+    return std::ranges::all_of(id, [&](char c) {
+        return lower(c) || digit(c) || c == '-';
+    });
+}
+
+/// A screen name and an artifact slug reduced to the one word they must both spell: lowercase, with
+/// every separator removed.
+///
+/// A weaker check than deriving one from the other, and deliberately so. A slug cannot be derived
+/// injectively from a screen name - a name may carry `-` and `_`, and lowercasing is not injective
+/// across case - which is why ADR-012 has the recipe *record* the mapping rather than compute it.
+/// What must not happen is the two drifting apart: `generated/screen/foo/` holding a package that
+/// calls itself `bar`. Comparing the reduced forms catches exactly that, and leaves an author free
+/// to hyphenate a slug as they like.
+[[nodiscard]] std::string reduced(std::string_view text) {
+    std::string out;
+    out.reserve(text.size());
+    for (const char c : text) {
+        if (c == '-' || c == '_') {
+            continue;
+        }
+        out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    }
+    return out;
+}
+
 [[nodiscard]] std::span<const std::byte> asBytes(const std::string& text) noexcept {
     return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
 }
@@ -185,6 +224,20 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
         return std::nullopt;
     }
 
+    // The slug shape ADR-012 fixes, checked here rather than left to `mdux_bake_artifact()`'s
+    // FATAL_ERROR: the id names the directory, the evidence test and the emitted C++ identifier, and
+    // a compile run outside CMake would otherwise write `generated/screen/NeuroSense500/`, which no
+    // registration could ever match.
+    if (!isArtifactSlug(recipe.id)) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               std::format("the id '{}' is not a lowercase slug", recipe.id),
+               "an artifact id matches ^[a-z0-9][a-z0-9-]*$ - it names a directory, a test and a C++ identifier");
+        return std::nullopt;
+    }
+
     const toml::Table* budget = document.table("budget");
     if (budget == nullptr) {
         report(diagnostics,
@@ -198,9 +251,10 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
     }
 
     try {
-        const std::int64_t vertices = budget->require("maxVertices").asInteger();
-        const std::int64_t indices  = budget->require("maxIndices").asInteger();
-        const std::int64_t commands = budget->require("maxCommands").asInteger();
+        const std::int64_t vertices   = budget->require("maxVertices").asInteger();
+        const std::int64_t indices    = budget->require("maxIndices").asInteger();
+        const std::int64_t commands   = budget->require("maxCommands").asInteger();
+        const std::size_t  budgetLine = budget->require("maxVertices").line();
         for (const std::int64_t value : {vertices, indices, commands}) {
             if (value < 0 || value > std::numeric_limits<std::uint32_t>::max()) {
                 report(diagnostics,
@@ -210,6 +264,18 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
                        std::format("a draw budget entry is {}, which is outside the range a budget holds", value));
                 return std::nullopt;
             }
+        }
+        // The 16-bit index bound, refused while the recipe can still be told about it. Left to
+        // `ScreenPackage::validate()` it becomes `BudgetExceedsIndexWidth` reported to a caller that
+        // treats a schema failure as a compiler bug and throws - so an author's extra digit would
+        // terminate the tool instead of producing a diagnostic.
+        if (vertices > mdux::draw::maxIndexableVertices) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   budgetLine,
+                   std::format("maxVertices is {}, and a 16-bit index cannot address more than {}", vertices, mdux::draw::maxIndexableVertices));
+            return std::nullopt;
         }
         recipe.budget = mdux::draw::DrawBudget{.maxVertices = static_cast<std::uint32_t>(vertices),
                                                .maxIndices  = static_cast<std::uint32_t>(indices),
@@ -293,6 +359,21 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
                        std::format("[dynamicText] entry '{}' names the range {}..{}, which is outside Unicode", names[index], first, last));
                 return std::nullopt;
             }
+            // A descending range is refused rather than read as empty, and it is the one entry here
+            // that would be fail-open if it were wrong. The budget stage deliberately skips a range
+            // with `last < first` - what an author wrote is a name, and the shape of the table behind
+            // it is not theirs to fix - so an inverted range produces *no* charset check at all for a
+            // Clock or a TextInput using that rule, while this table is the governed upper bound on
+            // what the runtime can put on screen.
+            if (first > last) {
+                report(diagnostics,
+                       Code::RecipeMissingMember,
+                       std::string{recipePath},
+                       namesLine,
+                       std::format("[dynamicText] entry '{}' names the descending range {}..{}", names[index], first, last),
+                       "an inverted range checks nothing, so it is refused rather than read as empty");
+                return std::nullopt;
+            }
             DynamicText rule;
             rule.name = names[index];
             rule.produces.push_back(mdux::font::CharsetRange{.first = static_cast<char32_t>(first), .last = static_cast<char32_t>(last)});
@@ -374,6 +455,79 @@ loadLocales(const Recipe& recipe, const std::filesystem::path& root, std::vector
     return locales;
 }
 
+/**
+ * @brief The cross-package invariants `checkTextBudgets()` would otherwise throw over.
+ *
+ * Its contract is that `locales` is *exactly* the set the font approves - one entry per tag, none
+ * missing, none repeated, none outside it - and that every package addresses that font's atlas. Each
+ * of those is decided by paths an author typed into a recipe, so each is a diagnostic here rather
+ * than a `std::logic_error` from a library whose caller is supposed to be code.
+ *
+ * The omission is the dangerous one and the reason the library refuses it: a budget is a claim about
+ * the worst approved translation, so a compile checked against only the locale someone happened to
+ * list would certify a screen against a set nobody approved - and the missing German or Finnish
+ * string is exactly the one that overflows the box.
+ */
+[[nodiscard]] bool checkLocaleWiring(const Recipe&                  recipe,
+                                     const mdux::font::FontPackage& font,
+                                     std::span<const LoadedLocale>  locales,
+                                     std::string_view               recipePath,
+                                     std::vector<cli::Diagnostic>&  diagnostics) {
+    if (locales.empty()) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "this screen draws text and the recipe lists no text package",
+               "[text] needs one committed package per locale the font approves");
+        return false;
+    }
+
+    std::vector<std::string_view> seen;
+    seen.reserve(locales.size());
+    for (const LoadedLocale& locale : locales) {
+        if (locale.package.atlasId != font.id) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   0,
+                   std::format("the text package for '{}' was baked against the font '{}', and the recipe names '{}'",
+                               locale.package.locale,
+                               locale.package.atlasId,
+                               font.id),
+                   "a package measured against one atlas cannot be checked against another");
+            return false;
+        }
+        if (std::ranges::find(seen, std::string_view{locale.package.locale}) != seen.end()) {
+            report(diagnostics, Code::RecipeMissingMember, std::string{recipePath}, 0, std::format("the locale '{}' is listed twice", locale.package.locale));
+            return false;
+        }
+        if (std::ranges::find(font.locales, locale.package.locale) == font.locales.end()) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   0,
+                   std::format("the locale '{}' is not one the font package approves", locale.package.locale));
+            return false;
+        }
+        seen.push_back(locale.package.locale);
+    }
+
+    for (const std::string& approved : font.locales) {
+        if (std::ranges::find(seen, std::string_view{approved}) == seen.end()) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   0,
+                   std::format("the font approves '{}' and the recipe lists no text package for it", approved),
+                   "a budget checked against fewer locales than were approved is a claim nobody made");
+            return false;
+        }
+    }
+
+    return true;
+}
+
 }  // namespace
 
 std::optional<CompileOutputs> run(const Recipe&                 recipe,
@@ -395,12 +549,29 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
     ParseResult parsed = parse(textOf(*sourceBytes), recipe.source);
     if (!parsed.diagnostics.empty() || !parsed.screen.has_value()) {
         diagnostics.insert(diagnostics.end(), parsed.diagnostics.begin(), parsed.diagnostics.end());
-        if (diagnostics.empty()) {
+        // Guarded on the parser's own diagnostics, not on the caller's vector: `diagnostics` is an
+        // out-parameter a caller may hand over already populated, and then a parse that produced
+        // neither a screen nor a reason would have returned nullopt with nothing of its own to say.
+        if (parsed.diagnostics.empty()) {
             report(diagnostics, Code::SourceUnreadable, recipe.source, 0, "the source produced no screen and no diagnostic");
         }
         return std::nullopt;
     }
     const ast::Screen& screen = *parsed.screen;
+
+    // The slug and the screen name have to be the same screen. Without this the registration can
+    // put outputs in `generated/screen/foo/` while the package inside calls itself `bar`, and every
+    // later consumer - the evidence test, the emitted identifier, a requirement trace - follows one
+    // of the two names with nothing to say the other exists.
+    if (reduced(recipe.id) != reduced(screen.name)) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               std::format("the recipe compiles 'Screen {}' as the artifact '{}', which is a different name", screen.name, recipe.id),
+               "the slug is the screen's name in lowercase; hyphenation is free, the word is not");
+        return std::nullopt;
+    }
 
     // The recipe has to be complete for *this* screen. Asked of the budget stage's own module rather
     // than answered here, so the two cannot disagree about what counts as text.
@@ -428,6 +599,14 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
             return std::nullopt;
         }
         locales = std::move(*loaded);
+
+        // `checkTextBudgets()` classifies every one of these as a *caller wiring* error and throws
+        // `std::logic_error`, which is right for a library whose caller is code. Here the caller is
+        // a recipe an author wrote, so each one is diagnosed instead: a mistyped path or a forgotten
+        // locale must produce a report, not terminate the compiler.
+        if (!checkLocaleWiring(*font, locales, recipePath, diagnostics)) {
+            return std::nullopt;
+        }
     }
 
     std::vector<mdux::text::TextPackage> textPackages;
@@ -487,6 +666,21 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
             diagnostics.insert(diagnostics.end(), budgets.diagnostics.begin(), budgets.diagnostics.end());
             return std::nullopt;
         }
+    }
+
+    // The budget the recipe declared has to be usable for the screen that came out of the solver.
+    // `ScreenPackage::validate()` refuses an empty budget on a screen with nodes - the first
+    // rectangle would be turned away and the frame would silently be blank - and `buildPackage()`
+    // treats a schema failure as a compiler bug and throws. So the recipe is told here, where it can
+    // still be corrected.
+    if (!layout.nodes.empty() && (recipe.budget.maxVertices == 0 || recipe.budget.maxIndices == 0 || recipe.budget.maxCommands == 0)) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               std::format("the budget is empty and this screen resolves to {} nodes", layout.nodes.size()),
+               "a screen with nodes needs room for at least one rectangle, or every draw call it makes is refused");
+        return std::nullopt;
     }
 
     // 6. Goldens, from the resolved screen. Called rather than re-derived: ADR-012 decision 4 makes

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -1,0 +1,515 @@
+/**
+ * @file Compile.cpp
+ * @brief Implementation of the `.medui` compiler driver.
+ */
+
+module;
+
+module mdux.tools.medui.compile;
+
+import std;
+import mdux.draw;
+import mdux.evidence.digest;
+import mdux.evidence.json;
+import mdux.evidence.report;
+import mdux.font.schema;
+import mdux.medui.schema;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.package;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
+import mdux.tools.medui.textbudget;
+import mdux.tools.toml;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+namespace ms = mdux::medui;
+
+void report(std::vector<cli::Diagnostic>& diagnostics, Code code, std::string file, std::size_t line, std::string message, std::string fixHint = {}) {
+    diagnostics.push_back(diagnose(code, std::move(file), line, 0, std::move(message), std::move(fixHint)));
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string& text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] evidence::FileRecord fileRecord(std::string path, std::span<const std::byte> bytes) {
+    return evidence::FileRecord{.path = std::move(path), .sha256 = evidence::sha256(bytes)};
+}
+
+/// A path as a report and a diagnostic spell it: forward slashes on every platform, because
+/// `BakeReport::validate()` rejects a backslash and would be right to.
+///
+/// Named for the spelling rather than for the file, because `verify()` takes a `reportPath`
+/// parameter and a helper sharing that name would be shadowed at exactly one call site.
+[[nodiscard]] std::string displayPath(const std::filesystem::path& path) {
+    return path.generic_string();
+}
+
+[[nodiscard]] std::string_view textOf(std::span<const std::byte> bytes) noexcept {
+    return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+/// Reads a committed package beside the recipe, as text, reporting the path that failed.
+[[nodiscard]] std::optional<std::vector<std::byte>>
+readInput(const std::filesystem::path& root, const std::string& relative, std::vector<cli::Diagnostic>& diagnostics) {
+    std::optional<std::vector<std::byte>> bytes = readFile(root / relative);
+    if (!bytes.has_value()) {
+        report(diagnostics, Code::SourceUnreadable, relative, 0, "the file named by the recipe could not be read");
+    }
+    return bytes;
+}
+
+}  // namespace
+
+std::optional<std::vector<std::byte>> readFile(const std::filesystem::path& path) {
+    std::ifstream file{path, std::ios::binary | std::ios::ate};
+    if (!file) {
+        return std::nullopt;
+    }
+    // tellg() answers -1 on a stream error rather than throwing, and sizing the vector before the
+    // check would turn that into a request for 2^64-1 bytes.
+    const std::streamoff size = file.tellg();
+    if (size < 0 || !file.seekg(0)) {
+        return std::nullopt;
+    }
+    std::vector<std::byte> bytes(static_cast<std::size_t>(size));
+    if (size > 0) {
+        file.read(reinterpret_cast<char*>(bytes.data()), size);
+        if (!file) {
+            return std::nullopt;
+        }
+    }
+    return bytes;
+}
+
+evidence::json::Value Recipe::toOptions() const {
+    using evidence::json::Value;
+
+    const auto put = [](Value& object, std::string key, Value value) {
+        if (const auto inserted = object.set(std::move(key), std::move(value)); !inserted.has_value()) {
+            throw std::logic_error("canonical JSON refused a recipe option");
+        }
+    };
+
+    Value budgetValue = Value::emptyObject();
+    put(budgetValue, "maxCommands", Value::unsignedInteger(budget.maxCommands));
+    put(budgetValue, "maxIndices", Value::unsignedInteger(budget.maxIndices));
+    put(budgetValue, "maxVertices", Value::unsignedInteger(budget.maxVertices));
+
+    std::vector<Value> packages;
+    packages.reserve(textPackages.size());
+    for (const std::string& package : textPackages) {
+        packages.push_back(Value::string(package));
+    }
+
+    Value options = Value::emptyObject();
+    put(options, "budget", std::move(budgetValue));
+    put(options, "fontPackage", Value::string(fontPackage));
+    put(options, "source", Value::string(source));
+    put(options, "surfaceHeight", Value::integer(surfaceHeight));
+    put(options, "surfaceWidth", Value::integer(surfaceWidth));
+    put(options, "textPackages", Value::array(std::move(packages)));
+    return options;
+}
+
+std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipePath, std::vector<cli::Diagnostic>& diagnostics) {
+    toml::Document document{};
+    try {
+        document = toml::parse(text);
+    } catch (const toml::TomlError& error) {
+        report(diagnostics,
+               Code::RecipeUnparsed,
+               std::string{recipePath},
+               error.line(),
+               error.what(),
+               "see recipes/screen/ for the accepted shape; there is no [[table]] support");
+        return std::nullopt;
+    }
+
+    Recipe recipe;
+
+    const toml::Table* package = document.table("package");
+    if (package == nullptr) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "recipe has no [package] table",
+               "add a [package] table with 'id' and 'source' keys");
+        return std::nullopt;
+    }
+
+    // Every knob is required, defaults included - which is to say there are none. MEDUI-E002 states
+    // the reason: a defaulted knob does not appear in report.json, so changing the default later
+    // would leave every report looking unchanged, which ADR-007 forbids.
+    try {
+        recipe.id            = package->require("id").asString();
+        recipe.source        = package->require("source").asString();
+        recipe.surfaceWidth  = package->require("surfaceWidth").asInteger();
+        recipe.surfaceHeight = package->require("surfaceHeight").asInteger();
+    } catch (const toml::TomlError& error) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               error.line(),
+               error.what(),
+               "[package] needs 'id', 'source', 'surfaceWidth' and 'surfaceHeight'");
+        return std::nullopt;
+    }
+
+    const toml::Table* budget = document.table("budget");
+    if (budget == nullptr) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "recipe has no [budget] table",
+               "add a [budget] table with 'maxVertices', 'maxIndices' and 'maxCommands'. The runtime "
+               "fails closed against these, so a product declares them rather than inheriting them");
+        return std::nullopt;
+    }
+
+    try {
+        const std::int64_t vertices = budget->require("maxVertices").asInteger();
+        const std::int64_t indices  = budget->require("maxIndices").asInteger();
+        const std::int64_t commands = budget->require("maxCommands").asInteger();
+        for (const std::int64_t value : {vertices, indices, commands}) {
+            if (value < 0 || value > std::numeric_limits<std::uint32_t>::max()) {
+                report(diagnostics,
+                       Code::RecipeMissingMember,
+                       std::string{recipePath},
+                       budget->require("maxVertices").line(),
+                       std::format("a draw budget entry is {}, which is outside the range a budget holds", value));
+                return std::nullopt;
+            }
+        }
+        recipe.budget = mdux::draw::DrawBudget{.maxVertices = static_cast<std::uint32_t>(vertices),
+                                               .maxIndices  = static_cast<std::uint32_t>(indices),
+                                               .maxCommands = static_cast<std::uint32_t>(commands)};
+    } catch (const toml::TomlError& error) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               error.line(),
+               error.what(),
+               "[budget] needs 'maxVertices', 'maxIndices' and 'maxCommands'");
+        return std::nullopt;
+    }
+
+    // The text half is optional as a *table*, and the compile refuses later if the screen turns out
+    // to need it - see run(). A screen that draws no text has no font to name, and requiring one
+    // would mean inventing an approved locale set for a screen that has no text to approve.
+    if (const toml::Table* textTable = document.table("text"); textTable != nullptr) {
+        try {
+            recipe.fontPackage  = textTable->require("fontPackage").asString();
+            recipe.textPackages = textTable->require("packages").asStringArray();
+        } catch (const toml::TomlError& error) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   error.line(),
+                   error.what(),
+                   "[text] needs 'fontPackage' and a 'packages' array, one committed text package per approved locale");
+            return std::nullopt;
+        }
+    }
+
+    return recipe;
+}
+
+
+// ---------------------------------------------------------------------------
+// run(): every stage, in the one order this file fixes
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// One approved locale's committed package and the sidecar its runs address.
+struct LoadedLocale {
+    mdux::text::TextPackage package;
+    std::vector<std::byte>  sidecar;
+};
+
+/// Reads the font package the recipe names, or reports why it could not.
+[[nodiscard]] std::optional<mdux::font::FontPackage>
+loadFont(const Recipe& recipe, const std::filesystem::path& root, std::vector<evidence::FileRecord>& inputs, std::vector<cli::Diagnostic>& diagnostics) {
+    const std::optional<std::vector<std::byte>> bytes = readInput(root, recipe.fontPackage, diagnostics);
+    if (!bytes.has_value()) {
+        return std::nullopt;
+    }
+    inputs.push_back(fileRecord(recipe.fontPackage, *bytes));
+
+    auto package = mdux::font::FontPackage::parse(textOf(*bytes));
+    if (!package.has_value()) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               recipe.fontPackage,
+               0,
+               std::format("the font package is not valid: {}", mdux::font::describe(package.error())));
+        return std::nullopt;
+    }
+    return std::move(*package);
+}
+
+/// Reads every text package the recipe names, with the sidecar each one records.
+[[nodiscard]] std::optional<std::vector<LoadedLocale>>
+loadLocales(const Recipe& recipe, const std::filesystem::path& root, std::vector<evidence::FileRecord>& inputs, std::vector<cli::Diagnostic>& diagnostics) {
+    std::vector<LoadedLocale> locales;
+    locales.reserve(recipe.textPackages.size());
+
+    for (const std::string& relative : recipe.textPackages) {
+        const std::optional<std::vector<std::byte>> bytes = readInput(root, relative, diagnostics);
+        if (!bytes.has_value()) {
+            return std::nullopt;
+        }
+        inputs.push_back(fileRecord(relative, *bytes));
+
+        auto package = mdux::text::TextPackage::parse(textOf(*bytes));
+        if (!package.has_value()) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   relative,
+                   0,
+                   std::format("the text package is not valid: {}", mdux::text::describe(package.error())));
+            return std::nullopt;
+        }
+
+        // The sidecar sits beside the package, under the name the package itself records - the same
+        // arrangement every other artifact kind uses, so a caller never guesses a filename.
+        const std::filesystem::path                 sidecarRelative = std::filesystem::path{relative}.parent_path() / package->sidecarPath;
+        const std::optional<std::vector<std::byte>> sidecar         = readInput(root, sidecarRelative.generic_string(), diagnostics);
+        if (!sidecar.has_value()) {
+            return std::nullopt;
+        }
+        inputs.push_back(fileRecord(sidecarRelative.generic_string(), *sidecar));
+
+        locales.push_back(LoadedLocale{.package = std::move(*package), .sidecar = *sidecar});
+    }
+    return locales;
+}
+
+}  // namespace
+
+std::optional<CompileOutputs> run(const Recipe&                 recipe,
+                                  std::string_view              recipePath,
+                                  std::span<const std::byte>    recipeBytes,
+                                  const std::filesystem::path&  root,
+                                  std::vector<cli::Diagnostic>& diagnostics) {
+    std::vector<evidence::FileRecord> inputs;
+
+    const std::optional<std::vector<std::byte>> sourceBytes = readFile(root / recipe.source);
+    if (!sourceBytes.has_value()) {
+        report(diagnostics, Code::SourceUnreadable, recipe.source, 0, "the .medui source could not be read");
+        return std::nullopt;
+    }
+    inputs.push_back(fileRecord(recipe.source, *sourceBytes));
+
+    // 1. Parse. The lexer decides UTF-8 validity, so MEDUI-E004 comes from there rather than from a
+    //    second check here that could disagree with it.
+    ParseResult parsed = parse(textOf(*sourceBytes), recipe.source);
+    if (!parsed.diagnostics.empty() || !parsed.screen.has_value()) {
+        diagnostics.insert(diagnostics.end(), parsed.diagnostics.begin(), parsed.diagnostics.end());
+        if (diagnostics.empty()) {
+            report(diagnostics, Code::SourceUnreadable, recipe.source, 0, "the source produced no screen and no diagnostic");
+        }
+        return std::nullopt;
+    }
+    const ast::Screen& screen = *parsed.screen;
+
+    // The recipe has to be complete for *this* screen. Asked of the budget stage's own module rather
+    // than answered here, so the two cannot disagree about what counts as text.
+    const bool measurable = needsTextBudget(screen);
+    if (measurable && recipe.fontPackage.empty()) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "this screen draws text, so the recipe needs a [text] table naming the font package and one text package per "
+               "approved locale",
+               "a screen that draws text and declares no approved locale would be certified against a set nobody approved");
+        return std::nullopt;
+    }
+
+    std::optional<mdux::font::FontPackage> font;
+    std::vector<LoadedLocale>              locales;
+    if (measurable) {
+        font = loadFont(recipe, root, inputs, diagnostics);
+        if (!font.has_value()) {
+            return std::nullopt;
+        }
+        std::optional<std::vector<LoadedLocale>> loaded = loadLocales(recipe, root, inputs, diagnostics);
+        if (!loaded.has_value()) {
+            return std::nullopt;
+        }
+        locales = std::move(*loaded);
+    }
+
+    std::vector<mdux::text::TextPackage> textPackages;
+    textPackages.reserve(locales.size());
+    for (const LoadedLocale& locale : locales) {
+        textPackages.push_back(locale.package);
+    }
+
+    // 2. Semantic analysis. The theme tokens are the governed table the schema publishes, not a
+    //    second list: `resolveColorToken()` on a device and this check on the host then agree by
+    //    construction rather than by review.
+    std::vector<std::string_view> themeTokens;
+    themeTokens.reserve(ms::themeColors.size());
+    for (const ms::ThemeColor& colour : ms::themeColors) {
+        themeTokens.push_back(colour.token);
+    }
+
+    const SemanticResult semantic = analyze(screen, recipe.source, {.themeTokens = themeTokens, .textPackages = textPackages});
+    if (!semantic.ok()) {
+        diagnostics.insert(diagnostics.end(), semantic.diagnostics.begin(), semantic.diagnostics.end());
+        return std::nullopt;
+    }
+
+    // 3. Annotations, before layout: the shared conformance suite pins MEDUI-E070 on a screen with
+    //    no `surface:`, which the solver cannot resolve at all.
+    const SafetyResult safety = validateSafetyAnnotations(screen, recipe.source);
+    if (!safety.ok()) {
+        diagnostics.insert(diagnostics.end(), safety.diagnostics.begin(), safety.diagnostics.end());
+        return std::nullopt;
+    }
+
+    // 4. Layout, against the surface the recipe declares. The solver checks the source's own
+    //    `surface:` against it, so a screen drawn for another panel is a diagnostic rather than a
+    //    silently rescaled frame.
+    const LayoutResult layout = resolveLayout(screen, recipe.source, {.surfaceWidth = recipe.surfaceWidth, .surfaceHeight = recipe.surfaceHeight});
+    if (!layout.ok()) {
+        diagnostics.insert(diagnostics.end(), layout.diagnostics.begin(), layout.diagnostics.end());
+        return std::nullopt;
+    }
+
+    // 5. Text budgets, when there is anything to measure.
+    if (measurable) {
+        std::vector<LocaleText> localeTexts;
+        localeTexts.reserve(locales.size());
+        for (const LoadedLocale& locale : locales) {
+            localeTexts.push_back(LocaleText{.package = &locale.package, .sidecar = locale.sidecar});
+        }
+
+        const TextBudgetResult budgets = checkTextBudgets(layout, recipe.source, {.font = &*font, .locales = localeTexts});
+        if (!budgets.diagnostics.empty()) {
+            diagnostics.insert(diagnostics.end(), budgets.diagnostics.begin(), budgets.diagnostics.end());
+            return std::nullopt;
+        }
+    }
+
+    // 6. Goldens, from the resolved screen. Called rather than re-derived: ADR-012 decision 4 makes
+    //    one implementation of the predicate, applied once, the thing that guarantees completeness.
+    const std::vector<GoldenReference> goldens = collectGoldens(layout);
+
+    // 7. The compiled screen and its bytes.
+    const ScreenDocument    document = buildPackage(layout, {.id = recipe.id, .budget = recipe.budget});
+    const ms::ScreenPackage package  = document.package();
+
+    CompileOutputs outputs;
+    outputs.packageJson = writePackage(package);
+    outputs.goldensJson = writeGoldens(goldens);
+    outputs.screenId    = recipe.id;
+    outputs.nodeCount   = package.nodes.size();
+    outputs.goldenCount = goldens.size();
+
+    evidence::BakeReport bakeReport;
+    bakeReport.tool        = std::string{compilerToolName};
+    bakeReport.toolVersion = MDUX_TOOL_VERSION;
+    bakeReport.recipe      = fileRecord(std::string{recipePath}, recipeBytes);
+    bakeReport.inputs      = std::move(inputs);
+    bakeReport.options     = recipe.toOptions();
+    // report.json is deliberately absent from its own outputs: a file cannot carry its own digest,
+    // for the same reason ADR-007 gives for there being no commit SHA in one.
+    bakeReport.outputs = {fileRecord("goldens.json", asBytes(outputs.goldensJson)), fileRecord("package.json", asBytes(outputs.packageJson))};
+
+    auto reportText = bakeReport.write();
+    if (!reportText.has_value()) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               std::format("the bake report is not valid: {}", evidence::describe(reportText.error())));
+        return std::nullopt;
+    }
+    outputs.reportJson = std::move(*reportText);
+
+    return outputs;
+}
+
+// ---------------------------------------------------------------------------
+// write() / verify()
+// ---------------------------------------------------------------------------
+
+namespace {
+
+[[nodiscard]] bool writeText(const std::filesystem::path& path, const std::string& text, std::vector<cli::Diagnostic>& diagnostics) {
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    if (!file) {
+        report(diagnostics, Code::SourceUnreadable, displayPath(path), 0, "cannot open for writing");
+        return false;
+    }
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+    if (!file) {
+        report(diagnostics, Code::SourceUnreadable, displayPath(path), 0, "write failed");
+        return false;
+    }
+    return true;
+}
+
+[[nodiscard]] bool matches(const std::filesystem::path& path, const std::string& expected, std::vector<cli::Diagnostic>& diagnostics) {
+    const std::optional<std::vector<std::byte>> committed = readFile(path);
+    if (!committed.has_value()) {
+        report(diagnostics, Code::SourceUnreadable, displayPath(path), 0, "the committed artifact could not be read");
+        return false;
+    }
+    if (textOf(*committed) != expected) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               displayPath(path),
+               0,
+               "the committed artifact differs from what this compiler produces",
+               "run `cmake --build <dir> --target mdux-bake-update` and review the diff; do not hand-edit generated/");
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+bool write(const CompileOutputs& outputs, const std::filesystem::path& outputDir, std::vector<cli::Diagnostic>& diagnostics) {
+    std::error_code code;
+    std::filesystem::create_directories(outputDir, code);
+    if (code) {
+        report(diagnostics, Code::SourceUnreadable, displayPath(outputDir), 0, std::format("cannot create the output directory: {}", code.message()));
+        return false;
+    }
+
+    // All three, unconditionally. ADR-012 declares each an add_custom_command OUTPUT, so a compiler
+    // that skipped `goldens.json` for a screen with nothing to pin would break the build rather than
+    // produce a smaller artifact.
+    bool ok = writeText(outputDir / "package.json", outputs.packageJson, diagnostics);
+    ok      = writeText(outputDir / "goldens.json", outputs.goldensJson, diagnostics) && ok;
+    ok      = writeText(outputDir / "report.json", outputs.reportJson, diagnostics) && ok;
+    return ok;
+}
+
+bool verify(const CompileOutputs&         outputs,
+            const std::filesystem::path&  packagePath,
+            const std::filesystem::path&  goldensPath,
+            const std::filesystem::path&  reportPath,
+            std::vector<cli::Diagnostic>& diagnostics) {
+    bool ok = matches(packagePath, outputs.packageJson, diagnostics);
+    ok      = matches(goldensPath, outputs.goldensJson, diagnostics) && ok;
+    ok      = matches(reportPath, outputs.reportJson, diagnostics) && ok;
+    return ok;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -110,8 +110,28 @@ evidence::json::Value Recipe::toOptions() const {
         packages.push_back(Value::string(package));
     }
 
+    // The table as resolved, so a report shows what a compile was actually checked against rather
+    // than the name of a table whose contents nobody can see.
+    std::vector<Value> dynamic;
+    dynamic.reserve(dynamicText.size());
+    for (const DynamicText& rule : dynamicText) {
+        std::vector<Value> ranges;
+        ranges.reserve(rule.produces.size());
+        for (const mdux::font::CharsetRange& range : rule.produces) {
+            Value entry = Value::emptyObject();
+            put(entry, "first", Value::unsignedInteger(static_cast<std::uint64_t>(range.first)));
+            put(entry, "last", Value::unsignedInteger(static_cast<std::uint64_t>(range.last)));
+            ranges.push_back(std::move(entry));
+        }
+        Value named = Value::emptyObject();
+        put(named, "name", Value::string(rule.name));
+        put(named, "produces", Value::array(std::move(ranges)));
+        dynamic.push_back(std::move(named));
+    }
+
     Value options = Value::emptyObject();
     put(options, "budget", std::move(budgetValue));
+    put(options, "dynamicText", Value::array(std::move(dynamic)));
     put(options, "fontPackage", Value::string(fontPackage));
     put(options, "source", Value::string(source));
     put(options, "surfaceHeight", Value::integer(surfaceHeight));
@@ -219,6 +239,64 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
                    error.what(),
                    "[text] needs 'fontPackage' and a 'packages' array, one committed text package per approved locale");
             return std::nullopt;
+        }
+    }
+
+    // The governed dynamic-text table. Optional as a table for the same reason [text] is: a screen
+    // with no `format:` and no `charset:` has no name to resolve, and the budget stage refuses an
+    // unknown name rather than accepting one, so an absent table is fail-closed.
+    if (const toml::Table* dynamicTable = document.table("dynamicText"); dynamicTable != nullptr) {
+        std::vector<std::string>  names;
+        std::vector<std::int64_t> firstPoints;
+        std::vector<std::int64_t> lastPoints;
+        std::size_t               namesLine = 0;
+        try {
+            const toml::Value& namesValue = dynamicTable->require("names");
+            namesLine                     = namesValue.line();
+            names                         = namesValue.asStringArray();
+            firstPoints                   = dynamicTable->require("firstCodePoints").asIntegerArray();
+            lastPoints                    = dynamicTable->require("lastCodePoints").asIntegerArray();
+        } catch (const toml::TomlError& error) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   error.line(),
+                   error.what(),
+                   "[dynamicText] needs parallel 'names', 'firstCodePoints' and 'lastCodePoints' arrays");
+            return std::nullopt;
+        }
+
+        if (names.size() != firstPoints.size() || names.size() != lastPoints.size()) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   namesLine,
+                   std::format("[dynamicText] names has {} entries, firstCodePoints {} and lastCodePoints {}",
+                               names.size(),
+                               firstPoints.size(),
+                               lastPoints.size()),
+                   "the arrays are positional: entry N of each describes rule N");
+            return std::nullopt;
+        }
+
+        for (std::size_t index = 0; index < names.size(); ++index) {
+            const std::int64_t first = firstPoints[index];
+            const std::int64_t last  = lastPoints[index];
+            // Bounded here rather than left to the walk: the budget stage refuses a range outside
+            // Unicode, but a recipe naming one should be told which entry it was rather than which
+            // glyph the walk stopped at.
+            if (first < 0 || last < 0 || first > 0x10FFFF || last > 0x10FFFF) {
+                report(diagnostics,
+                       Code::RecipeMissingMember,
+                       std::string{recipePath},
+                       namesLine,
+                       std::format("[dynamicText] entry '{}' names the range {}..{}, which is outside Unicode", names[index], first, last));
+                return std::nullopt;
+            }
+            DynamicText rule;
+            rule.name = names[index];
+            rule.produces.push_back(mdux::font::CharsetRange{.first = static_cast<char32_t>(first), .last = static_cast<char32_t>(last)});
+            recipe.dynamicText.push_back(std::move(rule));
         }
     }
 
@@ -398,7 +476,13 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
             localeTexts.push_back(LocaleText{.package = &locale.package, .sidecar = locale.sidecar});
         }
 
-        const TextBudgetResult budgets = checkTextBudgets(layout, recipe.source, {.font = &*font, .locales = localeTexts});
+        std::vector<DynamicTextRule> dynamicRules;
+        dynamicRules.reserve(recipe.dynamicText.size());
+        for (const DynamicText& rule : recipe.dynamicText) {
+            dynamicRules.push_back(DynamicTextRule{.name = rule.name, .produces = rule.produces});
+        }
+
+        const TextBudgetResult budgets = checkTextBudgets(layout, recipe.source, {.font = &*font, .locales = localeTexts, .dynamicText = dynamicRules});
         if (!budgets.diagnostics.empty()) {
             diagnostics.insert(diagnostics.end(), budgets.diagnostics.begin(), budgets.diagnostics.end());
             return std::nullopt;

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -468,8 +468,7 @@ loadLocales(const Recipe& recipe, const std::filesystem::path& root, std::vector
  * list would certify a screen against a set nobody approved - and the missing German or Finnish
  * string is exactly the one that overflows the box.
  */
-[[nodiscard]] bool checkLocaleWiring(const Recipe&                  recipe,
-                                     const mdux::font::FontPackage& font,
+[[nodiscard]] bool checkLocaleWiring(const mdux::font::FontPackage& font,
                                      std::span<const LoadedLocale>  locales,
                                      std::string_view               recipePath,
                                      std::vector<cli::Diagnostic>&  diagnostics) {

--- a/tools/medui/Compile.cppm
+++ b/tools/medui/Compile.cppm
@@ -53,12 +53,33 @@ export module mdux.tools.medui.compile;
 import std;
 import mdux.draw;
 import mdux.evidence.json;
+import mdux.font.schema;
 import mdux.tools.cli;
 
 export namespace mdux::tools::medui {
 
 /// The tool name that appears in every diagnostic and in `report.json`.
 inline constexpr std::string_view compilerToolName = "mdux-meduic";
+
+/**
+ * @brief One named dynamic-text source from the recipe, and every code point it can produce.
+ *
+ * The governed table an author's `format: TimeSeconds` or `charset: Ascii` resolves against. It is a
+ * recipe input rather than a compiler constant for the reason `DynamicTextRule` gives: the names
+ * belong to a product's governed tables, and a compiler shipping its own list would be authoritative
+ * about a set it does not own.
+ *
+ * Spelled as parallel arrays because `mdux.tools.toml` implements a subset with no array-of-tables
+ * support - the same shape `recipes/font/dejavu-ui.toml` uses for its charset, and the same
+ * length-mismatch check.
+ *
+ * Owning its ranges rather than viewing them: a `DynamicTextRule` is a view, and the storage it
+ * views has to outlive the compile that uses it.
+ */
+struct DynamicText {
+    std::string                           name;
+    std::vector<mdux::font::CharsetRange> produces;
+};
 
 /**
  * @brief A parsed and resolved screen recipe.
@@ -79,6 +100,7 @@ struct Recipe {
     mdux::draw::DrawBudget   budget{};
     std::string              fontPackage;   ///< committed font package.json, or empty
     std::vector<std::string> textPackages;  ///< committed text package.json, one per approved locale
+    std::vector<DynamicText> dynamicText;   ///< the product's governed dynamic-text table
 
     /// The fully resolved options, as `report.json` records them.
     [[nodiscard]] evidence::json::Value toOptions() const;

--- a/tools/medui/Compile.cppm
+++ b/tools/medui/Compile.cppm
@@ -1,0 +1,140 @@
+/**
+ * @file Compile.cppm
+ * @brief The `.medui` compiler driver: a recipe in, three committed artifacts out.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-005 Error handling and exceptions policy (host tools may throw)
+ * @compliance ADR-007 Evidence pipeline doctrine (canonical form, byte-identity, bake reports)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Every stage this epic built exists as a call. This is the file that says in what order they run,
+ * and it is the only place that answer is written down - a driver that let each caller choose would
+ * make the order a convention rather than a contract.
+ *
+ * ## The order, and why it is this one
+ *
+ * 1. **parse** - structure the grammar fixes, nothing the dictionary does (#192).
+ * 2. **analyze** - components, field domains, theme tokens, and keys against *every* approved
+ *    locale (#193).
+ * 3. **validate annotations** - `@safety_critical` needs a requirement, and a `cv_check` must name a
+ *    verification that exists (#196). Before layout, deliberately: the shared conformance suite pins
+ *    `MEDUI-E070` on a screen with no `surface:`, which the solver cannot resolve at all, so a
+ *    design that could only report it after layout could not satisfy the contract it implements.
+ * 4. **resolve layout** - integer-only, bounded, one absolute rectangle per node (#194).
+ * 5. **check text budgets** - every resolved box against the widest approved translation (#195).
+ * 6. **collect goldens** - where safety-critical content must appear (#196).
+ * 7. **build and write** - the compiled screen, its sidecar and the bake report (#197).
+ *
+ * A stage that reports anything stops the compile. Diagnostics are not accumulated across stages,
+ * because a later stage reading a screen an earlier one rejected reports consequences rather than
+ * causes - the layout solver on an unresolvable surface being the clearest case.
+ *
+ * ## The budget stage runs when there is anything to measure
+ *
+ * `checkTextBudgets()` requires a font package and *exactly* the locales that font approves, so a
+ * recipe that declares neither cannot run it. That is not a hole: a screen carrying any `t("KEY")`
+ * with no approved locale to check it against is already refused by stage 2, which validates every
+ * key against every declared locale and finds none. So the stage is skipped only for a screen that
+ * draws no text at all, and a screen that draws text cannot reach stage 5 without the inputs.
+ *
+ * ## What the recipe carries, and why nothing defaults
+ *
+ * Every knob is required. `MEDUI-E002` says why in the registry: a defaulted knob does not appear in
+ * `report.json`, so a silently changed default would leave every report looking unchanged - which
+ * ADR-007 forbids. The surface is declared by the recipe rather than taken from the source, and the
+ * solver checks the source's own `surface:` against it, so the panel a product ships and the screen
+ * an author drew for it disagree loudly rather than silently.
+ */
+module;
+
+export module mdux.tools.medui.compile;
+
+import std;
+import mdux.draw;
+import mdux.evidence.json;
+import mdux.tools.cli;
+
+export namespace mdux::tools::medui {
+
+/// The tool name that appears in every diagnostic and in `report.json`.
+inline constexpr std::string_view compilerToolName = "mdux-meduic";
+
+/**
+ * @brief A parsed and resolved screen recipe.
+ *
+ * Paths are repository-relative, because the compiler runs with the repository root as its working
+ * directory and `BakeReport::validate()` rejects an absolute path - a report naming a path that
+ * exists on one machine is not evidence.
+ *
+ * `textPackages` is one committed text package per approved locale, and `fontPackage` the font they
+ * were baked into. Both are empty for a screen that draws no text; see the module comment for why
+ * that is safe rather than a way around the check.
+ */
+struct Recipe {
+    std::string              id;      ///< the artifact slug: `generated/screen/<id>/`
+    std::string              source;  ///< the `.medui` file
+    std::int64_t             surfaceWidth{0};
+    std::int64_t             surfaceHeight{0};
+    mdux::draw::DrawBudget   budget{};
+    std::string              fontPackage;   ///< committed font package.json, or empty
+    std::vector<std::string> textPackages;  ///< committed text package.json, one per approved locale
+
+    /// The fully resolved options, as `report.json` records them.
+    [[nodiscard]] evidence::json::Value toOptions() const;
+};
+
+/**
+ * @brief Everything a compile produces, held in memory so bake and verify share one code path.
+ *
+ * Bytes and two counts, not the structured screen: a caller wanting the package parses the JSON,
+ * which exercises the reader on the writer's own output rather than inspecting a value that never
+ * made the round trip. `mdux.tools.shaderbake` gives the same reasoning at greater length, plus the
+ * GCC 15 `std::optional` constraint that makes carrying a module type here a hazard.
+ */
+struct CompileOutputs {
+    std::string packageJson;  ///< canonical `package.json` text
+    std::string goldensJson;  ///< canonical `goldens.json` text, `[]` when nothing is pinned
+    std::string reportJson;   ///< canonical `report.json` text
+    std::string screenId;     ///< for the summary line
+    std::size_t nodeCount{0};
+    std::size_t goldenCount{0};
+};
+
+/// Reads a file as bytes. Returns nullopt when it cannot be opened or read.
+[[nodiscard]] std::optional<std::vector<std::byte>> readFile(const std::filesystem::path& path);
+
+/// Parses recipe text. Diagnostics are appended; nullopt means it did not parse.
+[[nodiscard]] std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipePath, std::vector<cli::Diagnostic>& diagnostics);
+
+/**
+ * @brief Runs every compiler stage over the screen the recipe names.
+ *
+ * @param recipe      the resolved recipe
+ * @param recipePath  repository-relative, for `report.json`'s recipe record and for diagnostics
+ * @param recipeBytes the recipe's own bytes, for its digest
+ * @param root        the directory the recipe's paths resolve against - the repository root
+ * @param diagnostics appended to; a stage that reports anything stops the compile
+ *
+ * Returns nullopt when any stage rejects the screen, when an input cannot be read, or when the
+ * compiled screen fails its own schema.
+ */
+[[nodiscard]] std::optional<CompileOutputs> run(const Recipe&                 recipe,
+                                                std::string_view              recipePath,
+                                                std::span<const std::byte>    recipeBytes,
+                                                const std::filesystem::path&  root,
+                                                std::vector<cli::Diagnostic>& diagnostics);
+
+/// Writes `outputs` into `outputDir`, creating it if needed. All three files, always: ADR-012 makes
+/// them unconditional outputs, so "this screen pins nothing" is an empty array rather than a missing
+/// file.
+[[nodiscard]] bool write(const CompileOutputs& outputs, const std::filesystem::path& outputDir, std::vector<cli::Diagnostic>& diagnostics);
+
+/// Compares `outputs` against the committed files, appending a diagnostic per mismatch.
+[[nodiscard]] bool verify(const CompileOutputs&         outputs,
+                          const std::filesystem::path&  packagePath,
+                          const std::filesystem::path&  goldensPath,
+                          const std::filesystem::path&  reportPath,
+                          std::vector<cli::Diagnostic>& diagnostics);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/MeduicMain.cpp
+++ b/tools/medui/MeduicMain.cpp
@@ -51,6 +51,55 @@ namespace medui = mdux::tools::medui;
     return medui::run(*recipe, recipePath, *recipeBytes, std::filesystem::current_path(), diagnostics);
 }
 
+/**
+ * @brief Runs the compile and returns the summary line, or nothing when a diagnostic was reported.
+ *
+ * The `try` is an outermost boundary for a *bug*, not for author input. Every recipe-controlled
+ * failure - a malformed slug, an unusable budget, a locale the font does not approve - is a
+ * diagnostic the driver reports, so an escaping exception means a gate was bypassed or an invariant
+ * this compiler believes in does not hold. Even then the tool has to fail like a tool: a consumer
+ * that asked for `--format=json` is entitled to an envelope, not a terminate handler's message.
+ */
+[[nodiscard]] std::string compile(const cli::Invocation& invocation, const std::string& recipePath, std::vector<cli::Diagnostic>& diagnostics) {
+    try {
+        auto outputs = produce(recipePath, diagnostics);
+        if (!outputs.has_value()) {
+            return {};
+        }
+
+        bool ok = false;
+        if (invocation.mode == cli::Mode::Bake) {
+            ok = medui::write(*outputs, invocation.bake.outputDir, diagnostics);
+        } else {
+            // The shared grammar carries two output paths and a screen has three. The goldens
+            // sidecar is not an independent fact: ADR-012 puts all three files in one directory, so
+            // it is read from beside the package rather than named a second time on a command line
+            // where the two could disagree.
+            const std::filesystem::path packagePath{invocation.verify.packagePath};
+            const std::filesystem::path goldensPath = packagePath.parent_path() / "goldens.json";
+            ok                                      = medui::verify(*outputs, packagePath, goldensPath, invocation.verify.reportPath, diagnostics);
+        }
+        if (!ok) {
+            return {};
+        }
+        return std::format("{}: OK ({} {}: {} nodes, {} golden references)",
+                           medui::compilerToolName,
+                           invocation.mode == cli::Mode::Bake ? "compiled" : "verified",
+                           outputs->screenId,
+                           outputs->nodeCount,
+                           outputs->goldenCount);
+    } catch (const std::exception& error) {
+        cli::Diagnostic internal;
+        internal.file     = recipePath;
+        internal.code     = "MEDUI-E000";
+        internal.severity = cli::Severity::Error;
+        internal.message  = std::format("the compiler stopped on an internal error: {}", error.what());
+        internal.fixHint  = "this is a defect in mdux-meduic rather than in the recipe; please report it with the recipe attached";
+        diagnostics.push_back(std::move(internal));
+        return {};
+    }
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -66,29 +115,7 @@ int main(int argc, char** argv) {
 
     const std::string& recipePath = invocation.mode == cli::Mode::Bake ? invocation.bake.recipe : invocation.verify.recipe;
 
-    std::string summary;
-    if (auto outputs = produce(recipePath, diagnostics); outputs.has_value()) {
-        bool ok = false;
-        if (invocation.mode == cli::Mode::Bake) {
-            ok = medui::write(*outputs, invocation.bake.outputDir, diagnostics);
-        } else {
-            // The shared grammar carries two output paths and a screen has three. The goldens
-            // sidecar is not an independent fact: ADR-012 puts all three files in one directory, so
-            // it is read from beside the package rather than named a second time on a command line
-            // where the two could disagree.
-            const std::filesystem::path packagePath{invocation.verify.packagePath};
-            const std::filesystem::path goldensPath = packagePath.parent_path() / "goldens.json";
-            ok                                      = medui::verify(*outputs, packagePath, goldensPath, invocation.verify.reportPath, diagnostics);
-        }
-        if (ok) {
-            summary = std::format("{}: OK ({} {}: {} nodes, {} golden references)",
-                                  medui::compilerToolName,
-                                  invocation.mode == cli::Mode::Bake ? "compiled" : "verified",
-                                  outputs->screenId,
-                                  outputs->nodeCount,
-                                  outputs->goldenCount);
-        }
-    }
+    const std::string summary = compile(invocation, recipePath, diagnostics);
 
     // Both formats go to stdout, matching every other MduX tool: an agent should not have to know
     // which stream each one uses, which is what the shared envelope exists to remove.

--- a/tools/medui/MeduicMain.cpp
+++ b/tools/medui/MeduicMain.cpp
@@ -1,0 +1,104 @@
+/**
+ * @file MeduicMain.cpp
+ * @brief `mdux-meduic` entry point: the `.medui` compiler as a baker.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Split library-and-executable like every other baker, so tests drive `run()`, `write()` and
+ * `verify()` as calls. Spawning this process per case would make a failing assertion report that an
+ * exit status was wrong, which is the least useful thing it could say about a compiler.
+ *
+ * It speaks the shared `bake`/`verify` grammar, so `mdux_bake_artifact()` registers a screen the
+ * same way it registers a font or a shader, and `--format=json` produces the same envelope every
+ * other MduX tool produces.
+ */
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.compile;
+
+namespace {
+
+namespace cli   = mdux::tools::cli;
+namespace medui = mdux::tools::medui;
+
+/// Reads the recipe and runs every compiler stage. Shared by both modes: `verify` must produce the
+/// same bytes `bake` would before it can compare them to what is committed.
+[[nodiscard]] std::optional<medui::CompileOutputs> produce(const std::string& recipePath, std::vector<cli::Diagnostic>& diagnostics) {
+    const std::optional<std::vector<std::byte>> recipeBytes = medui::readFile(recipePath);
+    if (!recipeBytes.has_value()) {
+        // The one diagnostic this tool raises itself; every other one comes from a stage.
+        cli::Diagnostic unreadable;
+        unreadable.file     = recipePath;
+        unreadable.code     = "MEDUI-E000";
+        unreadable.severity = cli::Severity::Error;
+        unreadable.message  = "the recipe file could not be opened";
+        unreadable.fixHint  = "check the path passed on the command line, and that the file is readable";
+        diagnostics.push_back(std::move(unreadable));
+        return std::nullopt;
+    }
+
+    const std::string_view             recipeText{reinterpret_cast<const char*>(recipeBytes->data()), recipeBytes->size()};
+    const std::optional<medui::Recipe> recipe = medui::parseRecipe(recipeText, recipePath, diagnostics);
+    if (!recipe.has_value()) {
+        return std::nullopt;
+    }
+
+    // The working directory is the repository root - `mdux_bake_artifact()` runs every baker that
+    // way - so every path the recipe names and every path the report records stays repository
+    // relative, which is what keeps a report free of absolute paths.
+    return medui::run(*recipe, recipePath, *recipeBytes, std::filesystem::current_path(), diagnostics);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    cli::Invocation invocation;
+    try {
+        invocation = cli::parse(medui::compilerToolName, argc, argv);
+    } catch (const cli::UsageError& error) {
+        std::println(std::cerr, "{}", error.what());
+        return 2;
+    }
+
+    std::vector<cli::Diagnostic> diagnostics;
+
+    const std::string& recipePath = invocation.mode == cli::Mode::Bake ? invocation.bake.recipe : invocation.verify.recipe;
+
+    std::string summary;
+    if (auto outputs = produce(recipePath, diagnostics); outputs.has_value()) {
+        bool ok = false;
+        if (invocation.mode == cli::Mode::Bake) {
+            ok = medui::write(*outputs, invocation.bake.outputDir, diagnostics);
+        } else {
+            // The shared grammar carries two output paths and a screen has three. The goldens
+            // sidecar is not an independent fact: ADR-012 puts all three files in one directory, so
+            // it is read from beside the package rather than named a second time on a command line
+            // where the two could disagree.
+            const std::filesystem::path packagePath{invocation.verify.packagePath};
+            const std::filesystem::path goldensPath = packagePath.parent_path() / "goldens.json";
+            ok                                      = medui::verify(*outputs, packagePath, goldensPath, invocation.verify.reportPath, diagnostics);
+        }
+        if (ok) {
+            summary = std::format("{}: OK ({} {}: {} nodes, {} golden references)",
+                                  medui::compilerToolName,
+                                  invocation.mode == cli::Mode::Bake ? "compiled" : "verified",
+                                  outputs->screenId,
+                                  outputs->nodeCount,
+                                  outputs->goldenCount);
+        }
+    }
+
+    // Both formats go to stdout, matching every other MduX tool: an agent should not have to know
+    // which stream each one uses, which is what the shared envelope exists to remove.
+    const std::string rendered = cli::render(diagnostics, invocation.format, medui::compilerToolName);
+    if (!rendered.empty()) {
+        std::print(std::cout, "{}", rendered);
+    }
+    if (invocation.format == cli::Format::Text && !summary.empty()) {
+        std::println(std::cout, "{}", summary);
+    }
+
+    return cli::exitStatus(diagnostics);
+}

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -464,4 +464,45 @@ TextBudgetResult checkTextBudgets(const LayoutResult& layout, std::string file, 
     return Checker{std::move(file), inputs}.run(layout);
 }
 
+
+bool needsTextBudget(const ast::Screen& screen) {
+    // Walks the authored tree rather than a resolved layout: the question is asked before layout
+    // runs, because its answer decides whether the recipe is complete enough to compile at all.
+    const auto carriesMeasurableText = [](const ast::Node& node) {
+        for (const ast::Field& field : node.fields) {
+            if (field.value == nullptr) {
+                continue;
+            }
+            if (field.value->kind == ast::ValueKind::TextKey) {
+                return true;
+            }
+            if (field.value->kind == ast::ValueKind::List) {
+                for (const std::shared_ptr<ast::Value>& element : field.value->list) {
+                    if (element != nullptr && element->kind == ast::ValueKind::TextKey) {
+                        return true;
+                    }
+                }
+            }
+            // Asked through the same predicate the measuring pass uses, so a third dynamic-text
+            // field reaches this question without anyone having to remember it.
+            if (namesDynamicText(node.component, field.name)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    for (const ast::Node& node : screen.nodes) {
+        if (carriesMeasurableText(node)) {
+            return true;
+        }
+        for (const ast::Node& child : node.children) {
+            if (carriesMeasurableText(child)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 }  // namespace mdux::tools::medui

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -226,4 +226,18 @@ struct TextBudgetResult {
  */
 [[nodiscard]] TextBudgetResult checkTextBudgets(const LayoutResult& layout, std::string file, TextBudgetInputs inputs);
 
+/**
+ * @brief Whether this screen has anything for the budget stage to measure.
+ *
+ * True when the screen carries a text key, or a field whose value names a dynamic-text source -
+ * `Clock`'s `format:` and `TextInput`'s `charset:`, the two the table in this module's
+ * implementation lists. Both are things `checkTextBudgets()` checks and nothing else does.
+ *
+ * Exported so a compiler driver can decide whether a recipe *must* supply a font package and its
+ * approved locales, rather than deciding by inspecting the screen itself. The list of dynamic-text
+ * fields would otherwise exist in two places, and the second copy is the one that would go stale the
+ * day a third field joins them.
+ */
+[[nodiscard]] bool needsTextBudget(const ast::Screen& screen);
+
 }  // namespace mdux::tools::medui

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -104,6 +104,7 @@ import std;
 import mdux.font.schema;
 import mdux.text.schema;
 import mdux.tools.cli;
+import mdux.tools.medui.ast;
 import mdux.tools.medui.layout;
 
 export namespace mdux::tools::medui {

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -157,10 +157,14 @@ struct DynamicTextRule {
  * would overflow on a device with the compiler's blessing. Requiring the whole set makes that
  * particular silence impossible.
  */
+// Every member carries a default initialiser. `-Wmissing-field-initializers` is an error in this
+// tree, so a type whose optional members still have to be spelled at every call site is a trap - and
+// an omitted `dynamicText` is fail-closed anyway: a name with no rule behind it is `MEDUI-E053`
+// rather than a name silently accepted.
 struct TextBudgetInputs {
     const mdux::font::FontPackage*   font{nullptr};
-    std::span<const LocaleText>      locales;
-    std::span<const DynamicTextRule> dynamicText;
+    std::span<const LocaleText>      locales{};
+    std::span<const DynamicTextRule> dynamicText{};
 };
 
 /// The ink one baked run paints, in surface pixels.


### PR DESCRIPTION
First of two for S9. This one is the compiler: a recipe in, three artifacts out. The
`mdux_compile_screen()` registration, the first committed screen under `generated/screen/` and its
`evidence.screen.<id>` test follow in the second.

## What it adds

`mdux.tools.medui.compile` plus the `mdux-meduic` executable, split library-and-executable like every
other baker so the scenarios drive `run()`, `write()` and `verify()` as calls. Spawning the process
per case would make a failing assertion report that an exit status was wrong, which is the least
useful thing it could say about a compiler.

**The order is the deliverable.** Every stage this epic built already existed as a call; what did not
exist was a statement of the order they run in. This driver is the only place that answer is written
down - parse, analyze, validate annotations, resolve layout, check text budgets, collect goldens,
build and write. Annotations before layout is not arbitrary: the shared conformance suite pins
`MEDUI-E070` on a screen with no `surface:`, which the solver cannot resolve at all, so a design that
could only report it after layout could not satisfy the contract it implements.

A stage that reports anything stops the compile, rather than accumulating across stages. A later
stage reading a screen an earlier one rejected reports consequences rather than causes, and the
surface-mismatch scenario asserts exactly one diagnostic for that reason.

## The rule I would most like you to check

`checkTextBudgets()` requires a font package and **exactly** the locales that font approves, so a
recipe declaring neither cannot run the stage at all. Skipping it silently would be a hole: a screen
that draws text and declares no approved locale would be certified against a set nobody approved, and
the omitted translation is precisely the one that overflows a box.

So the driver asks whether the screen has anything to measure, and refuses an incomplete recipe with
`MEDUI-E002` rather than compiling without the check. The question is asked through
`needsTextBudget()`, added to #195's module next to the dynamic-text table it already owns - the two
dynamic-text fields (`Clock.format`, `TextInput.charset`) are checked *only* by the budget stage, so
a driver that answered this itself would be the second place that knows what counts as text, and the
one that goes stale when a third field joins them.

The stage is therefore skipped only for a screen with no text key and no dynamic-text field, which is
what `accepted-textless.medui` is: a Row background, an Image, a VulkanViewport and a positioned
SignalTrace.

## Recipe shape

No defaults, anywhere. `MEDUI-E002`'s registry entry gives the reason and I have kept to it: a
defaulted knob does not appear in `report.json`, so changing that default later would leave every
report looking unchanged, which ADR-007 forbids.

The surface is declared by the recipe rather than read from the source. The solver then checks the
source's own `surface:` against it, so the panel a product ships and the screen an author drew for it
disagree loudly instead of silently rescaling.

## Two things deferred deliberately

- **No text package is committed anywhere in this repository yet**, so no screen that draws text can
  be compiled end to end today. That is #201's (S12) job, and it is why the first artifact this epic
  commits will be text-free. Flagging it because it surprised me: the tool exists and is tested, but
  nothing registers a `recipes/text/` bake.
- **`verify` derives `goldens.json` from the package's directory.** The shared CLI grammar carries
  two output paths and a screen has three; ADR-012 puts all three in one directory, so the sidecar's
  location is not an independent fact and naming it twice would let the two disagree.

## Tests

`tests/medui/CompileTests.cpp`, five scenarios in `medui_tools_spec`: every knob required (each
removal refused, one at a time), the three artifacts a compile produces, the locale rule above, a
rejected stage stopping at the cause, and write/verify agreeing - including that a hand-edited
artifact does not verify.

The package is read back through `readPackage()` rather than inspected as the value that produced it,
so the scenario exercises the round trip a device's build would take.

## Regulatory impact

No device code changes; everything here is host-tools zone. What changes is that the compile order
becomes a contract rather than a convention, and that an incomplete recipe is refused rather than
producing a screen whose text boxes nobody measured. The bake report records the recipe, the source
and every input's digest, with `toolVersion` as the project's semantic version and nothing that
varies per machine - ADR-007 decision 5's rule, which a byte-compared artifact depends on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `mdux-meduic` command-line compiler for `.medui` recipes.
  - Generates validated screen packages, golden artifacts, and evidence reports.
  - Supports artifact writing, verification, tamper detection, and text or JSON diagnostics.
  - Added validation for recipe completeness, locales, text budgets, Unicode ranges, and compilation stages.
  - Textless screens can compile without text-budget or locale configuration.

- **Tests**
  - Added comprehensive coverage for compilation, validation failures, diagnostics, artifact verification, and textless screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->