### PR TITLE
Draw an authored screen, and compare the pixels [#201]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,7 +10,7 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: the compiler is complete front to back; one end-to-end screen remains
+## Status: an authored screen reaches pixels; the text half is what remains
 
 **A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, text-budget
 check, and golden-reference pass exist** in the host-tools zone (`tools/medui/`). The diagnostic
@@ -49,9 +49,10 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
 [`Compliatory/MedUI` at `d5136a8`](https://github.com/Compliatory/MedUI/tree/d5136a8518bd499760ecff2aad215d3721329f20).
-A `.medui` file builds something in MduX today: register it with `mdux_compile_screen()` and it
-becomes a committed, byte-compared artifact plus generated C++ a device links. What it cannot yet do
-is carry text, for the reason above.
+A `.medui` file builds something in MduX today, and it reaches the screen: register it with
+`mdux_compile_screen()` and it becomes a committed, byte-compared artifact plus generated C++ a
+device links, which the governed runtime draws and `ScreenPixelTests` compares pixel by pixel under
+lavapipe. What it cannot yet do is carry text, for the reason above.
 
 ## Grammar shape
 

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -30,9 +30,10 @@ and a `.hpp` carrying `static_assert(screen.validate().has_value())`, so a malfo
 build error rather than a startup failure (#197). A governed runtime draws one without allocating
 (#199), and `mdux-medui-check` validates a single file (#200).
 
-Two limits are worth knowing before you write a screen. **No text package is baked in this
-repository yet**, so a screen carrying `t("STR-KEY")` cannot be compiled end to end — that is #201,
-the last child of the epic. And the runtime draws a `Panel`; every other component is visited,
+Two limits are worth knowing before you write a screen. A font package is baked; **no text package
+is** — the per-locale glyph runs a `t("STR-KEY")` resolves against — so a screen carrying a text key
+cannot be compiled end to end
+([#235](https://github.com/ambroise-leclerc/MduX/issues/235)). And the runtime draws a `Panel`; every other component is visited,
 counted in `FrameStats::deferred` and left undrawn, because text needs that package and live-data
 components have no geometry until the frame does.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,17 @@ mdux_compile_screen(
     RECIPE recipes/screen/endoscope-monitor.toml
 )
 
+# ...and the generated C++ for it (issue #201). Build-tree only, never committed. This is the last
+# link in the chain the epic set out to build: a `.medui` file becomes a committed artifact, the
+# artifact becomes `constexpr` C++, and a pixel test links that C++ and renders it - so the first
+# pixel drawn from an authored screen is compared against an expectation rather than described.
+include(cmake/MduXScreenEmit.cmake)
+mdux_emit_screen_package(
+    ID endoscope-monitor
+    OUT_MODULE MDUX_ENDOSCOPE_SCREEN_MODULE
+    OUT_DIR MDUX_GENERATED_SCREEN_DIR
+)
+
 # Generated C++ for that package (issue #121). Build-tree only, never committed - see
 # cmake/MduXShaderEmit.cmake. The renderer (#124) and the triangle example (#122) consume the
 # module form; the header form exists for a translation unit that cannot import a named module.

--- a/README.md
+++ b/README.md
@@ -161,8 +161,11 @@ carrying `static_assert(screen.validate().has_value())`, a governed runtime turn
 commands without allocating, and `mdux.render.vulkan` draws them. `ScreenPixelTests` walks the whole
 chain and compares the result pixel by pixel under lavapipe in CI.
 
-Two limits are worth stating beside that. No text package is baked in this repository yet, so a
-screen carrying `t("STR-KEY")` cannot be compiled end to end; and the runtime draws a `Panel` while
+Two limits are worth stating beside that. A **font** package is baked and committed
+(`generated/font/dejavu-ui/`), but no **text** package is — the per-locale glyph runs a screen's
+`t("STR-KEY")` resolves against, which would live under `generated/text/`. `mdux-textbake` can
+produce one and no recipe registers one, so a screen carrying a text key cannot be compiled end to
+end ([#235](https://github.com/ambroise-leclerc/MduX/issues/235)); and the runtime draws a `Panel` while
 counting every other component as deferred, because text needs that package and live-data components
 have no geometry until a frame exists. The committed screen therefore renders one bar — from a file
 an author wrote, through every stage, with nothing hand-carried between them.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
-| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, integer-only bounded layout, per-locale text budgets, and golden references for safety-critical nodes; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| `MduXMeduiLib` | Implemented | The `.medui` compiler end to end: parsing, semantic validation, integer-only bounded layout, per-locale text budgets, golden references, the canonical package, two C++ emitters, and the `mdux-meduic` / `mdux-medui-check` tools ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |
@@ -154,10 +154,22 @@ Derived from the targets and tests that build on `develop`.
 | Text and glyph rendering | Planned | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) |
 | Content components (`SignalTrace`, `StatusIndicator`, …) | Planned | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) |
 
+`.medui` reaches pixels today, and the path is built rather than planned. An authored screen is
+compiled by `mdux-meduic` into `generated/screen/<id>/` — a package, a golden sidecar and a bake
+report, byte-compared across MSVC and GCC. Two emitters render that package as `constexpr` C++
+carrying `static_assert(screen.validate().has_value())`, a governed runtime turns it into draw
+commands without allocating, and `mdux.render.vulkan` draws them. `ScreenPixelTests` walks the whole
+chain and compares the result pixel by pixel under lavapipe in CI.
+
+Two limits are worth stating beside that. No text package is baked in this repository yet, so a
+screen carrying `t("STR-KEY")` cannot be compiled end to end; and the runtime draws a `Panel` while
+counting every other component as deferred, because text needs that package and live-data components
+have no geometry until a frame exists. The committed screen therefore renders one bar — from a file
+an author wrote, through every stage, with nothing hand-carried between them.
+
 The HTML/CSS path that earlier revisions described was **deleted** by
 [#127](https://github.com/ambroise-leclerc/MduX/issues/127) — `MedicalUiRenderer::render()` recorded
-no Vulkan commands. `mdux.draw` plus `mdux.render.vulkan` replace it; `.medui` will generate the
-former.
+no Vulkan commands. `mdux.draw` plus `mdux.render.vulkan` replaced it.
 
 ## Regulatory material, and what it is for
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,7 +256,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, bounded layout, text budgets, and golden references are implemented; packaging and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | complete front to back: parsing, semantic validation, bounded layout, text budgets, golden references, the canonical package, both C++ emitters, `mdux-meduic`, `mdux-medui-check`, and a governed runtime that draws a compiled screen. One committed screen reaches pixels in `ScreenPixelTests`; what remains is the text package (#201) and the components' own geometry (#17) |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |
@@ -269,7 +269,7 @@ tracking issue; the issue is authoritative for what remains.
 for the object's whole lifetime; it was removed rather than fixed.
 
 What replaces it is `mdux.draw` (a governed description of a frame) plus `mdux.render.vulkan` (the
-adapter that renders it). `.medui` will generate the former. **Do not reintroduce HTML/CSS parsing.**
+adapter that renders it). `.medui` generates the former today, through the chain in the previous section. **Do not reintroduce HTML/CSS parsing.**
 
 ## Reading order
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,7 +256,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | complete front to back: parsing, semantic validation, bounded layout, text budgets, golden references, the canonical package, both C++ emitters, `mdux-meduic`, `mdux-medui-check`, and a governed runtime that draws a compiled screen. One committed screen reaches pixels in `ScreenPixelTests`; what remains is the text package (#201) and the components' own geometry (#17) |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | complete front to back: parsing, semantic validation, bounded layout, text budgets, golden references, the canonical package, both C++ emitters, `mdux-meduic`, `mdux-medui-check`, and a governed runtime that draws a compiled screen. One committed screen reaches pixels in `ScreenPixelTests`; what remains is the text package ([#235](https://github.com/ambroise-leclerc/MduX/issues/235)) and the components' own geometry (#17) |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # MduX → TrustSC parity roadmap
 
 > Backlog · ambroise-leclerc/MduX · updated 22 August 2026
-> Epic status verified against `develop` @ `a5cc41f` · 22 August 2026 · `#15` current through `#200`.
+> Epic status verified against `develop` @ `06b2a59` · 22 August 2026 · `#15` current through `#201`.
 > The divergence table below was last re-verified on 17 August 2026 and is not re-checked here.
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
@@ -10,7 +10,7 @@ backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draw
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. Eleven of its twelve children have landed — the ADRs,
+that generates the screens it draws. All twelve of its children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
 golden references, the canonical package with its C++ emitters, and the `mdux-meduic` compiler with
 its CMake registration — so the compiler now reads a `.medui` file, resolves it to a bounded box
@@ -19,8 +19,11 @@ content must appear, and writes the result as a byte-compared artifact and as `c
 device links without a parser. The first compiled screen is committed under
 `generated/screen/endoscope-monitor/`, the governed runtime draws one without allocating, and
 `mdux-medui-check` validates a single file while naming the two checks a file on its own cannot
-cover. #201 is next, and last: the first end-to-end screen, which is what the missing text package
-blocks.
+cover. With #201 the chain reaches pixels: `ScreenPixelTests` renders the committed screen through
+the governed runtime and compares the frame pixel by pixel under lavapipe. What the epic leaves for
+its successors is content rather than path — no text package is baked yet, so a screen carrying
+`t("STR-KEY")` cannot be compiled, and the runtime draws a `Panel` while counting every other
+component as deferred.
 
 | Metric | Count |
 |---|---|
@@ -39,7 +42,7 @@ the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build. What is still ahead is the first end-to-end screen (#201), which is what the missing text package blocks. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build, and an authored screen reaches pixels through the governed runtime in `ScreenPixelTests` (#201). What is still ahead is content rather than path: the text package, and the components' own geometry (#17). | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Six artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
@@ -64,21 +67,26 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S11 done · S12 next)
+Wave 5 · in progress        #15 (S1–S12 done · epic closing)
 Wave 6                      #16  #17
 ```
 
 #### When v0.6.0 gets cut
 
-**After #201, not before.** The convention above is one version per wave, and Wave 5 is #15 alone.
-Cutting a version at 10/12 would break the pattern the last four releases followed, and would ship a
-compiler whose runtime draws one component kind and whose text half is missing: no text package is
-baked in this tree, so no screen carrying `t("STR-KEY")` compiles at all. Both gaps close in #201, and
-a 0.6.0 released before them would need its notes to explain that it cannot draw a label.
+**Now.** The convention above is one version per wave, Wave 5 is #15 alone, and #201 closed it at
+12/12: an authored `.medui` file reaches compared pixels through every stage.
 
-If a version has to be cut sooner than that, the line *after* #199 is the one to take rather than the
-line before it. Today's `develop` is a compiler producing artifacts nothing on a device consumes;
-#199 is what makes a device able to draw one, so it is the better boundary of the two.
+This recommendation was written at 10/12 and said the two content gaps — no baked text package, a
+runtime that draws one component kind — would close in #201. **They did not, and that expectation was
+mine rather than the issue's.** #201's acceptance asked for an end-to-end screen exercising a
+safety-critical node, and that is what it delivered; nothing in it promised the text half. So the
+gaps outlive the wave and belong to its successors: the text package to whoever bakes one, the
+components' own geometry to #17.
+
+That does not argue for delaying the tag. What v0.6.0 ships is a complete *path* — authored file,
+byte-compared artifact, `constexpr` C++, governed runtime, compared pixel — and the honest release
+note says exactly that: the chain is built and the content is one rectangle. A version held back
+until the content filled in would be waiting on #17, which is a wave of its own.
 
 Two things worth settling before the tag rather than during it:
 
@@ -265,7 +273,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 11/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 12/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -290,7 +298,7 @@ happened to read.
 - #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #231)_
 - #199 S10 Allocation-free screen runtime · _closed (PR #232)_
 - #200 S11 `mdux-medui-check` · _closed (PR #233)_
-- #201 S12 First end-to-end screen · **next**
+- #201 S12 First end-to-end screen · _closed (PR #234)_
 
 _Blocks #16, #17_
 
@@ -396,6 +404,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Epic status verified at `develop` @ `a5cc41f` · 22 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 11/12) · no enforcement gaps outstanding_
+_Epic status verified at `develop` @ `06b2a59` · 22 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 12/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,9 +21,10 @@ device links without a parser. The first compiled screen is committed under
 `mdux-medui-check` validates a single file while naming the two checks a file on its own cannot
 cover. With #201 the chain reaches pixels: `ScreenPixelTests` renders the committed screen through
 the governed runtime and compares the frame pixel by pixel under lavapipe. What the epic leaves for
-its successors is content rather than path — no text package is baked yet, so a screen carrying
+its successors is content rather than path: no text package is baked yet (#235), so a screen carrying
 `t("STR-KEY")` cannot be compiled, and the runtime draws a `Panel` while counting every other
-component as deferred.
+component as deferred (#17). The golden sidecar gains a static consumer in `ScreenPixelTests` and
+still awaits the rendered one ADR-012 describes, which is #16 over content #17 teaches to draw.
 
 | Metric | Count |
 |---|---|

--- a/generated/screen/endoscope-monitor/goldens.json
+++ b/generated/screen/endoscope-monitor/goldens.json
@@ -1,6 +1,20 @@
 [
   {
     "bounds": {
+      "height": 96,
+      "width": 1280,
+      "x": 0,
+      "y": 496
+    },
+    "colorToken": "Theme.Colors.ScoreDigits",
+    "cvChecks": [
+      "Bounds",
+      "ColorHash"
+    ],
+    "nodeId": "insufflation-pressure"
+  },
+  {
+    "bounds": {
       "height": 128,
       "width": 1280,
       "x": 0,

--- a/generated/screen/endoscope-monitor/package.json
+++ b/generated/screen/endoscope-monitor/package.json
@@ -35,7 +35,7 @@
     },
     {
       "bounds": {
-        "height": 520,
+        "height": 424,
         "width": 1280,
         "x": 0,
         "y": 72
@@ -44,6 +44,22 @@
       "kind": "VulkanViewport",
       "spec": {
         "streamSource": "ENDOSCOPE_PRIMARY"
+      }
+    },
+    {
+      "bounds": {
+        "height": 96,
+        "width": 1280,
+        "x": 0,
+        "y": 496
+      },
+      "id": "insufflation-pressure",
+      "kind": "NumericDisplay",
+      "spec": {
+        "colorToken": "Theme.Colors.ScoreDigits",
+        "requirement": "REQ-EM-001",
+        "source": "INSUFFLATION_PRESSURE",
+        "templateId": "TPL-PRESSURE-MMHG"
       }
     },
     {

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -2,7 +2,7 @@
   "inputs": [
     {
       "path": "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui",
-      "sha256": "90ace4675f2ba636a950f333310cd997bf19d4496aa0aa05a5c15f55b49a6c7c"
+      "sha256": "c35fd66ae804cb6ac14ea691914f52b3690355fd32a361a14bc46058f257642c"
     }
   ],
   "options": {

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -2,7 +2,7 @@
   "inputs": [
     {
       "path": "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui",
-      "sha256": "7edbb61c9e6e196bb8f38b9a1339491cf2b2abbf51e47515c9fb37b0df8f32ae"
+      "sha256": "90ace4675f2ba636a950f333310cd997bf19d4496aa0aa05a5c15f55b49a6c7c"
     }
   ],
   "options": {
@@ -22,11 +22,11 @@
   "outputs": [
     {
       "path": "goldens.json",
-      "sha256": "d287cf21560be2891a0ab11ba6bcf197cd2295fc20ed900d95ea931aef3bdf4c"
+      "sha256": "60c555cbeceb4e897e5a4302c0d667aaca84dd72d28ef2c13d96178d86eb1a2a"
     },
     {
       "path": "package.json",
-      "sha256": "c0aa463ba4f87185729aaa99870e2497012c4e3506eb5a101fbc166e54433cef"
+      "sha256": "72066d6b6ef6a80c974a99b807a3e5fe7e40aba08fa0d0885eff67e2348554f0"
     }
   ],
   "recipe": {

--- a/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
+++ b/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
@@ -33,10 +33,14 @@ Screen EndoscopeMonitor {
         stream_source: "ENDOSCOPE_PRIMARY";
     }
 
-    // The safety-critical node, and the reason this screen has one: S7's golden references need a
-    // consumer that is not a test fixture. Annotated and traced, so `goldens.json` carries an entry
-    // a frame verifier can check the insufflation reading against - where it appears and in what
-    // tint, never what the number says, because the number is live.
+    // The safety-critical node, and the reason this screen has one: `goldens.json` should describe a
+    // real screen rather than only a test fixture. Annotated and traced, so the sidecar carries an
+    // entry saying where the insufflation reading must appear and in what tint - never what the
+    // number says, because the number is live.
+    //
+    // What that entry does *not* have yet is a verifier reading it against a frame. This component
+    // is deferred by the runtime, so there are no pixels to compare; the check ADR-012 describes
+    // arrives with #16, over content that #17 teaches to draw.
     //
     // A NumericDisplay deliberately: it is the one traceable component that carries no text key, so
     // this screen exercises the annotation rules without needing the text package that does not

--- a/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
+++ b/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
@@ -29,8 +29,27 @@ Screen EndoscopeMonitor {
     VulkanViewport {
         id: endoscope-view;
         width: 1280px;
-        height: 520px;
+        height: 424px;
         stream_source: "ENDOSCOPE_PRIMARY";
+    }
+
+    // The safety-critical node, and the reason this screen has one: S7's golden references need a
+    // consumer that is not a test fixture. Annotated and traced, so `goldens.json` carries an entry
+    // a frame verifier can check the insufflation reading against - where it appears and in what
+    // tint, never what the number says, because the number is live.
+    //
+    // A NumericDisplay deliberately: it is the one traceable component that carries no text key, so
+    // this screen exercises the annotation rules without needing the text package that does not
+    // exist yet (#201's remaining half, and the reason the runtime draws what it draws).
+    @safety_critical(cv_check: [Bounds, ColorHash])
+    NumericDisplay {
+        id: insufflation-pressure;
+        width: 1280px;
+        height: 96px;
+        requirement: "REQ-EM-001";
+        template: "TPL-PRESSURE-MMHG";
+        source: "INSUFFLATION_PRESSURE";
+        color: Theme.Colors.ScoreDigits;
     }
 
     // Positioned, so its rectangle is pinned by a golden reference: a waveform that drifts off its

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -262,6 +262,7 @@ add_executable(offscreen_tests
     render/OffscreenTests.cpp
     render/PixelTests.cpp
     render/TextPixelTests.cpp
+    render/ScreenPixelTests.cpp
 )
 
 target_sources(offscreen_tests
@@ -271,12 +272,20 @@ target_sources(offscreen_tests
             TYPE CXX_MODULES
             BASE_DIRS ${MDUX_GENERATED_SHADER_DIR}
             FILES ${MDUX_UI_SHADER_MODULE}
+        # The emitted screen joins its own file set, because its base directory is the screen output
+        # directory rather than the shader one. ScreenPixelTests (#201) links it: the last link in
+        # the chain from an authored .medui file to a compared pixel.
+        FILE_SET generated_screen_modules
+            TYPE CXX_MODULES
+            BASE_DIRS ${MDUX_GENERATED_SCREEN_DIR}
+            FILES ${MDUX_ENDOSCOPE_SCREEN_MODULE}
 )
-add_dependencies(offscreen_tests emit-shader-mdux-ui)
+add_dependencies(offscreen_tests emit-shader-mdux-ui emit-screen-endoscope-monitor)
 target_link_libraries(offscreen_tests PRIVATE MduX::MduX)
 target_include_directories(offscreen_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${MDUX_GENERATED_SHADER_DIR}
+    ${MDUX_GENERATED_SCREEN_DIR}
 )
 
 set_target_properties(offscreen_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -281,6 +281,11 @@ target_sources(offscreen_tests
             FILES ${MDUX_ENDOSCOPE_SCREEN_MODULE}
 )
 add_dependencies(offscreen_tests emit-shader-mdux-ui emit-screen-endoscope-monitor)
+
+# ScreenPixelTests reads the committed golden sidecar under generated/, a fixed location in the
+# source tree rather than anything the build produces. It reads only; the source-tree-cleanliness
+# gate in CI stays satisfied.
+target_compile_definitions(offscreen_tests PRIVATE MDUX_REPO_ROOT="${CMAKE_SOURCE_DIR}")
 target_link_libraries(offscreen_tests PRIVATE MduX::MduX)
 target_include_directories(offscreen_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/render/ScreenPixelTests.cpp
+++ b/tests/render/ScreenPixelTests.cpp
@@ -26,6 +26,25 @@
  * content grows when the text package lands and the remaining components learn their geometry; the
  * path does not have to be built again.
  *
+ * ## What the golden sidecar has here, and what it does not
+ *
+ * `goldens.json` gets its first consumer in this file, and it is a **static** one: the last scenario
+ * reads the committed sidecar and cross-checks every entry against the compiled screen. That is a
+ * real check - it fails if the `@safety_critical` annotation is removed, or if a golden's bounds stop
+ * matching the node it names - and it is not the consumer ADR-012 describes.
+ *
+ * The rendered one cannot exist yet, and the reason is structural rather than an omission here.
+ * Both golden nodes on this screen are deferred - a `NumericDisplay` and a `SignalTrace` - so there
+ * are no pixels to check `Bounds` or `ColorHash` against, and the only node that *is* drawn is the
+ * Row's synthetic `Panel`, which no golden can ever name: `collectGoldens()` skips synthetic nodes,
+ * and a `Row` carries neither `requirement:` nor `position:`. So no screen in this repository can
+ * have a rendered golden consumer until a golden-eligible component learns to draw, which is #17,
+ * and the verifier that would consume it is #16.
+ *
+ * The scenario below therefore asserts the one rendered fact that is true: the region the golden
+ * names is empty today. That is a tripwire rather than a goal - the day the `NumericDisplay` draws,
+ * it fails and has to be replaced by the check ADR-012 actually wants.
+ *
  * ## Compared against the compiled screen, not against a copy of it
  *
  * The expectation is painted from the package's own node bounds and the governed colour table -
@@ -41,6 +60,7 @@
 import std;
 import mdux.core.result;
 import mdux.core.units;
+import mdux.evidence.json;
 import mdux.draw;
 import mdux.medui.generated.screen_endoscope_monitor;
 import mdux.medui.schema;
@@ -80,11 +100,17 @@ using mdux::test::sharedDevice;
 
 constexpr core::ColorRgba8 background{.r = 0, .g = 0, .b = 0, .a = 255};
 
-/// Storage sized once from the screen's own budget, as a device would size it.
+/// The screen as a constant expression, so the storage below can be sized from the budget the
+/// artifact bakes rather than from three numbers copied out of it.
+constexpr medui::ScreenPackage compiled = medui::generated::screen_endoscope_monitor::package();
+
+/// Storage sized once from the screen's own budget, as a device would size it - and sized *by* it,
+/// so the two cannot drift. Hard-coding the three numbers would have left this test claiming a
+/// contract it did not exercise the moment a recipe changed one.
 struct Frame {
-    std::array<draw::UiVertex, 4096>  vertices{};
-    std::array<draw::Index, 6144>     indices{};
-    std::array<draw::DrawCommand, 64> commands{};
+    std::array<draw::UiVertex, compiled.budget.maxVertices>    vertices{};
+    std::array<draw::Index, compiled.budget.maxIndices>        indices{};
+    std::array<draw::DrawCommand, compiled.budget.maxCommands> commands{};
 };
 
 struct RecordContext {
@@ -166,4 +192,116 @@ TEST_CASE("An authored screen draws its panel where the compiler put it", "pixel
 
     const auto diff = compare(expected, *pixels);
     CHECK_MESSAGE(diff.matched(), diff.message);
+}
+
+TEST_CASE("The golden sidecar names this screen's safety-critical content", "pixel") {
+    // The sidecar's first consumer in this tree, and a static one: it reads the committed file and
+    // checks it against the compiled screen. See this file's header for why the rendered consumer
+    // ADR-012 describes cannot exist yet, and what would have to change for it to.
+    const medui::ScreenPackage package = screen();
+
+    const std::filesystem::path sidecar = std::filesystem::path{MDUX_REPO_ROOT} / "generated" / "screen" / "endoscope-monitor" / "goldens.json";
+    std::ifstream               file{sidecar, std::ios::binary};
+    REQUIRE(file.is_open());
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+
+    const auto parsed = mdux::evidence::json::parse(buffer.str());
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->kind() == mdux::evidence::json::Value::Kind::Array);
+
+    // Two entries, one per rule ADR-011 fixes: the annotated node, and the positioned one.
+    const std::span<const mdux::evidence::json::Value> entries = parsed->elements();
+    CHECK(entries.size() == 2);
+
+    bool sawAnnotated = false;
+    for (const mdux::evidence::json::Value& entry : entries) {
+        const auto nodeId = entry.require("nodeId");
+        REQUIRE(nodeId.has_value());
+        const auto name = (*nodeId)->asString();
+        REQUIRE(name.has_value());
+
+        // Every golden names a node this screen actually has, and pins the rectangle that node
+        // actually occupies. A sidecar that drifted from the package would address content the
+        // verifier could never find.
+        const medui::CompiledNode* node = package.find(*name);
+        REQUIRE(node != nullptr);
+
+        const auto bounds = entry.require("bounds");
+        REQUIRE(bounds.has_value());
+        const auto x      = (*bounds)->require("x");
+        const auto y      = (*bounds)->require("y");
+        const auto width  = (*bounds)->require("width");
+        const auto height = (*bounds)->require("height");
+        REQUIRE(x.has_value());
+        REQUIRE(y.has_value());
+        REQUIRE(width.has_value());
+        REQUIRE(height.has_value());
+        CHECK((*x)->asInt().value_or(-1) == node->bounds.x);
+        CHECK((*y)->asInt().value_or(-1) == node->bounds.y);
+        CHECK((*width)->asInt().value_or(-1) == node->bounds.width);
+        CHECK((*height)->asInt().value_or(-1) == node->bounds.height);
+
+        if (*name == "insufflation-pressure") {
+            sawAnnotated = true;
+            // The two checks the annotation asked for, and the tint the ColorHash one would compare
+            // against. Removing `@safety_critical` from the screen drops this entry entirely, which
+            // is what makes this scenario a check on the authored safety marking rather than on the
+            // serialiser.
+            const auto checks = entry.require("cvChecks");
+            REQUIRE(checks.has_value());
+            const std::span<const mdux::evidence::json::Value> named = (*checks)->elements();
+            REQUIRE(named.size() == 2);
+            CHECK(named[0].asString().value_or("") == "Bounds");
+            CHECK(named[1].asString().value_or("") == "ColorHash");
+
+            const auto tint = entry.require("colorToken");
+            REQUIRE(tint.has_value());
+            CHECK((*tint)->asString().value_or("") == "Theme.Colors.ScoreDigits");
+        }
+    }
+    CHECK(sawAnnotated);
+}
+
+TEST_CASE("The safety-critical region is empty, which is what the golden cannot yet check", "pixel") {
+    // A tripwire, not a goal. `insufflation-pressure` is deferred, so its golden's Bounds and
+    // ColorHash have nothing to compare against - and saying that out loud, in a test that fails the
+    // day the component draws, is more honest than a comment nobody re-reads. When #17 gives a
+    // NumericDisplay its geometry, this scenario must be replaced by the check ADR-012 wants.
+    const medui::ScreenPackage package = screen();
+    const core::Extent2D       surface = surfaceOf(package);
+
+    const auto& gpu    = sharedDevice();
+    auto        target = OffscreenTarget::create(gpu.device(), gpu.physicalDevice(), surface, gpu.queueFamilyIndex());
+    REQUIRE(target.has_value());
+
+    VulkanRenderContext context;
+    context.device           = gpu.device();
+    context.physicalDevice   = gpu.physicalDevice();
+    context.renderPass       = target->renderPass();
+    context.queue            = gpu.queue();
+    context.queueFamilyIndex = gpu.queueFamilyIndex();
+    context.viewport         = surface;
+
+    auto renderer = UiRenderer::create(context, mdux::shader::generated::mdux_ui::package(), package.budget);
+    REQUIRE(renderer.has_value());
+
+    Frame frame;
+    auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, package.budget);
+    REQUIRE(list.has_value());
+    REQUIRE(medui::render(package, *list).has_value());
+
+    RecordContext recording{.renderer = &*renderer, .list = &*list};
+    auto          pixels = target->renderAndRead(gpu.queue(), background, recordFrame, &recording);
+    REQUIRE(pixels.has_value());
+
+    const medui::CompiledNode* traced = package.find("insufflation-pressure");
+    REQUIRE(traced != nullptr);
+
+    // Sampled at the centre of the region the golden pins, which is where content would appear.
+    const auto        centreX = static_cast<std::size_t>(traced->bounds.x + traced->bounds.width / 2);
+    const auto        centreY = static_cast<std::size_t>(traced->bounds.y + traced->bounds.height / 2);
+    const std::size_t index   = centreY * static_cast<std::size_t>(surface.width) + centreX;
+    REQUIRE(index < pixels->size());
+    CHECK((*pixels)[index] == background);
 }

--- a/tests/render/ScreenPixelTests.cpp
+++ b/tests/render/ScreenPixelTests.cpp
@@ -1,0 +1,169 @@
+/**
+ * @file ScreenPixelTests.cpp
+ * @brief The first pixel drawn from an authored screen (issue #201).
+ *
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Every link in the chain this epic set out to build, exercised end to end in one test: an authored
+ * `.medui` file becomes a committed, byte-compared artifact (#198), the artifact becomes `constexpr`
+ * C++ this translation unit links (#197), the governed runtime turns that into draw commands without
+ * allocating (#199), and the Vulkan renderer draws them into an offscreen target that is read back
+ * and compared pixel by pixel (#125, #126).
+ *
+ * ## What is on screen, and why it is one rectangle
+ *
+ * The runtime draws a `Panel`. `EndoscopeMonitor`'s Row declares a background, so the solver
+ * synthesised one, and that is what appears: a 1280x72 bar in `Theme.Colors.TopbarBackground`. Its
+ * image, its video surface, its numeric readout and its waveform are visited, counted as deferred,
+ * and left undrawn - because a compiled screen carries a `textKey` rather than glyphs and no text
+ * package is baked in this tree, and because live-data components have no geometry until a sample
+ * exists.
+ *
+ * That makes this test thin in content and complete in path, and the distinction is the point. What
+ * it proves is not that MduX can draw a clinical screen; it is that a rectangle on this display came
+ * from a file an author wrote, through every stage, with nothing hand-carried between them. The
+ * content grows when the text package lands and the remaining components learn their geometry; the
+ * path does not have to be built again.
+ *
+ * ## Compared against the compiled screen, not against a copy of it
+ *
+ * The expectation is painted from the package's own node bounds and the governed colour table -
+ * `screen.find("topbar-background")->bounds` - rather than from four numbers written here. A test
+ * carrying its own copy of the rectangle would pass while the compiler moved it, which is the one
+ * regression this test exists to catch.
+ */
+#include <cstddef>
+#include <cstdint>
+
+#include <vulkan/vulkan.h>
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.medui.generated.screen_endoscope_monitor;
+import mdux.medui.schema;
+import mdux.medui.screen;
+import mdux.render.offscreen;
+import mdux.render.vulkan;
+import mdux.shader.schema;
+import mdux.shader.generated.mdux_ui;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+#include "HeadlessDevice.hpp"
+#include "PixelExpectation.hpp"
+
+namespace {
+
+using namespace mdux::render;
+namespace core  = mdux::core;
+namespace draw  = mdux::draw;
+namespace medui = mdux::medui;
+using mdux::test::compare;
+using mdux::test::ExpectedImage;
+using mdux::test::sharedDevice;
+
+/// The screen as generated code holds it: read-only data, validated at compile time by the
+/// `static_assert` the emitter wrote beside it.
+[[nodiscard]] medui::ScreenPackage screen() noexcept {
+    return medui::generated::screen_endoscope_monitor::package();
+}
+
+/// The offscreen surface is the screen's own, so a node lands where the compiler said it would.
+/// Taken from the package rather than written out: a test that fixed its own extent would keep
+/// passing while the screen was drawn for a different panel.
+[[nodiscard]] core::Extent2D surfaceOf(const medui::ScreenPackage& package) noexcept {
+    return core::Extent2D{.width = package.surfaceWidth, .height = package.surfaceHeight};
+}
+
+constexpr core::ColorRgba8 background{.r = 0, .g = 0, .b = 0, .a = 255};
+
+/// Storage sized once from the screen's own budget, as a device would size it.
+struct Frame {
+    std::array<draw::UiVertex, 4096>  vertices{};
+    std::array<draw::Index, 6144>     indices{};
+    std::array<draw::DrawCommand, 64> commands{};
+};
+
+struct RecordContext {
+    UiRenderer*           renderer;
+    const draw::DrawList* list;
+};
+
+void recordFrame(VkCommandBuffer commandBuffer, void* context) {
+    auto* recording = static_cast<RecordContext*>(context);
+    static_cast<void>(recording->renderer->record(commandBuffer, *recording->list));
+}
+
+}  // namespace
+
+TEST_CASE("The compiled screen is the one the compiler produced", "pixel") {
+    // Checked before any GPU is involved, so a mismatch here reports the compiler rather than the
+    // renderer. This is also the assertion that would fail if the committed artifact and the
+    // generated source ever stopped agreeing.
+    const medui::ScreenPackage package = screen();
+
+    CHECK(package.id == "endoscope-monitor");
+    CHECK(package.validate().has_value());
+    CHECK(package.surfaceWidth == 1280);
+    CHECK(package.surfaceHeight == 720);
+    CHECK(package.nodes.size() == 5);
+
+    // The safety-critical node #201 asks for, reached through the function a traceability export
+    // walks rather than by index.
+    const medui::CompiledNode* traced = package.find("insufflation-pressure");
+    REQUIRE(traced != nullptr);
+    CHECK(medui::requirementOf(*traced) == "REQ-EM-001");
+}
+
+TEST_CASE("An authored screen draws its panel where the compiler put it", "pixel") {
+    const medui::ScreenPackage package = screen();
+    const core::Extent2D       surface = surfaceOf(package);
+
+    const auto& gpu    = sharedDevice();
+    auto        target = OffscreenTarget::create(gpu.device(), gpu.physicalDevice(), surface, gpu.queueFamilyIndex());
+    REQUIRE(target.has_value());
+
+    VulkanRenderContext context;
+    context.device           = gpu.device();
+    context.physicalDevice   = gpu.physicalDevice();
+    context.renderPass       = target->renderPass();
+    context.queue            = gpu.queue();
+    context.queueFamilyIndex = gpu.queueFamilyIndex();
+    context.viewport         = surface;
+
+    auto renderer = UiRenderer::create(context, mdux::shader::generated::mdux_ui::package(), package.budget);
+    REQUIRE(renderer.has_value());
+
+    Frame frame;
+    auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, package.budget);
+    REQUIRE(list.has_value());
+
+    // The governed runtime, doing the only work between a compiled screen and a frame.
+    const auto recorded = medui::render(package, *list);
+    REQUIRE(recorded.has_value());
+    CHECK(recorded->rects == 1);
+    // Four of five nodes are visited and left undrawn, and the frame says so rather than looking
+    // complete. See this file's header for which, and why each.
+    CHECK(recorded->deferred == 4);
+
+    RecordContext recording{.renderer = &*renderer, .list = &*list};
+    auto          pixels = target->renderAndRead(gpu.queue(), background, recordFrame, &recording);
+    REQUIRE(pixels.has_value());
+
+    // Painted from the package and the governed table, so the expectation moves when the screen
+    // does. The colour is the quantisation the runtime applies - {0.82, 0.84, 0.86, 1.0} linear
+    // becoming {209, 214, 219, 255} - which makes this a check on the whole conversion rather than
+    // on the geometry alone.
+    const medui::CompiledNode* panel = package.find("topbar-background");
+    REQUIRE(panel != nullptr);
+
+    ExpectedImage expected{surface, background};
+    expected.paint(core::Rect{.x = panel->bounds.x, .y = panel->bounds.y, .width = panel->bounds.width, .height = panel->bounds.height},
+                   core::ColorRgba8{.r = 209, .g = 214, .b = 219, .a = 255});
+
+    const auto diff = compare(expected, *pixels);
+    CHECK_MESSAGE(diff.matched(), diff.message);
+}


### PR DESCRIPTION
Closes #201, and with it #15 — the largest epic of the programme, at 12/12.

## What it does

`ScreenPixelTests` walks every link the epic built, in one test:

1. an authored `.medui` file, committed under `recipes/screen/`;
2. compiled by `mdux-meduic` into a byte-compared artifact (#198);
3. rendered as `constexpr` C++ this translation unit links (#197);
4. turned into draw commands by the governed runtime, without allocating (#199);
5. drawn by `mdux.render.vulkan` into an offscreen target, read back, and compared pixel by pixel
   under lavapipe (#125, #126).

Nothing is hand-carried between stages. The expectation is painted from the package's **own** node
bounds and the governed colour table, not from four numbers written in the test — so a compiler that
moved the rectangle fails here rather than passing against a copy of its old answer.

## The safety-critical node, and why it is a NumericDisplay

#201 asks for one so S7's golden references have a consumer that is not a test fixture. The committed
screen gains an annotated, traced `NumericDisplay`, and the choice is deliberate: it is the one
traceable component in the dictionary that carries **no text key**, so the annotation rules are
exercised without the text package this repository does not have. Its golden pins where the
insufflation reading appears and in what tint — never what the number says, because the number is
live.

`goldens.json` now carries two entries, one from each rule ADR-011 fixes: the annotated node, and the
positioned waveform.

## What is on screen: one bar, said plainly

The runtime draws the Row's synthesised `Panel`. The image, the video surface, the numeric readout
and the waveform are visited, counted in `FrameStats::deferred`, and left undrawn — because a
compiled screen carries a `textKey` rather than glyphs and no text package is baked here, and because
live-data components have no geometry until a sample exists.

That makes this **thin in content and complete in path**, and the test's header says so in those
words. What it proves is not that MduX can draw a clinical screen; it is that a rectangle on this
display came from a file an author wrote, through every stage. The content grows when the text
package lands and the components learn their geometry; the path does not have to be built again.

## A correction to my own earlier note

The release recommendation I recorded in `docs/roadmap.md` at 10/12 said the two content gaps — no
text package, a runtime drawing one component kind — **would close in #201**. They did not, and that
expectation was mine rather than the issue's: #201's acceptance asks for an end-to-end screen
exercising a safety-critical node, which is what it delivers. Nothing in it promised the text half.

The section now says that, and still recommends cutting v0.6.0 now: what ships is a complete path,
and holding the tag until the content fills in would be waiting on #17, which is a wave of its own.

## Documentation, as #201's acceptance requires

- `README.md` and `docs/architecture.md` describe the `.medui`-to-pixels path **as built**, with the
  two limits stated beside it rather than left to be discovered.
- The `medui-authoring` skill's status heading and claims are rewritten again — an authored screen
  reaches pixels.

## Regulatory impact

The first pixel on a display that originated in an authored screen rather than in example code, and
it is compared rather than eyeballed. Every stage between the file and the frame is one already
covered by its own evidence — a byte-compared artifact, a compile-time `static_assert`, a no-heap
runtime — and this test is what shows they compose. The screen also gives the golden-reference
mechanism its first real consumer, which is what makes #16's frame verification something to
implement against rather than to design for.

Roadmap: #15 closes at 12/12.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endoscope monitor screen that renders authored `.medui` content through the complete display pipeline.
  - Added an insufflation-pressure numeric display with safety bounds, live data, themed coloring, and requirement metadata.
  - Improved the viewport layout for the monitor screen.

- **Bug Fixes**
  - Confirmed rendered output through automated pixel comparison, improving confidence in visual accuracy.

- **Documentation**
  - Updated project documentation and roadmap to reflect completed screen rendering capabilities and remaining text/component limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->