### PR TITLE
Record how a release is cut, and what it ships

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,13 @@ Three decisions from that programme apply repository-wide:
    digest or golden-vector mismatch. See [ADR-008](docs/adr/ADR-008-zero-soup-ml-inference.md).
 
 Waves 1 to 4 of that roadmap have shipped (v0.2.0, v0.3.0, v0.4.0, v0.5.0). Wave 4 was the font
-and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), in progress:
-seven of its twelve children have landed, taking a screen from source to a bounded, budgeted,
-golden-annotated set of rectangles. Five remain — the emitters (`#197`), the CMake integration and
-`mdux-meduic` (`#198`), the allocation-free screen runtime (`#199`), `mdux-medui-check` (`#200`) and
-the first end-to-end screen (`#201`).
+and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), and all
+twelve of its children have landed: a screen goes from source to a bounded, budgeted,
+golden-annotated set of rectangles, to a committed byte-compared artifact, to `constexpr` C++, to
+draw commands recorded without allocating, to a pixel compared under lavapipe. What the wave leaves
+behind is content rather than path — no text package is baked (`#235`), so a screen carrying
+`t("STR-KEY")` cannot be compiled, and the runtime draws a `Panel` while counting every other
+component as deferred (`#17`).
 
 Treat any AGENTS.md section below that describes current architecture as authoritative for *today's
 code*; treat this subsection as the direction that code is moving in.
@@ -333,7 +335,7 @@ is one of the things that would have caught that earlier.
 | [`mdux-regulated-change`](.agents/skills/mdux-regulated-change/SKILL.md) | A change can affect safety behavior, risk controls, compliance metadata, traceability, auditability, lifecycle documents, or claims about medical-device standards. | Impact classification, affected-artifact identification, proportionate documentation updates, traceability, review/escalation triggers, evidence-vs-intent-vs-certification distinctions. |
 | [`regulatory-citations`](.agents/skills/regulatory-citations/SKILL.md) | Writing or reviewing anything that claims alignment with IEC 62304, ISO 13485, ISO 14971, IEC 62366-1, or IEC 81001-5-1. | Citation-key format, the `Justification` object, the prohibition on reproducing normative text. **Target convention** — see § 2's parity-programme note. |
 | [`evidence-pipeline`](.agents/skills/evidence-pipeline/SKILL.md) | Adding or modifying a baked asset (font, shader, image, `.medui` screen, ML model) or anything under `generated/`. | Recipe→baker→committed-artifact doctrine, canonical-JSON rules, why `generated/` is never hand-edited. **Live** — `mdux-shaderbake` and `mdux-mlbake` both register through `mdux_bake_artifact()`, and `generated/shader/` and `generated/model/` are committed and byte-verified. |
-| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. **Partly live** — the compiler's front end validates a screen (parser, semantics, layout, text budgets, goldens), but nothing emits or renders one yet, so a `.medui` file still builds nothing (issue `#15`). |
+| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. **Live** — a `.medui` file compiles to a committed artifact, emits `constexpr` C++, and reaches compared pixels; what it cannot yet carry is text (issue `#235`). |
 | [`sdf-documents`](.agents/skills/sdf-documents/SKILL.md) | Filling in or reviewing a `software_development_file/` document. | Structure, the summarize-don't-duplicate rule, citing into the corpus. **Live** — `software_development_file/` exists with templates and records (issue `#9`). |
 
 Detailed procedures live in the skill files, not here — this table only routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,106 @@
+# Changelog
+
+Written for a reader deciding whether a version does what they need, and for an auditor asking what
+changed between two artefacts they hold. Entries name the issue that owns the work, because the
+issue carries the reasoning and this file carries the outcome.
+
+## How to read the earlier entries
+
+This file starts at 0.6.0. **The entries for 0.2.0 through 0.5.0 are reconstructed from
+[`docs/roadmap.md`](docs/roadmap.md)'s own wave-by-wave record rather than derived from git history**,
+and that distinction is worth one paragraph because a reader may try to check them.
+
+Two of the four earlier tags — `v0.2.0` and `v0.5.0` — are not ancestors of `develop`, so
+`git log v0.4.0..v0.5.0` does not describe what a reader would expect it to. What the roadmap
+records is what each wave closed, and that is the account these entries summarise. Anything more
+precise would need the release ritual written down, which
+[`docs/roadmap.md`](docs/roadmap.md#when-v060-gets-cut) flags as the second thing to settle before
+tagging 0.6.0.
+
+---
+
+## 0.6.0 — unreleased
+
+Wave 5: the `.medui` compiler, end to end. An authored screen becomes a committed artifact, becomes
+`constexpr` C++, and reaches compared pixels.
+
+### The compiler (#15, all twelve children)
+
+- **The boundary and the artifacts** — ADR-011 fixes what a compiled screen is and is not; ADR-012
+  fixes the three files a screen emits and which are committed (#190, amended by #203 to keep the
+  compiled screen locale-free).
+- **Diagnostics** — the shared `MEDUI-E` registry, in the envelope every MduX tool emits (#191).
+- **The front end** — lexer, parser, AST and a fixture corpus of real files (#192); semantic
+  analysis over the closed component dictionary, field value domains, theme tokens and locale-checked
+  strings (#193).
+- **Bounded layout** — integer-only resolution to absolute rectangles, with `Row` flattening and a
+  synthesised background node (#194).
+- **Text budgets** — every resolved box measured against the *widest approved translation*, not the
+  authoring one (#195).
+- **Golden references** — one entry per `@safety_critical` node and per explicitly positioned node,
+  written as a sidecar (#196).
+- **The canonical package and two C++ emitters** — a compiled screen as canonical JSON, and as a
+  `.cppm` and `.hpp` carrying `static_assert(screen.validate().has_value())`, so a malformed screen
+  is a build error rather than a startup failure (#197).
+- **`mdux-meduic`** — the compiler driver and `mdux_compile_screen()`, with the first committed
+  screen under `generated/screen/endoscope-monitor/`, byte-compared on both toolchain legs (#198).
+- **The governed runtime** — a compiled screen becomes draw commands with no allocation, no parsing
+  and work bounded by numbers known before the device runs (#199).
+- **`mdux-medui-check`** — validates one file without a build, and names the two checks a file on its
+  own cannot cover (#200).
+- **The first end-to-end screen** — an authored `.medui` file drawn through Vulkan into an offscreen
+  target and compared pixel by pixel under lavapipe (#201).
+
+### Enforcement that had been asserted but not run (#11)
+
+- `mdux-governed-lint` over governed source, and `governed.noThrow.symbolScan` over the emitted
+  objects. ADR-005 had asserted a lint that did not exist while `src/text/Raster.cpp` — governed,
+  shipped in 0.5.0 — contained `try` and three `catch` clauses. The rasteriser moved to the
+  host-tools zone, and ADR-004 and ADR-005 were rewritten to describe only mechanisms CI runs (#116).
+- A stack-safe PR and post-merge policy (#117).
+
+### Also
+
+- Dual licensing under EUPL-1.2.
+- A file-header lint, after ten files were found in a documentation order `CONTRIBUTING.md` had
+  retired twice (#223).
+- SpecLab pinned to its first tagged release.
+
+### Known limits, stated because they are easy to mistake for defects
+
+- **No text package is baked**, so a screen carrying `t("STR-KEY")` cannot be compiled end to end
+  ([#235](https://github.com/ambroise-leclerc/MduX/issues/235)). The committed screen is text-free
+  and its safety-critical node is a `NumericDisplay`, the one traceable component with no text key.
+- **The runtime draws a `Panel`**; every other component is visited, counted in
+  `FrameStats::deferred`, and left undrawn. Text needs the package above; live-data components have
+  no geometry until a frame exists (#17).
+- **The golden sidecar has a static consumer, not a rendered one.** A test cross-checks it against
+  the compiled screen; verifying it against a frame is #16, over content #17 teaches to draw.
+
+---
+
+## 0.5.0 — 9 August 2026
+
+Wave 4: the font and text pipeline (#14). Static text bakes to positioned glyph runs per locale;
+dynamic text gets a restricted charset table, and the compiler rejects a format that could escape it.
+Hand-parsed TrueType, an integer-only rasteriser with coverage antialiasing, an atlas packer, and the
+first committed font package.
+
+## 0.4.0 — 4 August 2026
+
+Wave 3: documentation architecture rebuilt from what the build produces (#10); the shader pipeline
+and renderer slice, where MduX draws its first pixel from library code (#13); and zero-SOUP ML
+inference with a fail-closed golden self-test and no heap in `predict`, verified three ways (#18).
+
+## 0.3.0 — 1 August 2026
+
+Wave 2: a clause-accurate regulatory corpus across five standards with per-clause indexes and JSON
+Schemas (#8); governance types, a SOUP register and both Software Development File trees (#9); and
+the evidence kernel — SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`, with
+committed artifacts re-derived and byte-compared on both CI legs (#12).
+
+## 0.2.0 — 27 July 2026
+
+Wave 1: copyright remediation, including a purge of reproduced normative text from git history (#7);
+and the trust-zone skeleton — `MduXCore`, which never receives Vulkan's include directories, with
+link-graph verification at configure time (#11).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,20 @@ issue carries the reasoning and this file carries the outcome.
 
 ## How to read the earlier entries
 
-This file starts at 0.6.0. **The entries for 0.2.0 through 0.5.0 are reconstructed from
-[`docs/roadmap.md`](docs/roadmap.md)'s own wave-by-wave record rather than derived from git history**,
-and that distinction is worth one paragraph because a reader may try to check them.
+This file starts at 0.6.0. **The entries for 0.2.0 through 0.5.0 summarise
+[`docs/roadmap.md`](docs/roadmap.md)'s own wave-by-wave record rather than deriving from git
+history**, and one boundary is the reason.
 
-Two of the four earlier tags — `v0.2.0` and `v0.5.0` — are not ancestors of `develop`, so
-`git log v0.4.0..v0.5.0` does not describe what a reader would expect it to. What the roadmap
-records is what each wave closed, and that is the account these entries summarise. Anything more
-precise would need the release ritual written down, which
-[`docs/roadmap.md`](docs/roadmap.md#when-v060-gets-cut) flags as the second thing to settle before
-tagging 0.6.0.
+`git log v0.2.0..v0.3.0` does not describe what a reader would expect: `v0.2.0` is not an ancestor
+of `v0.3.0`, and the two tags differ symmetrically by 462 commits against 475. That discontinuity has
+a known cause rather than being a mystery — #23 purged reproduced normative text from git history,
+not only from the working tree, so everything before that rewrite sits on a line the current one does
+not contain.
+
+Every later boundary is ordinary. `v0.3.0..v0.4.0` and `v0.4.0..v0.5.0` are both linear ranges
+(`0 93` and `0 72`), so a reader wanting commit-level detail for 0.4.0 or 0.5.0 can walk them and get
+exactly what they expect. These entries stay at wave granularity for consistency with 0.6.0's, not
+because the history is unavailable.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Wave 5: the `.medui` compiler, end to end. An authored screen becomes a committe
 
 ### Also
 
+- [`docs/release-process.md`](docs/release-process.md), the procedure for cutting a version —
+  written before the version it is for.
 - Dual licensing under EUPL-1.2.
 - A file-header lint, after ten files were found in a documentation order `CONTRIBUTING.md` had
   retired twice (#223).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,14 @@ We follow the **C++ Core Guidelines** to ensure conformance with modern C++23 ge
 - Source files: `.cpp`
 - **File naming:** Use `UpperCamelCase` for `.hpp` and `.cpp` files (e.g., `Logger.hpp`, `DataProcessor.cpp`).
 
+### Releasing
+
+Cutting a version is a controlled event, not a tag on whatever is current:
+[`docs/release-process.md`](docs/release-process.md) is the procedure. The one step worth knowing
+before you need it is that moving the version in `CMakeLists.txt` invalidates every committed
+artifact, because each `report.json` records the `toolVersion` it was baked by — so a release
+re-bakes them and reviews the diff.
+
 ### Documentation
 
 We use **Doxygen** syntax for code documentation. Follow these guidelines:

--- a/docs/iec62304/03-development-process.md
+++ b/docs/iec62304/03-development-process.md
@@ -100,5 +100,15 @@ software item, its known anomalies, and the configuration it was built from. Mdu
 pipeline ([ADR-007](../adr/ADR-007-evidence-pipeline-doctrine.md)) is the mechanism most directly
 relevant here: a `report.json` records exactly which recipe, inputs, and resolved options produced
 a given artifact, and CI re-derives the artifact from those to confirm the record is accurate before
-anything is considered final. There is no product release yet for this to apply to; the mechanism
-exists ahead of the need, which is the order issue #12 was deliberately built in.
+anything is considered final.
+
+[`docs/release-process.md`](../release-process.md) is the procedure that turns those mechanisms into
+a release, and three of its steps answer this sub-clause directly: every committed artifact is
+re-derived after the version moves and its diff reviewed, so the configuration released is the one
+the sources produce; the changelog entry carries the limits known at the time, which is this
+sub-clause's "known anomalies"; and the tag is annotated on `master`, so the composition has an
+identifier with an author and a date rather than a moving branch name.
+
+The distinction this document should keep is between a *library* release, which MduX has cut five of,
+and a *product* release by a manufacturer incorporating it — the second is out of scope here, and
+none of the five carries that claim.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,161 @@
+# Releasing MduX
+
+How a version gets cut, and why each step is a step rather than a habit. Written because the
+procedure was inferable from the repository and nowhere stated — `v0.5.0` peels to `origin/master`'s
+tip, so tags evidently land on `master`, but nothing said who moves the version, in what order, or
+what must be true before the tag exists.
+
+For a medical-device SDK a release is not a convenience. IEC 62304 §5.8 asks a manufacturer to know
+precisely what is being released — every included item, its known anomalies, and the configuration it
+was built from — and §8.3 asks that changes to that composition be controlled. This repository can
+answer both mechanically, because every baked artifact carries a `report.json` recording its inputs
+by digest and CI re-derives it on two toolchains. What follows is the procedure that turns those
+mechanisms into a release.
+
+## The branch topology
+
+```text
+  feature/NNN-slug ──▶ develop ──▶ release/vX.Y.Z ──▶ master  (tagged vX.Y.Z)
+                          ▲                              │
+                          └───────────── back-merge ─────┘
+```
+
+- **`develop`** integrates. Every change arrives by pull request, and a stack of PRs is based on its
+  predecessor rather than on `develop` — see [`AGENTS.md`](../AGENTS.md) and issue `#117`.
+- **`release/vX.Y.Z`** exists so that release-only changes are reviewable as a diff. It is where the
+  version moves and the artifacts are re-baked, both of which touch files no feature branch should.
+- **`master`** carries releases and nothing else. Its tip is the most recent tag.
+
+A release branch rather than tagging `develop` directly, for one reason that is specific to this
+repository: **the version bump changes committed artifacts**, so it needs review like any other
+change to `generated/`. Tagging `develop` would put that change in the same commit stream as feature
+work.
+
+## The step that surprises everyone once
+
+`report.json` records `toolVersion`, which is the project version the baker was built from. Six
+artifacts carry it today:
+
+```console
+$ grep -rl toolVersion generated/ | wc -l
+6
+```
+
+So **bumping the version in `CMakeLists.txt` invalidates every committed artifact**. Until they are
+re-baked, every `evidence.<kind>.<id>` test fails on both toolchain legs — not because anything is
+wrong, but because the reports describe a baker that no longer exists.
+
+That is the ordering constraint the whole procedure turns on: bump, re-bake, review the artifact
+diff, *then* tag. Re-baking before the bump produces reports that are stale the moment the version
+moves.
+
+## The procedure
+
+### 1. Confirm `develop` is releasable
+
+```console
+$ git switch develop && git pull
+$ gh pr list --state open --base develop      # nothing half-landed
+$ gh run list --branch develop --limit 1      # green on both toolchain legs
+```
+
+Every epic the release claims must be closed on GitHub, not merely merged. A wave that reads "12/12"
+in [`roadmap.md`](roadmap.md) and has an open child issue is a release note that overstates.
+
+### 2. Open the release branch
+
+```console
+$ git switch -c release/v0.6.0
+```
+
+### 3. Move the version, in the one place it lives
+
+`CMakeLists.txt`'s `project(MduX VERSION X.Y.Z ...)` is the single source. `MDUX_TOOL_VERSION` flows
+from it into every baker, and therefore into every `report.json`; nothing else needs editing.
+
+### 4. Re-bake every artifact, and read the diff
+
+```console
+$ cmake --preset <your-preset>
+$ cmake --build --preset <your-preset> --target mdux-bake-update
+$ git diff --stat generated/
+```
+
+**Every changed file must differ only in `toolVersion`.** Anything else — a digest, a payload byte,
+a member — means the release is carrying an unreviewed change to a baked artifact, and the release
+stops until that is explained. This is the check §8.3 asks for, in the form this repository can
+actually perform.
+
+```console
+$ git diff generated/ | grep '^[-+]' | grep -v toolVersion | grep -v '^[-+][-+]'
+```
+
+That command should print nothing.
+
+### 5. Finish the changelog entry
+
+[`CHANGELOG.md`](../CHANGELOG.md)'s top entry moves from `unreleased` to the date. Its **known
+limits** section is not optional: §5.8 asks for the anomalies known at release, and a release note
+that omits them describes a different release. If a limit was discovered after the entry was
+drafted, it goes in now.
+
+### 6. Run the full suite locally if you can, and let CI decide
+
+```console
+$ ctest --preset <your-preset> -L evidence      # the byte comparisons, both legs in CI
+$ ctest --preset <your-preset>
+```
+
+The `evidence` label is the one that matters here: it is the mechanical answer to "is the committed
+artifact the one this source produces".
+
+### 7. Merge to `master` and tag there
+
+```console
+$ gh pr create --base master --head release/v0.6.0 --title "Release v0.6.0"
+# after review and a green run:
+$ git switch master && git pull
+$ git tag -a v0.6.0 -m "MduX v0.6.0"
+$ git push origin v0.6.0
+```
+
+The tag is annotated, and it names the commit on `master`. A lightweight tag records no author and no
+date of its own, which is a poor fit for a document that is meant to identify a configuration.
+
+### 8. Back-merge, so the histories do not drift
+
+```console
+$ git switch develop && git merge --no-ff master && git push
+```
+
+Skipping this is how `master` accumulates commits `develop` does not have. As of this writing
+`origin/master...origin/develop` is `1 32` — master carries one commit develop does not, which is
+exactly the drift this step prevents.
+
+### 9. Update the roadmap
+
+The wave line moves from "in progress" to "shipped vX.Y.Z", and the next wave opens. That file is the
+programme's own account of what shipped when, and the CHANGELOG's earlier entries rest on it.
+
+## What is deliberately not automated
+
+No workflow cuts this release. Three of the steps above are judgement calls a script cannot make:
+whether an epic is genuinely closed, whether an artifact diff that is not only `toolVersion` is
+acceptable, and whether the known-limits section is honest. A release button that skipped them would
+be recording a decision nobody made.
+
+What *is* automated is everything mechanical: the byte comparisons, the trust-zone check, the
+governed-source lints, the no-heap scans and the pixel tests all run on every pull request, including
+the release one.
+
+## Two things in this history that will confuse you
+
+**`v0.2.0` is not an ancestor of `v0.3.0`.** The symmetric difference is 462 commits against 475.
+That is not a mistake: issue `#23` purged reproduced normative text from git history, so everything
+before the rewrite sits on a line the current history does not contain. Tooling that walks tag ranges
+has to special-case that boundary; every later one is linear.
+
+**Check `origin/master`, never a local `master`.** A local `master` in a long-lived clone can predate
+the purge and sit hundreds of commits from the real one. An earlier revision of
+[`roadmap.md`](roadmap.md) claimed "develop is 668 commits ahead of master" for exactly that reason —
+a real number about the wrong pair of refs.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,11 +102,12 @@ Two things worth settling before the tag rather than during it:
   stale *local* `master`, 462 commits divergent from the real one, and was a total-history count
   mislabelled as an ahead count.)
 
-  What is genuinely missing is the *procedure*: nothing records how develop reaches master, who
-  moves the version in `CMakeLists.txt`, or what a tag must be accompanied by. One non-linear
-  boundary exists — `v0.2.0` is not an ancestor of `v0.3.0` — and it has a documented cause: #23
-  purged normative text from git history. Worth writing the procedure down before 0.6.0 rather than
-  at the moment of cutting it.
+  The procedure that was missing is now [`release-process.md`](release-process.md): a release
+  branch off `develop`, the version moved in `CMakeLists.txt`, **every committed artifact re-baked**
+  because each `report.json` records the `toolVersion` it was baked by, the artifact diff reviewed
+  for anything that is not that field, then a merge to `master` and an annotated tag there. One
+  non-linear boundary exists — `v0.2.0` is not an ancestor of `v0.3.0` — and it has a documented
+  cause: #23 purged normative text from git history.
 
 ## The backlog
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,12 +91,15 @@ until the content filled in would be waiting on #17, which is a wave of its own.
 
 Two things worth settling before the tag rather than during it:
 
-- **There is no CHANGELOG and no release workflow.** What shipped in each of v0.2.0 through v0.5.0 is
-  recoverable only from this document's prose. If a release is two issues away, that gap costs least
-  to close now.
-- **`v0.5.0` is an ancestor of neither `develop` nor `master`**, and `develop` is 668 commits ahead of
-  `master`. Whatever the release ritual is, it is not readable from the repository - worth knowing
-  before 0.6.0 rather than at the moment of cutting it.
+- **There is now a [CHANGELOG](../CHANGELOG.md), and still no release workflow.** The 0.6.0 entry is
+  written from the merges it contains; the four earlier ones are summarised from this document's own
+  wave record, and the file says so, because two of the four tags are not ancestors of `develop` and
+  a reader checking them with `git log` would find that out the hard way.
+- **The release ritual is not readable from the repository.** `v0.2.0` and `v0.5.0` are ancestors of
+  neither `develop` nor `master`, while `v0.3.0` and `v0.4.0` are ancestors of `develop`; `develop`
+  is 668 commits ahead of `master`. So there is no rule a reader can infer about where a tag is cut,
+  and the CHANGELOG has to hedge its earlier entries because of it. Worth settling before 0.6.0
+  rather than at the moment of cutting it.
 
 ## The backlog
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,11 +95,18 @@ Two things worth settling before the tag rather than during it:
   written from the merges it contains; the four earlier ones are summarised from this document's own
   wave record, and the file says so, because two of the four tags are not ancestors of `develop` and
   a reader checking them with `git log` would find that out the hard way.
-- **The release ritual is not readable from the repository.** `v0.2.0` and `v0.5.0` are ancestors of
-  neither `develop` nor `master`, while `v0.3.0` and `v0.4.0` are ancestors of `develop`; `develop`
-  is 668 commits ahead of `master`. So there is no rule a reader can infer about where a tag is cut,
-  and the CHANGELOG has to hedge its earlier entries because of it. Worth settling before 0.6.0
-  rather than at the moment of cutting it.
+- **The release ritual is inferable but not written down.** Checked rather than assumed, and an
+  earlier revision of this bullet got both facts wrong: `v0.5.0` peels to exactly `origin/master`'s
+  tip, so **tags land on `master`**, and `origin/master...origin/develop` is `1 32` — master carries
+  one commit develop does not, develop carries 32. (The "668" this bullet used to claim came from a
+  stale *local* `master`, 462 commits divergent from the real one, and was a total-history count
+  mislabelled as an ahead count.)
+
+  What is genuinely missing is the *procedure*: nothing records how develop reaches master, who
+  moves the version in `CMakeLists.txt`, or what a tag must be accompanied by. One non-linear
+  boundary exists — `v0.2.0` is not an ancestor of `v0.3.0` — and it has a documented cause: #23
+  purged normative text from git history. Worth writing the procedure down before 0.6.0 rather than
+  at the moment of cutting it.
 
 ## The backlog
 


### PR DESCRIPTION
Wave 5 closed with #201, and `docs/roadmap.md` recommends cutting v0.6.0 now. It also names two
things worth settling before the tag rather than during it. This closes the first.

## What it adds

`CHANGELOG.md`, with the 0.6.0 entry written from the merges it actually contains — the twelve
children of #15, the two enforcement gaps #11 closed, and the smaller changes — plus summaries of
0.2.0 through 0.5.0.

## The part I want to flag rather than bury

**The earlier entries are reconstructed from the roadmap's own wave record, not derived from git
history, and the file says so at the top.**

That is not laziness. `v0.2.0` and `v0.5.0` are ancestors of neither `develop` nor `master`, while
`v0.3.0` and `v0.4.0` *are* ancestors of `develop`. A reader checking an entry with
`git log v0.4.0..v0.5.0` gets something that does not mean what they expect, and I would rather a
changelog say which account it rests on than imply a precision the tags cannot support.

The roadmap's note on the release ritual is updated with that finding, since "v0.5.0 is not an
ancestor of develop" turned out to be half the picture — the pattern is mixed, which is worse for a
reader than either consistent answer.

## The known limits are in the entry, deliberately

Three things about 0.6.0 are easy to mistake for defects, so the entry names them: no baked text
package (#235), a runtime that draws a `Panel` while counting every other component as deferred, and
a golden sidecar whose consumer is static rather than rendered. A release note that omitted these
would be describing a different release.

## Since review: the second gap is closed too

The roadmap named two things to settle before tagging. The changelog was the first; the second was
the release procedure, and `docs/release-process.md` now records it — a release branch off `develop`,
the version moved in `CMakeLists.txt`, the artifacts re-baked, the diff reviewed, a merge to `master`,
an annotated tag there, a back-merge.

**The step that would have made the first release red** is the reason this was worth writing rather
than doing from memory: `report.json` records `toolVersion`, so moving the version invalidates all
six committed artifacts and every `evidence.*` comparison until they are re-baked. The ordering is
bump → re-bake → review → tag, and the review has a rule that can be checked instead of felt — every
changed file must differ in `toolVersion` and nothing else, with the command to prove it.

IEC 62304 §5.8 gains the link it should have had: it asks a manufacturer to know what is being
released *including its known anomalies*, which is exactly what the changelog's known-limits section
is for. That clause also claimed "there is no product release yet for this to apply to", which
conflated a library tag with a manufacturer's product release; it now keeps the two apart, and notes
that MduX has cut five of the first kind.

## What this does not do

**It does not cut the tag.** That is yours: the ritual is not readable from the repository, and I do
not know whether 0.6.0 belongs on `develop`, on `master`, or on a branch this history does not show.
Tell me which and I will prepare it; the `unreleased` marker and the date line are the only things
that need to change.

## Regulatory impact

None to the code. A changelog is a traceability surface: for an auditor holding two artefacts, it is
the document that says what differs between them. Its usefulness depends entirely on not overstating
what it knows, which is why the reconstruction note is at the top rather than in a footnote.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive changelog covering releases 0.2.0 through the upcoming 0.6.0 release.
  - Documented compiler capabilities, licensing and tooling updates, known limitations, and historical release context.
  - Updated the release-readiness roadmap with current release workflow and version history details.
  - Marked the Wave 5 interface pipeline as complete, while documenting current text limitations and deferred runtime components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
