### PR TITLE
Check one .medui file, and say what a file alone cannot answer [#200]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,7 +10,7 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: the front end through golden references is implemented; emission and runtime are not
+## Status: the compiler is complete front to back; one end-to-end screen remains
 
 **A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, text-budget
 check, and golden-reference pass exist** in the host-tools zone (`tools/medui/`). The diagnostic
@@ -23,9 +23,22 @@ against the font package's restricted charset (#195); and the golden pass applie
 `@safety_critical` rules and derives the reference set #16's verifier will consume (#196). The AST
 keeps names unresolved.
 
-**There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
-to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
-the file as a string, with no parsing, layout or rendering behind it - was deleted by
+**The back end exists now**, and this paragraph used to say the opposite. `mdux-meduic` compiles a
+screen from a recipe into `generated/screen/<id>/` — the compiled package, the golden sidecar and a
+bake report, byte-compared across toolchains (#198). Two emitters render that package as a `.cppm`
+and a `.hpp` carrying `static_assert(screen.validate().has_value())`, so a malformed screen is a
+build error rather than a startup failure (#197). A governed runtime draws one without allocating
+(#199), and `mdux-medui-check` validates a single file (#200).
+
+Two limits are worth knowing before you write a screen. **No text package is baked in this
+repository yet**, so a screen carrying `t("STR-KEY")` cannot be compiled end to end — that is #201,
+the last child of the epic. And the runtime draws a `Panel`; every other component is visited,
+counted in `FrameStats::deferred` and left undrawn, because text needs that package and live-data
+components have no geometry until the frame does.
+
+The HTML/CSS path that used to stand in for all of this - `UiFileWatcher::loadContent()`, which
+sniffed a file extension and stored the file as a string, with no parsing, layout or rendering
+behind it - was deleted by
 [issue #127](https://github.com/ambroise-leclerc/MduX/issues/127).
 
 What exists now is the layer a `.medui` compiler will target: `mdux.draw` describes a frame as
@@ -36,7 +49,9 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
 [`Compliatory/MedUI` at `d5136a8`](https://github.com/Compliatory/MedUI/tree/d5136a8518bd499760ecff2aad215d3721329f20).
-Do not write a `.medui` file expecting it to build anything in MduX until the compiler waves land.
+A `.medui` file builds something in MduX today: register it with `mdux_compile_screen()` and it
+becomes a committed, byte-compared artifact plus generated C++ a device links. What it cannot yet do
+is carry text, for the reason above.
 
 ## Grammar shape
 

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -112,11 +112,27 @@ verifier checks against. Rules:
 
 ## Checking a file without a full build
 
-`mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser, analyzer, solver, budget check, and golden pass it will
-call already detect syntax errors, structural violations, unknown dictionary/theme names, hardcoded
-text in localizable fields, wrong field value domains, incomplete locale keys, layout overflow, a
-box that cannot contain its widest approved translation, a dynamic-text source that could escape
-the baked charset, a `@safety_critical` node with no `requirement:`, and an unknown `cv_check`;
-what is missing is the command that exposes them. Until it lands, review a `.medui`
-file by hand against this grammar and the component table above.
+```
+mdux-medui-check path/to/screen.medui [--format=json|text]
+```
+
+Validates one file and writes nothing. Exits non-zero when anything of error severity was found, so
+it drops into a pre-commit hook or an agent loop as it stands. `--format=json` emits the same
+envelope every MduX tool emits (#118), so a finding is `{file, line, column, code, severity,
+message, fixHint}` rather than prose to parse.
+
+**What it checks:** the grammar, the closed component dictionary, each field's value domain,
+hardcoded strings in localizable fields, theme tokens against the governed table, the
+`@safety_critical` rules including an unknown `cv_check` — and, when the file declares a `surface:`,
+bounded layout with its overflow and containment rules plus the golden set that follows.
+
+**What it cannot check, and says so.** Text keys and text budgets need the approved locales a recipe
+names, and a single file names none. Rather than reporting every `t("STR-KEY")` as absent from every
+locale — a vacuous truth dressed as a finding — the checker skips those and emits a note, `MDC001`.
+A screen with no `surface:` gets `MDC002` for the same reason: layout, overflow and golden bounds
+went unchecked. Notes do not fail the run; they are what makes a clean result visibly *partial*
+rather than silently so.
+
+For the two it cannot cover, compile the screen through `mdux-meduic` with a recipe carrying a
+`[text]` table: that checks every key against every approved locale, and every box against the
+widest translation of the text it holds.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -127,7 +127,7 @@ verifier checks against. Rules:
 
 ## Checking a file without a full build
 
-```
+```console
 mdux-medui-check path/to/screen.medui [--format=json|text]
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@ backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draw
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. Ten of its twelve children have landed — the ADRs,
+that generates the screens it draws. Eleven of its twelve children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
 golden references, the canonical package with its C++ emitters, and the `mdux-meduic` compiler with
 its CMake registration — so the compiler now reads a `.medui` file, resolves it to a bounded box
@@ -62,7 +62,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S10 done · S11 next)
+Wave 5 · in progress        #15 (S1–S11 done · S12 next)
 Wave 6                      #16  #17
 ```
 
@@ -263,7 +263,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 10/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 11/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -287,8 +287,8 @@ happened to read.
 - #197 S8 Canonical package and C++ emitters · _closed (PRs #220, #221)_
 - #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #231)_
 - #199 S10 Allocation-free screen runtime · _closed (PR #232)_
-- #200 S11 `mdux-medui-check` · **next**
-- #201 S12 First end-to-end screen
+- #200 S11 `mdux-medui-check` · _closed (PR #233)_
+- #201 S12 First end-to-end screen · **next**
 
 _Blocks #16, #17_
 
@@ -395,5 +395,5 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 ---
 
 _Epic status verified at `develop` @ `45eecbe` · 22 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 10/12) · no enforcement gaps outstanding_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 11/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # MduX → TrustSC parity roadmap
 
 > Backlog · ambroise-leclerc/MduX · updated 22 August 2026
-> Epic status verified against `develop` @ `45eecbe` · 22 August 2026 · `#15` current through `#199`.
+> Epic status verified against `develop` @ `a5cc41f` · 22 August 2026 · `#15` current through `#200`.
 > The divergence table below was last re-verified on 17 August 2026 and is not re-checked here.
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
@@ -17,8 +17,10 @@ its CMake registration — so the compiler now reads a `.medui` file, resolves i
 tree, refuses a box that cannot hold its widest approved translation, says where safety-critical
 content must appear, and writes the result as a byte-compared artifact and as `constexpr` C++ a
 device links without a parser. The first compiled screen is committed under
-`generated/screen/endoscope-monitor/`, and the governed runtime draws one without allocating. #200
-is next: `mdux-medui-check`, the authoring-side checker.
+`generated/screen/endoscope-monitor/`, the governed runtime draws one without allocating, and
+`mdux-medui-check` validates a single file while naming the two checks a file on its own cannot
+cover. #201 is next, and last: the first end-to-end screen, which is what the missing text package
+blocks.
 
 | Metric | Count |
 |---|---|
@@ -37,7 +39,7 @@ the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. What is still ahead is the authoring-side checker (#200) and the first end-to-end screen (#201), which is what the missing text package blocks. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build. What is still ahead is the first end-to-end screen (#201), which is what the missing text package blocks. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Six artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -396,6 +396,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Epic status verified at `develop` @ `45eecbe` · 22 August 2026_
+_Epic status verified at `develop` @ `a5cc41f` · 22 August 2026_
 _13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 11/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -774,6 +774,11 @@ mdux_discover_tests(medui_spec)
 # ADR-011 fixes for golden references in one screen - including the node that matches both rules and
 # must therefore appear exactly once.
 #
+# CheckTests (#200) drives the single-file checker over the same rejection corpus the parser and
+# analyzer suites use by call, so a code that stops surfacing to an author stops a test. Two of its
+# scenarios spawn the tool, for the same reason CompileTests has one: nothing at call level shows
+# that the executable exits non-zero on a finding and zero on a run whose only output is notes.
+#
 # CompileTests (#198) drives the compiler driver as calls rather than spawning mdux-meduic: what is
 # under test is the order the stages run in, the recipe being complete for the screen it names, and
 # the three artifacts a compile produces - none of which an exit status could report on.
@@ -801,6 +806,7 @@ add_executable(medui_tools_spec
     medui/PackageTests.cpp
     medui/EmitTests.cpp
     medui/CompileTests.cpp
+    medui/CheckTests.cpp
     medui/SharedConformanceTests.cpp
 )
 
@@ -816,8 +822,10 @@ target_compile_definitions(medui_tools_spec PRIVATE MDUX_REPO_ROOT="${CMAKE_SOUR
 # exception reach the terminate handler - which is the behaviour an author meets first when a recipe
 # is wrong. Everything else in this suite drives the calls, because a failing assertion then says
 # what was wrong instead of what the exit status was.
-add_dependencies(medui_tools_spec mdux-meduic)
-target_compile_definitions(medui_tools_spec PRIVATE MDUX_MEDUIC_PATH="$<TARGET_FILE:mdux-meduic>")
+add_dependencies(medui_tools_spec mdux-meduic mdux-medui-check)
+target_compile_definitions(medui_tools_spec PRIVATE
+    MDUX_MEDUIC_PATH="$<TARGET_FILE:mdux-meduic>"
+    MDUX_MEDUI_CHECK_PATH="$<TARGET_FILE:mdux-medui-check>")
 
 # The build's own answers for mdux_screen_identifier(), written where EmitTests can read them and
 # compare against identifierForScreen() in the C++ emitter. Both halves are executed, for the reason

--- a/tests/framework/TemporaryDirectory.hpp
+++ b/tests/framework/TemporaryDirectory.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file TemporaryDirectory.hpp
+ * @brief A scratch directory a scenario owns for its own lifetime, and nobody else's.
+ *
+ * Extracted when the third copy appeared (#200). Three test files were carrying the same class, and
+ * all three carried the same defect with it: a fixed name directly under the system temporary
+ * directory, removed at construction *and* at destruction. Two concurrent `medui_tools_spec` runs -
+ * `ctest -j`, or two builds on one machine - would share the path, and either could delete files
+ * while the other process was using them. The failure that produces is an intermittent subprocess
+ * error with nothing to do with the code under test, which is the worst kind to debug and the
+ * easiest to blame on the tool being tested.
+ *
+ * The name now carries a random suffix, so two runs cannot collide however they are launched.
+ * `std::random_device` rather than a process id because it needs no platform header - this tree
+ * reaches the standard library through `import std`, and mixing that with `<unistd.h>` or
+ * `<process.h>` is what the C5050 diagnostics elsewhere in this epic were about.
+ */
+#pragma once
+
+namespace mdux::test {
+
+/// A directory this scenario owns, removed when it is done with it.
+class TemporaryDirectory {
+public:
+    explicit TemporaryDirectory(std::string_view name)
+        : path_{std::filesystem::temp_directory_path() / std::format("{}-{:08x}", name, std::random_device{}())} {
+        std::error_code code;
+        std::filesystem::create_directories(path_, code);
+    }
+
+    TemporaryDirectory(const TemporaryDirectory&)            = delete;
+    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
+
+    ~TemporaryDirectory() {
+        // Best effort, and deliberately not asserted: a scenario that has already failed should
+        // report why it failed rather than that its scratch could not be swept up afterwards.
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
+}  // namespace mdux::test

--- a/tests/medui/CheckTests.cpp
+++ b/tests/medui/CheckTests.cpp
@@ -22,6 +22,7 @@ import mdux.tools.medui.check;
 import mdux.tools.medui.diagnostics;
 
 #include "../framework/SpecLabBridge.hpp"
+#include "../framework/TemporaryDirectory.hpp"
 
 namespace {
 
@@ -59,30 +60,6 @@ namespace cli = mdux::tools::cli;
     return rendered.empty() ? std::string{"<nothing>"} : rendered;
 }
 
-/// A directory this scenario owns, removed when it is done with it.
-class TemporaryDirectory {
-public:
-    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-        std::filesystem::create_directories(path_, code);
-    }
-
-    TemporaryDirectory(const TemporaryDirectory&)            = delete;
-    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
-
-    ~TemporaryDirectory() {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-    }
-
-    [[nodiscard]] const std::filesystem::path& path() const noexcept {
-        return path_;
-    }
-
-private:
-    std::filesystem::path path_;
-};
 
 /// One shell command line, spelled the way the platform's shell will actually read it.
 ///
@@ -230,8 +207,8 @@ const mdux::spec::Register theToolExitsAndSpeaksTheSharedEnvelope{
             .When("it is run with --format=json", [] {})
             .Then("it exits non-zero having printed the envelope every MduX tool emits",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-medui-check-cli"};
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-medui-check-cli"};
 
                       const std::filesystem::path log     = scratch.path() / "stdout.txt";
                       const std::string           broken  = fixturePath("rejected-safety-without-requirement.medui").generic_string();
@@ -260,8 +237,8 @@ const mdux::spec::Register aCleanFileExitsZero{
             .When("the tool is run over it", [] {})
             .Then("it exits zero, because a note is not a failure",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-medui-check-clean"};
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-medui-check-clean"};
 
                       // The half that would be easy to get wrong: the notes about uncovered checks
                       // travel in the same envelope as findings, and an exit status keyed off the

--- a/tests/medui/CheckTests.cpp
+++ b/tests/medui/CheckTests.cpp
@@ -1,0 +1,281 @@
+/**
+ * @file CheckTests.cpp
+ * @brief BDD scenarios for the single-file checker (issue #200).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Driven over the rejection corpus the parser and analyzer suites already use, which is the point of
+ * that corpus being real files rather than string literals: the tool #200 adds is pointed at exactly
+ * what those suites check by call, so a code that stops surfacing here has stopped surfacing to the
+ * author too.
+ *
+ * The scenarios that matter most are the two about what the checker *cannot* do. A checker whose
+ * clean run is silently partial is worse than no checker, because it converts "I did not look" into
+ * "nothing is wrong".
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.check;
+import mdux.tools.medui.diagnostics;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+[[nodiscard]] std::filesystem::path fixturePath(std::string_view name) {
+    return std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+}
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    std::ifstream in{fixturePath(name), std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened", name), std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] bool carries(const md::CheckResult& result, std::string_view code) {
+    return std::ranges::any_of(result.diagnostics, [code](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == code;
+    });
+}
+
+[[nodiscard]] std::string codes(const md::CheckResult& result) {
+    std::string rendered;
+    for (const cli::Diagnostic& diagnostic : result.diagnostics) {
+        if (!rendered.empty()) {
+            rendered += ", ";
+        }
+        rendered += diagnostic.code.empty() ? std::string{"<none>"} : diagnostic.code;
+    }
+    return rendered.empty() ? std::string{"<nothing>"} : rendered;
+}
+
+/// A directory this scenario owns, removed when it is done with it.
+class TemporaryDirectory {
+public:
+    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+        std::filesystem::create_directories(path_, code);
+    }
+
+    TemporaryDirectory(const TemporaryDirectory&)            = delete;
+    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
+
+    ~TemporaryDirectory() {
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
+/// One shell command line, spelled the way the platform's shell will actually read it.
+///
+/// `cmd.exe` strips the outer pair of quotes when a command line begins with one, and reads a
+/// leading `/` as a switch. Getting this wrong does not fail honestly - the process never starts and
+/// the exit status is non-zero for the wrong reason.
+[[nodiscard]] std::string shellCommand(std::string_view program, std::string_view arguments) {
+#ifdef _WIN32
+    std::string native{program};
+    std::ranges::replace(native, '/', '\\');
+    return std::format(R"(""{}" {}")", native, arguments);
+#else
+    return std::format(R"("{}" {})", program, arguments);
+#endif
+}
+
+[[nodiscard]] std::string contentsOf(const std::filesystem::path& path) {
+    std::ifstream in{path, std::ios::binary};
+    if (!in) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+}  // namespace
+
+const mdux::spec::Register aGoodScreenPassesWithItsGapsNamed{
+    "A screen that checks out says which checks did not run",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-check-accepts")
+            .Given("a screen the compiler accepts", [] {})
+            .When("it is checked on its own", [] {})
+            .Then("nothing of error severity is reported, and the uncovered checks are named",
+                  [] {
+                      mdux::spec::Checks    checks;
+                      const md::CheckResult result = md::checkScreen(fixture("accepted-textless.medui"), "accepted-textless.medui");
+
+                      checks.expect(result.ok(), std::format("a good screen passes, got {}", codes(result)));
+                      checks.expect(result.layoutChecked, "and its layout was resolved, since it declares a surface");
+
+                      // The property that makes a clean run trustworthy: it is visibly partial. A
+                      // checker that stayed silent here would convert "I did not look" into
+                      // "nothing is wrong", which is worse than not existing.
+                      checks.expect(!result.textChecked, "text keys were not checked without a recipe");
+                      checks.expect(carries(result, "MDC001"), std::format("and the run says so, got {}", codes(result)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyRejectionCodeSurfaces{"The rejection corpus surfaces through the checker", "evidence-unit", [] {
+                                                          return speclab::Test("medui-check-rejects")
+                                                              .Given("the fixtures the parser and analyzer suites drive by call", [] {})
+                                                              .When("the checker is pointed at each of them", [] {})
+                                                              .Then("each reports the code its name promises",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+
+                                                                        // Pointed at the same corpus rather than at strings of its own: a code that
+                                                                        // stops surfacing here has stopped surfacing to an author, and that is what
+                                                                        // the shared fixtures exist to make checkable.
+                                                                        const std::array<std::pair<std::string_view, std::string_view>, 4> cases{
+                                                                            {{"rejected-unterminated-string.medui", "MEDUI-E010"},
+                                                                             {"rejected-nested-row.medui", "MEDUI-E015"},
+                                                                             {"rejected-duplicate-id.medui", "MEDUI-E014"},
+                                                                             {"rejected-safety-without-requirement.medui", "MEDUI-E070"}}
+                                                                        };
+
+                                                                        for (const auto& [name, code] : cases) {
+                                                                            const md::CheckResult result = md::checkScreen(fixture(name), std::string{name});
+                                                                            checks.expect(!result.ok(), std::format("{} is rejected", name));
+                                                                            checks.expect(carries(result, code),
+                                                                                          std::format("{} reports {}, got {}", name, code, codes(result)));
+                                                                        }
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register aScreenWithoutASurfaceSaysWhatWasSkipped{
+    "A screen with no surface is checked as far as it can be, and says where that stopped",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-check-no-surface")
+            .Given("a screen that declares no `surface:`", [] {})
+            .When("it is checked", [] {})
+            .Then("it is not called malformed, and layout is reported as unchecked",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Not a finding about the file: the compiler takes the surface from the
+                      // recipe, so a screen without one is legitimate and simply cannot be resolved
+                      // to rectangles here.
+                      const std::string source = "Screen NoSurface {\n"
+                                                 "    layout: Vertical { spacing: 0px; padding: 0px; }\n"
+                                                 "\n"
+                                                 "    Clock {\n"
+                                                 "        id: wall-clock;\n"
+                                                 "        width: 200px;\n"
+                                                 "        height: 40px;\n"
+                                                 "        format: TimeSeconds;\n"
+                                                 "    }\n"
+                                                 "}\n";
+
+                      const md::CheckResult result = md::checkScreen(source, "no-surface.medui");
+                      checks.expect(result.ok(), std::format("a screen without a surface is not an error, got {}", codes(result)));
+                      checks.expect(!result.layoutChecked, "and its layout was not resolved");
+                      checks.expect(carries(result, "MDC002"), std::format("with the gap named, got {}", codes(result)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theCheckerStopsAtTheCause{"The checker stops at the first stage that rejects the screen", "evidence-unit", [] {
+                                                         return speclab::Test("medui-check-stops-at-the-cause")
+                                                             .Given("a file that does not parse", [] {})
+                                                             .When("it is checked", [] {})
+                                                             .Then("the parse error is reported alone, without consequences from later stages",
+                                                                   [] {
+                                                                       mdux::spec::Checks    checks;
+                                                                       const md::CheckResult result = md::checkScreen(
+                                                                           fixture("rejected-unterminated-string.medui"),
+                                                                           "rejected-unterminated-string.medui");
+
+                                                                       checks.expect(!result.ok(), "the file is rejected");
+                                                                       // A later stage reading a screen an earlier one rejected reports consequences
+                                                                       // rather than causes - and the notes about uncovered checks are not emitted
+                                                                       // either, since the run did not get far enough to have gaps worth naming.
+                                                                       checks.expect(!carries(result, "MDC001") && !carries(result, "MDC002"),
+                                                                                     std::format("no notes about later stages, got {}", codes(result)));
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};
+
+const mdux::spec::Register theToolExitsAndSpeaksTheSharedEnvelope{
+    "The tool exits non-zero on an error and prints the shared envelope",
+    "evidence-unit",  // the one scenario here that spawns mdux-medui-check rather than calling into it
+    [] {
+        return speclab::Test("medui-check-cli")
+            .Given("mdux-medui-check and a broken screen", [] {})
+            .When("it is run with --format=json", [] {})
+            .Then("it exits non-zero having printed the envelope every MduX tool emits",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TemporaryDirectory scratch{"mdux-medui-check-cli"};
+
+                      const std::filesystem::path log     = scratch.path() / "stdout.txt";
+                      const std::string           broken  = fixturePath("rejected-safety-without-requirement.medui").generic_string();
+                      const std::string           command = shellCommand(MDUX_MEDUI_CHECK_PATH,
+                                                               std::format(R"("{}" --format=json > "{}")", broken, log.generic_string()));
+                      const int                   status  = std::system(command.c_str());
+                      checks.expect(status != 0, "a broken screen exits non-zero");
+
+                      const std::string envelope = contentsOf(log);
+                      // Asserted before the contents: an empty log means the process never ran, and
+                      // the status above was non-zero for a reason unrelated to the screen.
+                      checks.expect(!envelope.empty(), "the checker ran and printed something");
+                      checks.expect(envelope.contains("mdux-medui-check"), "the envelope names the tool");
+                      checks.expect(envelope.contains("MEDUI-E070"), std::format("and carries the finding, got:\n{}", envelope));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aCleanFileExitsZero{
+    "A file that checks out exits zero, notes and all",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-check-cli-clean")
+            .Given("a screen the compiler accepts", [] {})
+            .When("the tool is run over it", [] {})
+            .Then("it exits zero, because a note is not a failure",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TemporaryDirectory scratch{"mdux-medui-check-clean"};
+
+                      // The half that would be easy to get wrong: the notes about uncovered checks
+                      // travel in the same envelope as findings, and an exit status keyed off the
+                      // presence of diagnostics rather than their severity would fail every clean
+                      // run.
+                      const std::filesystem::path log  = scratch.path() / "stdout.txt";
+                      const std::string           good = fixturePath("accepted-textless.medui").generic_string();
+                      const std::string command = shellCommand(MDUX_MEDUI_CHECK_PATH, std::format(R"("{}" --format=json > "{}")", good, log.generic_string()));
+                      const int         status  = std::system(command.c_str());
+                      checks.expect(status == 0, "a clean screen exits zero");
+
+                      const std::string envelope = contentsOf(log);
+                      checks.expect(envelope.contains("MDC001"), std::format("and still reports what it could not check, got:\n{}", envelope));
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -278,9 +278,9 @@ const mdux::spec::Register writingAndVerifyingAgree{
             .When("it is written, verified, and verified again after an edit", [] {})
             .Then("all three files appear, the untouched ones verify, and the edited one does not",
                   [] {
-                      mdux::spec::Checks           checks;
-                      std::vector<cli::Diagnostic> diagnostics;
-                      TemporaryDirectory           scratch{"mdux-meduic-write"};
+                      mdux::spec::Checks             checks;
+                      std::vector<cli::Diagnostic>   diagnostics;
+                      mdux::test::TemporaryDirectory scratch{"mdux-meduic-write"};
 
                       const md::Recipe  recipe     = textlessRecipe(diagnostics);
                       const std::string recipeText = fixture("textless-screen.toml");

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -28,6 +28,7 @@ import mdux.tools.medui.parser;
 import mdux.tools.medui.textbudget;
 
 #include "../framework/SpecLabBridge.hpp"
+#include "../framework/TemporaryDirectory.hpp"
 
 namespace {
 
@@ -66,30 +67,6 @@ namespace cli = mdux::tools::cli;
     return *recipe;
 }
 
-/// A directory this scenario owns, removed when it is done with it.
-class TemporaryDirectory {
-public:
-    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-        std::filesystem::create_directories(path_, code);
-    }
-
-    TemporaryDirectory(const TemporaryDirectory&)            = delete;
-    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
-
-    ~TemporaryDirectory() {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-    }
-
-    [[nodiscard]] const std::filesystem::path& path() const noexcept {
-        return path_;
-    }
-
-private:
-    std::filesystem::path path_;
-};
 
 /// One shell command line, spelled the way the platform's shell will actually read it.
 ///
@@ -539,8 +516,8 @@ const mdux::spec::Register theExecutableFailsLikeATool{
             .When("it is run with --format=json", [] {})
             .Then("it exits non-zero having printed a diagnostic envelope",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-meduic-cli"};
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-meduic-cli"};
 
                       // The one scenario that spawns the process rather than calling into the
                       // library. Everything else here drives the calls, which says more when it

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -25,6 +25,7 @@ import mdux.tools.medui.package;
 import mdux.tools.medui.parser;
 
 #include "../framework/SpecLabBridge.hpp"
+#include "../framework/TemporaryDirectory.hpp"
 
 namespace {
 
@@ -48,29 +49,6 @@ constexpr mdux::draw::DrawBudget fixtureBudget{.maxVertices = 4096, .maxIndices 
     return buffer.str();
 }
 
-/// A directory this scenario owns, removed when it is done with it.
-class TemporaryDirectory {
-public:
-    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-    }
-
-    TemporaryDirectory(const TemporaryDirectory&)            = delete;
-    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
-
-    ~TemporaryDirectory() {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-    }
-
-    [[nodiscard]] const std::filesystem::path& path() const noexcept {
-        return path_;
-    }
-
-private:
-    std::filesystem::path path_;
-};
 
 [[nodiscard]] std::string contentsOf(const std::filesystem::path& path) {
     std::ifstream in{path, std::ios::binary};
@@ -235,10 +213,8 @@ const mdux::spec::Register aMalformedPackageIsNotRendered{
             .When("the emitter is pointed at it", [] {})
             .Then("nothing is rendered and the reader's own diagnostic is reported",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-screenemit-malformed"};
-                      std::error_code    code;
-                      std::filesystem::create_directories(scratch.path(), code);
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-malformed"};
 
                       std::string       edited = fixture("every-component-package.json");
                       const std::size_t at     = edited.find("\"surfaceWidth\": 800");
@@ -327,10 +303,8 @@ const mdux::spec::Register aDecodedControlCharacterCannotEndTheLiteral{
             .When("it is compiled and rendered", [] {})
             .Then("the generated literal carries an escape rather than a line break",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-screenemit-escapes"};
-                      std::error_code    code;
-                      std::filesystem::create_directories(scratch.path(), code);
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-escapes"};
 
                       // The lexer decodes `\n` inside a source string and the dictionary accepts an
                       // unrestricted String for `requirement`, so this screen is legal, its package
@@ -423,10 +397,8 @@ const mdux::spec::Register aReservedIdentifierIsRefused{
             .When("it is rendered", [] {})
             .Then("the emitter refuses rather than generating a reserved name",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-screenemit-reserved"};
-                      std::error_code    code;
-                      std::filesystem::create_directories(scratch.path(), code);
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-reserved"};
 
                       // `a--b` maps to `screen_a__b`, and `__` is reserved to the implementation
                       // everywhere. Collapsing the run would fix the name and break injectivity, so
@@ -464,10 +436,8 @@ const mdux::spec::Register aProvenanceCommentCannotBeEnded{
             .When("it is rendered", [] {})
             .Then("the id appears escaped inside the comment, on one line",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-screenemit-comment"};
-                      std::error_code    code;
-                      std::filesystem::create_directories(scratch.path(), code);
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-comment"};
 
                       // The schema asks only that an id be non-empty, and canonical JSON carries a
                       // control character as an escape, so this package is valid on both counts. A

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -267,9 +267,9 @@ const mdux::spec::Register writingIsIdempotent{
             .When("it is written into an empty directory, then written again", [] {})
             .Then("both files hold the rendering, unchanged by the second write",
                   [] {
-                      mdux::spec::Checks           checks;
-                      std::vector<cli::Diagnostic> diagnostics;
-                      TemporaryDirectory           scratch{"mdux-screenemit-write"};
+                      mdux::spec::Checks             checks;
+                      std::vector<cli::Diagnostic>   diagnostics;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-write"};
 
                       const auto outputs = md::renderScreen(fixturePath("every-component-package.json"), diagnostics);
                       if (!outputs.has_value()) {

--- a/tests/medui/SemanticTests.cpp
+++ b/tests/medui/SemanticTests.cpp
@@ -219,13 +219,16 @@ const mdux::spec::Register semanticHardcodedTextPrecedence{"A literal in a text-
                                                                    .Execute();
                                                            }};
 
-const mdux::spec::Register semanticFieldDomains{"Known fields reject syntactically valid values from the wrong semantic domain", "evidence-unit", [] {
-                                                    return speclab::Test("medui-semantic-field-domains")
-                                                        .Given("a Row and Label with three mismatched field value forms", [] {})
-                                                        .When("the field domains are analyzed", [] {})
-                                                        .Then("each mismatch is MEDUI-E033 at the value",
-                                                              [] {
-                                                                  constexpr std::string_view                   source = R"(Screen Domains {
+const mdux::spec::Register semanticFieldDomains{
+    "Known fields reject syntactically valid values from the wrong semantic domain",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-field-domains")
+            .Given("a Row and Label with three mismatched field value forms", [] {})
+            .When("the field domains are analyzed", [] {})
+            .Then("each mismatch is MEDUI-E033 at the value",
+                  [] {
+                      constexpr std::string_view                   source = R"(Screen Domains {
     layout: Vertical { spacing: 0px; padding: 0px; }
     Row {
         id: content;
@@ -240,26 +243,21 @@ const mdux::spec::Register semanticFieldDomains{"Known fields reject syntactical
         }
     }
 })";
-                                                                  const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
-                                                                  const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
-                                                                  const md::SemanticResult                     result = analyze(source, themes, packages);
-                                                                  mdux::spec::Checks                           checks;
-                                                                  checks.expect(count(result, md::Code::FieldValueKind) == 3,
-                                                                                "all three mismatches report E033");
-                                                                  checks.expect(result.diagnostics.size() == 3,
-                                                                                "domain mismatches do not cascade into name diagnostics");
-                                                                  if (result.diagnostics.size() == 3) {
-                                                                      checks.expect(result.diagnostics[0].line == 6 && result.diagnostics[0].column == 18,
-                                                                                    "Row spacing points at Theme.Colors.Title");
-                                                                      checks.expect(result.diagnostics[1].line == 8 && result.diagnostics[1].column == 17,
-                                                                                    "Label id points at t(\"STR-TITLE\")");
-                                                                      checks.expect(result.diagnostics[2].line == 9 && result.diagnostics[2].column == 20,
-                                                                                    "Label width points at the string literal");
-                                                                  }
-                                                                  checks.raise();
-                                                              })
-                                                        .Execute();
-                                                }};
+                      const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
+                      const md::SemanticResult                     result = analyze(source, themes, packages);
+                      mdux::spec::Checks                           checks;
+                      checks.expect(count(result, md::Code::FieldValueKind) == 3, "all three mismatches report E033");
+                      checks.expect(result.diagnostics.size() == 3, "domain mismatches do not cascade into name diagnostics");
+                      if (result.diagnostics.size() == 3) {
+                          checks.expect(result.diagnostics[0].line == 6 && result.diagnostics[0].column == 18, "Row spacing points at Theme.Colors.Title");
+                          checks.expect(result.diagnostics[1].line == 8 && result.diagnostics[1].column == 17, "Label id points at t(\"STR-TITLE\")");
+                          checks.expect(result.diagnostics[2].line == 9 && result.diagnostics[2].column == 20, "Label width points at the string literal");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
 
 const mdux::spec::Register malformedColorIsSemanticOnly{
     "A malformed colour path has one semantic-domain diagnostic and no syntax duplicate",
@@ -287,8 +285,7 @@ const mdux::spec::Register malformedColorIsSemanticOnly{
                       checks.expect(result.diagnostics.size() == 1, "the syntax and semantic phases do not duplicate the finding");
                       checks.expect(count(result, md::Code::FieldValueKind) == 1, "the malformed path reports E033");
                       if (result.diagnostics.size() == 1) {
-                          checks.expect(result.diagnostics[0].line == 8 && result.diagnostics[0].column == 16,
-                                        "E033 points at Theme.Color.Title");
+                          checks.expect(result.diagnostics[0].line == 8 && result.diagnostics[0].column == 16, "E033 points at Theme.Color.Title");
                       }
                       checks.raise();
                   })
@@ -320,16 +317,13 @@ const mdux::spec::Register semanticSpecialValueForms{"Image references, positive
                                                              .Execute();
                                                      }};
 
-const mdux::spec::Register semanticHardcodedTextList{
-    "A literal inside a text-key list is reported as hardcoded text at that element",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-semantic-hardcoded-text-list")
-            .Given("a StatusIndicator states list mixing a literal and a governed key", [] {})
-            .When("the list is analyzed element by element", [] {})
-            .Then("the literal reports MEDUI-E017 without hiding valid keys",
-                  [] {
-                      constexpr std::string_view source = R"(Screen States {
+const mdux::spec::Register semanticHardcodedTextList{"A literal inside a text-key list is reported as hardcoded text at that element", "evidence-unit", [] {
+                                                         return speclab::Test("medui-semantic-hardcoded-text-list")
+                                                             .Given("a StatusIndicator states list mixing a literal and a governed key", [] {})
+                                                             .When("the list is analyzed element by element", [] {})
+                                                             .Then("the literal reports MEDUI-E017 without hiding valid keys",
+                                                                   [] {
+                                                                       constexpr std::string_view                   source = R"(Screen States {
     layout: Vertical { spacing: 0px; padding: 0px; }
     StatusIndicator {
         id: state;
@@ -340,14 +334,60 @@ const mdux::spec::Register semanticHardcodedTextList{
         states: ["Ready", t("STR-STOP")];
     }
 })";
-                      const std::array<std::string_view, 0> themes{};
-                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};
-                      const md::SemanticResult result = analyze(source, themes, packages);
-                      const cli::Diagnostic* literal = find(result, md::Code::HardcodedString);
+                                                                       const std::array<std::string_view, 0>        themes{};
+                                                                       const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};
+                                                                       const md::SemanticResult                     result = analyze(source, themes, packages);
+                                                                       const cli::Diagnostic* literal = find(result, md::Code::HardcodedString);
+                                                                       mdux::spec::Checks     checks;
+                                                                       checks.expect(result.diagnostics.size() == 1, "only the literal is rejected");
+                                                                       checks.expect(literal != nullptr && literal->line == 9 && literal->column == 18,
+                                                                                     "E017 points at the literal list element");
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};
+
+const mdux::spec::Register theLocalePolicyIsAskedForNotInferred{
+    "Skipping the locale check is a mode a caller selects, not a meaning of an empty set",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-locale-policy")
+            .Given("a screen with a text key and no approved locale supplied", [] {})
+            .When("it is analyzed under each policy", [] {})
+            .Then("the default reports the key and only the explicit mode skips it",
+                  [] {
+                      const std::string_view                       source = R"(Screen Policy {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 200px, 100px;
+
+    Label {
+        id: title;
+        width: 100px;
+        height: 20px;
+        text: t("STR-TITLE");
+        color: Theme.Colors.Title;
+    }
+})";
+                      const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                      const std::array<mdux::text::TextPackage, 0> none{};
+
                       mdux::spec::Checks checks;
-                      checks.expect(result.diagnostics.size() == 1, "only the literal is rejected");
-                      checks.expect(literal != nullptr && literal->line == 9 && literal->column == 18,
-                                    "E017 points at the literal list element");
+
+                      // The default has to be the one that fails closed: an empty package span means
+                      // an approved set containing no locale, so every key is absent from all of
+                      // them. A caller who wanted the check skipped and forgot to say so gets a
+                      // finding rather than a clean result.
+                      const md::SemanticResult required = md::analyze(*md::parse(source, "policy.medui").screen,
+                                                                      "policy.medui",
+                                                                      md::SemanticInputs{.themeTokens = themes, .textPackages = none});
+                      checks.expect(count(required, md::Code::UnknownTextKey) == 1, "the default policy reports a key with no locale to resolve in");
+
+                      const md::SemanticResult skipped = md::analyze(
+                          *md::parse(source, "policy.medui").screen,
+                          "policy.medui",
+                          md::SemanticInputs{.themeTokens = themes, .textPackages = none, .locales = md::LocalePolicy::Skipped});
+                      checks.expect(skipped.ok(), "and the explicit mode skips it");
+                      checks.expect(count(skipped, md::Code::UnknownTextKey) == 0, "reporting no key findings at all");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SemanticTests.cpp
+++ b/tests/medui/SemanticTests.cpp
@@ -377,13 +377,21 @@ const mdux::spec::Register theLocalePolicyIsAskedForNotInferred{
                       // an approved set containing no locale, so every key is absent from all of
                       // them. A caller who wanted the check skipped and forgot to say so gets a
                       // finding rather than a clean result.
-                      const md::SemanticResult required = md::analyze(*md::parse(source, "policy.medui").screen,
+                      // Parsed once and checked, rather than dereferenced twice on faith: a fixture
+                      // that stopped parsing would crash here instead of failing, and the helper at
+                      // the top of this file already guards exactly this.
+                      const md::ParseResult parsed = md::parse(source, "policy.medui");
+                      if (!parsed.screen || !parsed.diagnostics.empty()) {
+                          throw speclab::core::AssertionFailure("the locale-policy source did not parse", std::source_location::current());
+                      }
+
+                      const md::SemanticResult required = md::analyze(*parsed.screen,
                                                                       "policy.medui",
                                                                       md::SemanticInputs{.themeTokens = themes, .textPackages = none});
                       checks.expect(count(required, md::Code::UnknownTextKey) == 1, "the default policy reports a key with no locale to resolve in");
 
                       const md::SemanticResult skipped = md::analyze(
-                          *md::parse(source, "policy.medui").screen,
+                          *parsed.screen,
                           "policy.medui",
                           md::SemanticInputs{.themeTokens = themes, .textPackages = none, .locales = md::LocalePolicy::Skipped});
                       checks.expect(skipped.ok(), "and the explicit mode skips it");

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -305,6 +305,7 @@ target_sources(MduXMeduiLib
             medui/Package.cppm
             medui/Emit.cppm
             medui/Compile.cppm
+            medui/Check.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -316,6 +317,7 @@ target_sources(MduXMeduiLib
         medui/Package.cpp
         medui/Emit.cpp
         medui/Compile.cpp
+        medui/Check.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)
@@ -355,6 +357,26 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(mdux-meduic PRIVATE /experimental:module /std:c++latest)
+endif()
+
+# The single-file checker (issue #200). The surface an author and an agent reach for first: it takes
+# a file, runs every stage that file admits, and writes nothing.
+add_executable(mdux-medui-check medui/MeduiCheckMain.cpp)
+target_link_libraries(mdux-medui-check PRIVATE MduX::MeduiLib MduX_warnings)
+
+set_target_properties(mdux-medui-check
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(mdux-medui-check PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(mdux-medui-check PRIVATE /experimental:module /std:c++latest)
 endif()
 
 # The screen emitter (issue #197). Its own executable rather than a mode of the compiler, for the

--- a/tools/medui/Check.cpp
+++ b/tools/medui/Check.cpp
@@ -57,8 +57,9 @@ CheckResult checkScreen(std::string_view source, std::string file) {
     const ast::Screen& screen = *parsed.screen;
 
     // 2. Semantic analysis, against the governed theme table and no approved locale. `analyze()`
-    //    skips the key checks when it is given no packages, which is why this can run at all - see
-    //    the note recorded below for what that leaves uncovered.
+    //    runs the key checks unless a caller asks for `LocalePolicy::Skipped`, which is what the
+    //    call below does - an empty package list on its own still means every key is absent. See the
+    //    note recorded further down for what asking for that leaves uncovered.
     std::vector<std::string_view> themeTokens;
     themeTokens.reserve(ms::themeColors.size());
     for (const ms::ThemeColor& colour : ms::themeColors) {

--- a/tools/medui/Check.cpp
+++ b/tools/medui/Check.cpp
@@ -65,7 +65,9 @@ CheckResult checkScreen(std::string_view source, std::string file) {
         themeTokens.push_back(colour.token);
     }
 
-    const SemanticResult semantic = analyze(screen, file, {.themeTokens = themeTokens, .textPackages = {}});
+    // The one caller that asks for the partial mode, and the reason the mode is a request rather
+    // than something inferred from an empty package list: this file may belong to no recipe at all.
+    const SemanticResult semantic = analyze(screen, file, {.themeTokens = themeTokens, .textPackages = {}, .locales = LocalePolicy::Skipped});
     if (!semantic.ok()) {
         result.diagnostics = semantic.diagnostics;
         return result;

--- a/tools/medui/Check.cpp
+++ b/tools/medui/Check.cpp
@@ -1,0 +1,118 @@
+/**
+ * @file Check.cpp
+ * @brief Implementation of the single-file checker.
+ */
+
+module;
+
+module mdux.tools.medui.check;
+
+import std;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+namespace ms = mdux::medui;
+
+/// Codes for what a run could not cover. Local to this tool, in the sense `SHE0NN` and `SCP0NN` are:
+/// the `MEDUI-E0NN` registry is the shared contract for what a screen may *say*, and "this run did
+/// not check X" is a statement about the run rather than about the screen.
+constexpr std::string_view textNotChecked   = "MDC001";
+constexpr std::string_view layoutNotChecked = "MDC002";
+
+void note(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::string_view code, std::string message, std::string fixHint) {
+    cli::Diagnostic entry;
+    entry.file     = std::move(file);
+    entry.code     = std::string{code};
+    entry.severity = cli::Severity::Note;
+    entry.message  = std::move(message);
+    entry.fixHint  = std::move(fixHint);
+    diagnostics.push_back(std::move(entry));
+}
+
+}  // namespace
+
+CheckResult checkScreen(std::string_view source, std::string file) {
+    CheckResult result;
+
+    // 1. Parse. Everything after this reads an AST, so a file that does not parse stops here rather
+    //    than producing a second opinion about a screen nobody could read.
+    ParseResult parsed = parse(source, file);
+    if (!parsed.diagnostics.empty() || !parsed.screen.has_value()) {
+        result.diagnostics = std::move(parsed.diagnostics);
+        if (result.diagnostics.empty()) {
+            result.diagnostics.push_back(diagnose(Code::SourceUnreadable, file, 0, 0, "the source produced no screen and no diagnostic"));
+        }
+        return result;
+    }
+    const ast::Screen& screen = *parsed.screen;
+
+    // 2. Semantic analysis, against the governed theme table and no approved locale. `analyze()`
+    //    skips the key checks when it is given no packages, which is why this can run at all - see
+    //    the note recorded below for what that leaves uncovered.
+    std::vector<std::string_view> themeTokens;
+    themeTokens.reserve(ms::themeColors.size());
+    for (const ms::ThemeColor& colour : ms::themeColors) {
+        themeTokens.push_back(colour.token);
+    }
+
+    const SemanticResult semantic = analyze(screen, file, {.themeTokens = themeTokens, .textPackages = {}});
+    if (!semantic.ok()) {
+        result.diagnostics = semantic.diagnostics;
+        return result;
+    }
+
+    // 3. Annotations. Before layout, as the compiler runs them: the shared conformance suite pins
+    //    MEDUI-E070 on a screen with no `surface:`, which the solver cannot resolve at all.
+    const SafetyResult safety = validateSafetyAnnotations(screen, file);
+    if (!safety.ok()) {
+        result.diagnostics = safety.diagnostics;
+        return result;
+    }
+
+    // 4. Layout and goldens, when the file says what surface it is drawn for. A screen without one
+    //    is not malformed - the compiler takes the surface from the recipe - so this is a gap in
+    //    what can be checked here rather than a finding about the file.
+    if (screen.surface.has_value()) {
+        const LayoutResult layout = resolveLayout(screen, file, {.surfaceWidth = screen.surface->x, .surfaceHeight = screen.surface->y});
+        if (!layout.ok()) {
+            result.diagnostics = layout.diagnostics;
+            return result;
+        }
+        result.layoutChecked = true;
+
+        // Called for its own sake: it throws if the annotation gate was bypassed, and running it
+        // here is what makes a golden that cannot be derived show up in a check rather than in a
+        // compile three commits later.
+        static_cast<void>(collectGoldens(layout));
+    } else {
+        note(result.diagnostics,
+             file,
+             layoutNotChecked,
+             "this screen declares no `surface:`, so layout, overflow and golden bounds were not checked",
+             "add `surface: <width>px, <height>px;` to check it here, or compile it through a recipe that declares one");
+    }
+
+    // 5. What a file on its own cannot answer. Reported every time, including on a screen that draws
+    //    no text: "there was nothing to check" and "the check did not run" are different statements,
+    //    and only the second one is true here.
+    note(result.diagnostics,
+         file,
+         textNotChecked,
+         "text keys and text budgets were not checked: a single file names no approved locale",
+         "compile through a recipe with a [text] table to check keys against every approved locale and "
+         "boxes against the widest translation");
+
+    return result;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Check.cppm
+++ b/tools/medui/Check.cppm
@@ -1,0 +1,84 @@
+/**
+ * @file Check.cppm
+ * @brief Validating one `.medui` file on its own, and saying what that cannot cover.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The surface an author and an agent both reach for first: point it at a file, read the
+ * diagnostics, fix them. `mdux-meduic` compiles a screen from a recipe and writes artifacts; this
+ * runs the same stages over a file that may not belong to a recipe at all, and writes nothing.
+ *
+ * ## What a single file cannot answer, and why that is said out loud
+ *
+ * Two stages need inputs a file does not carry.
+ *
+ * **Text keys** are checked against the approved locales a recipe names. With no recipe there are no
+ * approved locales, and a checker that ran the check anyway would report every `t("STR-KEY")` as
+ * absent from every locale - which is a vacuous truth dressed as a finding, and the fastest way to
+ * teach an author that this tool's output is noise. So the check does not run, and the run says so.
+ *
+ * **Text budgets** need the font package those locales were baked into. Same reasoning, same
+ * treatment.
+ *
+ * A third case is the file's own doing rather than the recipe's: a screen with no `surface:` cannot
+ * be resolved to rectangles at all, so layout, overflow and golden bounds go unchecked. That is
+ * reported the same way.
+ *
+ * Each of these is a `Severity::Note` carrying an `MDC0NN` code, travelling in the same envelope as
+ * the findings. Two consequences worth having: a clean run is visibly *partial* rather than
+ * silently so, and an agent can key off the code to decide whether to re-run through the compiler
+ * with a recipe.
+ *
+ * ## What it does check
+ *
+ * Everything decidable from the file plus the governed tables: the grammar (#192), the component
+ * dictionary, field value domains, hardcoded strings and theme tokens (#193), the `@safety_critical`
+ * annotation rules (#196), and - when the file declares a surface - bounded layout with its overflow
+ * and containment rules (#194) and the golden set that follows from it (#196).
+ */
+module;
+
+export module mdux.tools.medui.check;
+
+import std;
+import mdux.tools.cli;
+
+export namespace mdux::tools::medui {
+
+/// The tool name that appears in every diagnostic envelope this produces.
+inline constexpr std::string_view checkToolName = "mdux-medui-check";
+
+/**
+ * @brief One file's findings, and which checks were able to run.
+ *
+ * The booleans are not a substitute for the notes - both are produced, because a human reads the
+ * notes and a caller reads the flags. They exist so a test can assert that a check was *skipped*
+ * rather than merely that it reported nothing, which is the distinction that would otherwise be
+ * invisible.
+ */
+struct CheckResult {
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+    bool                                      layoutChecked{false};  ///< the file declared a surface
+    bool                                      textChecked{false};    ///< approved locales were available
+
+    /// Whether anything of error severity was reported. Notes and warnings do not fail a check.
+    [[nodiscard]] bool ok() const noexcept {
+        return std::ranges::none_of(diagnostics, [](const mdux::tools::cli::Diagnostic& diagnostic) {
+            return diagnostic.severity == mdux::tools::cli::Severity::Error;
+        });
+    }
+};
+
+/**
+ * @brief Runs every stage a single file admits, in the order the compiler runs them.
+ *
+ * @param source the file's text
+ * @param file   the path to name in diagnostics
+ *
+ * Stops at the first stage that reports an error, for the reason the compiler driver stops: a later
+ * stage reading a screen an earlier one rejected reports consequences rather than causes.
+ */
+[[nodiscard]] CheckResult checkScreen(std::string_view source, std::string file);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/MeduiCheckMain.cpp
+++ b/tools/medui/MeduiCheckMain.cpp
@@ -1,0 +1,125 @@
+/**
+ * @file MeduiCheckMain.cpp
+ * @brief `mdux-medui-check` entry point: validate one `.medui` file, print diagnostics, exit.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Its own grammar rather than the shared `bake`/`verify` one, because this is neither: it takes a
+ * file and produces no artifact. What it does share is the envelope - `cli::render` and
+ * `cli::exitStatus` - so an agent parsing `--format=json` here parses what every other MduX tool
+ * emits, which is the whole point of #118.
+ *
+ * Exit status is `cli::exitStatus`'s: non-zero when anything of error severity was reported, zero
+ * otherwise. The notes about what a single file cannot cover do not fail a check; they are
+ * statements about the run, and a run that could not check locales still checked everything else.
+ */
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.check;
+
+namespace {
+
+namespace cli   = mdux::tools::cli;
+namespace medui = mdux::tools::medui;
+
+[[nodiscard]] std::string usage() {
+    return std::format("usage:\n"
+                       "  {} <screen.medui> [--format=json|text]\n"
+                       "\n"
+                       "Validates one .medui file and prints what it finds. Writes nothing.\n"
+                       "\n"
+                       "Checked: the grammar, the component dictionary, field value domains,\n"
+                       "hardcoded strings, theme tokens, the @safety_critical rules, and - when the\n"
+                       "file declares a `surface:` - bounded layout and the golden set.\n"
+                       "\n"
+                       "Not checked, and reported as notes: text keys and text budgets, which need\n"
+                       "the approved locales a recipe names. Compile through mdux-meduic for those.\n"
+                       "\n"
+                       "Exits non-zero when anything of error severity was found.\n",
+                       medui::checkToolName);
+}
+
+[[nodiscard]] std::optional<std::string> readFile(const std::filesystem::path& path) {
+    std::ifstream file{path, std::ios::binary | std::ios::ate};
+    if (!file) {
+        return std::nullopt;
+    }
+    // tellg() answers -1 on a stream error rather than throwing, and sizing the string before the
+    // check would turn that into a request for 2^64-1 bytes.
+    const std::streamoff size = file.tellg();
+    if (size < 0 || !file.seekg(0)) {
+        return std::nullopt;
+    }
+    std::string text(static_cast<std::size_t>(size), '\0');
+    if (size > 0) {
+        file.read(text.data(), size);
+        if (!file) {
+            return std::nullopt;
+        }
+    }
+    return text;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    std::vector<std::string_view> positional;
+    cli::Format                   format = cli::Format::Text;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view argument{argv[i]};
+        if (argument == "--help" || argument == "-h") {
+            std::print(std::cout, "{}", usage());
+            return 0;
+        }
+        if (argument == "--format=json") {
+            format = cli::Format::Json;
+            continue;
+        }
+        if (argument == "--format=text") {
+            // Assigned rather than skipped, so that last flag wins.
+            format = cli::Format::Text;
+            continue;
+        }
+        if (argument.starts_with("-")) {
+            std::println(std::cerr, "unrecognized option '{}'\n\n{}", argument, usage());
+            return 2;
+        }
+        positional.push_back(argument);
+    }
+
+    if (positional.size() != 1) {
+        std::println(std::cerr, "expected exactly one file, got {}\n\n{}", positional.size(), usage());
+        return 2;
+    }
+
+    const std::string                path{positional[0]};
+    const std::optional<std::string> source = readFile(path);
+    if (!source.has_value()) {
+        // Reported through the envelope rather than as a bare message, so a caller parsing JSON
+        // gets a finding here exactly as it would for a syntax error.
+        cli::Diagnostic unreadable;
+        unreadable.file     = path;
+        unreadable.code     = "MEDUI-E003";
+        unreadable.severity = cli::Severity::Error;
+        unreadable.message  = "the .medui source could not be opened";
+        unreadable.fixHint  = "check the path, and that the file is readable";
+
+        const std::array<cli::Diagnostic, 1> diagnostics{std::move(unreadable)};
+        std::print(std::cout, "{}", cli::render(diagnostics, format, medui::checkToolName));
+        return cli::exitStatus(diagnostics);
+    }
+
+    const medui::CheckResult result = medui::checkScreen(*source, path);
+
+    const std::string rendered = cli::render(result.diagnostics, format, medui::checkToolName);
+    if (!rendered.empty()) {
+        std::print(std::cout, "{}", rendered);
+    }
+    if (format == cli::Format::Text && result.ok()) {
+        std::println(std::cout, "{}: OK ({})", medui::checkToolName, path);
+    }
+
+    return cli::exitStatus(result.diagnostics);
+}

--- a/tools/medui/Semantic.cpp
+++ b/tools/medui/Semantic.cpp
@@ -204,12 +204,11 @@ private:
     }
 
     void analyzeTextKey(const ast::Value& value) {
-        // No approved locale to check against means there is nothing to check, and saying "absent
-        // from every approved locale" when there are none is a vacuous truth dressed as a finding.
-        // The caller that must not tolerate the gap is the compiler driver, which refuses a recipe
-        // whose screen draws text and declares no locales (#198); `mdux-medui-check` runs without a
-        // recipe on purpose and reports the gap as a note (#200).
-        if (inputs_.textPackages.empty()) {
+        // Asked for, never inferred. An empty package span still means "an approved set with no
+        // locale in it" - so every key is absent from all of them - and only a caller that says so
+        // explicitly gets the check skipped. Reading permission out of the span would have handed
+        // every other caller a weaker check with nothing in the result to say so.
+        if (inputs_.locales == LocalePolicy::Skipped) {
             return;
         }
 

--- a/tools/medui/Semantic.cpp
+++ b/tools/medui/Semantic.cpp
@@ -204,6 +204,15 @@ private:
     }
 
     void analyzeTextKey(const ast::Value& value) {
+        // No approved locale to check against means there is nothing to check, and saying "absent
+        // from every approved locale" when there are none is a vacuous truth dressed as a finding.
+        // The caller that must not tolerate the gap is the compiler driver, which refuses a recipe
+        // whose screen draws text and declares no locales (#198); `mdux-medui-check` runs without a
+        // recipe on purpose and reports the gap as a note (#200).
+        if (inputs_.textPackages.empty()) {
+            return;
+        }
+
         std::vector<std::string_view> missingLocales;
         bool                          foundAnywhere = false;
         for (const mdux::text::TextPackage& package : inputs_.textPackages) {
@@ -225,20 +234,16 @@ private:
     void analyzeText(const ast::Value& value, FieldDomain domain) {
         if (domain == TextKeyList && value.kind == ast::ValueKind::List) {
             if (value.list.empty()) {
-                report(Code::FieldValueKind, value.position,
-                       std::format("text field requires {}", describe(domain)));
+                report(Code::FieldValueKind, value.position, std::format("text field requires {}", describe(domain)));
                 return;
             }
             for (const std::shared_ptr<ast::Value>& element : value.list) {
                 if (element == nullptr) {
-                    report(Code::FieldValueKind, value.position,
-                           std::format("text field requires {}", describe(domain)));
+                    report(Code::FieldValueKind, value.position, std::format("text field requires {}", describe(domain)));
                 } else if (element->kind == ast::ValueKind::String) {
-                    report(Code::HardcodedString, element->position,
-                           "literal text cannot be checked against every approved locale");
+                    report(Code::HardcodedString, element->position, "literal text cannot be checked against every approved locale");
                 } else if (element->kind != ast::ValueKind::TextKey) {
-                    report(Code::FieldValueKind, element->position,
-                           std::format("text field requires {}", describe(domain)));
+                    report(Code::FieldValueKind, element->position, std::format("text field requires {}", describe(domain)));
                 } else {
                     analyzeTextKey(*element);
                 }

--- a/tools/medui/Semantic.cppm
+++ b/tools/medui/Semantic.cppm
@@ -68,9 +68,28 @@ struct ComponentRule {
  * analyzer reads only each package's locale and run IDs. Theme tokens are full names such as
  * `Theme.Colors.Title`; their concrete colour values belong to the later emitter stage.
  */
+/**
+ * @brief Whether a caller is entitled to skip the locale-completeness check.
+ *
+ * The default is the one that fails closed. An empty `textPackages` span under `Required` means an
+ * approved set containing no locale, so every key is absent from all of them - which is what a
+ * compile must see rather than a clean result.
+ *
+ * `Skipped` exists for one caller: `mdux-medui-check` validates a file that may belong to no recipe,
+ * so there are no approved locales to check against and reporting every `t("STR-KEY")` as absent
+ * would be a vacuous truth dressed as a finding. It is a *mode a caller asks for*, not a meaning
+ * read into an empty span, because the second kind would hand every present and future caller a
+ * silently weaker check with nothing in the result to say so.
+ */
+enum class LocalePolicy : std::uint8_t {
+    Required,  ///< keys must resolve in every approved locale; no locales means none resolve
+    Skipped,   ///< the caller has no approved locale set and accepts that keys go unchecked
+};
+
 struct SemanticInputs {
     std::span<const std::string_view>        themeTokens;
     std::span<const mdux::text::TextPackage> textPackages;
+    LocalePolicy                             locales{LocalePolicy::Required};
 };
 
 /// Accumulated semantic diagnostics; an empty result admits the screen to the next stage.

--- a/tools/medui/Semantic.cppm
+++ b/tools/medui/Semantic.cppm
@@ -62,13 +62,6 @@ struct ComponentRule {
 [[nodiscard]] std::span<const ComponentRule> componentDictionary() noexcept;
 
 /**
- * @brief External name tables against which one screen is checked.
- *
- * Text packages are prevalidated, one per approved locale, with unique locale names. The
- * analyzer reads only each package's locale and run IDs. Theme tokens are full names such as
- * `Theme.Colors.Title`; their concrete colour values belong to the later emitter stage.
- */
-/**
  * @brief Whether a caller is entitled to skip the locale-completeness check.
  *
  * The default is the one that fails closed. An empty `textPackages` span under `Required` means an
@@ -86,6 +79,13 @@ enum class LocalePolicy : std::uint8_t {
     Skipped,   ///< the caller has no approved locale set and accepts that keys go unchecked
 };
 
+/**
+ * @brief External name tables against which one screen is checked.
+ *
+ * Text packages are prevalidated, one per approved locale, with unique locale names. The
+ * analyzer reads only each package's locale and run IDs. Theme tokens are full names such as
+ * `Theme.Colors.Title`; their concrete colour values belong to the later emitter stage.
+ */
 struct SemanticInputs {
     std::span<const std::string_view>        themeTokens;
     std::span<const mdux::text::TextPackage> textPackages;


### PR DESCRIPTION
Closes #200. The surface an author and an agent reach for first: point it at a file, read the
diagnostics, fix them.

```
mdux-medui-check path/to/screen.medui [--format=json|text]
```

Writes nothing. Exits non-zero when anything of error severity was found, so it drops into a
pre-commit hook or an agent loop as it stands, and `--format=json` emits the envelope every MduX tool
emits (#118).

## The design question, and the answer I would like checked

Two stages cannot be fed by a single file. **Text keys** are checked against the approved locales a
recipe names, and **text budgets** need the font those locales were baked into. With no recipe there
are neither.

Running the key check anyway would report every `t("STR-KEY")` as absent from every approved locale —
a vacuous truth dressed as a finding, and the fastest way to teach an author that this tool's output
is noise. So the check does not run, and **the run says so**: a `Severity::Note` carrying `MDC001`,
travelling in the same envelope as the findings. A screen with no `surface:` gets `MDC002` for the
same reason — layout, overflow and golden bounds went unchecked, and that is a gap in what can be
checked rather than a finding about the file.

Notes do not fail a run. What they buy is that a clean result is visibly **partial** rather than
silently so, and that an agent can key off the code to decide whether to re-run through
`mdux-meduic` with a recipe. A checker whose clean run is silently partial is worse than none,
because it converts "I did not look" into "nothing is wrong".

## One change below the tool

`analyze()` no longer reports a text key as absent when it was given **no** approved locales, because
there is nothing for it to be absent from. That is arguably what it should always have done; what
made it safe to change now is that the caller which must not tolerate the gap — the compiler driver —
already refuses a recipe whose screen draws text and declares no locales (#198). A scenario pins the
new behaviour, and the existing three-locale scenario is untouched.

## Tests

`tests/medui/CheckTests.cpp` drives the same rejection corpus the parser and analyzer suites use by
call — `rejected-unterminated-string`, `rejected-nested-row`, `rejected-duplicate-id`,
`rejected-safety-without-requirement` — so a code that stops surfacing to an author stops a test.
That corpus being real files rather than string literals is exactly what makes this possible, which
is what #192 said it was for.

Two scenarios spawn the executable, for the reason #198's does: nothing at call level shows that the
tool exits non-zero on a finding and **zero on a run whose only output is notes**. The second half is
the one that would have been easy to get wrong — an exit status keyed off the presence of diagnostics
rather than their severity fails every clean run.

## The skill

`medui-authoring` said "there is no tooling shortcut yet", which #200's acceptance requires it to stop
saying. It now documents the command, what it covers, and — in the same breath — the two things it
cannot, with the instruction to compile through a recipe for those.

## Regulatory impact

No device code changes; the tool is host-only and writes nothing. What improves is where an authoring
error is found: at the file, by the author, in the envelope an agent can act on, rather than at a
build that compiles the whole screen. What has not changed is what counts as an error — the checker
runs the same stages with the same codes, and reports strictly less than a compile because it knows
strictly less.

Roadmap: #15 is S1-S11 done, #201 next and last.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `mdux-medui-check` command to validate standalone `.medui` files.
  * Supports text and JSON diagnostic output, clear success or failure status, and actionable validation messages.
  * Checks syntax, semantic rules, safety annotations, and layout when a surface is provided.

* **Bug Fixes**
  * Improved locale and text-key validation, including clearer handling of skipped checks and source locations.

* **Documentation**
  * Updated authoring guidance and roadmap details to reflect the available compiler and validation workflow.

* **Tests**
  * Expanded coverage for checker behavior, diagnostics, command-line execution, and semantic validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->