### PR TITLE
Register the first compiled screen as an evidence artifact [#198]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ Makefile
 *.cmake
 !cmake/*.cmake
 
+# ...and the CMake-level tests, which are scripts CTest runs rather than build output. Without this
+# `git add` skips them silently and the tests fail on CI with "Not a file", which is how this line
+# came to exist.
+!tests/cmake/*.cmake
+
 # Compiled binaries
 *.exe
 *.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,20 @@ mdux_bake_artifact(
         shaders.spv
 )
 
+# The first compiled screen (issue #198). Registered through mdux_compile_screen(), which is a thin
+# front for mdux_bake_artifact() - a screen earns the same build-tree bake, the same -update target
+# and the same evidence.screen.<id> byte comparison as a font or a shader, because nothing about a
+# screen justifies weaker evidence than its neighbours.
+#
+# It draws no text on purpose: no text package is baked in this tree yet, so the text-budget stage
+# has nothing to measure against and a screen carrying t("STR-KEY") would be refused for declaring no
+# approved locale. #201 lands the text half.
+include(cmake/MduXCompileScreen.cmake)
+mdux_compile_screen(
+    ID endoscope-monitor
+    RECIPE recipes/screen/endoscope-monitor.toml
+)
+
 # Generated C++ for that package (issue #121). Build-tree only, never committed - see
 # cmake/MduXShaderEmit.cmake. The renderer (#124) and the triangle example (#122) consume the
 # module form; the header form exists for a translation unit that cannot import a named module.

--- a/cmake/MduXCompileScreen.cmake
+++ b/cmake/MduXCompileScreen.cmake
@@ -1,0 +1,81 @@
+# Registering a compiled screen as an evidence artifact (issue #198).
+#
+# `mdux_compile_screen()` is a thin front for `mdux_bake_artifact()`: a screen is baked like a font,
+# a shader or a model, so it gets the same build-tree output, the same `-update` target that stages
+# into `generated/`, and the same `evidence.screen.<id>` byte-comparison on every toolchain leg.
+# Nothing about a screen justifies a second mechanism, and a second mechanism is how one artifact
+# kind ends up with weaker evidence than its neighbours.
+#
+# What this wrapper adds over calling `mdux_bake_artifact()` directly is the two things a caller
+# could otherwise get wrong silently:
+#
+#   - **The three outputs are fixed here**, not per call site. ADR-012 makes `package.json`,
+#     `goldens.json` and `report.json` unconditional, so a screen that pins nothing writes `[]`
+#     rather than one fewer file. A call site listing its own OUTPUTS could drop one and produce a
+#     smaller artifact that still passed its own comparison.
+#   - **The `.medui` source becomes a dependency automatically**, read out of the recipe. A
+#     forgotten SOURCES entry does not fail: it makes edits to the screen stop triggering a rebake,
+#     so the committed artifact quietly stops matching its source until someone runs the update
+#     target for another reason.
+
+include_guard(GLOBAL)
+
+# mdux_compile_screen(ID <id> RECIPE <path> [SOURCES <path>...])
+#
+# SOURCES names further inputs the recipe references - the font and text packages a screen that
+# draws text needs. The `.medui` source itself is found in the recipe and does not have to be
+# repeated.
+function(mdux_compile_screen)
+    set(options "")
+    set(single ID RECIPE)
+    set(multi SOURCES)
+    cmake_parse_arguments(ARG "${options}" "${single}" "${multi}" ${ARGN})
+
+    if(ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "mdux_compile_screen: unexpected arguments: ${ARG_UNPARSED_ARGUMENTS}")
+    endif()
+    foreach(required ID RECIPE)
+        if(NOT ARG_${required})
+            message(FATAL_ERROR "mdux_compile_screen: ${required} is required")
+        endif()
+    endforeach()
+
+    set(recipe_path "${CMAKE_SOURCE_DIR}/${ARG_RECIPE}")
+    if(NOT EXISTS "${recipe_path}")
+        message(FATAL_ERROR "mdux_compile_screen: recipe '${ARG_RECIPE}' does not exist")
+    endif()
+
+    # The screen source, taken from the recipe rather than from the call site. A regex over one
+    # `key = "value"` line rather than a TOML parse: CMake has no TOML reader, the compiler is the
+    # authority on the recipe's meaning, and the only thing needed here is the dependency edge.
+    # A recipe whose `source` this cannot find is a configure error rather than a build that
+    # silently never rebakes.
+    file(READ "${recipe_path}" recipe_text)
+    string(REGEX MATCH "\n[ \t]*source[ \t]*=[ \t]*\"([^\"]+)\"" _match "\n${recipe_text}")
+    if(NOT CMAKE_MATCH_1)
+        message(FATAL_ERROR
+            "mdux_compile_screen: no `source = \"...\"` line in ${ARG_RECIPE}. The screen source has "
+            "to be a dependency of the bake, or editing it would not trigger one.")
+    endif()
+    set(screen_source "${CMAKE_MATCH_1}")
+
+    if(NOT EXISTS "${CMAKE_SOURCE_DIR}/${screen_source}")
+        message(FATAL_ERROR
+            "mdux_compile_screen: ${ARG_RECIPE} names the source '${screen_source}', which does not exist")
+    endif()
+
+    mdux_bake_artifact(
+        KIND screen
+        ID ${ARG_ID}
+        TOOL mdux-meduic
+        RECIPE ${ARG_RECIPE}
+        SOURCES
+            ${screen_source}
+            ${ARG_SOURCES}
+        # Fixed here rather than per call site: all three are unconditional (ADR-012, decision 1).
+        OUTPUTS
+            package.json
+            goldens.json
+            report.json
+    )
+endfunction()

--- a/cmake/MduXCompileScreen.cmake
+++ b/cmake/MduXCompileScreen.cmake
@@ -20,6 +20,80 @@
 
 include_guard(GLOBAL)
 
+# _mdux_screen_package_field(<out_var> <recipe_text> <key> <label>)
+#
+# The value of `key` in the recipe's `[package]` table, and nothing else's.
+#
+# Scoped to that table on purpose. `mdux-meduic` reads `document.table("package")->require("source")`
+# and ignores tables it does not know, so a recipe may legally carry an earlier `source` key in
+# another table - and a regex over the whole document would then hand CMake a different file from the
+# one the compiler compiles. The dependency edge would point at the wrong input, editing the real
+# screen would stop triggering a rebake, and `mdux-bake-update` would stage bytes nobody asked for.
+# That is precisely the silent drift this wrapper exists to prevent, so getting the scope wrong here
+# is worse than not having the wrapper.
+#
+# Two keys in one table is an error rather than a first-wins: the compiler's TOML reader decides that
+# case, this does not have to guess the same way, and a recipe that ambiguous should be fixed.
+#
+# Line-based rather than a single regex, because a value or a comment may contain `[` - this
+# repository's own recipes carry `^[a-z0-9]...` inside a comment in `[package]` - and a section match
+# that stopped at the next bracket would truncate the table.
+function(_mdux_screen_package_field out_var recipe_text key label)
+    string(REPLACE ";" "\\;" escaped "${recipe_text}")
+    string(REGEX REPLACE "\r?\n" ";" lines "${escaped}")
+
+    set(current_table "")
+    set(found "")
+    foreach(line IN LISTS lines)
+        # Both patterns are anchored after leading whitespace, so a commented-out `# source = "x"` or
+        # `# [package]` cannot match. That is why no comment stripping is needed, and why stripping
+        # would be wrong: a `#` inside a quoted value is part of the value.
+        if(line MATCHES "^[ \t]*\\[([A-Za-z0-9_.-]+)\\]")
+            set(current_table "${CMAKE_MATCH_1}")
+        elseif(current_table STREQUAL "package" AND line MATCHES "^[ \t]*${key}[ \t]*=[ \t]*\"([^\"]*)\"")
+            list(APPEND found "${CMAKE_MATCH_1}")
+        endif()
+    endforeach()
+
+    list(LENGTH found count)
+    if(count EQUAL 0)
+        message(FATAL_ERROR
+            "mdux_compile_screen: ${label} has no `${key} = \"...\"` line in its [package] table. "
+            "The compiler reads that table, so anything else here would describe a different recipe.")
+    endif()
+    if(count GREATER 1)
+        message(FATAL_ERROR
+            "mdux_compile_screen: ${label} declares `${key}` ${count} times in [package]. "
+            "Which one the compiler uses is its TOML reader's business; this refuses to guess.")
+    endif()
+
+    list(GET found 0 value)
+    set(${out_var} "${value}" PARENT_SCOPE)
+endfunction()
+
+# _mdux_screen_check_recipe(<recipe_text> <label> <expected_id> <out_source_var>)
+#
+# Fails configuration unless the recipe describes the screen the caller says it does, and yields the
+# `.medui` source so it can become a dependency.
+#
+# The id check is the one that keeps identity single. `mdux-meduic` checks the recipe's id against the
+# screen's own name, but it never sees the CMake `ID` - so without this, `mdux_compile_screen(ID foo
+# RECIPE bar.toml)` bakes a package that calls itself `bar` into `mdux_bake/screen/foo`, compares it
+# as `evidence.screen.foo` and stages it into `generated/screen/foo/`. Every check passes while the
+# directory, the test and the package disagree about which screen this is.
+function(_mdux_screen_check_recipe recipe_text label expected_id out_source_var)
+    _mdux_screen_package_field(recipe_id "${recipe_text}" "id" "${label}")
+    if(NOT recipe_id STREQUAL expected_id)
+        message(FATAL_ERROR
+            "mdux_compile_screen: ${label} declares id '${recipe_id}', but was registered as "
+            "'${expected_id}'. The id names the artifact directory, the evidence test and the "
+            "emitted C++ identifier, so these must be one name.")
+    endif()
+
+    _mdux_screen_package_field(screen_source "${recipe_text}" "source" "${label}")
+    set(${out_source_var} "${screen_source}" PARENT_SCOPE)
+endfunction()
+
 # mdux_compile_screen(ID <id> RECIPE <path> [SOURCES <path>...])
 #
 # SOURCES names further inputs the recipe references - the font and text packages a screen that
@@ -45,19 +119,10 @@ function(mdux_compile_screen)
         message(FATAL_ERROR "mdux_compile_screen: recipe '${ARG_RECIPE}' does not exist")
     endif()
 
-    # The screen source, taken from the recipe rather than from the call site. A regex over one
-    # `key = "value"` line rather than a TOML parse: CMake has no TOML reader, the compiler is the
-    # authority on the recipe's meaning, and the only thing needed here is the dependency edge.
-    # A recipe whose `source` this cannot find is a configure error rather than a build that
-    # silently never rebakes.
+    # The screen source and the recipe's own id, taken from the recipe rather than from the call
+    # site. See the two helpers above for what each check is for.
     file(READ "${recipe_path}" recipe_text)
-    string(REGEX MATCH "\n[ \t]*source[ \t]*=[ \t]*\"([^\"]+)\"" _match "\n${recipe_text}")
-    if(NOT CMAKE_MATCH_1)
-        message(FATAL_ERROR
-            "mdux_compile_screen: no `source = \"...\"` line in ${ARG_RECIPE}. The screen source has "
-            "to be a dependency of the bake, or editing it would not trigger one.")
-    endif()
-    set(screen_source "${CMAKE_MATCH_1}")
+    _mdux_screen_check_recipe("${recipe_text}" "${ARG_RECIPE}" "${ARG_ID}" screen_source)
 
     if(NOT EXISTS "${CMAKE_SOURCE_DIR}/${screen_source}")
         message(FATAL_ERROR

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,7 @@ recipes/<kind>/<id>.toml  ──[ mdux-<kind>bake ]──▶  generated/<kind>/<
                                                       <payload>.bin
 ```
 
-Five artifacts are committed today:
+Six artifacts are committed today:
 
 | Artifact | Baker | Payload |
 |---|---|---|
@@ -145,6 +145,13 @@ Five artifacts are committed today:
 | `generated/model/ecg-demo/` | `mdux-mlbake` | `weights.bin` |
 | `generated/model/ecg-demo-alt/` | `mdux-mlbake` | `weights.bin` |
 | `generated/font/dejavu-ui/` | `mdux-textbake` | `atlas.bin` |
+| `generated/screen/endoscope-monitor/` | `mdux-meduic` | `goldens.json` |
+
+The screen is the one entry whose payload is not opaque bytes, and ADR-012 explains why: a screen
+cannot bake vertices, because four of its components draw from live data and their geometry does not
+exist until the frame does. What it bakes instead is layout - where each node is, how much it may
+draw, and which validated token and key it draws with - and a sidecar of golden references saying
+where safety-critical content must appear. Both are reviewable as text, which is the point.
 
 Every baker registers through `mdux_bake_artifact()`
 ([`cmake/MduXBake.cmake`](../cmake/MduXBake.cmake)), which creates the bake target, an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,13 +145,18 @@ Six artifacts are committed today:
 | `generated/model/ecg-demo/` | `mdux-mlbake` | `weights.bin` |
 | `generated/model/ecg-demo-alt/` | `mdux-mlbake` | `weights.bin` |
 | `generated/font/dejavu-ui/` | `mdux-textbake` | `atlas.bin` |
-| `generated/screen/endoscope-monitor/` | `mdux-meduic` | `goldens.json` |
+| `generated/screen/endoscope-monitor/` | `mdux-meduic` | `package.json` + `goldens.json` |
 
 The screen is the one entry whose payload is not opaque bytes, and ADR-012 explains why: a screen
-cannot bake vertices, because four of its components draw from live data and their geometry does not
-exist until the frame does. What it bakes instead is layout - where each node is, how much it may
-draw, and which validated token and key it draws with - and a sidecar of golden references saying
-where safety-critical content must appear. Both are reviewable as text, which is the point.
+cannot bake vertices, because four of the eleven components in the dictionary — `NumericDisplay`,
+`SignalTrace`, `StatusIndicator` and `Clock` — draw from live data, and their geometry does not exist
+until the frame does. What `package.json` carries instead is layout: where each node is, how much it
+may draw, and which validated token and key it draws with.
+
+`goldens.json` is a sidecar with a different consumer — #16's frame verifier, not the runtime — and a
+different rule. ADR-011 puts **every `@safety_critical` node and every node with an explicit
+`position:`** in the golden set, which is why the committed screen has one entry: its `SignalTrace`
+is positioned, not annotated. Both files are reviewable as text, which is the point.
 
 Every baker registers through `mdux_bake_artifact()`
 ([`cmake/MduXBake.cmake`](../cmake/MduXBake.cmake)), which creates the bake target, an

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -262,7 +262,7 @@ happened to read.
 - #195 S6 Text-budget validation against every approved locale · _closed_
 - #196 S7 Golden references for safety-critical nodes · _closed_
 - #197 S8 Canonical package and C++ emitters · _closed (PRs #220, #221)_
-- #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #228)_
+- #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #231)_
 - #199 S10 Allocation-free screen runtime · **next**
 - #200 S11 `mdux-medui-check`
 - #201 S12 First end-to-end screen

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,11 +11,12 @@ what the build actually produces. Track C's authoring story is what remains: #14
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
 that generates the screens it draws. Eight of its twelve children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
-golden references, and the canonical package with its C++ emitters — so the compiler now reads a
-`.medui` file, resolves it to a bounded box tree, refuses a box that cannot hold its widest approved
-translation, says where safety-critical content must appear, and writes the result as both a
-byte-compared artifact and `constexpr` C++ a device links without a parser. #198 is next: the CMake
-integration and the `mdux-meduic` host tool that runs all of it from a recipe.
+golden references, the canonical package with its C++ emitters, and the `mdux-meduic` compiler with
+its CMake registration — so the compiler now reads a `.medui` file, resolves it to a bounded box
+tree, refuses a box that cannot hold its widest approved translation, says where safety-critical
+content must appear, and writes the result as a byte-compared artifact and as `constexpr` C++ a
+device links without a parser. The first compiled screen is committed under
+`generated/screen/endoscope-monitor/`. #199 is next: the allocation-free runtime that draws one.
 
 | Metric | Count |
 |---|---|
@@ -59,7 +60,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S8 done · S9 next)
+Wave 5 · in progress        #15 (S1–S9 done · S10 next)
 Wave 6                      #16  #17
 ```
 
@@ -239,7 +240,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 8/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 9/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -261,8 +262,8 @@ happened to read.
 - #195 S6 Text-budget validation against every approved locale · _closed_
 - #196 S7 Golden references for safety-critical nodes · _closed_
 - #197 S8 Canonical package and C++ emitters · _closed (PRs #220, #221)_
-- #198 S9 CMake integration and the `mdux-meduic` host tool · **next**
-- #199 S10 Allocation-free screen runtime
+- #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #228)_
+- #199 S10 Allocation-free screen runtime · **next**
 - #200 S11 `mdux-medui-check`
 - #201 S12 First end-to-end screen
 

--- a/generated/screen/endoscope-monitor/goldens.json
+++ b/generated/screen/endoscope-monitor/goldens.json
@@ -1,0 +1,15 @@
+[
+  {
+    "bounds": {
+      "height": 128,
+      "width": 1280,
+      "x": 0,
+      "y": 592
+    },
+    "colorToken": "Theme.Colors.Nominal",
+    "cvChecks": [
+      "Bounds"
+    ],
+    "nodeId": "ecg-lead-ii"
+  }
+]

--- a/generated/screen/endoscope-monitor/package.json
+++ b/generated/screen/endoscope-monitor/package.json
@@ -1,0 +1,67 @@
+{
+  "budget": {
+    "maxCommands": 64,
+    "maxIndices": 6144,
+    "maxVertices": 4096
+  },
+  "id": "endoscope-monitor",
+  "kind": "screen",
+  "nodes": [
+    {
+      "bounds": {
+        "height": 72,
+        "width": 1280,
+        "x": 0,
+        "y": 0
+      },
+      "id": "topbar-background",
+      "kind": "Panel",
+      "spec": {
+        "colorToken": "Theme.Colors.TopbarBackground"
+      }
+    },
+    {
+      "bounds": {
+        "height": 72,
+        "width": 240,
+        "x": 0,
+        "y": 0
+      },
+      "id": "brand-mark",
+      "kind": "Image",
+      "spec": {
+        "source": "IMG-BRAND-MARK"
+      }
+    },
+    {
+      "bounds": {
+        "height": 520,
+        "width": 1280,
+        "x": 0,
+        "y": 72
+      },
+      "id": "endoscope-view",
+      "kind": "VulkanViewport",
+      "spec": {
+        "streamSource": "ENDOSCOPE_PRIMARY"
+      }
+    },
+    {
+      "bounds": {
+        "height": 128,
+        "width": 1280,
+        "x": 0,
+        "y": 592
+      },
+      "id": "ecg-lead-ii",
+      "kind": "SignalTrace",
+      "spec": {
+        "colorToken": "Theme.Colors.Nominal",
+        "streamSource": "ECG_LEAD_II"
+      }
+    }
+  ],
+  "schemaVersion": 1,
+  "surfaceHeight": 720,
+  "surfaceWidth": 1280
+}

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -1,0 +1,39 @@
+{
+  "inputs": [
+    {
+      "path": "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui",
+      "sha256": "7edbb61c9e6e196bb8f38b9a1339491cf2b2abbf51e47515c9fb37b0df8f32ae"
+    }
+  ],
+  "options": {
+    "budget": {
+      "maxCommands": 64,
+      "maxIndices": 6144,
+      "maxVertices": 4096
+    },
+    "dynamicText": [],
+    "fontPackage": "",
+    "id": "endoscope-monitor",
+    "source": "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui",
+    "surfaceHeight": 720,
+    "surfaceWidth": 1280,
+    "textPackages": []
+  },
+  "outputs": [
+    {
+      "path": "goldens.json",
+      "sha256": "d287cf21560be2891a0ab11ba6bcf197cd2295fc20ed900d95ea931aef3bdf4c"
+    },
+    {
+      "path": "package.json",
+      "sha256": "c0aa463ba4f87185729aaa99870e2497012c4e3506eb5a101fbc166e54433cef"
+    }
+  ],
+  "recipe": {
+    "path": "recipes/screen/endoscope-monitor.toml",
+    "sha256": "098afa4645afdb85dcf238c511c062bebedebf1148e8a565383df905db761af5"
+  },
+  "schemaVersion": 1,
+  "tool": "mdux-meduic",
+  "toolVersion": "0.5.0"
+}

--- a/recipes/screen/endoscope-monitor.toml
+++ b/recipes/screen/endoscope-monitor.toml
@@ -1,0 +1,43 @@
+# The endoscope monitor screen, compiled by mdux-meduic into generated/screen/endoscope-monitor/,
+# which is committed and byte-verified by `ctest -L evidence` on every active toolchain (ADR-007,
+# ADR-011, ADR-012).
+#
+# ## The id is the mapping ADR-012 asks to be recorded
+#
+# A screen's identity in the grammar is CamelCase - `Screen EndoscopeMonitor` - while an artifact id
+# must match `^[a-z0-9][a-z0-9-]*$` because it names a directory, a test and a generated C++
+# identifier. The recipe records the pairing rather than the compiler deriving it: a slug cannot be
+# derived injectively from a name, since names admit `-` and `_` and lowercasing is not injective
+# across case. What the compiler does check is that the two are the same word.
+#
+# ## Why this screen draws no text
+#
+# Not a simplification for its own sake. No text package is baked anywhere in this tree yet, so the
+# text-budget stage has nothing to measure against and a screen carrying `t("STR-KEY")` would be
+# refused - correctly - for declaring no approved locale. #201 lands the text half; this screen
+# proves the rest of the pipeline end to end in the meantime.
+#
+# To change the screen, edit the .medui source and run
+#
+#   cmake --build <build-dir> --target mdux-bake-update
+#
+# then review the diff to generated/screen/endoscope-monitor/.
+
+[package]
+id            = "endoscope-monitor"
+source        = "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui"
+
+# The panel this screen is drawn for. Declared here rather than taken from the source, so a screen
+# drawn for another panel is a diagnostic rather than a silently rescaled frame; the solver checks
+# the source's own `surface:` against these two numbers.
+surfaceWidth  = 1280
+surfaceHeight = 720
+
+# What the runtime may draw for this screen, declared by the product rather than computed. The cost
+# model that would let a compiler compute it belongs to the runtime (#199), and until then a declared
+# ceiling is the honest form: DrawList fails closed against these numbers at run time, and the schema
+# refuses an empty budget on a screen that has nodes.
+[budget]
+maxVertices = 4096
+maxIndices  = 6144
+maxCommands = 64

--- a/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
+++ b/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
@@ -1,0 +1,46 @@
+// The first screen this repository compiles into a committed artifact (#198).
+//
+// It draws no text, and that is a deliberate limit rather than a design: no text package is baked
+// anywhere in this tree yet, so a screen carrying `t("STR-KEY")` cannot be compiled end to end until
+// #201 lands the text half. What this screen does exercise is everything that does not depend on
+// that - the Row background the solver synthesises, a live video surface, a live waveform, a baked
+// image, and an explicitly positioned node whose rectangle a golden reference pins.
+//
+// One property per line, matching TrustSC's own sources: its parser splits a component body line by
+// line, so a fixture written the portable way is evidence about a shared grammar rather than about
+// one implementation.
+Screen EndoscopeMonitor {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 1280px, 720px;
+
+    Row {
+        id: topbar;
+        height: 72px;
+        background: Theme.Colors.TopbarBackground;
+
+        Image {
+            id: brand-mark;
+            width: 240px;
+            height: 72px;
+            source: img("IMG-BRAND-MARK");
+        }
+    }
+
+    VulkanViewport {
+        id: endoscope-view;
+        width: 1280px;
+        height: 520px;
+        stream_source: "ENDOSCOPE_PRIMARY";
+    }
+
+    // Positioned, so its rectangle is pinned by a golden reference: a waveform that drifts off its
+    // band is the kind of regression a screenshot comparison catches and a unit test does not.
+    SignalTrace {
+        id: ecg-lead-ii;
+        width: 1280px;
+        height: 128px;
+        position: 0px, 592px;
+        stream_source: "ECG_LEAD_II";
+        color: Theme.Colors.Nominal;
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -877,8 +877,11 @@ endforeach()
 add_test(NAME "screen.recipe.identity"
     COMMAND ${CMAKE_COMMAND} -DCASE=identity
             -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+# Short fragments, on purpose: CMake wraps the text of a FATAL_ERROR to its own width, so a regex
+# spanning two clauses can straddle the line break it inserts. This one did - the message was right
+# and the test failed anyway - which is worth one line here to save the next person the same hunt.
 set_tests_properties("screen.recipe.identity" PROPERTIES
-    PASS_REGULAR_EXPRESSION "declares id 'real-screen', but was registered as")
+    PASS_REGULAR_EXPRESSION "declares id 'real-screen'")
 
 add_test(NAME "screen.recipe.ambiguous"
     COMMAND ${CMAKE_COMMAND} -DCASE=ambiguous

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -857,6 +857,41 @@ endif()
 
 mdux_discover_tests(medui_tools_spec)
 
+# mdux_compile_screen()'s recipe reading (issue #198)
+#
+# Script-mode CMake, because what is under test is a pure function of the recipe text: which
+# `[package]` keys the wrapper extracts, and whether it refuses a registration that names a different
+# screen than the recipe compiles. Configuring a fixture project to reach the same two functions
+# would be slower and would report a failure two layers from its cause.
+#
+# The negative cases match the message rather than the exit status, following
+# governed.noThrow.symbolScan.negative - and, as that test's comment records, PASS_REGULAR_EXPRESSION
+# must not be combined with WILL_FAIL, which would invert the verdict. A bare "it failed" would be
+# satisfied by a typo in the script.
+foreach(mdux_screen_recipe_case scoped identity-accepts committed)
+    add_test(NAME "screen.recipe.${mdux_screen_recipe_case}"
+        COMMAND ${CMAKE_COMMAND} -DCASE=${mdux_screen_recipe_case}
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+endforeach()
+
+add_test(NAME "screen.recipe.identity"
+    COMMAND ${CMAKE_COMMAND} -DCASE=identity
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+set_tests_properties("screen.recipe.identity" PROPERTIES
+    PASS_REGULAR_EXPRESSION "declares id 'real-screen', but was registered as")
+
+add_test(NAME "screen.recipe.ambiguous"
+    COMMAND ${CMAKE_COMMAND} -DCASE=ambiguous
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+set_tests_properties("screen.recipe.ambiguous" PROPERTIES
+    PASS_REGULAR_EXPRESSION "declares .source. 2 times")
+
+add_test(NAME "screen.recipe.missing"
+    COMMAND ${CMAKE_COMMAND} -DCASE=missing
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+set_tests_properties("screen.recipe.missing" PROPERTIES
+    PASS_REGULAR_EXPRESSION "has no .source")
+
 # ML host-tools suite (issue #60)
 #
 # Links MduX::MlBakeLib, the host-tools-zone target. Deliberately separate from ml_spec, which

--- a/tests/cmake/CompileScreenRecipeTest.cmake
+++ b/tests/cmake/CompileScreenRecipeTest.cmake
@@ -1,0 +1,85 @@
+# Configure-time checks for mdux_compile_screen()'s recipe reading (issue #198).
+#
+# Run as `cmake -DCASE=<case> -P tests/cmake/CompileScreenRecipeTest.cmake`. Each case is registered
+# as its own CTest entry in tests/CMakeLists.txt; the negative ones match the message rather than the
+# exit status, because a bare "it failed" would be satisfied by a typo in this file.
+#
+# Script mode rather than a fixture project: what is under test is the extraction and the identity
+# check, both of which are pure functions of the recipe text. Configuring a whole project to exercise
+# them would be slower and would report a failure two layers away from its cause.
+
+cmake_minimum_required(VERSION 4.0.0)
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/MduXCompileScreen.cmake")
+
+# A recipe carrying a decoy `source` in a table the compiler ignores, before the one it reads. This
+# is the shape that made an unscoped regex dangerous: CMake would take `decoy.png` as the dependency
+# while mdux-meduic compiled `real.medui`, so editing the screen would stop triggering a rebake.
+set(decoy_recipe
+"# a comment mentioning [package] and source = \"commented-out.medui\"
+[assets]
+source = \"decoy.png\"
+
+[package]
+id            = \"real-screen\"
+source        = \"recipes/screen/real-screen/RealScreen.medui\"
+surfaceWidth  = 400
+surfaceHeight = 300
+")
+
+if(CASE STREQUAL "scoped")
+    _mdux_screen_package_field(value "${decoy_recipe}" "source" "decoy.toml")
+    if(NOT value STREQUAL "recipes/screen/real-screen/RealScreen.medui")
+        message(FATAL_ERROR "expected the [package] source, got '${value}'")
+    endif()
+    _mdux_screen_package_field(id_value "${decoy_recipe}" "id" "decoy.toml")
+    if(NOT id_value STREQUAL "real-screen")
+        message(FATAL_ERROR "expected the [package] id, got '${id_value}'")
+    endif()
+    message(STATUS "scoped: OK")
+
+elseif(CASE STREQUAL "identity")
+    # The pair the wrapper must refuse: a recipe that compiles one screen, registered as another.
+    _mdux_screen_check_recipe("${decoy_recipe}" "decoy.toml" "another-screen" unused_source)
+    message(FATAL_ERROR "unreachable: a mismatched id was accepted")
+
+elseif(CASE STREQUAL "identity-accepts")
+    _mdux_screen_check_recipe("${decoy_recipe}" "decoy.toml" "real-screen" source_value)
+    if(NOT source_value STREQUAL "recipes/screen/real-screen/RealScreen.medui")
+        message(FATAL_ERROR "expected the [package] source, got '${source_value}'")
+    endif()
+    message(STATUS "identity-accepts: OK")
+
+elseif(CASE STREQUAL "ambiguous")
+    set(ambiguous
+"[package]
+id     = \"real-screen\"
+source = \"one.medui\"
+source = \"two.medui\"
+")
+    _mdux_screen_package_field(value "${ambiguous}" "source" "ambiguous.toml")
+    message(FATAL_ERROR "unreachable: two source keys were accepted")
+
+elseif(CASE STREQUAL "missing")
+    set(missing
+"[assets]
+source = \"decoy.png\"
+
+[package]
+id = \"real-screen\"
+")
+    _mdux_screen_package_field(value "${missing}" "source" "missing.toml")
+    message(FATAL_ERROR "unreachable: a [package] with no source was accepted")
+
+elseif(CASE STREQUAL "committed")
+    # The recipe this repository actually commits, read the way the wrapper reads it.
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/../../recipes/screen/endoscope-monitor.toml" committed)
+    _mdux_screen_check_recipe("${committed}" "recipes/screen/endoscope-monitor.toml" "endoscope-monitor" source_value)
+    if(NOT source_value STREQUAL "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui")
+        message(FATAL_ERROR "expected the committed screen's source, got '${source_value}'")
+    endif()
+    message(STATUS "committed: OK")
+
+else()
+    message(FATAL_ERROR "unknown CASE '${CASE}'")
+endif()

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -171,6 +171,10 @@ evidence::json::Value Recipe::toOptions() const {
     Value options = Value::emptyObject();
     put(options, "budget", std::move(budgetValue));
     put(options, "dynamicText", Value::array(std::move(dynamic)));
+    // The id belongs in the report for the reason every other resolved knob does: it names the
+    // directory the artifact lives in, and a report that did not record it would describe a compile
+    // without saying which screen it produced.
+    put(options, "id", Value::string(id));
     put(options, "fontPackage", Value::string(fontPackage));
     put(options, "source", Value::string(source));
     put(options, "surfaceHeight", Value::integer(surfaceHeight));


### PR DESCRIPTION
Closes #198. The second half of S9: a screen becomes an evidence artifact like every other kind.

## What it adds

- **`mdux_compile_screen()`** - a thin front for `mdux_bake_artifact()`, so a screen gets the same
  build-tree bake, the same `-update` target and the same `evidence.screen.<id>` byte comparison on
  both toolchain legs. Nothing about a screen justifies a second mechanism, and a second mechanism is
  how one artifact kind ends up with weaker evidence than its neighbours.
- **`generated/screen/endoscope-monitor/`** - the first screen this repository commits, with its
  recipe and `.medui` source under `recipes/screen/`.

## What the wrapper adds over calling the baker directly

Two things a call site could otherwise get wrong without anything failing:

- **The three outputs are fixed in the function.** ADR-012 makes `package.json`, `goldens.json` and
  `report.json` unconditional, so a screen pinning nothing writes `[]` rather than one fewer file. A
  call site listing its own `OUTPUTS` could drop one and still pass its own comparison.
- **The `.medui` source is read out of the recipe** and becomes a dependency automatically. A
  forgotten `SOURCES` entry does not fail loudly: it makes edits to the screen stop triggering a
  rebake, so the committed artifact quietly stops matching its source until someone runs the update
  target for an unrelated reason. A recipe whose `source` line the regex cannot find is a configure
  error instead.

## The screen, and the limit it is under

`EndoscopeMonitor` draws a Row background, a baked image, a live video surface and a live waveform.
The waveform is positioned, so `goldens.json` carries one entry rather than being empty and proving
nothing.

**It draws no text, and that is a limit rather than a design.** No text package is baked anywhere in
this tree, so the text-budget stage has nothing to measure against and a screen carrying `t("STR-KEY")`
is refused - correctly - for declaring no approved locale. #201 lands the text half; this screen
proves the rest of the pipeline end to end meanwhile. Both the recipe and the source say so where a
reader will meet the question.

## How the committed bytes were produced, since it matters here

I cannot build this repository locally - the GCC 16 floor means CI is the only place it compiles - so
the three artifacts were computed rather than baked: the JSON by the same canonical rules
`mdux.evidence.json` implements (sorted keys, two-space indent, trailing newline), and every digest
in `report.json` with SHA-256 over the exact committed bytes.

That is a claim, not evidence, and it is exactly what `evidence.screen.endoscope-monitor` exists to
check: CI bakes the screen with `mdux-meduic` and byte-compares. If any of my arithmetic is off - a
rectangle, a node order, a digest - that test fails on both legs and says so. Reviewing this PR is
partly reading whether the test passed.

## Regulatory impact

A screen joins the evidence pipeline on the same terms as a font, a shader and a model: reviewed as
committed text, byte-compared across MSVC and GCC, and rebuilt only through `mdux-bake-update`, the
one path allowed to write into the source tree. `report.json` records the recipe, the source and both
outputs by digest, with `toolVersion` as the project's semantic version and nothing that varies per
machine.

Roadmap: #15 is S1-S9 done, #199 next. `docs/architecture.md` lists six committed artifacts, and says
why the screen is the one whose payload is not opaque bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endoscope monitor screen with a themed header, live Vulkan viewport, and ECG signal trace.
  * Added a 1280×720 screen recipe with defined runtime drawing limits.
  * Integrated automatic screen compilation and evidence artifact generation.

* **Documentation**
  * Documented the new reviewable screen artifact and updated project roadmap progress.

* **Tests**
  * Added validation for screen recipe parsing, identity checks, and source-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->