### PR TITLE
Release v0.6.0

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,14 +10,16 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: parsing, semantic validation, and bounded layout are implemented; emission and runtime are not
+## Status: parsing, semantic validation, bounded layout, and text budgets are implemented; emission and runtime are not
 
-**A `.medui` lexer, AST, parser, semantic analyzer, and integer-only bounded layout solver exist**
-in the host-tools zone (`tools/medui/`). The diagnostic codes they emit are registered as
-`MEDUI-E###` (#191). The parser rejects structural violations (#192); the analyzer checks the
-closed component dictionary, each field's value domain, theme-token names, and text-key presence
-across every approved locale (#193); and the solver flattens Vertical/Row layout to absolute
-rectangles without floating-point arithmetic (#194). The AST keeps names unresolved.
+**A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, and
+text-budget check exist** in the host-tools zone (`tools/medui/`). The diagnostic codes they emit
+are registered as `MEDUI-E###` (#191). The parser rejects structural violations (#192); the
+analyzer checks the closed component dictionary, each field's value domain, theme-token names, and
+text-key presence across every approved locale (#193); the solver flattens Vertical/Row layout to
+absolute rectangles without floating-point arithmetic (#194); and the budget check measures each
+resolved box against the widest approved translation and each named dynamic-text source against the
+font package's restricted charset (#195). The AST keeps names unresolved.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -109,8 +111,9 @@ verifier checks against. Rules:
 ## Checking a file without a full build
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser, analyzer, and solver it will call already detect syntax
-errors, structural violations, unknown dictionary/theme names, hardcoded text in localizable
-fields, wrong field value domains, incomplete locale keys, and layout overflow; what is missing is
-the command that exposes them. Until it lands, review a `.medui` file by hand against this grammar
-and the component table above.
+diagnostics — once it exists. The parser, analyzer, solver, and budget check it will call already
+detect syntax errors, structural violations, unknown dictionary/theme names, hardcoded text in
+localizable fields, wrong field value domains, incomplete locale keys, layout overflow, a box that
+cannot contain its widest approved translation, and a dynamic-text source that could escape the
+baked charset; what is missing is the command that exposes them. Until it lands, review a `.medui`
+file by hand against this grammar and the component table above.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -97,7 +97,7 @@ Screen NeuroSense500 {
 ## `@safety_critical` — when it's mandatory, and when it's automatic
 
 `@safety_critical(cv_check: [Bounds, ColorHash])` on the line before a component emits a golden
-reference (`node_id`, `bounds`, `text_key?`, `color_token?`, `cv_checks`) that the rendered-truth
+reference (`nodeId`, `bounds`, `textKey?`, `colorToken?`, `cvChecks`) that the rendered-truth
 verifier checks against. Rules:
 
 - **A safety-critical component must carry an explicit `requirement:`.** If you're annotating a
@@ -105,7 +105,7 @@ verifier checks against. Rules:
   annotation or the missing requirement.
 - **Any node with an explicit `position:` gets an automatic `Bounds` golden reference**, even
   without `@safety_critical` — a declared position is a safety-relevant claim by itself.
-- **A node with both gets exactly one merged entry** (deduplicated `cv_checks`), never two.
+- **A node with both gets exactly one merged entry** (deduplicated `cvChecks`), never two.
 - Dynamic content (`NumericDisplay`, `StatusIndicator`, `Clock`, `SignalTrace`) pins its *bounds*
   and *color* but never its varying value — the golden reference says **where** critical content
   must appear and in what tint, not what the live number is.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,9 +10,13 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: planned, not yet implemented
+## Status: the front end is implemented; the compiler and runtime are not
 
-**There is no `.medui` parser, compiler, or runtime in MduX today.** The HTML/CSS path that used
+**A `.medui` lexer, AST and parser exist** in the host-tools zone as of issue #192 (`tools/medui/`), and
+the diagnostic codes they emit are registered as `MDX-E###` (#191). They parse a screen and reject
+the grammar's structural violations; they resolve nothing.
+
+**There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
 the file as a string, with no parsing, layout or rendering behind it - was deleted by
 [issue #127](https://github.com/ambroise-leclerc/MduX/issues/127).
@@ -35,7 +39,8 @@ Screen NeuroSense500 {
     @safety_critical(cv_check: [Bounds, ColorHash])
     NumericDisplay {
         id: sedation-index;
-        width: 512px; height: 512px;
+        width: 512px;
+        height: 512px;
         position: 1392px, 80px;
         requirement: "REQ-NS-001";
         template: "TPL-SEDATION-INDEX-160";
@@ -46,6 +51,14 @@ Screen NeuroSense500 {
 ```
 
 - Sizes are `Npx` or `Fill`. `position: Xpx, Ypx` takes a node out of flow at exact pixel coords.
+- **One property per line.** The sibling implementation parses a component body line by line and
+  splits each on its first `:`, so `width: 512px; height: 512px;` on one line is read as a width of
+  `512px; height: 512px` and rejected. This example previously showed that form; it was condensed
+  prose, not a supported shorthand, and TrustSC's own `neurosense.medui` has always had the two on
+  separate lines. MduX's parser is token-based and would accept either, so a screen written this
+  way stays portable in both directions - which is the reason to write it this way.
+- `position` requires fixed `width` and `height`; `Fill` is flow-only, and combining them is a
+  compile error in the reference implementation (#194 owns this check in MduX).
 - `Row { id; height; background?; spacing? }` is a single-level horizontal group, flattened at
   compile time — it cannot nest another `Row`.
 - Text is **always** `t("STR-KEY")` against an approved text package. Hardcoded strings are a
@@ -87,6 +100,8 @@ verifier checks against. Rules:
 
 ## Checking a file without a full build
 
-`mdux-medui-check path/to/screen.medui` (issue #15, S11) will validate a single file and print
-diagnostics — once it exists. Until then, review a `.medui` file by hand against this grammar and
-the component table above; there is no tooling shortcut yet.
+`mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
+diagnostics — once it exists. The parser it will call already does (#192), so a syntax error, a
+nested `Row`, a control-flow keyword or a duplicate id are already detectable; what is missing is
+the command that exposes them. Until it lands, review a `.medui` file by hand against this grammar
+and the component table above.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,11 +10,13 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: the front end is implemented; the compiler and runtime are not
+## Status: parsing and semantic validation are implemented; emission and runtime are not
 
-**A `.medui` lexer, AST and parser exist** in the host-tools zone as of issue #192 (`tools/medui/`), and
-the diagnostic codes they emit are registered as `MEDUI-E###` (#191). They parse a screen and reject
-the grammar's structural violations; they resolve nothing.
+**A `.medui` lexer, AST, parser and semantic analyzer exist** in the host-tools zone
+(`tools/medui/`). The diagnostic codes they emit are registered as `MEDUI-E###` (#191). The parser
+rejects structural violations (#192); the analyzer checks the closed component dictionary, each
+field's value domain, theme-token names, and text-key presence across every approved locale (#193).
+It does not substitute resolved values.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -28,7 +30,7 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 [issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). The implementation pins the shared
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
-[`Compliatory/MedUI` at `c8cc45e`](https://github.com/Compliatory/MedUI/tree/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d).
+[`Compliatory/MedUI` at `d5136a8`](https://github.com/Compliatory/MedUI/tree/d5136a8518bd499760ecff2aad215d3721329f20).
 Do not write a `.medui` file expecting it to build anything in MduX until the compiler waves land.
 
 ## Grammar shape
@@ -71,18 +73,19 @@ Screen NeuroSense500 {
 
 ## Component dictionary (target)
 
-| Component | Required fields | Notes |
+| Component | Required fields | Optional fields |
 |---|---|---|
-| `CriticalButton` | `id, requirement, width, height, label, color, on_press` | always needs `requirement:` |
-| `Button` | `id, width, height, label, color, source` | `requirement:` optional |
-| `VulkanViewport` | `id, width, height, stream_source` | |
-| `SignalTrace` | `id, width, height, stream_source, color` | scrolling waveform |
-| `NumericDisplay` | `id, width, height, requirement, template, source, color` | live value, restricted charset |
-| `StatusIndicator` | `id, width, height, requirement, source, states` | `states: [t(...), ...]` |
-| `Label` | `id, width, height, text, color` | |
-| `Clock` | `id, width, height, format` | |
-| `Image` | `id, width, height, source` | `source: img("ID")` |
-| `TextInput` | `id, width, height, source, max_length, color` | display + caret only, no IME |
+| `Row` | `id`, `height` | `spacing`, `background` |
+| `CriticalButton` | `id`, `requirement`, `width`, `height`, `label`, `color`, `on_press` | `position` |
+| `Button` | `id`, `width`, `height`, `label`, `color`, `source` | `position`, `requirement` |
+| `VulkanViewport` | `id`, `width`, `height`, `stream_source` | `position` |
+| `SignalTrace` | `id`, `width`, `height`, `stream_source`, `color` | `position` |
+| `NumericDisplay` | `id`, `width`, `height`, `requirement`, `template`, `source`, `color` | `position` |
+| `StatusIndicator` | `id`, `width`, `height`, `requirement`, `source`, `states` | `position`, `colors` |
+| `Label` | `id`, `width`, `height`, `text`, `color` | `position` |
+| `Clock` | `id`, `width`, `height`, `format` | `position` |
+| `Image` | `id`, `width`, `height`, `source` | `position` |
+| `TextInput` | `id`, `width`, `height`, `source`, `max_length`, `color` | `position`, `charset`, `requirement` |
 
 ## `@safety_critical` — when it's mandatory, and when it's automatic
 
@@ -103,7 +106,8 @@ verifier checks against. Rules:
 ## Checking a file without a full build
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser it will call already does (#192), so a syntax error, a
-nested `Row`, a control-flow keyword or a duplicate id are already detectable; what is missing is
-the command that exposes them. Until it lands, review a `.medui` file by hand against this grammar
-and the component table above.
+diagnostics — once it exists. The parser and analyzer it will call already detect syntax errors,
+structural violations, unknown dictionary/theme names, hardcoded text in localizable fields,
+wrong field value domains, and incomplete locale keys; what is missing is the command that exposes
+them. Until it lands, review a `.medui` file by hand against this grammar and the component table
+above.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,7 +10,7 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: the front end through golden references is implemented; emission and runtime are not
+## Status: the compiler is complete front to back; one end-to-end screen remains
 
 **A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, text-budget
 check, and golden-reference pass exist** in the host-tools zone (`tools/medui/`). The diagnostic
@@ -23,9 +23,22 @@ against the font package's restricted charset (#195); and the golden pass applie
 `@safety_critical` rules and derives the reference set #16's verifier will consume (#196). The AST
 keeps names unresolved.
 
-**There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
-to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
-the file as a string, with no parsing, layout or rendering behind it - was deleted by
+**The back end exists now**, and this paragraph used to say the opposite. `mdux-meduic` compiles a
+screen from a recipe into `generated/screen/<id>/` — the compiled package, the golden sidecar and a
+bake report, byte-compared across toolchains (#198). Two emitters render that package as a `.cppm`
+and a `.hpp` carrying `static_assert(screen.validate().has_value())`, so a malformed screen is a
+build error rather than a startup failure (#197). A governed runtime draws one without allocating
+(#199), and `mdux-medui-check` validates a single file (#200).
+
+Two limits are worth knowing before you write a screen. **No text package is baked in this
+repository yet**, so a screen carrying `t("STR-KEY")` cannot be compiled end to end — that is #201,
+the last child of the epic. And the runtime draws a `Panel`; every other component is visited,
+counted in `FrameStats::deferred` and left undrawn, because text needs that package and live-data
+components have no geometry until the frame does.
+
+The HTML/CSS path that used to stand in for all of this - `UiFileWatcher::loadContent()`, which
+sniffed a file extension and stored the file as a string, with no parsing, layout or rendering
+behind it - was deleted by
 [issue #127](https://github.com/ambroise-leclerc/MduX/issues/127).
 
 What exists now is the layer a `.medui` compiler will target: `mdux.draw` describes a frame as
@@ -36,7 +49,9 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
 [`Compliatory/MedUI` at `d5136a8`](https://github.com/Compliatory/MedUI/tree/d5136a8518bd499760ecff2aad215d3721329f20).
-Do not write a `.medui` file expecting it to build anything in MduX until the compiler waves land.
+A `.medui` file builds something in MduX today: register it with `mdux_compile_screen()` and it
+becomes a committed, byte-compared artifact plus generated C++ a device links. What it cannot yet do
+is carry text, for the reason above.
 
 ## Grammar shape
 
@@ -112,11 +127,27 @@ verifier checks against. Rules:
 
 ## Checking a file without a full build
 
-`mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser, analyzer, solver, budget check, and golden pass it will
-call already detect syntax errors, structural violations, unknown dictionary/theme names, hardcoded
-text in localizable fields, wrong field value domains, incomplete locale keys, layout overflow, a
-box that cannot contain its widest approved translation, a dynamic-text source that could escape
-the baked charset, a `@safety_critical` node with no `requirement:`, and an unknown `cv_check`;
-what is missing is the command that exposes them. Until it lands, review a `.medui`
-file by hand against this grammar and the component table above.
+```console
+mdux-medui-check path/to/screen.medui [--format=json|text]
+```
+
+Validates one file and writes nothing. Exits non-zero when anything of error severity was found, so
+it drops into a pre-commit hook or an agent loop as it stands. `--format=json` emits the same
+envelope every MduX tool emits (#118), so a finding is `{file, line, column, code, severity,
+message, fixHint}` rather than prose to parse.
+
+**What it checks:** the grammar, the closed component dictionary, each field's value domain,
+hardcoded strings in localizable fields, theme tokens against the governed table, the
+`@safety_critical` rules including an unknown `cv_check` — and, when the file declares a `surface:`,
+bounded layout with its overflow and containment rules plus the golden set that follows.
+
+**What it cannot check, and says so.** Text keys and text budgets need the approved locales a recipe
+names, and a single file names none. Rather than reporting every `t("STR-KEY")` as absent from every
+locale — a vacuous truth dressed as a finding — the checker skips those and emits a note, `MDC001`.
+A screen with no `surface:` gets `MDC002` for the same reason: layout, overflow and golden bounds
+went unchecked. Notes do not fail the run; they are what makes a clean result visibly *partial*
+rather than silently so.
+
+For the two it cannot cover, compile the screen through `mdux-meduic` with a recipe carrying a
+`[text]` table: that checks every key against every approved locale, and every box against the
+widest translation of the text it holds.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,16 +10,18 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: parsing, semantic validation, bounded layout, and text budgets are implemented; emission and runtime are not
+## Status: the front end through golden references is implemented; emission and runtime are not
 
-**A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, and
-text-budget check exist** in the host-tools zone (`tools/medui/`). The diagnostic codes they emit
-are registered as `MEDUI-E###` (#191). The parser rejects structural violations (#192); the
-analyzer checks the closed component dictionary, each field's value domain, theme-token names, and
-text-key presence across every approved locale (#193); the solver flattens Vertical/Row layout to
-absolute rectangles without floating-point arithmetic (#194); and the budget check measures each
-resolved box against the widest approved translation and each named dynamic-text source against the
-font package's restricted charset (#195). The AST keeps names unresolved.
+**A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, text-budget
+check, and golden-reference pass exist** in the host-tools zone (`tools/medui/`). The diagnostic
+codes they emit are registered as `MEDUI-E###` (#191). The parser rejects structural violations
+(#192); the analyzer checks the closed component dictionary, each field's value domain, theme-token
+names, and text-key presence across every approved locale (#193); the solver flattens Vertical/Row
+layout to absolute rectangles without floating-point arithmetic (#194); the budget check measures
+each resolved box against the widest approved translation and each named dynamic-text source
+against the font package's restricted charset (#195); and the golden pass applies the
+`@safety_critical` rules and derives the reference set #16's verifier will consume (#196). The AST
+keeps names unresolved.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -111,9 +113,10 @@ verifier checks against. Rules:
 ## Checking a file without a full build
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser, analyzer, solver, and budget check it will call already
-detect syntax errors, structural violations, unknown dictionary/theme names, hardcoded text in
-localizable fields, wrong field value domains, incomplete locale keys, layout overflow, a box that
-cannot contain its widest approved translation, and a dynamic-text source that could escape the
-baked charset; what is missing is the command that exposes them. Until it lands, review a `.medui`
+diagnostics — once it exists. The parser, analyzer, solver, budget check, and golden pass it will
+call already detect syntax errors, structural violations, unknown dictionary/theme names, hardcoded
+text in localizable fields, wrong field value domains, incomplete locale keys, layout overflow, a
+box that cannot contain its widest approved translation, a dynamic-text source that could escape
+the baked charset, a `@safety_critical` node with no `requirement:`, and an unknown `cv_check`;
+what is missing is the command that exposes them. Until it lands, review a `.medui`
 file by hand against this grammar and the component table above.

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -13,7 +13,7 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 ## Status: the front end is implemented; the compiler and runtime are not
 
 **A `.medui` lexer, AST and parser exist** in the host-tools zone as of issue #192 (`tools/medui/`), and
-the diagnostic codes they emit are registered as `MDX-E###` (#191). They parse a screen and reject
+the diagnostic codes they emit are registered as `MEDUI-E###` (#191). They parse a screen and reject
 the grammar's structural violations; they resolve nothing.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
@@ -25,9 +25,11 @@ What exists now is the layer a `.medui` compiler will target: `mdux.draw` descri
 bounded vertex, index and command buffers with a compiler-computed budget, and
 `mdux.render.vulkan` renders one. So the compiler's job is to emit a `DrawList` and a
 `DrawBudget`, not to invent a rendering path. `.medui` itself is
-[issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). This skill describes the *target*
-grammar, adapted from the sibling Rust project TrustSC, so authoring work can start the moment the
-compiler exists — do not write a `.medui` file expecting it to build anything yet.
+[issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). The implementation pins the shared
+contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
+grammar, component semantics, diagnostics, and portable guidance live in
+[`Compliatory/MedUI` at `c8cc45e`](https://github.com/Compliatory/MedUI/tree/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d).
+Do not write a `.medui` file expecting it to build anything in MduX until the compiler waves land.
 
 ## Grammar shape
 

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,7 +10,7 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: the compiler is complete front to back; one end-to-end screen remains
+## Status: an authored screen reaches pixels; the text half is what remains
 
 **A `.medui` lexer, AST, parser, semantic analyzer, integer-only bounded layout solver, text-budget
 check, and golden-reference pass exist** in the host-tools zone (`tools/medui/`). The diagnostic
@@ -30,9 +30,10 @@ and a `.hpp` carrying `static_assert(screen.validate().has_value())`, so a malfo
 build error rather than a startup failure (#197). A governed runtime draws one without allocating
 (#199), and `mdux-medui-check` validates a single file (#200).
 
-Two limits are worth knowing before you write a screen. **No text package is baked in this
-repository yet**, so a screen carrying `t("STR-KEY")` cannot be compiled end to end — that is #201,
-the last child of the epic. And the runtime draws a `Panel`; every other component is visited,
+Two limits are worth knowing before you write a screen. A font package is baked; **no text package
+is** — the per-locale glyph runs a `t("STR-KEY")` resolves against — so a screen carrying a text key
+cannot be compiled end to end
+([#235](https://github.com/ambroise-leclerc/MduX/issues/235)). And the runtime draws a `Panel`; every other component is visited,
 counted in `FrameStats::deferred` and left undrawn, because text needs that package and live-data
 components have no geometry until the frame does.
 
@@ -49,9 +50,10 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
 [`Compliatory/MedUI` at `d5136a8`](https://github.com/Compliatory/MedUI/tree/d5136a8518bd499760ecff2aad215d3721329f20).
-A `.medui` file builds something in MduX today: register it with `mdux_compile_screen()` and it
-becomes a committed, byte-compared artifact plus generated C++ a device links. What it cannot yet do
-is carry text, for the reason above.
+A `.medui` file builds something in MduX today, and it reaches the screen: register it with
+`mdux_compile_screen()` and it becomes a committed, byte-compared artifact plus generated C++ a
+device links, which the governed runtime draws and `ScreenPixelTests` compares pixel by pixel under
+lavapipe. What it cannot yet do is carry text, for the reason above.
 
 ## Grammar shape
 

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -10,13 +10,14 @@ governs the *authoring* of a `.medui` screen; for the baking mechanics behind it
 `evidence-pipeline`, and for the compliance framing of a safety-critical node see
 `regulatory-citations`.
 
-## Status: parsing and semantic validation are implemented; emission and runtime are not
+## Status: parsing, semantic validation, and bounded layout are implemented; emission and runtime are not
 
-**A `.medui` lexer, AST, parser and semantic analyzer exist** in the host-tools zone
-(`tools/medui/`). The diagnostic codes they emit are registered as `MEDUI-E###` (#191). The parser
-rejects structural violations (#192); the analyzer checks the closed component dictionary, each
-field's value domain, theme-token names, and text-key presence across every approved locale (#193).
-It does not substitute resolved values.
+**A `.medui` lexer, AST, parser, semantic analyzer, and integer-only bounded layout solver exist**
+in the host-tools zone (`tools/medui/`). The diagnostic codes they emit are registered as
+`MEDUI-E###` (#191). The parser rejects structural violations (#192); the analyzer checks the
+closed component dictionary, each field's value domain, theme-token names, and text-key presence
+across every approved locale (#193); and the solver flattens Vertical/Row layout to absolute
+rectangles without floating-point arithmetic (#194). The AST keeps names unresolved.
 
 **There is still no compiler, no emitter and no runtime.** The HTML/CSS path that used
 to stand in for one - `UiFileWatcher::loadContent()`, which sniffed a file extension and stored
@@ -54,7 +55,9 @@ Screen NeuroSense500 {
 }
 ```
 
-- Sizes are `Npx` or `Fill`. `position: Xpx, Ypx` takes a node out of flow at exact pixel coords.
+- Sizes are `Npx` or `Fill`. `position: Xpx, Ypx` takes a node out of flow at exact absolute
+  surface coordinates. A top-level positioned node must remain inside the padded content box; a
+  positioned Row child must remain inside that Row's already-resolved absolute band.
 - **One property per line.** The sibling implementation parses a component body line by line and
   splits each on its first `:`, so `width: 512px; height: 512px;` on one line is read as a width of
   `512px; height: 512px` and rejected. This example previously showed that form; it was condensed
@@ -106,8 +109,8 @@ verifier checks against. Rules:
 ## Checking a file without a full build
 
 `mdux-medui-check path/to/screen.medui` (issue #200) will validate a single file and print
-diagnostics — once it exists. The parser and analyzer it will call already detect syntax errors,
-structural violations, unknown dictionary/theme names, hardcoded text in localizable fields,
-wrong field value domains, and incomplete locale keys; what is missing is the command that exposes
-them. Until it lands, review a `.medui` file by hand against this grammar and the component table
-above.
+diagnostics — once it exists. The parser, analyzer, and solver it will call already detect syntax
+errors, structural violations, unknown dictionary/theme names, hardcoded text in localizable
+fields, wrong field value domains, incomplete locale keys, and layout overflow; what is missing is
+the command that exposes them. Until it lands, review a `.medui` file by hand against this grammar
+and the component table above.

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,11 +2,22 @@
 # Based on C++ Core Guidelines
 # Enforces coding standards from CONTRIBUTING.md
 
+# bugprone-exception-escape is deliberately NOT disabled. It was, until issue #116: ADR-005 opens
+# by citing that suppression as the reason a `noexcept` violation in governed code was invisible to
+# static analysis, and listed re-enabling it as a follow-up gated on MduXCore existing. MduXCore has
+# existed since Wave 1.
+#
+# Scope, stated honestly: this check is *available* rather than *enforced*. The only CI job running
+# clang-tidy is security-analysis.yml, which invokes it with `|| true` against a GCC-generated
+# compile_commands.json that clang-tidy cannot parse for module interface units - both limitations
+# are documented in that workflow. So re-enabling this catches a noexcept violation for a developer
+# running clang-tidy locally, and will catch one in CI when the Clang leg is restored (#48), but it
+# is not what stops one landing today. That is governed.noThrow.symbolScan, which reads the emitted
+# objects and runs on every ctest.
 Checks: >
   -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
-  -bugprone-exception-escape,
   cert-*,
   -cert-dcl21-cpp,
   -cert-dcl50-cpp,

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,9 @@
 # `-text` means "store and check out verbatim": no end-of-line conversion in either direction.
 recipes/** -text
 generated/** -text
+
+# A test fixture that is byte-compared needs the same rule for the same reason. `medui-package-*`
+# and `medui-screen-emit-fixture-is-current` compare a committed package.json against what the
+# compiler produces in memory, so a checkout that added carriage returns would fail on the MSVC leg
+# alone - which is exactly how this was found.
+tests/medui/fixtures/** -text

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @ambroise-leclerc
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Invitation and contributor agreement
+
+- [ ] I was invited by a maintainer to contribute this change.
+- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.
+
+Invitation / CLA issue: #
+
+## Verification
+
+List the checks performed and their results.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,14 @@
+<!--
+Every section is required. Where a field does not apply, write "none" or "not stacked" rather
+than deleting the heading — a missing heading reads as an oversight, an explicit "none" reads as
+an answer. See CONTRIBUTING.md § "Stacked delivery" for what the dependency fields are for.
+-->
+
 ## Summary
 
 Describe the change and why it is needed.
+
+Closes #
 
 ## Invitation and contributor agreement
 
@@ -9,7 +17,65 @@ Describe the change and why it is needed.
 
 Invitation / CLA issue: #
 
+## Dependency
+
+- **Base branch:** <!-- `develop`, or the predecessor branch this is stacked on -->
+- **Predecessor PR:** <!-- #NNN, or "not stacked" -->
+- **Merge order:** <!-- "mergeable now", or "must not merge until #NNN has merged" -->
+
+<!--
+A stacked PR targets its predecessor rather than `develop`, so a reviewer sees one issue's diff
+instead of the cumulative one. It must not merge until its predecessor has.
+-->
+
+## Shared registries touched
+
+Tick every registry this PR edits. These are the files two branches collide in, and where Wave 2
+lost wiring during conflict resolution:
+
+- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
+- [ ] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
+- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
+- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
+- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
+- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
+- [ ] Committed artifacts under `generated/`
+- [ ] None of the above
+
+## Rebase state
+
+- **Rebased onto:** <!-- the `develop` SHA this branch sits on, or the predecessor's head SHA -->
+- **Conflicts resolved as a union:** <!-- yes / no conflicts. If a conflict was resolved by taking one side, say which and why. -->
+
 ## Verification
 
-List the checks performed and their results.
+List the checks performed and their results. Do not tick anything you did not run — "not run
+locally, CI covers it" is an acceptable answer and a more useful one than a wrong tick.
 
+- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc`
+- [ ] `ctest --test-dir build-gcc` — <!-- N/N passed -->
+- [ ] `python3 tools/docs-lint/mdux_docs_lint.py`
+- [ ] Other: <!-- sanitizers, evidence re-bake, install consumer, MSVC leg -->
+
+## Post-merge gate
+
+- [ ] I understand that the `develop` workflow must be green after this merges before the next
+      dependent PR may merge.
+- **Post-merge `develop` run:** <!-- workflow URL or run ID once this has merged, or "no successor" -->
+- [ ] That run is green. *(Tick after merging this PR and before merging its successor. "No
+      successor" above means there is nothing to gate, and this box may be left unticked.)*
+
+<!--
+The first box records that the author knows the rule; the second records that the rule was
+followed. They are not redundant - a successor could otherwise merge against an unverified
+integration while the template looked complete, which is the gap this section exists to close.
+-->
+
+
+## Regulatory impact
+
+<!--
+Required by AGENTS.md § 8. If this change can affect safety behaviour, risk controls, compliance
+metadata, traceability, or any claim about a standard, say so and name the artifacts updated.
+"None — <reason>" is a complete answer for changes that carry no such impact.
+-->

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -33,6 +33,8 @@ jobs:
   clang-build:
     name: Linux (Clang, Vulkan)
     runs-on: ubuntu-latest
+    env:
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -41,6 +43,26 @@ jobs:
       # reason to survive into .git/config where any later build or test step could read it
       # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
+        persist-credentials: false
+
+    - name: Resolve the pinned MedUI contract commit
+      id: medui-contract
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="$(sed -n 's/^commit = "\([0-9a-f]\{40\}\)"$/\1/p' medui-conformance.toml)"
+        if [ -z "$commit" ]; then
+          echo "medui-conformance.toml has no 40-character commit pin" >&2
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+    - name: Checkout pinned MedUI conformance contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Compliatory/MedUI
+        ref: ${{ steps.medui-contract.outputs.commit }}
+        path: .medui-conformance
         persist-credentials: false
 
     - name: Setup CMake (latest)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,14 +55,14 @@ jobs:
     # windows-build.yml both build this tree on every PR, so nothing here was the only thing
     # proving it compiles.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         languages: cpp
         build-mode: none
         config-file: ./.github/codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         category: "/language:cpp"
 

--- a/.github/workflows/compliance-docs.yml
+++ b/.github/workflows/compliance-docs.yml
@@ -24,7 +24,11 @@ jobs:
   compliance-docs:
     name: Compliance & Documentation
     runs-on: ubuntu-latest
-    container: gcc:16
+    # Pinned for the reason linux-gcc16-build.yml states at length: the floating `gcc:16` tag
+    # moved to 16.2.0 and broke the module build (#205). This job does not compile modules, so it
+    # survived - but a floating toolchain makes any failure here ambiguous between "the code
+    # changed" and "the container changed", which is the property worth removing everywhere.
+    container: gcc:16.1.0
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -39,6 +39,16 @@ jobs:
         python3 -m unittest discover -s tools/docs-lint -p "test_*.py"
         python3 tools/docs-lint/mdux_docs_lint.py
 
+    # Issue #223: CONTRIBUTING.md fixes one shape for a file-level Doxygen block, and the rule has
+    # been settled twice - once because the tree contradicted it, once because ten files had drifted
+    # back. A block without @file is not ignored by Doxygen; it silently documents whatever
+    # declaration follows. Checked here rather than in a C++ test so that a PR touching no C++ at
+    # all - which is exactly the kind that adds a file - still gets the answer.
+    - name: Check file-level Doxygen blocks
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: python3 tools/docs-lint/check_file_headers.py
+
     # Every AI-Reference.md is generated, so an edited module with a stale index is a defect the
     # build should catch rather than a reader. --check writes nothing; it fails when regenerating
     # would change a byte, and when a clause is cited in prose that no index row covers.

--- a/.github/workflows/governed-lint.yml
+++ b/.github/workflows/governed-lint.yml
@@ -1,0 +1,47 @@
+name: Governed Source Lint
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    # Matches the PR's *base*, not its head: a base branch missing from this list means that PR
+    # reports no checks at all, silently - which is worse than reporting failures. `[0-9]+-*` is
+    # the scheme GitHub's "create a branch for this issue" button generates (issue number, dash,
+    # slugified title) and this project's standard - see AGENTS.md "Branch naming". It is also
+    # what gets a stacked PR checked, i.e. one targeting its predecessor rather than develop so a
+    # reviewer sees one issue's diff instead of the cumulative one. `feat/**` predates the
+    # convention and is kept for branches already in flight.
+    branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
+
+permissions:
+  contents: read
+
+jobs:
+  governed-lint:
+    name: Governed Source Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # No step here performs an authenticated Git operation, so the checkout token has no
+      # reason to survive into .git/config where any later build or test step could read it
+      # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
+      with:
+        persist-credentials: false
+
+    # ADR-005's governed-zone source rules (issue #116): no throw/try/catch, no throwing
+    # `.value()`, no raw allocation, no filesystem/console/clock/randomness, no unsafe cast, no
+    # std::fma. Needs no C++ toolchain - the lint parses MduXCore's source list out of
+    # CMakeLists.txt rather than configuring the project - so it runs as its own fast job.
+    #
+    # This is one of two layers. The other, governed.noThrow.symbolScan, reads the emitted objects
+    # and therefore needs a build; it runs inside the toolchain legs as a ctest. Neither subsumes
+    # the other: this sees a std::filesystem call that never throws, and the scan sees a throw
+    # arriving through a std facility the source never spells out.
+    - name: Run mdux-governed-lint
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: |
+        python3 -m unittest discover -s tools/governed-lint -p "test_*.py"
+        python3 tools/governed-lint/mdux_governed_lint.py

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -36,6 +36,8 @@ jobs:
     # tag in a PR of its own, so the diff that changes the compiler is the diff that fixes whatever
     # the change breaks.
     container: gcc:16.1.0
+    env:
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -44,6 +46,26 @@ jobs:
       # reason to survive into .git/config where any later build or test step could read it
       # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
+        persist-credentials: false
+
+    - name: Resolve the pinned MedUI contract commit
+      id: medui-contract
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="$(sed -n 's/^commit = "\([0-9a-f]\{40\}\)"$/\1/p' medui-conformance.toml)"
+        if [ -z "$commit" ]; then
+          echo "medui-conformance.toml has no 40-character commit pin" >&2
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+    - name: Checkout pinned MedUI conformance contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Compliatory/MedUI
+        ref: ${{ steps.medui-contract.outputs.commit }}
+        path: .medui-conformance
         persist-credentials: false
 
     - name: Install dependencies

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -1,7 +1,7 @@
 name: Linux GCC 16 Build
 
 # NOTE: This project requires C++23 import std support:
-# - GCC 16+ ✅ Available via gcc:16 Docker container
+# - GCC 16+ ✅ Available via the gcc Docker image, pinned to a patch release below
 
 on:
   push:
@@ -24,7 +24,18 @@ jobs:
   linux-build-gcc16:
     name: Linux (GCC 16, Vulkan)
     runs-on: ubuntu-latest
-    container: gcc:16
+    # Pinned to a patch release, not the floating `gcc:16` tag. That tag moved from 16.1.0 to
+    # 16.2.0 on 2026-08-12 and turned develop red on a markdown-only commit (#205): GCC 16.2 could
+    # not read the module BMIs the SpecLab sources produce - "failed to read compiled module
+    # cluster ... Bad file data". The BMI format is not stable across GCC patch releases, and every
+    # other input to this job is already pinned (SpecLab to a commit SHA, CMake to 4.1.1), so the
+    # compiler was the one floating input - and the one most likely to break a C++23 modules build.
+    #
+    # Same reasoning as the CMake pin in windows-build.yml, which that file states at length after
+    # the same thing happened with `latest`. Moving to a newer GCC is a deliberate change: bump this
+    # tag in a PR of its own, so the diff that changes the compiler is the diff that fixes whatever
+    # the change breaks.
+    container: gcc:16.1.0
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -108,6 +108,15 @@ jobs:
     - name: Verify ML determinism (GCC 16)
       run: ctest --preset ninja-gcc -L determinism --output-on-failure
 
+    # Governed-zone no-throw, at the object level (ADR-005, issue #116). Broken out with -V rather
+    # than folded into the full run above, because a passing ctest prints none of a test's output -
+    # and this scan's output is half its purpose. It reports the throw-helper references it
+    # deliberately tolerates, and the ADR justifies tolerating them on the grounds that they stay
+    # "visible and counted". A number nobody can see in a job log is not counted. -V is what makes
+    # the claim true, and is the same reason the pixel step below uses it.
+    - name: Verify governed-zone no-throw (GCC 16)
+      run: ctest --preset ninja-gcc -L governed -V --no-tests=error
+
     # Rendered-truth verification (issue #125), moved here when the GCC 15 leg was retired.
     # Without it a broken ICD turns the only test that renders anything into a silent no-op:
     # offscreen_tests exits 77 with no device and CTest reports Skipped, which does not fail a run.

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -52,7 +52,7 @@ jobs:
       security-events: write
       contents: read
     if: ${{ github.event_name == 'pull_request' }}
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
     with:
       fail-on-vuln: false
       scan-args: |-

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -39,7 +39,7 @@ jobs:
       security-events: write
       contents: read
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
     with:
       fail-on-vuln: false
       scan-args: |-

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -41,6 +41,8 @@ jobs:
     # tag in a PR of its own, so the diff that changes the compiler is the diff that fixes whatever
     # the change breaks.
     container: gcc:16.1.0
+    env:
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -49,6 +51,26 @@ jobs:
       # reason to survive into .git/config where any later build or test step could read it
       # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
+        persist-credentials: false
+
+    - name: Resolve the pinned MedUI contract commit
+      id: medui-contract
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="$(sed -n 's/^commit = "\([0-9a-f]\{40\}\)"$/\1/p' medui-conformance.toml)"
+        if [ -z "$commit" ]; then
+          echo "medui-conformance.toml has no 40-character commit pin" >&2
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+    - name: Checkout pinned MedUI conformance contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Compliatory/MedUI
+        ref: ${{ steps.medui-contract.outputs.commit }}
+        path: .medui-conformance
         persist-credentials: false
 
     - name: Install dependencies

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -29,7 +29,18 @@ jobs:
   sanitize:
     name: ASan + UBSan (GCC 16)
     runs-on: ubuntu-latest
-    container: gcc:16
+    # Pinned to a patch release, not the floating `gcc:16` tag. That tag moved from 16.1.0 to
+    # 16.2.0 on 2026-08-12 and turned develop red on a markdown-only commit (#205): GCC 16.2 could
+    # not read the module BMIs the SpecLab sources produce - "failed to read compiled module
+    # cluster ... Bad file data". The BMI format is not stable across GCC patch releases, and every
+    # other input to this job is already pinned (SpecLab to a commit SHA, CMake to 4.1.1), so the
+    # compiler was the one floating input - and the one most likely to break a C++23 modules build.
+    #
+    # Same reasoning as the CMake pin in windows-build.yml, which that file states at length after
+    # the same thing happened with `latest`. Moving to a newer GCC is a deliberate change: bump this
+    # tag in a PR of its own, so the diff that changes the compiler is the diff that fixes whatever
+    # the change breaks.
+    container: gcc:16.1.0
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,6 @@ jobs:
         retention-days: 5
 
     - name: Upload to code-scanning
-      uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         sarif_file: results.sarif

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -21,7 +21,11 @@ jobs:
   security-analysis:
     name: Security Analysis
     runs-on: ubuntu-latest
-    container: gcc:16
+    # Pinned for the reason linux-gcc16-build.yml states at length: the floating `gcc:16` tag
+    # moved to 16.2.0 and broke the module build (#205). This job does not compile modules, so it
+    # survived - but a floating toolchain makes any failure here ambiguous between "the code
+    # changed" and "the container changed", which is the property worth removing everywhere.
+    container: gcc:16.1.0
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,6 +24,8 @@ jobs:
   windows-build:
     name: Windows (MSVC, Vulkan)
     runs-on: windows-latest
+    env:
+      MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance
 
     steps:
     - name: Checkout repository
@@ -32,6 +34,26 @@ jobs:
       # reason to survive into .git/config where any later build or test step could read it
       # (OpenSSF Scorecard's Token-Permissions check, zizmor's `artipacked`).
       with:
+        persist-credentials: false
+
+    - name: Resolve the pinned MedUI contract commit
+      id: medui-contract
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="$(sed -n 's/^commit = "\([0-9a-f]\{40\}\)"$/\1/p' medui-conformance.toml)"
+        if [ -z "$commit" ]; then
+          echo "medui-conformance.toml has no 40-character commit pin" >&2
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+    - name: Checkout pinned MedUI conformance contract
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: Compliatory/MedUI
+        ref: ${{ steps.medui-contract.outputs.commit }}
+        path: .medui-conformance
         persist-credentials: false
 
     # Pinned, not 'latest': CMakeLists.txt hardcodes CMAKE_EXPERIMENTAL_CXX_IMPORT_STD

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -115,6 +115,16 @@ jobs:
       run: ctest --preset ninja-msvc -L determinism
       shell: cmd
 
+    # Governed-zone no-throw (ADR-005, issue #116). Informational on this toolchain, and run
+    # anyway: the MSVC STL inlines its own throw sites, so _CxxThrowException in a governed object
+    # is the same symbol whether it came from a hand-written throw or a std::string growth path.
+    # The scan therefore forbids nothing here and prints what it found, which is worth having in
+    # the log - it is the only place the MSVC-side references are visible at all. mdux-governed-lint
+    # is what actually gates the rule on Windows. -V because a passing ctest prints no test output.
+    - name: Verify governed-zone no-throw (MSVC, informational)
+      run: ctest --preset ninja-msvc -L governed -V --no-tests=error
+      shell: cmd
+
     - name: Verify no source-tree writes
       shell: pwsh
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ GEMINI.md
 # CI sets PYTHONDONTWRITEBYTECODE=1, but a local run of the self-tests still leaves these behind.
 __pycache__/
 *.pyc
+
+# Ephemeral exact-SHA checkout of the shared MedUI conformance contract in CI.
+.medui-conformance/

--- a/.gitignore
+++ b/.gitignore
@@ -51,12 +51,20 @@ Makefile
 *.user
 *.sln.docstates
 
-# Documentation files (large PDFs, proprietary standards)
-inputs/Documentation/*.pdf
-inputs/Documentation/*.epub
-inputs/Documentation/ISO\ 13485/
-inputs/Documentation/ISO\ 14971\ The\ Definitive\ Guide/
-inputs/Documentation/Medical\ Device\ Cybersecurity\ for\ Engineers\ and\ Manufacturers/
+# Local reference material - never committed.
+#
+# The whole directory, not selected paths inside it. Five specific sub-paths were listed here
+# until issue #116, which left inputs/CMake/ and any newly-added folder under
+# inputs/Documentation/ untracked-but-not-ignored - so a `git add -A` would have committed them.
+# That is the exact class of content #7 and #23 spent a history rewrite removing, and ADR-006
+# forbids outright. A directory-level rule cannot be defeated by adding a file to it.
+#
+# This lives in the *first* PR of the #116 stack rather than the last, because the narrow rule
+# actually caught someone out while that stack was in review: a `git add -A` on this branch staged
+# `inputs/CMake` as a gitlink. It was a one-line SHA rather than the 431 MB behind it, and it was
+# amended out before anyone pulled, but a guard that lands after the thing it guards against is
+# not a guard.
+inputs/
 
 # Temporary files
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ Makefile
 *.cmake
 !cmake/*.cmake
 
+# ...and the CMake-level tests, which are scripts CTest runs rather than build output. Without this
+# `git add` skips them silently and the tests fail on CI with "Not a file", which is how this line
+# came to exist.
+!tests/cmake/*.cmake
+
 # Compiled binaries
 *.exe
 *.dll

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,13 @@ Three decisions from that programme apply repository-wide:
    digest or golden-vector mismatch. See [ADR-008](docs/adr/ADR-008-zero-soup-ml-inference.md).
 
 Waves 1 to 4 of that roadmap have shipped (v0.2.0, v0.3.0, v0.4.0, v0.5.0). Wave 4 was the font
-and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), in progress:
-seven of its twelve children have landed, taking a screen from source to a bounded, budgeted,
-golden-annotated set of rectangles. Five remain — the emitters (`#197`), the CMake integration and
-`mdux-meduic` (`#198`), the allocation-free screen runtime (`#199`), `mdux-medui-check` (`#200`) and
-the first end-to-end screen (`#201`).
+and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), and all
+twelve of its children have landed: a screen goes from source to a bounded, budgeted,
+golden-annotated set of rectangles, to a committed byte-compared artifact, to `constexpr` C++, to
+draw commands recorded without allocating, to a pixel compared under lavapipe. What the wave leaves
+behind is content rather than path — no text package is baked (`#235`), so a screen carrying
+`t("STR-KEY")` cannot be compiled, and the runtime draws a `Panel` while counting every other
+component as deferred (`#17`).
 
 Treat any AGENTS.md section below that describes current architecture as authoritative for *today's
 code*; treat this subsection as the direction that code is moving in.
@@ -333,7 +335,7 @@ is one of the things that would have caught that earlier.
 | [`mdux-regulated-change`](.agents/skills/mdux-regulated-change/SKILL.md) | A change can affect safety behavior, risk controls, compliance metadata, traceability, auditability, lifecycle documents, or claims about medical-device standards. | Impact classification, affected-artifact identification, proportionate documentation updates, traceability, review/escalation triggers, evidence-vs-intent-vs-certification distinctions. |
 | [`regulatory-citations`](.agents/skills/regulatory-citations/SKILL.md) | Writing or reviewing anything that claims alignment with IEC 62304, ISO 13485, ISO 14971, IEC 62366-1, or IEC 81001-5-1. | Citation-key format, the `Justification` object, the prohibition on reproducing normative text. **Target convention** — see § 2's parity-programme note. |
 | [`evidence-pipeline`](.agents/skills/evidence-pipeline/SKILL.md) | Adding or modifying a baked asset (font, shader, image, `.medui` screen, ML model) or anything under `generated/`. | Recipe→baker→committed-artifact doctrine, canonical-JSON rules, why `generated/` is never hand-edited. **Live** — `mdux-shaderbake` and `mdux-mlbake` both register through `mdux_bake_artifact()`, and `generated/shader/` and `generated/model/` are committed and byte-verified. |
-| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. **Partly live** — the compiler's front end validates a screen (parser, semantics, layout, text budgets, goldens), but nothing emits or renders one yet, so a `.medui` file still builds nothing (issue `#15`). |
+| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. **Live** — a `.medui` file compiles to a committed artifact, emits `constexpr` C++, and reaches compared pixels; what it cannot yet carry is text (issue `#235`). |
 | [`sdf-documents`](.agents/skills/sdf-documents/SKILL.md) | Filling in or reviewing a `software_development_file/` document. | Structure, the summarize-don't-duplicate rule, citing into the corpus. **Live** — `software_development_file/` exists with templates and records (issue `#9`). |
 
 Detailed procedures live in the skill files, not here — this table only routes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,11 @@ Three decisions from that programme apply repository-wide:
    digest or golden-vector mismatch. See [ADR-008](docs/adr/ADR-008-zero-soup-ml-inference.md).
 
 Waves 1 to 4 of that roadmap have shipped (v0.2.0, v0.3.0, v0.4.0, v0.5.0). Wave 4 was the font
-and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), now
-unblocked.
+and text pipeline (`#14`), closed by `#162`. Wave 5 is the `.medui` compiler (`#15`), in progress:
+seven of its twelve children have landed, taking a screen from source to a bounded, budgeted,
+golden-annotated set of rectangles. Five remain — the emitters (`#197`), the CMake integration and
+`mdux-meduic` (`#198`), the allocation-free screen runtime (`#199`), `mdux-medui-check` (`#200`) and
+the first end-to-end screen (`#201`).
 
 Treat any AGENTS.md section below that describes current architecture as authoritative for *today's
 code*; treat this subsection as the direction that code is moving in.
@@ -330,7 +333,7 @@ is one of the things that would have caught that earlier.
 | [`mdux-regulated-change`](.agents/skills/mdux-regulated-change/SKILL.md) | A change can affect safety behavior, risk controls, compliance metadata, traceability, auditability, lifecycle documents, or claims about medical-device standards. | Impact classification, affected-artifact identification, proportionate documentation updates, traceability, review/escalation triggers, evidence-vs-intent-vs-certification distinctions. |
 | [`regulatory-citations`](.agents/skills/regulatory-citations/SKILL.md) | Writing or reviewing anything that claims alignment with IEC 62304, ISO 13485, ISO 14971, IEC 62366-1, or IEC 81001-5-1. | Citation-key format, the `Justification` object, the prohibition on reproducing normative text. **Target convention** — see § 2's parity-programme note. |
 | [`evidence-pipeline`](.agents/skills/evidence-pipeline/SKILL.md) | Adding or modifying a baked asset (font, shader, image, `.medui` screen, ML model) or anything under `generated/`. | Recipe→baker→committed-artifact doctrine, canonical-JSON rules, why `generated/` is never hand-edited. **Live** — `mdux-shaderbake` and `mdux-mlbake` both register through `mdux_bake_artifact()`, and `generated/shader/` and `generated/model/` are committed and byte-verified. |
-| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. **Planned** — no `.medui` compiler exists yet (issue `#15`). |
+| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. **Partly live** — the compiler's front end validates a screen (parser, semantics, layout, text budgets, goldens), but nothing emits or renders one yet, so a `.medui` file still builds nothing (issue `#15`). |
 | [`sdf-documents`](.agents/skills/sdf-documents/SKILL.md) | Filling in or reviewing a `software_development_file/` document. | Structure, the summarize-don't-duplicate rule, citing into the corpus. **Live** — `software_development_file/` exists with templates and records (issue `#9`). |
 
 Detailed procedures live in the skill files, not here — this table only routes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,35 @@ easiest to miss on review. So:
 `push:` triggers stay limited to `main` and `develop` deliberately: an open PR already covers its
 own branch, and adding work branches there would run every workflow twice per commit.
 
+### Stacked delivery
+
+Branch naming above is what keeps CI *attached* to a stack. This is what keeps a stack *correct*.
+The full policy is in [`CONTRIBUTING.md`](CONTRIBUTING.md) § "Stacked delivery"; the rules an agent
+has to apply while working are:
+
+- **Declare the base.** A PR states whether it targets `develop` or a predecessor branch, and
+  which PR that predecessor is. `.github/pull_request_template.md` has the fields.
+- **Never merge a successor before its predecessor.** After the predecessor merges, rebase onto
+  current `develop` and re-request review of the final diff against `develop` — not against the
+  predecessor.
+- **Wait for the post-merge `develop` run**, not just the PR check, before merging the next
+  dependent PR. The PR check proves the branch builds; only the `develop` run proves the
+  integration does.
+- **Resolve a shared-registry conflict as a union by default.** The root `CMakeLists.txt`, the
+  `FILE_SET CXX_MODULES` lists, `tools/CMakeLists.txt`, `tests/CMakeLists.txt`, the schemas, the
+  generated indexes and the committed artifacts under `generated/` are the files where taking one
+  side deletes the other side's work while leaving a build that still compiles and tests that
+  still pass. If a conflict genuinely has to be resolved by taking one side, say in the PR
+  description which side you took and why — an undocumented one-sided resolution is the Wave 2
+  failure, a documented one is a decision.
+- **Land canonical types and schemas before their consumers.** Import what the predecessor
+  defined; do not restate it on a parallel branch.
+
+This is not general good practice written down for its own sake. Wave 2's stacked PRs lost CMake,
+module and test wiring during conflict resolution, and allowed two incompatible governance models
+to coexist until integration found them — repaired by #104 and reconciled by #105. Each rule above
+is one of the things that would have caught that earlier.
+
 ### Conventions
 
 - Follow the naming, formatting, and documentation conventions in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,112 @@
+# Changelog
+
+Written for a reader deciding whether a version does what they need, and for an auditor asking what
+changed between two artefacts they hold. Entries name the issue that owns the work, because the
+issue carries the reasoning and this file carries the outcome.
+
+## How to read the earlier entries
+
+This file starts at 0.6.0. **The entries for 0.2.0 through 0.5.0 summarise
+[`docs/roadmap.md`](docs/roadmap.md)'s own wave-by-wave record rather than deriving from git
+history**, and one boundary is the reason.
+
+`git log v0.2.0..v0.3.0` does not describe what a reader would expect: `v0.2.0` is not an ancestor
+of `v0.3.0`, and the two tags differ symmetrically by 462 commits against 475. That discontinuity has
+a known cause rather than being a mystery — #23 purged reproduced normative text from git history,
+not only from the working tree, so everything before that rewrite sits on a line the current one does
+not contain.
+
+Every later boundary is ordinary. `v0.3.0..v0.4.0` and `v0.4.0..v0.5.0` are both linear ranges
+(`0 93` and `0 72`), so a reader wanting commit-level detail for 0.4.0 or 0.5.0 can walk them and get
+exactly what they expect. These entries stay at wave granularity for consistency with 0.6.0's, not
+because the history is unavailable.
+
+---
+
+## 0.6.0 — unreleased
+
+Wave 5: the `.medui` compiler, end to end. An authored screen becomes a committed artifact, becomes
+`constexpr` C++, and reaches compared pixels.
+
+### The compiler (#15, all twelve children)
+
+- **The boundary and the artifacts** — ADR-011 fixes what a compiled screen is and is not; ADR-012
+  fixes the three files a screen emits and which are committed (#190, amended by #203 to keep the
+  compiled screen locale-free).
+- **Diagnostics** — the shared `MEDUI-E` registry, in the envelope every MduX tool emits (#191).
+- **The front end** — lexer, parser, AST and a fixture corpus of real files (#192); semantic
+  analysis over the closed component dictionary, field value domains, theme tokens and locale-checked
+  strings (#193).
+- **Bounded layout** — integer-only resolution to absolute rectangles, with `Row` flattening and a
+  synthesised background node (#194).
+- **Text budgets** — every resolved box measured against the *widest approved translation*, not the
+  authoring one (#195).
+- **Golden references** — one entry per `@safety_critical` node and per explicitly positioned node,
+  written as a sidecar (#196).
+- **The canonical package and two C++ emitters** — a compiled screen as canonical JSON, and as a
+  `.cppm` and `.hpp` carrying `static_assert(screen.validate().has_value())`, so a malformed screen
+  is a build error rather than a startup failure (#197).
+- **`mdux-meduic`** — the compiler driver and `mdux_compile_screen()`, with the first committed
+  screen under `generated/screen/endoscope-monitor/`, byte-compared on both toolchain legs (#198).
+- **The governed runtime** — a compiled screen becomes draw commands with no allocation, no parsing
+  and work bounded by numbers known before the device runs (#199).
+- **`mdux-medui-check`** — validates one file without a build, and names the two checks a file on its
+  own cannot cover (#200).
+- **The first end-to-end screen** — an authored `.medui` file drawn through Vulkan into an offscreen
+  target and compared pixel by pixel under lavapipe (#201).
+
+### Enforcement that had been asserted but not run (#11)
+
+- `mdux-governed-lint` over governed source, and `governed.noThrow.symbolScan` over the emitted
+  objects. ADR-005 had asserted a lint that did not exist while `src/text/Raster.cpp` — governed,
+  shipped in 0.5.0 — contained `try` and three `catch` clauses. The rasteriser moved to the
+  host-tools zone, and ADR-004 and ADR-005 were rewritten to describe only mechanisms CI runs (#116).
+- A stack-safe PR and post-merge policy (#117).
+
+### Also
+
+- [`docs/release-process.md`](docs/release-process.md), the procedure for cutting a version —
+  written before the version it is for.
+- Dual licensing under EUPL-1.2.
+- A file-header lint, after ten files were found in a documentation order `CONTRIBUTING.md` had
+  retired twice (#223).
+- SpecLab pinned to its first tagged release.
+
+### Known limits, stated because they are easy to mistake for defects
+
+- **No text package is baked**, so a screen carrying `t("STR-KEY")` cannot be compiled end to end
+  ([#235](https://github.com/ambroise-leclerc/MduX/issues/235)). The committed screen is text-free
+  and its safety-critical node is a `NumericDisplay`, the one traceable component with no text key.
+- **The runtime draws a `Panel`**; every other component is visited, counted in
+  `FrameStats::deferred`, and left undrawn. Text needs the package above; live-data components have
+  no geometry until a frame exists (#17).
+- **The golden sidecar has a static consumer, not a rendered one.** A test cross-checks it against
+  the compiled screen; verifying it against a frame is #16, over content #17 teaches to draw.
+
+---
+
+## 0.5.0 — 9 August 2026
+
+Wave 4: the font and text pipeline (#14). Static text bakes to positioned glyph runs per locale;
+dynamic text gets a restricted charset table, and the compiler rejects a format that could escape it.
+Hand-parsed TrueType, an integer-only rasteriser with coverage antialiasing, an atlas packer, and the
+first committed font package.
+
+## 0.4.0 — 4 August 2026
+
+Wave 3: documentation architecture rebuilt from what the build produces (#10); the shader pipeline
+and renderer slice, where MduX draws its first pixel from library code (#13); and zero-SOUP ML
+inference with a fail-closed golden self-test and no heap in `predict`, verified three ways (#18).
+
+## 0.3.0 — 1 August 2026
+
+Wave 2: a clause-accurate regulatory corpus across five standards with per-clause indexes and JSON
+Schemas (#8); governance types, a SOUP register and both Software Development File trees (#9); and
+the evidence kernel — SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`, with
+committed artifacts re-derived and byte-compared on both CI legs (#12).
+
+## 0.2.0 — 27 July 2026
+
+Wave 1: copyright remediation, including a purge of reproduced normative text from git history (#7);
+and the trust-zone skeleton — `MduXCore`, which never receives Vulkan's include directories, with
+link-graph verification at configure time (#11).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ because the history is unavailable.
 
 ---
 
-## 0.6.0 — unreleased
+## 0.6.0 — 23 August 2026
 
 Wave 5: the `.medui` compiler, end to end. An authored screen becomes a committed artifact, becomes
 `constexpr` C++, and reaches compared pixels.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,61 @@
+# Contributor Licence Agreement
+
+This Contributor Licence Agreement (the **Agreement**) applies to invited contributions to this
+repository.
+
+**Project Steward:** Ambroise Leclerc.  
+**You:** the individual or legal entity accepting this Agreement.  
+**Contribution:** any original work of authorship that You intentionally submit for inclusion in
+this repository after accepting this Agreement.
+
+## 1. Copyright licence
+
+You retain ownership of Your Contribution. You grant the Project Steward a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable copyright licence to reproduce, prepare derivative works
+of, publicly display, publicly perform, use, distribute, sublicense, and relicense Your
+Contribution, in source or object form, under EUPL-1.2 and under alternative commercial terms.
+
+## 2. Patent licence
+
+You grant the Project Steward and recipients of software distributed by the Project Steward a
+perpetual, worldwide, non-exclusive, royalty-free patent licence to make, have made, use, offer to
+sell, sell, import, and otherwise transfer Your Contribution, where that licence applies only to
+patent claims You can license that are necessarily infringed by Your Contribution alone or by its
+combination with the repository at the time it is submitted.
+
+If You initiate patent litigation alleging that the repository or a Contribution incorporated in
+it infringes a patent, the patent licences granted by You under this section terminate as of the
+date the litigation is filed.
+
+## 3. Your assurances
+
+You represent that:
+
+- You are legally entitled to grant the rights in this Agreement;
+- if an employer or another entity owns relevant rights, You have obtained its authorisation or
+  that entity has separately accepted an appropriate agreement;
+- Your Contribution is original, except for third-party material that You clearly identify along
+  with its source and licence; and
+- You will notify the Project Steward if any statement above becomes inaccurate.
+
+## 4. No support or warranty
+
+You are not required to provide support for Your Contribution. Unless separately agreed in
+writing, Your Contribution is provided without warranty.
+
+## 5. Successor project steward
+
+The Project Steward may assign this Agreement and the rights it grants to a legal entity that he
+controls and that becomes the steward of Compliatory, provided that entity assumes this
+Agreement's obligations and accepted Contributions remain available under EUPL-1.2.
+
+## 6. Acceptance
+
+You accept this Agreement by replying **`I agree`** to the GitHub invitation or CLA-record issue
+identified by the maintainer before Your first Contribution is merged. The maintainer records the
+acceptance by GitHub account and date. A pull request alone does not constitute acceptance.
+
+This Agreement is governed by French law. Contributors acting for a company may be asked for a
+separate corporate agreement. The Project Steward should obtain legal review before relying on
+this Agreement for commercial relicensing.
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ target_sources(MduXCore
             include/mdux/font/Schema.cppm
             include/mdux/text/Draw.cppm
             include/mdux/text/Schema.cppm
+            include/mdux/medui/Schema.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(cmake/PreventInSourceBuilds.cmake)
 
-project(MduX VERSION 0.5.0 DESCRIPTION "Modern C++23 Modules UI Library for Medical Devices" HOMEPAGE_URL "https://github.com/ambroise-leclerc/MduX" LANGUAGES CXX)
+project(MduX VERSION 0.6.0 DESCRIPTION "Modern C++23 Modules UI Library for Medical Devices" HOMEPAGE_URL "https://github.com/ambroise-leclerc/MduX" LANGUAGES CXX)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ target_sources(MduXCore
             include/mdux/text/Draw.cppm
             include/mdux/text/Schema.cppm
             include/mdux/medui/Schema.cppm
+            include/mdux/medui/Screen.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
@@ -209,6 +210,7 @@ target_sources(MduXCore
         src/font/Schema.cpp
         src/text/Draw.cpp
         src/text/Schema.cpp
+        src/medui/Screen.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp
         src/governance/Program.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,17 @@ mdux_compile_screen(
     RECIPE recipes/screen/endoscope-monitor.toml
 )
 
+# ...and the generated C++ for it (issue #201). Build-tree only, never committed. This is the last
+# link in the chain the epic set out to build: a `.medui` file becomes a committed artifact, the
+# artifact becomes `constexpr` C++, and a pixel test links that C++ and renders it - so the first
+# pixel drawn from an authored screen is compared against an expectation rather than described.
+include(cmake/MduXScreenEmit.cmake)
+mdux_emit_screen_package(
+    ID endoscope-monitor
+    OUT_MODULE MDUX_ENDOSCOPE_SCREEN_MODULE
+    OUT_DIR MDUX_GENERATED_SCREEN_DIR
+)
+
 # Generated C++ for that package (issue #121). Build-tree only, never committed - see
 # cmake/MduXShaderEmit.cmake. The renderer (#124) and the triangle example (#122) consume the
 # module form; the header form exists for a translation unit that cannot import a named module.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,6 @@ target_sources(MduXCore
             include/mdux/font/Schema.cppm
             include/mdux/text/Draw.cppm
             include/mdux/text/Schema.cppm
-            include/mdux/text/Raster.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
@@ -209,7 +208,6 @@ target_sources(MduXCore
         src/font/Schema.cpp
         src/text/Draw.cpp
         src/text/Schema.cpp
-        src/text/Raster.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp
         src/governance/Program.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,20 @@ mdux_bake_artifact(
         shaders.spv
 )
 
+# The first compiled screen (issue #198). Registered through mdux_compile_screen(), which is a thin
+# front for mdux_bake_artifact() - a screen earns the same build-tree bake, the same -update target
+# and the same evidence.screen.<id> byte comparison as a font or a shader, because nothing about a
+# screen justifies weaker evidence than its neighbours.
+#
+# It draws no text on purpose: no text package is baked in this tree yet, so the text-budget stage
+# has nothing to measure against and a screen carrying t("STR-KEY") would be refused for declaring no
+# approved locale. #201 lands the text half.
+include(cmake/MduXCompileScreen.cmake)
+mdux_compile_screen(
+    ID endoscope-monitor
+    RECIPE recipes/screen/endoscope-monitor.toml
+)
+
 # Generated C++ for that package (issue #121). Build-tree only, never committed - see
 # cmake/MduXShaderEmit.cmake. The renderer (#124) and the triangle example (#122) consume the
 # module form; the header form exists for a translation unit that cannot import a named module.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,16 @@
 # Contributing Guidelines
 
+## Invitation-only contributions
+
+This project accepts code and documentation contributions only from collaborators explicitly
+invited by a maintainer. Opening an issue or pull request does not constitute an invitation, and
+unsolicited pull requests may be closed without review.
+
+Before contributing, an invited collaborator must accept the [Contributor Licence
+Agreement](CLA.md) in the GitHub issue designated by the maintainer. Only collaborators with
+repository access may submit changes for review. Every change remains subject to maintainer review;
+an invitation does not guarantee merge.
+
 ## Coding Style
 
 We follow the **C++ Core Guidelines** to ensure conformance with modern C++23 generic programming. Please refer to the [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) for detailed rules. Key points are summarized below:
@@ -119,4 +130,3 @@ Please run these tools on your code before submitting a pull request.
 - Write clear, descriptive commit messages.
 - Add or update documentation as needed.
 - Run all tests locally before submitting your PR.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,14 @@ We follow the **C++ Core Guidelines** to ensure conformance with modern C++23 ge
 - Source files: `.cpp`
 - **File naming:** Use `UpperCamelCase` for `.hpp` and `.cpp` files (e.g., `Logger.hpp`, `DataProcessor.cpp`).
 
+### Releasing
+
+Cutting a version is a controlled event, not a tag on whatever is current:
+[`docs/release-process.md`](docs/release-process.md) is the procedure. The one step worth knowing
+before you need it is that moving the version in `CMakeLists.txt` invalidates every committed
+artifact, because each `report.json` records the `toolVersion` it was baked by — so a release
+re-bakes them and reviews the diff.
+
 ### Documentation
 
 We use **Doxygen** syntax for code documentation. Follow these guidelines:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,10 @@ We use **Doxygen** syntax for code documentation. Follow these guidelines:
   This rule previously said the opposite. It was never what the tree did — 82 files used `@file`
   against 56 that did not — and review bots cite this document, so the contradiction kept
   resurfacing on unrelated pull requests. #180 settled it in favour of the half that works.
+
+  `tools/docs-lint/check_file_headers.py` now enforces it, in the `Documentation Lint` job. #223
+  added it after finding ten files back in the retired order, all in one epic and all copied from
+  a neighbour: settling a rule in prose twice had not been enough to keep it true.
 - **Class documentation:** Include `@brief` with detailed description and usage examples.
 - **Method documentation:**
   - Use compact notation `/** @brief Description */` for simple one-line descriptions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,58 @@ Please run these tools on your code before submitting a pull request.
 - Ensure your branch is up to date with `develop` before submitting.
 - All code must pass CI checks and tests before merging.
 - Request a review from at least one maintainer.
+- Fill in [`.github/pull_request_template.md`](.github/pull_request_template.md) completely. Its
+  fields are the policy below, in the place where it is cheapest to apply.
+
+## Stacked delivery
+
+An epic is delivered as a chain of pull requests, each on its own issue branch, each targeting its
+predecessor rather than `develop` so a reviewer sees one issue's diff instead of the cumulative
+one. The branch-naming rule that keeps CI attached to such a chain is in
+[`AGENTS.md`](AGENTS.md) § 6; the rules below govern the *order* things merge in.
+
+They exist because of a specific failure. During Wave 2, stacked pull requests lost CMake, module
+and test wiring while their conflicts were being resolved, and two incompatible governance models
+coexisted on separate branches until integration discovered them — which took a repair PR (#104)
+and a reconciliation (#105) to undo. Every rule here is one of the things that would have caught
+it earlier.
+
+### Merge order
+
+- **A successor cannot merge before its predecessor.** Not "should not" — a stacked PR whose base
+  has not merged is proposing a diff against a branch that may still change under it.
+- After the predecessor merges, **rebase the successor onto current `develop`** and re-request
+  review of its final diff against `develop`. The diff a reviewer approved against the predecessor
+  is not the diff that will land.
+- **Required PR CI must be green, and then the resulting `develop` workflow must be green,**
+  before the next dependent PR merges. A green PR check proves the branch builds; only the
+  post-merge `develop` run proves the *integration* does. **Record that run** — its URL or id — in
+  the successor's "Post-merge gate" section, so the gate leaves evidence rather than only an
+  intention. A checkbox saying the author understood the rule is not a record that it was followed.
+
+### Conflicts
+
+- **Resolve a conflict in a shared registry as an explicit union, not a choice.** The registries
+  that matter are listed in the PR template: the root `CMakeLists.txt`, `FILE_SET CXX_MODULES`
+  lists, `tools/CMakeLists.txt`, `tests/CMakeLists.txt`, schemas, generated indexes and
+  `generated/` artifacts. Taking one side of a conflict in a source list silently deletes the other
+  side's target, which still compiles and still passes every test that was not the deleted one.
+- If a conflict genuinely has to be resolved by taking one side, say so in the PR description and
+  say why.
+
+### Ordering within a chain
+
+- **Canonical shared types and schemas land before their exports and consumers.** A successor
+  imports the type its predecessor defined; it does not restate it. Two branches each defining
+  their own version of "the same" type is how Wave 2 ended up with two governance models, and
+  neither branch's CI could see the problem.
+
+### Emergency merges
+
+A merge that bypasses the gates above — a local merge, an API push, an administrative override —
+requires a comment on the issue or PR naming **the exact head SHA that was incorporated** and
+**the post-merge CI run that covered it**. An undocumented bypass leaves no way to tell later
+which code was actually reviewed.
 
 ## Additional Notes
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,80 +1,287 @@
-Eclipse Public License - v 2.0
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+EUROPEAN UNION PUBLIC LICENCE v. 1.2
+EUPL © the European Union 2007, 2016
 
-1. DEFINITIONS
-“Contribution” means:
+This European Union Public Licence (the 'EUPL') applies to the Work (as defined
+below) which is provided under the terms of this Licence. Any use of the Work,
+other than as authorised under this Licence is prohibited (to the extent such
+use is covered by a right of the copyright holder of the Work).
 
-a) in the case of the initial Contributor, the initial content Distributed under this Agreement, and
-b) in the case of each subsequent Contributor:
-i) changes to the Program, and
-ii) additions to the Program;
-where such changes and/or additions to the Program originate from and are Distributed by that particular Contributor. A Contribution “originates” from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include changes or additions to the Program that are not Modified Works.
-“Contributor” means any person or entity that Distributes the Program.
+The Work is provided under the terms of this Licence when the Licensor (as
+defined below) has placed the following notice immediately after the copyright
+notice for the Work:
 
-“Licensed Patents” mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+        Licensed under the EUPL
 
-“Program” means the Contributions Distributed in accordance with this Agreement.
+or has expressed by any other means his willingness to license under the EUPL.
 
-“Recipient” means anyone who receives the Program under this Agreement or any Secondary License (as applicable), including Contributors.
+1. Definitions
 
-“Derivative Works” shall mean any work, whether in Source Code or other form, that is based on (or derived from) the Program and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship.
+In this Licence, the following terms have the following meaning:
 
-“Modified Works” shall mean any work in Source Code or other form that results from an addition to, deletion from, or modification of the contents of the Program, including, for purposes of clarity any new file in Source Code form that contains any contents of the Program. Modified Works shall not include works that contain only declarations, interfaces, types, classes, structures, or files of the Program solely in each case in order to link to, bind by name, or subclass the Program or Modified Works thereof.
+— 'The Licence': this Licence.
 
-“Distribute” means the acts of a) distributing or b) making available in any manner that enables the transfer of a copy.
+— 'The Original Work': the work or software distributed or communicated by the
+  Licensor under this Licence, available as Source Code and also as Executable
+  Code as the case may be.
 
-“Source Code” means the form of a Program preferred for making modifications, including but not limited to software source code, documentation source, and configuration files.
+— 'Derivative Works': the works or software that could be created by the
+  Licensee, based upon the Original Work or modifications thereof. This Licence
+  does not define the extent of modification or dependence on the Original Work
+  required in order to classify a work as a Derivative Work; this extent is
+  determined by copyright law applicable in the country mentioned in Article 15.
 
-“Secondary License” means either the GNU General Public License, Version 2.0, or any later versions of that license, including any exceptions or additional permissions as identified by the initial Contributor.
+— 'The Work': the Original Work or its Derivative Works.
 
-2. GRANT OF RIGHTS
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, Distribute and sublicense the Contribution of such Contributor, if any, and such Derivative Works.
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in Source Code or other form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to Distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-e) Notwithstanding the terms of any Secondary License, no Contributor makes additional grants to any Recipient (other than those set forth in this Agreement) as a result of such Recipient's receipt of the Program under the terms of a Secondary License (if permitted under the terms of Section 3).
-3. REQUIREMENTS
-3.1 If a Contributor Distributes the Program in any form, then:
+— 'The Source Code': the human-readable form of the Work which is the most
+  convenient for people to study and modify.
 
-a) the Program must also be made available as Source Code, in accordance with section 3.2, and the Contributor must accompany the Program with a statement that the Source Code for the Program is available under this Agreement, and informs Recipients how to obtain it in a reasonable manner on or through a medium customarily used for software exchange; and
-b) the Contributor may Distribute the Program under a license different than this Agreement, provided that such license:
-i) effectively disclaims on behalf of all other Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-ii) effectively excludes on behalf of all other Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-iii) does not attempt to limit or alter the recipients' rights in the Source Code under section 3.2; and
-iv) requires any subsequent distribution of the Program by any party to be under a license that satisfies the requirements of this section 3.
-3.2 When the Program is Distributed as Source Code:
+— 'The Executable Code': any code which has generally been compiled and which is
+  meant to be interpreted by a computer as a program.
 
-a) it must be made available under this Agreement, or if the Program (i) is combined with other material in a separate file or files made available under a Secondary License, and (ii) the initial Contributor attached to the Source Code the notice described in Exhibit A of this Agreement, then the Program may be made available under the terms of such Secondary Licenses, and
-b) a copy of this Agreement must be included with each copy of the Program.
-3.3 Contributors may not remove or alter any copyright, patent, trademark, attribution notices, disclaimers of warranty, or limitations of liability (‘notices’) contained within the Program from any copy of the Program which they Distribute, provided that Contributors may add their own appropriate notices.
+— 'The Licensor': the natural or legal person that distributes or communicates
+  the Work under the Licence.
 
-4. COMMERCIAL DISTRIBUTION
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (“Commercial Contributor”) hereby agrees to defend and indemnify every other Contributor (“Indemnified Contributor”) against any losses, damages and costs (collectively “Losses”) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+— 'Contributor(s)': any natural or legal person who modifies the Work under the
+  Licence, or otherwise contributes to the creation of a Derivative Work.
 
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+— 'The Licensee' or 'You': any natural or legal person who makes any usage,
+  distribution or modification of the Work under the terms of the Licence.
 
-5. NO WARRANTY
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+— 'Distribution' or 'Communication': any act of selling, giving, lending,
+  renting, distributing, communicating, transmitting, or otherwise making
+  available, online or offline, copies of the Work or providing access to its
+  essential functionalities at the disposal of any other natural or legal
+  person.
 
-6. DISCLAIMER OF LIABILITY
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+2. Scope of the rights granted by the Licence
 
-7. GENERAL
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+The Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+sublicensable licence to do the following, for the duration of copyright vested
+in the Original Work:
 
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+— use the Work in any circumstance and for all usage,
+— reproduce the Work,
+— modify the Work, and make Derivative Works based upon the Work,
+— communicate to the public, including the right to make available or display
+  the Work or copies thereof to the public and perform publicly, as the case may
+  be, the Work,
+— distribute the Work or copies thereof,
+— lend and rent the Work or copies thereof,
+— sublicense rights in the Work or copies thereof.
 
-All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+Those rights can be exercised on any media, supports and formats, whether now
+known or later invented, as far as the applicable law permits.
 
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be Distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to Distribute the Program (including its Contributions) under the new version.
+In the countries where moral rights apply, the Licensor waives his right to
+exercise his moral right to the extent allowed by law in order to make effective
+the licence of the economic rights here above listed.
 
-Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved. Nothing in this Agreement is intended to be enforceable by any entity that is not a Contributor or Recipient. No third-party beneficiary rights are created under this Agreement.
+The Licensor grants to the Licensee royalty-free, non-exclusive usage rights to
+any patents held by the Licensor, to the extent necessary to make use of the
+rights granted on the Work under this Licence.
 
-Exhibit A – Form of Secondary Licenses Notice
-“This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: {name license(s), version(s), and exceptions or additional permissions here}.”
+3. Communication of the Source Code
 
-Simply including a copy of this Agreement, including this Exhibit A is not sufficient to license the Source Code under Secondary Licenses.
+The Licensor may provide the Work either in its Source Code form, or as
+Executable Code. If the Work is provided as Executable Code, the Licensor
+provides in addition a machine-readable copy of the Source Code of the Work
+along with each copy of the Work that the Licensor distributes or indicates, in
+a notice following the copyright notice attached to the Work, a repository where
+the Source Code is easily and freely accessible for as long as the Licensor
+continues to distribute or communicate the Work.
 
-If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+4. Limitations on copyright
 
-You may add additional accurate notices of copyright ownership.
+Nothing in this Licence is intended to deprive the Licensee of the benefits from
+any exception or limitation to the exclusive rights of the rights owners in the
+Work, of the exhaustion of those rights or of other applicable limitations
+thereto.
+
+5. Obligations of the Licensee
+
+The grant of the rights mentioned above is subject to some restrictions and
+obligations imposed on the Licensee. Those obligations are the following:
+
+Attribution right: The Licensee shall keep intact all copyright, patent or
+trademarks notices and all notices that refer to the Licence and to the
+disclaimer of warranties. The Licensee must include a copy of such notices and a
+copy of the Licence with every copy of the Work he/she distributes or
+communicates. The Licensee must cause any Derivative Work to carry prominent
+notices stating that the Work has been modified and the date of modification.
+
+Copyleft clause: If the Licensee distributes or communicates copies of the
+Original Works or Derivative Works, this Distribution or Communication will be
+done under the terms of this Licence or of a later version of this Licence
+unless the Original Work is expressly distributed only under this version of the
+Licence — for example by communicating 'EUPL v. 1.2 only'. The Licensee
+(becoming Licensor) cannot offer or impose any additional terms or conditions on
+the Work or Derivative Work that alter or restrict the terms of the Licence.
+
+Compatibility clause: If the Licensee Distributes or Communicates Derivative
+Works or copies thereof based upon both the Work and another work licensed under
+a Compatible Licence, this Distribution or Communication can be done under the
+terms of this Compatible Licence. For the sake of this clause, 'Compatible
+Licence' refers to the licences listed in the appendix attached to this Licence.
+Should the Licensee's obligations under the Compatible Licence conflict with
+his/her obligations under this Licence, the obligations of the Compatible
+Licence shall prevail.
+
+Provision of Source Code: When distributing or communicating copies of the Work,
+the Licensee will provide a machine-readable copy of the Source Code or indicate
+a repository where this Source will be easily and freely available for as long
+as the Licensee continues to distribute or communicate the Work.
+
+Legal Protection: This Licence does not grant permission to use the trade names,
+trademarks, service marks, or names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the copyright notice.
+
+6. Chain of Authorship
+
+The original Licensor warrants that the copyright in the Original Work granted
+hereunder is owned by him/her or licensed to him/her and that he/she has the
+power and authority to grant the Licence.
+
+Each Contributor warrants that the copyright in the modifications he/she brings
+to the Work are owned by him/her or licensed to him/her and that he/she has the
+power and authority to grant the Licence.
+
+Each time You accept the Licence, the original Licensor and subsequent
+Contributors grant You a licence to their contributions to the Work, under the
+terms of this Licence.
+
+7. Disclaimer of Warranty
+
+The Work is a work in progress, which is continuously improved by numerous
+Contributors. It is not a finished work and may therefore contain defects or
+'bugs' inherent to this type of development.
+
+For the above reason, the Work is provided under the Licence on an 'as is' basis
+and without warranties of any kind concerning the Work, including without
+limitation merchantability, fitness for a particular purpose, absence of defects
+or errors, accuracy, non-infringement of intellectual property rights other than
+copyright as stated in Article 6 of this Licence.
+
+This disclaimer of warranty is an essential part of the Licence and a condition
+for the grant of any rights to the Work.
+
+8. Disclaimer of Liability
+
+Except in the cases of wilful misconduct or damages directly caused to natural
+persons, the Licensor will in no event be liable for any direct or indirect,
+material or moral, damages of any kind, arising out of the Licence or of the use
+of the Work, including without limitation, damages for loss of goodwill, work
+stoppage, computer failure or malfunction, loss of data or any commercial
+damage, even if the Licensor has been advised of the possibility of such damage.
+However, the Licensor will be liable under statutory product liability laws as
+far such laws apply to the Work.
+
+9. Additional agreements
+
+While distributing the Work, You may choose to conclude an additional agreement,
+defining obligations or services consistent with this Licence. However, if
+accepting obligations, You may act only on your own behalf and on your sole
+responsibility, not on behalf of the original Licensor or any other Contributor,
+and only if You agree to indemnify, defend, and hold each Contributor harmless
+for any liability incurred by, or claims asserted against such Contributor by
+the fact You have accepted any warranty or additional liability.
+
+10. Acceptance of the Licence
+
+The provisions of this Licence can be accepted by clicking on an icon 'I agree'
+placed under the bottom of a window displaying the text of this Licence or by
+affirming consent in any other similar way, in accordance with the rules of
+applicable law. Clicking on that icon indicates your clear and irrevocable
+acceptance of this Licence and all of its terms and conditions.
+
+Similarly, you irrevocably accept this Licence and all of its terms and
+conditions by exercising any rights granted to You by Article 2 of this Licence,
+such as the use of the Work, the creation by You of a Derivative Work or the
+Distribution or Communication by You of the Work or copies thereof.
+
+11. Information to the public
+
+In case of any Distribution or Communication of the Work by means of electronic
+communication by You (for example, by offering to download the Work from a
+remote location) the distribution channel or media (for example, a website) must
+at least provide to the public the information requested by the applicable law
+regarding the Licensor, the Licence and the way it may be accessible, concluded,
+stored and reproduced by the Licensee.
+
+12. Termination of the Licence
+
+The Licence and the rights granted hereunder will terminate automatically upon
+any breach by the Licensee of the terms of the Licence.
+
+Such a termination will not terminate the licences of any person who has
+received the Work from the Licensee under the Licence, provided such persons
+remain in full compliance with the Licence.
+
+13. Miscellaneous
+
+Without prejudice of Article 9 above, the Licence represents the complete
+agreement between the Parties as to the Work.
+
+If any provision of the Licence is invalid or unenforceable under applicable
+law, this will not affect the validity or enforceability of the Licence as a
+whole. Such provision will be construed or reformed so as necessary to make it
+valid and enforceable.
+
+The European Commission may publish other linguistic versions or new versions of
+this Licence or updated versions of the Appendix, so far this is required and
+reasonable, without reducing the scope of the rights granted by the Licence. New
+versions of the Licence will be published with a unique version number.
+
+All linguistic versions of this Licence, approved by the European Commission,
+have identical value. Parties can take advantage of the linguistic version of
+their choice.
+
+14. Jurisdiction
+
+Without prejudice to specific agreement between parties,
+
+— any litigation resulting from the interpretation of this License, arising
+  between the European Union institutions, bodies, offices or agencies, as a
+  Licensor, and any Licensee, will be subject to the jurisdiction of the Court
+  of Justice of the European Union, as laid down in article 272 of the Treaty on
+  the Functioning of the European Union,
+
+— any litigation arising between other parties and resulting from the
+  interpretation of this License, will be subject to the exclusive jurisdiction
+  of the competent court where the Licensor resides or conducts its primary
+  business.
+
+15. Applicable Law
+
+Without prejudice to specific agreement between parties,
+
+— this Licence shall be governed by the law of the European Union Member State
+  where the Licensor has his seat, resides or has his registered office,
+
+— this licence shall be governed by Belgian law if the Licensor has no seat,
+  residence or registered office inside a European Union Member State.
+
+Appendix
+
+'Compatible Licences' according to Article 5 EUPL are:
+
+— GNU General Public License (GPL) v. 2, v. 3
+— GNU Affero General Public License (AGPL) v. 3
+— Open Software License (OSL) v. 2.1, v. 3.0
+— Eclipse Public License (EPL) v. 1.0
+— CeCILL v. 2.0, v. 2.1
+— Mozilla Public Licence (MPL) v. 2
+— GNU Lesser General Public Licence (LGPL) v. 2.1, v. 3
+— Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) for
+  works other than software
+— European Union Public Licence (EUPL) v. 1.1, v. 1.2
+— Québec Free and Open-Source Licence — Reciprocity (LiLiQ-R) or Strong
+  Reciprocity (LiLiQ-R+)
+
+The European Commission may update this Appendix to later versions of the above
+licences without producing a new version of the EUPL, as long as they provide
+the rights granted in Article 2 of this Licence and protect the covered Source
+Code from exclusive appropriation.
+
+All other changes or additions to this Appendix require the production of a new
+EUPL version.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,30 @@
+# Licensing
+
+This project is available under a dual-licensing model.
+
+## Open-source licence
+
+Unless a separate written agreement applies, the repository is provided under the
+[European Union Public Licence 1.2](LICENSE) (`EUPL-1.2`).
+
+## Commercial licence
+
+Alternative commercial terms may be available from the project steward for organisations that
+need terms different from EUPL-1.2, including proprietary distribution or integration terms,
+contractual support, maintenance commitments, or warranties defined by contract.
+
+A commercial licence is granted only through a separate written agreement. The presence of this
+notice does not itself grant commercial-licence rights.
+
+## Earlier revisions
+
+Commits, tags, and releases published before the EUPL-1.2 licensing change remain available under
+the licence stated in the corresponding revision. This change governs the repository contents from
+the commit that adopts it onward; it does not retroactively alter the terms of earlier releases.
+
+Contact the project steward by opening a GitHub issue that contains no confidential information.
+
+## Contributions
+
+Contributions are accepted by invitation only and are governed by
+[the Contributor Licence Agreement](CLA.md). See [the contribution policy](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An experimental C++23-modules UI library for medical-device software, built on V
 [![CodeQL](https://github.com/ambroise-leclerc/MduX/actions/workflows/codeql.yml/badge.svg)](https://github.com/ambroise-leclerc/MduX/actions/workflows/codeql.yml)
 [![OSV-Scanner](https://github.com/ambroise-leclerc/MduX/actions/workflows/osv-scanner.yml/badge.svg)](https://github.com/ambroise-leclerc/MduX/actions/workflows/osv-scanner.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ambroise-leclerc/MduX/badge)](https://scorecard.dev/viewer/?uri=github.com/ambroise-leclerc/MduX)
-[![License: EPL-2.0](https://img.shields.io/badge/License-EPL--2.0-blue)](LICENSE)
+[![License: EUPL-1.2](https://img.shields.io/badge/License-EUPL--1.2-blue)](LICENSE)
 
 ## What this actually is
 
@@ -198,7 +198,8 @@ certification or compliance claim.
 
 ## License
 
-Eclipse Public License 2.0 ([EPL-2.0](LICENSE)).
+Available under the [European Union Public Licence 1.2](LICENSE), or under separate commercial
+terms. See [LICENSING.md](LICENSING.md).
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
+| `MduXMeduiLib` | Partial | `.medui` parsing and semantic validation; layout, packaging, and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |
@@ -151,7 +152,6 @@ Derived from the targets and tests that build on `develop`.
 | Risk management, QMS, lifecycle *code* | **Not started** | no `mdux::risk`, `mdux::qms` or `mdux::lifecycle` exists |
 | **Not started** | | |
 | Text and glyph rendering | Planned | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) |
-| `.medui` compiler | Planned | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) |
 | Content components (`SignalTrace`, `StatusIndicator`, …) | Planned | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) |
 
 The HTML/CSS path that earlier revisions described was **deleted** by

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
-| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, and integer-only bounded layout; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, integer-only bounded layout, and per-locale text budgets; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
-| `MduXMeduiLib` | Partial | `.medui` parsing and semantic validation; layout, packaging, and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, and integer-only bounded layout; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
-| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, integer-only bounded layout, and per-locale text budgets; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, integer-only bounded layout, per-locale text budgets, and golden references for safety-critical nodes; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Derived from the targets and tests that build on `develop`.
 | **Host tools** (never linked into a device target) | | |
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
-| `MduXMeduiLib` | Partial | `.medui` parsing, semantic validation, integer-only bounded layout, per-locale text budgets, and golden references for safety-critical nodes; packaging and emission remain ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| `MduXMeduiLib` | Implemented | The `.medui` compiler end to end: parsing, semantic validation, integer-only bounded layout, per-locale text budgets, golden references, the canonical package, two C++ emitters, and the `mdux-meduic` / `mdux-medui-check` tools ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |
@@ -154,10 +154,25 @@ Derived from the targets and tests that build on `develop`.
 | Text and glyph rendering | Planned | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) |
 | Content components (`SignalTrace`, `StatusIndicator`, …) | Planned | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) |
 
+`.medui` reaches pixels today, and the path is built rather than planned. An authored screen is
+compiled by `mdux-meduic` into `generated/screen/<id>/` — a package, a golden sidecar and a bake
+report, byte-compared across MSVC and GCC. Two emitters render that package as `constexpr` C++
+carrying `static_assert(screen.validate().has_value())`, a governed runtime turns it into draw
+commands without allocating, and `mdux.render.vulkan` draws them. `ScreenPixelTests` walks the whole
+chain and compares the result pixel by pixel under lavapipe in CI.
+
+Two limits are worth stating beside that. A **font** package is baked and committed
+(`generated/font/dejavu-ui/`), but no **text** package is — the per-locale glyph runs a screen's
+`t("STR-KEY")` resolves against, which would live under `generated/text/`. `mdux-textbake` can
+produce one and no recipe registers one, so a screen carrying a text key cannot be compiled end to
+end ([#235](https://github.com/ambroise-leclerc/MduX/issues/235)); and the runtime draws a `Panel` while
+counting every other component as deferred, because text needs that package and live-data components
+have no geometry until a frame exists. The committed screen therefore renders one bar — from a file
+an author wrote, through every stage, with nothing hand-carried between them.
+
 The HTML/CSS path that earlier revisions described was **deleted** by
 [#127](https://github.com/ambroise-leclerc/MduX/issues/127) — `MedicalUiRenderer::render()` recorded
-no Vulkan commands. `mdux.draw` plus `mdux.render.vulkan` replace it; `.medui` will generate the
-former.
+no Vulkan commands. `mdux.draw` plus `mdux.render.vulkan` replaced it.
 
 ## Regulatory material, and what it is for
 

--- a/cmake/MduXCompileScreen.cmake
+++ b/cmake/MduXCompileScreen.cmake
@@ -1,0 +1,146 @@
+# Registering a compiled screen as an evidence artifact (issue #198).
+#
+# `mdux_compile_screen()` is a thin front for `mdux_bake_artifact()`: a screen is baked like a font,
+# a shader or a model, so it gets the same build-tree output, the same `-update` target that stages
+# into `generated/`, and the same `evidence.screen.<id>` byte-comparison on every toolchain leg.
+# Nothing about a screen justifies a second mechanism, and a second mechanism is how one artifact
+# kind ends up with weaker evidence than its neighbours.
+#
+# What this wrapper adds over calling `mdux_bake_artifact()` directly is the two things a caller
+# could otherwise get wrong silently:
+#
+#   - **The three outputs are fixed here**, not per call site. ADR-012 makes `package.json`,
+#     `goldens.json` and `report.json` unconditional, so a screen that pins nothing writes `[]`
+#     rather than one fewer file. A call site listing its own OUTPUTS could drop one and produce a
+#     smaller artifact that still passed its own comparison.
+#   - **The `.medui` source becomes a dependency automatically**, read out of the recipe. A
+#     forgotten SOURCES entry does not fail: it makes edits to the screen stop triggering a rebake,
+#     so the committed artifact quietly stops matching its source until someone runs the update
+#     target for another reason.
+
+include_guard(GLOBAL)
+
+# _mdux_screen_package_field(<out_var> <recipe_text> <key> <label>)
+#
+# The value of `key` in the recipe's `[package]` table, and nothing else's.
+#
+# Scoped to that table on purpose. `mdux-meduic` reads `document.table("package")->require("source")`
+# and ignores tables it does not know, so a recipe may legally carry an earlier `source` key in
+# another table - and a regex over the whole document would then hand CMake a different file from the
+# one the compiler compiles. The dependency edge would point at the wrong input, editing the real
+# screen would stop triggering a rebake, and `mdux-bake-update` would stage bytes nobody asked for.
+# That is precisely the silent drift this wrapper exists to prevent, so getting the scope wrong here
+# is worse than not having the wrapper.
+#
+# Two keys in one table is an error rather than a first-wins: the compiler's TOML reader decides that
+# case, this does not have to guess the same way, and a recipe that ambiguous should be fixed.
+#
+# Line-based rather than a single regex, because a value or a comment may contain `[` - this
+# repository's own recipes carry `^[a-z0-9]...` inside a comment in `[package]` - and a section match
+# that stopped at the next bracket would truncate the table.
+function(_mdux_screen_package_field out_var recipe_text key label)
+    string(REPLACE ";" "\\;" escaped "${recipe_text}")
+    string(REGEX REPLACE "\r?\n" ";" lines "${escaped}")
+
+    set(current_table "")
+    set(found "")
+    foreach(line IN LISTS lines)
+        # Both patterns are anchored after leading whitespace, so a commented-out `# source = "x"` or
+        # `# [package]` cannot match. That is why no comment stripping is needed, and why stripping
+        # would be wrong: a `#` inside a quoted value is part of the value.
+        if(line MATCHES "^[ \t]*\\[([A-Za-z0-9_.-]+)\\]")
+            set(current_table "${CMAKE_MATCH_1}")
+        elseif(current_table STREQUAL "package" AND line MATCHES "^[ \t]*${key}[ \t]*=[ \t]*\"([^\"]*)\"")
+            list(APPEND found "${CMAKE_MATCH_1}")
+        endif()
+    endforeach()
+
+    list(LENGTH found count)
+    if(count EQUAL 0)
+        message(FATAL_ERROR
+            "mdux_compile_screen: ${label} has no `${key} = \"...\"` line in its [package] table. "
+            "The compiler reads that table, so anything else here would describe a different recipe.")
+    endif()
+    if(count GREATER 1)
+        message(FATAL_ERROR
+            "mdux_compile_screen: ${label} declares `${key}` ${count} times in [package]. "
+            "Which one the compiler uses is its TOML reader's business; this refuses to guess.")
+    endif()
+
+    list(GET found 0 value)
+    set(${out_var} "${value}" PARENT_SCOPE)
+endfunction()
+
+# _mdux_screen_check_recipe(<recipe_text> <label> <expected_id> <out_source_var>)
+#
+# Fails configuration unless the recipe describes the screen the caller says it does, and yields the
+# `.medui` source so it can become a dependency.
+#
+# The id check is the one that keeps identity single. `mdux-meduic` checks the recipe's id against the
+# screen's own name, but it never sees the CMake `ID` - so without this, `mdux_compile_screen(ID foo
+# RECIPE bar.toml)` bakes a package that calls itself `bar` into `mdux_bake/screen/foo`, compares it
+# as `evidence.screen.foo` and stages it into `generated/screen/foo/`. Every check passes while the
+# directory, the test and the package disagree about which screen this is.
+function(_mdux_screen_check_recipe recipe_text label expected_id out_source_var)
+    _mdux_screen_package_field(recipe_id "${recipe_text}" "id" "${label}")
+    if(NOT recipe_id STREQUAL expected_id)
+        message(FATAL_ERROR
+            "mdux_compile_screen: ${label} declares id '${recipe_id}', but was registered as "
+            "'${expected_id}'. The id names the artifact directory, the evidence test and the "
+            "emitted C++ identifier, so these must be one name.")
+    endif()
+
+    _mdux_screen_package_field(screen_source "${recipe_text}" "source" "${label}")
+    set(${out_source_var} "${screen_source}" PARENT_SCOPE)
+endfunction()
+
+# mdux_compile_screen(ID <id> RECIPE <path> [SOURCES <path>...])
+#
+# SOURCES names further inputs the recipe references - the font and text packages a screen that
+# draws text needs. The `.medui` source itself is found in the recipe and does not have to be
+# repeated.
+function(mdux_compile_screen)
+    set(options "")
+    set(single ID RECIPE)
+    set(multi SOURCES)
+    cmake_parse_arguments(ARG "${options}" "${single}" "${multi}" ${ARGN})
+
+    if(ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "mdux_compile_screen: unexpected arguments: ${ARG_UNPARSED_ARGUMENTS}")
+    endif()
+    foreach(required ID RECIPE)
+        if(NOT ARG_${required})
+            message(FATAL_ERROR "mdux_compile_screen: ${required} is required")
+        endif()
+    endforeach()
+
+    set(recipe_path "${CMAKE_SOURCE_DIR}/${ARG_RECIPE}")
+    if(NOT EXISTS "${recipe_path}")
+        message(FATAL_ERROR "mdux_compile_screen: recipe '${ARG_RECIPE}' does not exist")
+    endif()
+
+    # The screen source and the recipe's own id, taken from the recipe rather than from the call
+    # site. See the two helpers above for what each check is for.
+    file(READ "${recipe_path}" recipe_text)
+    _mdux_screen_check_recipe("${recipe_text}" "${ARG_RECIPE}" "${ARG_ID}" screen_source)
+
+    if(NOT EXISTS "${CMAKE_SOURCE_DIR}/${screen_source}")
+        message(FATAL_ERROR
+            "mdux_compile_screen: ${ARG_RECIPE} names the source '${screen_source}', which does not exist")
+    endif()
+
+    mdux_bake_artifact(
+        KIND screen
+        ID ${ARG_ID}
+        TOOL mdux-meduic
+        RECIPE ${ARG_RECIPE}
+        SOURCES
+            ${screen_source}
+            ${ARG_SOURCES}
+        # Fixed here rather than per call site: all three are unconditional (ADR-012, decision 1).
+        OUTPUTS
+            package.json
+            goldens.json
+            report.json
+    )
+endfunction()

--- a/cmake/MduXNoHeapScan.cmake
+++ b/cmake/MduXNoHeapScan.cmake
@@ -1,29 +1,80 @@
 # MduXNoHeapScan.cmake
 #
-# Layer 2 of issue #63: scan the compiled ML objects for any undefined reference to the allocation
-# and deallocation family, or to the exception-throwing runtime.
+# Scans compiled objects for undefined references that would contradict a zone's stated guarantee.
+# Two profiles, selected by MDUX_SCAN_PROFILE:
+#
+#   ml-noheap      Layer 2 of issue #63, over the ML objects: no allocation family, no throwing
+#                  runtime. This is the original scan.
+#   governed-throw Issue #116, over every MduXCore object: no literal throw. Allocation is NOT
+#                  forbidden here - mdux.evidence.json and mdux.governance legitimately allocate.
+#
+# Run as a ctest via `cmake -P`, not at configure time, because the object files do not exist until
+# after a build.
+#
+# ## ml-noheap
 #
 # The delete operators are in the forbidden set alongside the new ones deliberately. A reference to
 # `operator delete` means the object owns heap memory just as surely as a reference to `operator
 # new` does - often more visibly, because a destructor emitted for a std container is what pulls it
 # in. So a failure naming a delete symbol means the same thing as one naming new: something in the
-# governed ML zone acquired owning memory. Run as a ctest via `cmake -P`, not at configure time, because
-# the object files do not exist until after a build.
+# governed ML zone acquired owning memory.
 #
 # Where layer 1 (tests/ml/NoHeapTests.cpp) proves predict() does not allocate *when run*, this
 # proves the kernels and the runtime cannot allocate *at all* - no path through them, taken or not,
 # reaches operator new or malloc. It is also far cheaper, and it fails in the PR that introduced
 # the reference rather than whenever someone next executes that path.
 #
-# __cxa_throw is in the forbidden set for a second reason: it double-checks ADR-005's no-throwing
-# rule for the governed zone. A std::vector::at() or a std::stoi() that crept in would show up here
-# as a throw reference even if it never allocated.
+# ## governed-throw
+#
+# ADR-005 says governed code does not throw. The source lint checks that at the source level; this
+# checks it in the emitted objects, which is the stronger of the two - it sees through a std
+# facility that throws on a path the source never spells out.
+#
+# **This profile is only a gate on GCC/Clang, and reports rather than fails on MSVC.** The reason
+# is a genuine difference in how the two standard libraries generate code, not a gap in effort.
+#
+# On libstdc++, a `throw` expression emits `__cxa_throw`, while the library's own throw sites go
+# through out-of-line helpers. The two are therefore distinguishable in the object, and this
+# profile forbids the first while reporting the second.
+#
+# The reported set is `__throw_length_error`, `__throw_logic_error`, `__throw_out_of_range` and
+# `__throw_bad_alloc`, matched as substrings - so `__throw_out_of_range` also covers libstdc++'s
+# `__throw_out_of_range_fmt`, which is the spelling actually seen in this tree. `__throw_bad_alloc`
+# is in the set for completeness rather than because anything references it today; a scan that
+# reports only the symbols it has already met would go quiet exactly when something new arrived.
+#
+# Eight governed objects reference these, all from inside `std::string` and `std::vector`: growth
+# paths reference `__throw_length_error`, and `std::string_view::substr` references
+# `__throw_out_of_range_fmt` even
+# where the caller's invariant makes the throw unreachable (Json.cpp's parser and Governance.cpp's
+# id splitting are both of that shape).
+#
+# On the MSVC STL those throw sites are **inlined into the caller**, so the same `std::string` use
+# emits `_CxxThrowException` directly in the governed object - the identical symbol a hand-written
+# `throw` would emit. Nine governed objects reference it, and `mdux-governed-lint` independently
+# confirms there is no `throw` in any of their sources. The symbol simply cannot tell the two apart
+# there, so forbidding it would fail the build on correct code, and tolerating it would forbid
+# nothing at all. It is reported instead, and the source lint - which is toolchain-independent - is
+# what enforces the rule on Windows.
+#
+# Forbidding the helpers on GCC would mean banning `std::string`, `std::vector` and `substr` from
+# the governed zone outright. That may be the right end state for a Class C build, but it is a much
+# larger decision than this scan, and it needs its own ADR. Until then this file reports those
+# references rather than failing on them, so that they stay visible and counted instead of being
+# quietly implied not to exist. See ADR-005 for the claim as it is actually made.
 #
 # Expected variables (passed with -D):
+#   MDUX_SCAN_PROFILE       - "ml-noheap" or "governed-throw"
 #   MDUX_NOHEAP_OBJECT_LIST - path to a newline-separated file of object paths, written by
 #                             file(GENERATE) so that a generator expression resolves per config
 #   MDUX_NOHEAP_TOOL        - "nm" or "dumpbin"
 #   MDUX_NOHEAP_COMMAND     - path to that tool
+
+if(NOT DEFINED MDUX_SCAN_PROFILE)
+    message(FATAL_ERROR
+        "MduXNoHeapScan: MDUX_SCAN_PROFILE is not set. Pass 'ml-noheap' or 'governed-throw' - "
+        "defaulting would let a caller get the wrong forbidden set without noticing.")
+endif()
 
 if(NOT DEFINED MDUX_NOHEAP_OBJECT_LIST OR NOT EXISTS "${MDUX_NOHEAP_OBJECT_LIST}")
     message(FATAL_ERROR
@@ -35,33 +86,89 @@ file(STRINGS "${MDUX_NOHEAP_OBJECT_LIST}" MDUX_NOHEAP_OBJECTS)
 if(MDUX_NOHEAP_OBJECTS STREQUAL "")
     message(FATAL_ERROR
         "MduXNoHeapScan: the object list is empty. That would make this test pass by checking "
-        "nothing - the ML sources are expected to be part of MduXCore.")
+        "nothing. Whichever file(GENERATE) produced '${MDUX_NOHEAP_OBJECT_LIST}' resolved to no "
+        "objects - check the $<TARGET_OBJECTS:...> expression that writes it. Note that the "
+        "negative fixture deliberately scans an object library outside MduXCore, so an empty list "
+        "here does not necessarily mean MduXCore is the target that went missing.")
 endif()
 
 # Mangled and demangled spellings both, so this works whether or not the tool demangles.
-set(forbidden_symbols
-    "operator new"
-    "operator delete"
-    "_Znwm"      # operator new(unsigned long)
-    "_Znam"      # operator new[](unsigned long)
-    "_ZdlPv"     # operator delete(void*)
-    "_ZdaPv"     # operator delete[](void*)
-    "malloc"
-    "calloc"
-    "realloc"
-    "__cxa_throw"
-    "??2@"       # MSVC operator new
-    "??_U@"      # MSVC operator new[]
-)
+if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
+    set(forbidden_symbols
+        "operator new"
+        "operator delete"
+        "_Znwm"      # operator new(unsigned long)
+        "_Znam"      # operator new[](unsigned long)
+        "_ZdlPv"     # operator delete(void*)
+        "_ZdaPv"     # operator delete[](void*)
+        "malloc"
+        "calloc"
+        "realloc"
+        "__cxa_throw"
+        "??2@"       # MSVC operator new
+        "??_U@"      # MSVC operator new[]
+    )
+    set(reported_symbols "")
+    set(reported_explanation "")
+    # One string, not a list of strings: message() concatenates its own arguments cleanly, but a
+    # ;-separated list expanded through ${} arrives with the separators embedded in the text.
+    string(CONCAT violation_explanation
+        "mdux.ml.kernels and mdux.ml.runtime must reach neither. If this is a std facility that "
+        "allocates only on a path you believe is unreachable, that is not sufficient - the device "
+        "build must not contain the reference at all.")
+elseif(MDUX_SCAN_PROFILE STREQUAL "governed-throw")
+    # Toolchain-dependent, because the distinction this profile rests on is a property of the
+    # standard library's code generation rather than of the source. See the header comment.
+    if(MDUX_NOHEAP_TOOL STREQUAL "dumpbin")
+        set(forbidden_symbols "")
+        set(reported_symbols
+            "_CxxThrowException"
+            "_Xlength_error"
+            "_Xout_of_range"
+            "_Xbad_alloc"
+            "_Xinvalid_argument"
+        )
+        string(CONCAT reported_explanation
+            "tolerated throw reference(s). The MSVC STL inlines its own throw sites, so "
+            "_CxxThrowException in a governed object is indistinguishable from a hand-written "
+            "throw - see this file's header. mdux-governed-lint is what enforces the no-throw rule "
+            "on this toolchain; this scan is informational here")
+    else()
+        set(forbidden_symbols
+            "__cxa_throw"
+            "__cxa_rethrow"
+        )
+        # Counted and printed, never failed on.
+        set(reported_symbols
+            "__throw_length_error"
+            "__throw_logic_error"
+            "__throw_out_of_range"
+            "__throw_bad_alloc"
+        )
+        string(CONCAT reported_explanation
+            "tolerated throw-helper reference(s), from std::string, std::vector and "
+            "std::string_view::substr internals - see this file's header and ADR-005 for why "
+            "these are reported rather than forbidden")
+    endif()
+    string(CONCAT violation_explanation
+        "A governed module contains a throw expression. ADR-005 requires governed code to report "
+        "failure through mdux.core.result instead. If the throwing construct is unavoidable, the "
+        "module belongs in the host-tools zone - which is where mdux.text.raster went in #116.")
+else()
+    message(FATAL_ERROR
+        "MduXNoHeapScan: unknown MDUX_SCAN_PROFILE '${MDUX_SCAN_PROFILE}'. Expected 'ml-noheap' "
+        "or 'governed-throw'.")
+endif()
 
 set(violations "")
+set(reported "")
 set(scanned_count 0)
 
 foreach(object ${MDUX_NOHEAP_OBJECTS})
     if(NOT EXISTS "${object}")
         message(FATAL_ERROR
             "MduXNoHeapScan: object '${object}' does not exist. The scan would otherwise pass by "
-            "checking nothing - build the ML targets before running this test.")
+            "checking nothing - build the targets before running this test.")
     endif()
     math(EXPR scanned_count "${scanned_count} + 1")
 
@@ -99,6 +206,12 @@ foreach(object ${MDUX_NOHEAP_OBJECTS})
                 list(APPEND violations "${object_name}: ${line}")
             endif()
         endforeach()
+        foreach(symbol ${reported_symbols})
+            string(FIND "${line}" "${symbol}" found)
+            if(NOT found EQUAL -1)
+                list(APPEND reported "${object_name}: ${line}")
+            endif()
+        endforeach()
     endforeach()
 endforeach()
 
@@ -106,11 +219,31 @@ if(violations)
     list(REMOVE_DUPLICATES violations)
     string(REPLACE ";" "\n  " violation_text "${violations}")
     message(FATAL_ERROR
-        "No-heap violation (ADR-008, issue #63): the ML objects reference an allocator or the "
-        "throwing runtime.\n  ${violation_text}\n"
-        "mdux.ml.kernels and mdux.ml.runtime must reach neither. If this is a std facility that "
-        "allocates only on a path you believe is unreachable, that is not sufficient - the device "
-        "build must not contain the reference at all.")
+        "Symbol scan violation (profile '${MDUX_SCAN_PROFILE}'):\n  ${violation_text}\n"
+        "${violation_explanation}")
 endif()
 
-message(STATUS "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")
+# Printed rather than failed on, and printed every run rather than only when the count changes:
+# a tolerated reference that nobody sees becomes a reference nobody remembers tolerating.
+if(reported)
+    list(REMOVE_DUPLICATES reported)
+    list(LENGTH reported reported_count)
+    string(REPLACE ";" "\n  " reported_text "${reported}")
+    message(STATUS
+        "MduXNoHeapScan: ${reported_count} ${reported_explanation}:\n  ${reported_text}")
+endif()
+
+if(MDUX_SCAN_PROFILE STREQUAL "ml-noheap")
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} object(s) free of allocator and throw references")
+elseif(forbidden_symbols)
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} governed object(s) contain no throw expression")
+else()
+    # Never "no throw expression" here - nothing was forbidden, so nothing was established. Saying
+    # otherwise would be the exact shape of unearned claim issue #116 exists to remove.
+    message(STATUS
+        "MduXNoHeapScan: ${scanned_count} governed object(s) scanned; this toolchain cannot "
+        "distinguish a governed throw from an inlined std one, so no verdict is claimed here - "
+        "mdux-governed-lint enforces the rule at source level")
+endif()

--- a/cmake/MduXScreenEmit.cmake
+++ b/cmake/MduXScreenEmit.cmake
@@ -1,0 +1,133 @@
+# Generated C++ from a committed screen package (issue #197).
+#
+# `mdux_emit_screen_package()` runs mdux-screenemit over a committed screen `package.json` and
+# produces two files in the *build* tree:
+#
+#   <binary>/mdux_generated/screen/<identifier>.cppm   a module interface
+#   <binary>/mdux_generated/screen/<identifier>.hpp    the same screen, for consumers that cannot
+#                                                      import a named module
+#
+# Neither is committed. The reviewed artifact is the JSON and the digests beside it; the C++ is a
+# mechanical rendering of exactly those bytes. See tools/medui/Emit.cppm for the argument in full,
+# and cmake/MduXShaderEmit.cmake for the precedent this follows deliberately rather than by
+# resemblance - ADR-012 decision 3 names it as the arrangement to copy.
+#
+# Like the shader emitter, this is not a bake: an emission produces a build artifact and gets no
+# byte-comparison test, because the bytes it renders are already byte-compared as `package.json`.
+
+include_guard(GLOBAL)
+
+# mdux_screen_identifier(<out_var> <package_id>)
+#
+# The C++ identifier mdux-screenemit derives from a package id, and therefore the stem of the files
+# it writes. This must agree with identifierForScreen() in tools/medui/Emit.cpp exactly; a
+# disagreement surfaces as a build failure on a file nobody wrote, with nothing pointing at the
+# cause. It is a named function rather than two inline lines so that a test can call it - see
+# `medui-screen-identifier-parity`, which runs this and the C++ side over the same ids and compares.
+# Asserting only the C++ half is how the shader pair drifted on the leading-digit rule.
+function(mdux_screen_identifier out_var package_id)
+    # Unconditionally prefixed, which is what makes the answer an identifier rather than merely
+    # identifier-shaped: `class`, `namespace`, `module` and `import` are all legal package slugs, and
+    # mapping them to themselves produced a namespace and a module name no compiler accepts. Both
+    # sides agreed on that invalid answer, so the parity test could not see it - which is why the
+    # parity id list now carries keywords. The prefix also removes the leading-digit case this
+    # function used to handle with a second rule.
+    string(REGEX REPLACE "[^A-Za-z0-9]" "_" identifier "${package_id}")
+    set(${out_var} "screen_${identifier}" PARENT_SCOPE)
+endfunction()
+
+# mdux_emit_screen_package(ID <id> [PACKAGE <path>] [OUT_MODULE <var>] [OUT_HEADER <var>]
+#                          [OUT_DIR <var>])
+#
+# Adds a custom command generating the sources, and a target `emit-screen-<id>` that produces them.
+# The caller adds the returned module file to a target's CXX_MODULES file set.
+#
+# PACKAGE defaults to `generated/screen/<id>/package.json`, which is where #198's bake will put it.
+# It is an argument because no screen is committed there yet: the test corpus emits from a fixture,
+# and a function that could only read `generated/` would have to be rewritten the moment it had a
+# second caller.
+function(mdux_emit_screen_package)
+    set(options "")
+    set(single ID PACKAGE OUT_MODULE OUT_HEADER OUT_DIR)
+    set(multi "")
+    cmake_parse_arguments(ARG "${options}" "${single}" "${multi}" ${ARGN})
+
+    if(ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "mdux_emit_screen_package: unexpected arguments: ${ARG_UNPARSED_ARGUMENTS}")
+    endif()
+    if(NOT ARG_ID)
+        message(FATAL_ERROR "mdux_emit_screen_package: ID is required")
+    endif()
+    if(NOT TARGET mdux-screenemit)
+        message(FATAL_ERROR "mdux_emit_screen_package: target mdux-screenemit does not exist")
+    endif()
+
+    if(ARG_PACKAGE)
+        set(package_relative "${ARG_PACKAGE}")
+    else()
+        set(package_relative "generated/screen/${ARG_ID}/package.json")
+    endif()
+    set(package_path "${CMAKE_SOURCE_DIR}/${package_relative}")
+
+    if(NOT EXISTS "${package_path}")
+        message(FATAL_ERROR
+            "mdux_emit_screen_package: ${package_path} does not exist. Compile the screen first.")
+    endif()
+
+    # The id the caller declares and the id the package carries must be the same, because the
+    # filenames are predicted from the first and written from the second. Checked here rather than
+    # left to fail as a missing file: `string(JSON)` reads the artifact CMake already depends on,
+    # and the message can name both values.
+    file(READ "${package_path}" package_text)
+    string(JSON package_id GET "${package_text}" id)
+    if(NOT package_id STREQUAL ARG_ID)
+        message(FATAL_ERROR
+            "mdux_emit_screen_package: ${package_relative} declares id '${package_id}', but was "
+            "registered as '${ARG_ID}'. The generated filenames are derived from the id, so these "
+            "must match.")
+    endif()
+
+    mdux_screen_identifier(identifier "${ARG_ID}")
+
+    # Two adjacent separators map to `__`, which is reserved to the implementation everywhere in a
+    # program. One `_` per separator keeps the mapping injective - collapsing a run would let two
+    # screens claim one filename - so the reserved case is refused rather than rewritten, here and in
+    # identifierForScreen().
+    if(identifier MATCHES "__")
+        message(FATAL_ERROR
+            "mdux_emit_screen_package: id '${ARG_ID}' maps to '${identifier}', which is a reserved "
+            "identifier. Avoid two adjacent separators in a screen id.")
+    endif()
+
+    set(output_dir "${CMAKE_BINARY_DIR}/mdux_generated/screen")
+    set(module_file "${output_dir}/${identifier}.cppm")
+    set(header_file "${output_dir}/${identifier}.hpp")
+
+    # WORKING_DIRECTORY is the repository root and the package path is passed relative to it, as
+    # mdux_emit_shader_package() does, so the provenance comment the emitter writes into the
+    # generated source names a repository path rather than the machine that ran the build. The
+    # generated files are not committed, but two developers' copies should still be identical - an
+    # absolute path in there would defeat a shared compiler cache for no benefit.
+    add_custom_command(
+        OUTPUT "${module_file}" "${header_file}"
+        COMMAND mdux-screenemit "${package_relative}" "${output_dir}"
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        DEPENDS
+            mdux-screenemit
+            "${package_path}"
+        COMMENT "Emitting C++ for screen package ${ARG_ID}"
+        VERBATIM
+    )
+
+    add_custom_target(emit-screen-${ARG_ID} DEPENDS "${module_file}" "${header_file}")
+
+    if(ARG_OUT_MODULE)
+        set(${ARG_OUT_MODULE} "${module_file}" PARENT_SCOPE)
+    endif()
+    if(ARG_OUT_HEADER)
+        set(${ARG_OUT_HEADER} "${header_file}" PARENT_SCOPE)
+    endif()
+    if(ARG_OUT_DIR)
+        set(${ARG_OUT_DIR} "${output_dir}" PARENT_SCOPE)
+    endif()
+endfunction()

--- a/docs/adr/ADR-004-trust-zones-in-cpp.md
+++ b/docs/adr/ADR-004-trust-zones-in-cpp.md
@@ -62,12 +62,22 @@ existing precedent):
    accidental use of SDK-private headers that are reachable only through those targets. It does
    **not** make system-installed headers unreachable: a compiler may still find Vulkan, platform,
    or OS headers in its default search paths.
-2. **A mandatory CI banned-include lint** over governed directories rejects direct inclusion of
-   Vulkan, GLFW, platform, and OS headers. The same lint bans `reinterpret_cast`, `const_cast`,
-   `new `, `malloc`, `<random>`, `std::chrono::*_clock::now`, `std::fma`, `getenv`,
-   `std::filesystem`, and decimal float format specifiers (`%f`, `%g`, `%e`) in evidence-writing
-   code. This check, rather than include-directory isolation alone, enforces the source-level header
-   boundary on machines where those SDKs are installed.
+2. **`mdux-governed-lint`** (`tools/governed-lint/`, CI job `Governed Source Lint`, issue #116)
+   rejects direct inclusion of Vulkan, GLFW, platform and OS headers (GOV009), plus
+   `reinterpret_cast`, `const_cast`, raw `new`/`delete`/`malloc`, `<random>`,
+   `std::chrono::*_clock`, `std::fma`, `getenv`, `std::filesystem`, console streams, `throw`,
+   `try`/`catch` and throwing `.value()`. This check, rather than include-directory isolation
+   alone, enforces the source-level header boundary on machines where those SDKs are installed.
+
+   It scans exactly the sources `CMakeLists.txt` lists for `MduXCore`, parsed out of that block, so
+   a module is enrolled by being registered rather than by a second list someone maintains — and
+   generated code, which lives in the build tree, is excluded by construction. Matching runs on the
+   source with comments and string literals removed, so documentation may discuss the constructs it
+   bans. A line ending `mdux-governed-lint:allow` is a per-line, reviewed exception; there are two
+   in the tree, both the weights-blob `reinterpret_cast` in `src/ml/Runtime.cpp`.
+
+   Decimal float format specifiers in evidence-writing code are `mdux-evidence-lint`'s rule, not
+   this one — ADR-007 owns that boundary.
 3. **Configure-time link-graph assertion.** `cmake/MduXTrustZones.cmake` provides
    `mdux_declare_governed(<target>)`, recording the target in a global property, and
    `mdux_verify_trust_zones()`, called once at the end of the top-level `CMakeLists.txt`, which
@@ -88,8 +98,11 @@ existing precedent):
 
 - Nothing stops a governed module from writing undefined behavior inside its own translation unit.
   There is no `unsafe` keyword and no borrow checker to forbid.
-- `import std;` gives governed code `std::vector`, threads, and file/network I/O. Only the grep
-  lint (item 2) and code review keep those out of a module that should not need them.
+- `import std;` gives governed code `std::vector`, threads, and file/network I/O. Only
+  `mdux-governed-lint` (item 2) and code review keep those out of a module that should not need
+  them. `import std` also has a second cost, found in #116: it makes `-fno-exceptions` unavailable
+  to the governed zone, because GCC records the dialect in each module BMI and CMake synthesises
+  one shared `std` target for the whole build. See ADR-005, "What is enforced".
 - clang-tidy's analysis of C++23 module interface units is immature as of this writing. Run it in
   the Clang CI leg only (once issue #48 re-enables that leg); treat its results as advisory on
   Windows/MSVC.
@@ -122,7 +135,24 @@ evidence, draw-list, and ML modules to it as they land. `mdux.vulkansc.memory` a
 `mdux.vulkansc.objects` remain in the adapter zone — they take `VkDevice` in their public APIs by
 design and are not candidates for `MduXCore`.
 
-## Consequences
+### What allocation means for zone placement (issue #116)
+
+A module that allocates cannot be governed if its allocation failure has to be reported rather than
+terminate the process, because `std::vector` reports that failure by throwing.
+
+`mdux.text.raster` was governed on the argument that a device path might one day need to rasterise,
+which ADR-008 decision 1 would then require to be *that* module rather than a second one. It moved
+to the host-tools zone in #116. It allocates — the coverage accumulator alone can ask for 256 MiB —
+and `rasterise()`'s `noexcept` entry point therefore catches `std::bad_alloc` to turn an
+out-of-memory condition into a diagnostic instead of `std::terminate`. That is correct code, and it
+is not governed code.
+
+The general rule this establishes: **a speculative future device consumer does not justify governed
+placement against a present constraint.** The rasteriser runs once per glyph at build time, its
+only callers are `mdux-textbake` and its tests, and nothing on a device has ever called it. Where a
+module genuinely must be governed *and* must allocate, the pattern is `mdux.ml.runtime`'s — take
+caller-supplied scratch storage and never allocate at all, verified by
+`ml.noheap.symbolScan`.
 
 ### Positive
 - Target usage requirements cannot accidentally propagate native SDK dependencies into governed
@@ -156,9 +186,15 @@ context:
 
 > Governed targets have no declared platform or graphics dependencies; their sources are checked
 > to reject direct inclusion of platform, graphics, and OS headers, are checked by an enforced
-> static-analysis profile, and are covered by determinism tests. This is **not** a claim that
-> governed modules cannot contain undefined behaviour or that compiler system headers are
-> physically inaccessible.
+> static-analysis profile, contain no throw expression — verified at source level on every
+> toolchain and additionally in the emitted objects on GCC/Clang — and are covered by determinism
+> tests. This is **not** a claim that governed modules cannot contain undefined behaviour, that
+> compiler system headers are physically inaccessible, that governed code cannot reach a throwing
+> standard-library helper, or that governed targets can be built with `-fno-exceptions`.
+
+Each clause of that paragraph names a mechanism that runs in CI, and each exclusion names something
+that was checked and found not to hold — see ADR-005's "What is enforced" for the throw-related
+half. Nothing in it is aspirational.
 
 ## References
 - [TrustSC ADR-005: Pure-Rust project boundary and dependency policy](https://github.com/ambroise-leclerc/TrustSC/blob/main/docs/adr/ADR-005-pure-rust-project-boundary-and-dependency-policy.md)
@@ -169,4 +205,7 @@ context:
 ## Approval
 - **Decision Date**: 2026-07-26
 - **Approved By**: Project maintainer
-- **Review Date**: at the next parity-programme epic boundary (issue #12 landing)
+- **Amended**: 2026-08-11 (issue #116) — item 2's banned-include lint exists now and is named;
+  added the allocation-and-zone-placement rule that moved `mdux.text.raster` to host tools; the
+  claim paragraph gained its no-throw clause and its `-fno-exceptions` exclusion.
+- **Review Date**: at the next parity-programme epic boundary (issue #15 landing)

--- a/docs/adr/ADR-004-trust-zones-in-cpp.md
+++ b/docs/adr/ADR-004-trust-zones-in-cpp.md
@@ -128,8 +128,8 @@ correctly rather than on separate target usage requirements plus mandatory sourc
 
 ## Decision (continued): what "governed" will contain
 
-No code moves out of `mdux.cppm` as part of this ADR — it stays an adapter module for now. Issue
-#11 (S7) creates `MduXCore` with initial scaffolding (`mdux.core.units`, `mdux.core.result`) and
+No code moves out of `mdux.cppm` as part of this ADR — it stays an adapter module for now.
+Issue #11 (S7) creates `MduXCore` with initial scaffolding (`mdux.core.units`, `mdux.core.result`) and
 wires up the verification mechanism; later epics (`#12`, `#13`, `#15`, `#18`) add governed schema,
 evidence, draw-list, and ML modules to it as they land. `mdux.vulkansc.memory` and
 `mdux.vulkansc.objects` remain in the adapter zone — they take `VkDevice` in their public APIs by

--- a/docs/adr/ADR-005-error-handling-and-exceptions-policy.md
+++ b/docs/adr/ADR-005-error-handling-and-exceptions-policy.md
@@ -118,8 +118,8 @@ It **tolerates**, and prints on every run, libstdc++'s throw *helpers*: `__throw
 arrive from inside `std::string`, `std::vector` and `std::string_view::substr` — `Json.cpp`'s
 parser and `Governance.cpp`'s id splitting are both of that shape, and in both the caller's
 invariant makes the throw unreachable. Forbidding them means banning those types from the governed
-zone outright, which may be the right end state for a Class C build but is a larger decision than
-#116 and needs its own ADR.
+zone outright, which may be the right end state for a Class C build but is a larger decision
+than #116 and needs its own ADR.
 
 **This layer is a gate on GCC/Clang only, and is informational on MSVC.** The distinction it rests
 on — a literal `throw` emits one symbol, the library's own throw sites emit another — is a property

--- a/docs/adr/ADR-005-error-handling-and-exceptions-policy.md
+++ b/docs/adr/ADR-005-error-handling-and-exceptions-policy.md
@@ -13,8 +13,9 @@ MduX ↔ TrustSC parity programme requires:
   `src/mdux.cpp` was trimmed from 575 lines to 85 in the same change, so any line number here
   would now point at something unrelated. Git history is the reference for what it looked like.
 - `include/mdux/vulkansc/MemoryPoolManager.cppm:100` documents throwing behavior.
-- `.clang-tidy:9` **disables** `bugprone-exception-escape` — the check that would otherwise flag an
-  exception escaping a `noexcept` boundary.
+- `.clang-tidy` **disabled** `bugprone-exception-escape` — the check that would otherwise flag an
+  exception escaping a `noexcept` boundary. Re-enabled by issue #116; see "What is enforced" below
+  for what that is and is not worth.
 
 Separately, ADR-004 introduces a governed zone (`MduXCore`) whose whole purpose is to be usable in
 contexts a Vulkan-linked adapter target is not — including Class C / Vulkan SC deployments that
@@ -38,22 +39,23 @@ regardless of how clean its exception hierarchy is.
 
 | Zone | Rule |
 |---|---|
-| Governed (`MduXCore`) | `std::expected` and `noexcept` throughout. No throwing. |
+| Governed (`MduXCore`) | `std::expected` and `noexcept` throughout. No throwing — see "What is enforced" for the two layers that check this and the one thing they do not cover. |
 | Adapter (`MduX`) | Exceptions permitted at construction boundaries only, never across a `noexcept` render/predict path. |
 | Host tools (`tools/`) | Exceptions freely — they are never shipped, and their code is not qualified. |
 
 **Why `std::expected` and not exceptions, for the governed zone specifically:** Class C and Vulkan
-SC deployments routinely build with `-fno-exceptions`. The non-throwing operations on
+SC deployments routinely build with `-fno-exceptions`. That the governed zone cannot *currently* be
+built that way (see "What is enforced") does not weaken this reasoning — it is what keeps the
+option open, since an exception-based API would foreclose it permanently rather than temporarily.
+The non-throwing operations on
 `std::expected` do not require exception handling, and it is available on MSVC 19.33+, GCC 12+, and
 Clang 16+ — all comfortably below this project's enforced floor of MSVC 19.40 / GCC 15 / Clang 20
 (ADR-003), so adopting it costs nothing in toolchain reach. Throwing observers such as `.value()`
 remain prohibited in governed code.
 
-**Make it a build error, not a review comment.** Compile `MduXCore` (or, at minimum, any future
-`src/ml/` target — see issue #18) with `-fno-exceptions -fno-rtti` / `/EHs-c- /GR-` in its own
-object library. The governed-zone source lint also rejects `throw`, `try`, and `catch`; on MSVC,
-the exception-disabled diagnostics are promoted to errors. A stray throwing construct therefore
-fails the build rather than merely triggering a warning that a busy reviewer can miss.
+**Make it a build error, not a review comment.** A stray throwing construct fails CI rather than
+merely triggering a warning a busy reviewer can miss. What does the failing is described in "What
+is enforced" below, and it is not what this ADR originally specified.
 
 **Error types carry evidence.** A governed-zone error is a struct, not a bare enum, whenever the
 failure has diagnostic content worth keeping — e.g. the planned `MlError` (issue #18) records the
@@ -61,9 +63,93 @@ diverging layer index, golden-vector index, element index, and both the expected
 patterns. That struct is the audit record if a device fails closed in the field; a bare error code
 would discard exactly the information an incident report needs.
 
-**Re-enable `bugprone-exception-escape`** in the governed zone's `.clang-tidy` (see ADR-004) once
-`MduXCore` exists, so a `noexcept` violation is caught by static analysis rather than only at
-runtime or at link time.
+## What is enforced
+
+Added by issue #116, which found this ADR asserting in the present tense a lint that had never been
+written. The list below is exhaustive, and each entry names the file that does the work so a reader
+can check the claim rather than take it.
+
+### The constraint that shaped this
+
+**`import std` and `-fno-exceptions` are mutually exclusive on GCC 16.** This ADR originally
+specified compiling `MduXCore` with `-fno-exceptions -fno-rtti` / `/EHs-c- /GR-`. That is not
+available while the governed zone uses `import std`:
+
+- GCC records the language dialect in every module BMI. A governed module compiled with either flag
+  is rejected against the shared `std` BMI with `language dialect differs 'C++23', expected
+  'C++23/no-exceptions/no-rtti'`. Each flag fails this way on its own, not only in combination.
+- CMake synthesises exactly one `__CMAKE__CXX23` std target for the whole build, shared by the
+  adapter and host-tools targets, which must keep exceptions. There is no per-target std dialect.
+
+A separately built governed-dialect `std` BMI does work when driven by hand, so the constraint is
+the *sharing*, not the flags. Hand-rolling one would displace the most fragile part of this build,
+and was judged not worth it against the alternatives below.
+
+Two consequences worth stating plainly:
+
+1. The "usable in `-fno-exceptions` builds" claim under Consequences is **not currently true**, and
+   is not achievable by any project consuming `MduXCore` through `import std`. It is retained below
+   as the motivation for the `std::expected` API, which it still is, and marked as unmet.
+2. Revisiting this needs either a per-target std dialect from CMake, or the governed zone giving up
+   `import std`. Neither is scheduled.
+
+### The layers that do run
+
+| Layer | Reads | Where | Gates on |
+|---|---|---|---|
+| `mdux-governed-lint` | the source | `tools/governed-lint/`, CI job `Governed Source Lint` | every toolchain |
+| `governed.noThrow.symbolScan` | the emitted objects | `cmake/MduXNoHeapScan.cmake`, a ctest | GCC/Clang; reports only on MSVC |
+| `bugprone-exception-escape` | the AST | `.clang-tidy` | nothing yet — see below |
+
+Only the first is a gate everywhere. That is the honest reading of the table, and the reason the
+source lint rather than the symbol scan is what the no-throw claim rests on.
+
+**`mdux-governed-lint`** rejects `throw`, `try`/`catch`, throwing `.value()`, raw allocation,
+filesystem and console facilities, clocks and randomness, unsafe casts, and `std::fma`. It scans
+exactly the sources `CMakeLists.txt` lists for `MduXCore`, parsed out of that block rather than
+globbed, and matches on the source with comments and string literals removed.
+
+**`governed.noThrow.symbolScan`** sees a throw arriving through a std facility the source never
+spells out, which `-fno-exceptions` would only have caught by refusing to compile the facility. It
+forbids `__cxa_throw` across all 29 governed objects, and none references it.
+
+It **tolerates**, and prints on every run, libstdc++'s throw *helpers*: `__throw_length_error`,
+`__throw_logic_error` and `__throw_out_of_range_fmt`, 14 references across eight objects. They
+arrive from inside `std::string`, `std::vector` and `std::string_view::substr` — `Json.cpp`'s
+parser and `Governance.cpp`'s id splitting are both of that shape, and in both the caller's
+invariant makes the throw unreachable. Forbidding them means banning those types from the governed
+zone outright, which may be the right end state for a Class C build but is a larger decision than
+#116 and needs its own ADR.
+
+**This layer is a gate on GCC/Clang only, and is informational on MSVC.** The distinction it rests
+on — a literal `throw` emits one symbol, the library's own throw sites emit another — is a property
+of libstdc++'s code generation, not a portable one. The MSVC STL inlines its throw sites, so an
+ordinary `std::string` growth path emits `_CxxThrowException` directly into the governed object,
+the identical symbol a hand-written `throw` would emit. Nine governed objects reference it while
+`mdux-governed-lint` confirms none of their sources contains a `throw`.
+
+Forbidding that symbol would fail the build on correct code; tolerating it would forbid nothing. So
+under `dumpbin` the profile forbids nothing, reports what it finds, and its closing message states
+that no verdict is claimed. The rule is still enforced on Windows — by the source lint, which is
+toolchain-independent. What is GCC-specific is only the object-level corroboration, and the
+negative fixture is not registered on MSVC for the same reason.
+
+**`bugprone-exception-escape`** is re-enabled, as this ADR's original follow-up asked, but it is
+*available* rather than *enforced*: the only CI job running clang-tidy invokes it with `|| true`
+against a GCC-generated compile database it cannot parse for module interface units. It becomes a
+real gate when the Clang leg is restored (issue #48).
+
+### What is therefore claimed
+
+Governed code contains no throw expression and no source-level construct from the banned list,
+checked mechanically on every pull request and on every toolchain by `mdux-governed-lint`. On
+GCC/Clang that is independently corroborated in the emitted objects.
+
+Three things are **not** established. Governed code can still reach the standard library's throwing
+helpers through ordinary `std::string` and `std::vector` use. The object-level check does not gate
+on MSVC, so the no-throw property is single-sourced to the source lint there. And `MduXCore` cannot
+currently be compiled with `-fno-exceptions` on any toolchain. Anything stronger than the paragraph
+above is not established.
 
 **`MedicalUiRenderer`'s throwing constructor was grandfathered**, not retrofitted — it lived in the
 adapter zone and was scheduled for deletion with the HTML/CSS UI path rather than for a
@@ -97,12 +183,16 @@ call-site brevity; that is a naming convenience, not a reimplementation.
 ## Consequences
 
 ### Positive
-- The governed zone becomes usable in `-fno-exceptions` builds, which is a prerequisite for taking
-  any Vulkan SC / Class C deployment claim seriously rather than as aspiration.
+- **Unmet.** The governed zone was to become usable in `-fno-exceptions` builds, a prerequisite for
+  taking any Vulkan SC / Class C deployment claim seriously rather than as aspiration. `import std`
+  blocks it — see "The constraint that shaped this". The `std::expected` API is still the right
+  shape for that goal, and is what makes it reachable if the constraint ever lifts, but the goal is
+  not reached today.
 - Structured error types double as incident-evidence records, which is directly useful for the
   fail-closed patterns already planned for `.medui` compilation and ML inference.
-- The exception-disabled object library turns throwing constructs into build failures, closing the
-  gap left by `.clang-tidy:9` currently disabling the one check that would otherwise catch this.
+- A throwing construct fails CI — through `mdux-governed-lint` at the source level and
+  `governed.noThrow.symbolScan` at the object level, rather than through the exception-disabled
+  object library this ADR first proposed.
 
 ### Negative
 - Two error-handling idioms coexist in the codebase: the host-tools zone throws (the TOML parser
@@ -113,13 +203,22 @@ call-site brevity; that is a naming convenience, not a reimplementation.
   happy-path case — an accepted cost given the deployment constraint that motivates this decision.
 
 ### Risks and Mitigations
-- **A future governed-zone PR quietly adds a `throw`.** *Mitigation*: the exception-disabled object
-  library makes this a compile failure, not a style question.
+- **A future governed-zone PR quietly adds a `throw`.** *Mitigation*: `mdux-governed-lint` rejects
+  the construct and `governed.noThrow.symbolScan` rejects the resulting `__cxa_throw` reference.
+  Two independent layers, both required to pass, neither able to see everything the other does.
 - **`std::expected` gets used inconsistently** (some call sites check it, others `.value()` it and
-  risk termination when the expected is empty). *Mitigation*: the governed-zone CI lint rejects
-  `.value()`; callers must branch on `has_value()`/`operator bool` and then use non-throwing
-  accessors. The re-enabled `bugprone-exception-escape` check remains defense in depth for other
-  exception paths.
+  risk termination when the expected is empty). *Mitigation*: `mdux-governed-lint` rejects
+  `.value()` (GOV003); callers must branch on `has_value()`/`operator bool` and then use
+  non-throwing accessors.
+- **A governed module reaches a throwing std facility on a path that is actually taken.** The
+  tolerated `__throw_*` helper references are believed unreachable because of caller invariants,
+  and that belief is not mechanically checked. *Mitigation*: none today, stated rather than
+  papered over. The scan prints all 14 references on every run so they stay counted, and the ADR
+  that decides whether to ban `std::string` and `std::vector` from the governed zone is the
+  place to resolve it.
+- **A module is added to `MduXCore` and the lint does not notice.** *Mitigation*: the lint derives
+  its file list from the `target_sources(MduXCore ...)` block, so registering the module is what
+  enrols it. There is no second list to forget.
 
 ## References
 - [TrustSC ADR-001 through ADR-003](https://github.com/ambroise-leclerc/TrustSC/tree/main/docs/adr) (the text/font pipeline's fail-closed self-test pattern this policy is modeled on)
@@ -129,4 +228,9 @@ call-site brevity; that is a naming convenience, not a reimplementation.
 ## Approval
 - **Decision Date**: 2026-07-26
 - **Approved By**: Project maintainer
-- **Review Date**: when `MduXCore` first ships a public API (issue #11, S7)
+- **Amended**: 2026-08-11 (issue #116) — added "What is enforced", recording that `import std`
+  blocks the `-fno-exceptions` build this ADR specified, and replacing the never-written
+  exception-disabled object library with the two layers that do run.
+- **Review Date**: when either CMake gains a per-target `import std` dialect or the governed zone
+  stops using `import std`, whichever comes first — both would reopen the `-fno-exceptions`
+  question this ADR had to leave unmet.

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -111,7 +111,7 @@ parity programme's direction is MduX moving toward it.
 
 **A compiled screen is locale-free.** It carries no locale field and no glyph runs. Per-locale
 glyph runs stay in the text package where ADR-010 already put them, and the two are joined on device
-by looking each node's `text_key` up for the running locale. TrustSC does exactly this in
+by looking each node's `textKey` up for the running locale. TrustSC does exactly this in
 `ScreenTextLayout::from_screen(screen, package, locale)`.
 
 The consequence that decides it: **adding an approved locale touches no screen artifact at all.**
@@ -137,8 +137,32 @@ and `governed.noThrow.symbolScan` hold the runtime to that.
 the `medui-authoring` skill, stated here because ADR-012 depends on the same predicate: a
 `@safety_critical` node emits an entry, and **any** node with an explicit `position:` emits a
 `Bounds` entry whether annotated or not, because a declared position is a safety-relevant claim by
-itself. A node matching both rules emits exactly one merged entry with deduplicated `cv_checks`,
+itself. A node matching both rules emits exactly one merged entry with deduplicated `cvChecks`,
 never two. #196 implements this and ADR-012's `goldens.json` carries the result.
+
+**Amended: the emitted members are `nodeId`, `bounds`, `textKey`, `colorToken`, `cvChecks`.** An
+earlier revision of this ADR spelled them `node_id`, `text_key`, `color_token` and `cv_checks`, and
+that spelling was a transcription of TrustSC's *Rust identifiers* rather than a decision about a file
+format. Two facts settle it the other way, and both were checked rather than assumed:
+
+- **TrustSC emits no screen JSON at all.** Its `CompiledScreenPackage` derives `Clone, Copy, Debug,
+  Eq, PartialEq` and no `Serialize`, and its repository holds no `generated/screens/*/package.json` —
+  a compiled screen there is generated Rust source. There is therefore no sibling file for these
+  member names to match, and no parity is given up by choosing them freely.
+- **Every committed MduX package is camelCase** — `byteLength`, `occupancyPercent`, `advanceWidth`,
+  `codePoint` — across the three kinds that have committed artifacts today: font, shader and model
+  (`generated/font/`, `generated/shader/`, `generated/model/`). The text pipeline uses the same
+  convention in `mdux.text.schema` and `mdux-textbake`, but commits no package, so it is implemented
+  machinery rather than evidence and is named here as such. The repository's own tooling schema
+  (`fixHint`, `filesChecked`) is camelCase too. A screen directory holding `package.json`,
+  `report.json` and `goldens.json` in two conventions would make #16's verifier, which reads two of
+  the three, carry two vocabularies for no gain.
+
+The parity that *is* achievable here is the field vocabulary and the file structure, and both are
+unaffected: the same five facts per entry, under names a C++ reader spells the way this repository
+spells every other artifact. Decided before the first bake deliberately, because renaming a member
+of a committed, byte-compared artifact afterwards is a `schemaVersion` bump and a rebake of every
+screen.
 
 Concretely:
 

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -3,6 +3,13 @@
 ## Status
 Accepted (2026-08-11)
 
+## Shared decision identity
+
+This local C++ decision implements
+[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d/decisions/MEDUI-DEC-001-build-time-compilation.md)
+and the bounded-language portion of `MEDUI-DEC-002`. Its ADR number remains permanent and local;
+cross-repository citations use the shared identity.
+
 ## Context
 
 `.medui` is to become the single authored UI source for MduX (issue #15). The decision this record

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -6,7 +6,7 @@ Accepted (2026-08-11)
 ## Shared decision identity
 
 This local C++ decision implements
-[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d/decisions/MEDUI-DEC-001-build-time-compilation.md)
+[`MEDUI-DEC-001`](https://github.com/Compliatory/MedUI/blob/d5136a8518bd499760ecff2aad215d3721329f20/decisions/MEDUI-DEC-001-build-time-compilation.md)
 and the bounded-language portion of `MEDUI-DEC-002`. Its ADR number remains permanent and local;
 cross-repository citations use the shared identity.
 

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -1,0 +1,261 @@
+# ADR-011: The deterministic `.medui` compile boundary
+
+## Status
+Accepted (2026-08-11)
+
+## Context
+
+`.medui` is to become the single authored UI source for MduX (issue #15). The decision this record
+fixes is not the grammar — that is described in the `medui-authoring` skill and settled by the
+parser in #192 — but **where the work happens**: which stages run on a build machine and which, if
+any, may run on a device.
+
+Three things in the tree already constrain the answer, and they are the reason this ADR can be
+narrow.
+
+**The draw layer already exists and already assumes this decision.** `mdux.draw`'s `DrawBudget`
+carries the comment "Computed once by the `.medui` compiler for a screen (#15) and baked, so the
+storage a device needs is known before the device runs." A `DrawList` is built over caller-owned
+storage sized from that budget and never grown. A compiler that could not compute the budget at
+build time would leave that type with no way to be used as designed.
+
+**Text shaping is already forbidden on device.** ADR-010 settled that static text bakes to
+positioned glyph runs and dynamic text is restricted to a validated charset. A `.medui` runtime
+that resolved `t("STR-KEY")` itself would reopen the question ADR-010 closed.
+
+**The governed zone is a hostile place to put a parser.** ADR-004 keeps `MduXCore` on `std` alone,
+and issue #116 made ADR-005's no-throwing rule mechanical — `mdux-governed-lint` rejects
+`throw`/`try`/`catch`, `.value()`, raw allocation and filesystem or console access in governed
+source on every toolchain. That rules out the usual shape of a parser outright. It does not rule
+out every shape: a non-allocating, non-throwing reader over a span would pass all of those rules,
+and neither ADR-004 nor ADR-005 names parsing as such. The case against that residual shape is
+argued rather than enforced, under Alternative 2 below. Either way, a parser over untrusted input
+that must report failure without throwing, without allocating, and without a filesystem is a very
+different program from one that may do all three. The host-tools zone exists for the second kind.
+
+What is *not* yet settled, and what this ADR therefore has to state rather than assume, is whether
+the compiled result is a data blob a governed runtime interprets, or generated source a compiler
+consumes. That choice determines whether a device build links a parser at all.
+
+## Medical Device Considerations
+
+### IEC 62304 implications (software lifecycle)
+- **Verification moves left.** A screen whose layout, text budgets and colour tokens are resolved at
+  build time can be rejected by a build, and a build failure is an artifact of the development
+  process rather than a field observation. A screen resolved at runtime can only be verified by
+  running it, on every input that changes it.
+- **The device's software items shrink.** A runtime containing no parser, no layout solver and no
+  shaper has fewer items to verify, and the items it does have are simpler to argue about.
+
+### IEC 62366 implications (usability engineering)
+- A text budget checked against **every** approved locale at build time is a usability control that
+  cannot silently regress when a translation is updated: the update either fits or the build stops.
+  Deferring the check to runtime turns an overflowing label into a field defect.
+
+### Risk management
+- Unbounded runtime allocation driven by document content is a hazard class this boundary removes
+  outright rather than mitigates. A screen that does not fit its budget fails to compile.
+- The residual risk this boundary creates is stated under Consequences: a screen cannot change
+  without a rebuild, so a deployed device cannot be corrected by editing a file.
+
+### Traceability
+- `requirement:` on a component is resolved at compile time, so the requirement-to-node mapping is a
+  build output rather than a claim in prose. #196 makes safety-critical nodes emit golden references
+  carrying that mapping.
+
+## Decision
+
+**Every stage from source text to positioned, budgeted layout runs on the build machine. The
+device runtime performs none of them, and turns that layout into vertices.**
+
+| Stage | Where | Zone |
+|---|---|---|
+| Lex, parse, build AST | build machine | host tools |
+| Resolve theme tokens to literal RGBA8, and text keys to baked glyph runs | build machine | host tools |
+| Solve layout, flatten `Row`, compute absolute rectangles | build machine | host tools |
+| Validate text budgets against every approved locale | build machine | host tools |
+| Compute the `DrawBudget` | build machine | host tools |
+| Emit golden references (see rule below) | build machine | host tools |
+| **Build a `DrawList` from a compiled screen** | **device** | **governed** |
+
+*Layout*, not *geometry*: the compiler produces rectangles, colours and budgets, and the runtime
+produces vertices and indices from them. ADR-012 decision 2 explains why the vertex data cannot be
+baked. Both records use the word this way, and neither uses "geometry" for the compiled form.
+
+**Resolved means literal, not looked up.** A `Theme.Colors.<Token>` becomes an RGBA8 value in the
+package, not a token name the runtime resolves against a table; a `t("STR-KEY")` becomes the baked
+glyph run for that locale, not a key the runtime looks up. The authoring names are retained
+*alongside* the resolved values — for diff readability, for the golden references, and for
+diagnostics — but nothing on the device reads them to decide what to draw. A runtime holding an
+unresolved token would be performing the last step of a resolution this ADR places on the build
+machine, which is the boundary being drawn rather than a detail of it.
+
+Baking the glyph runs makes *which locale* a property of the artifact rather than of the running
+device, and this ADR does not settle whether one compiled screen carries every approved locale or
+whether there is one per locale. Colours have no such multiplicity; text does, because the budget
+row above validates against every approved locale. ADR-012 decision 1 owns the file layout and
+records the question against #197 and #198.
+
+**Golden references cover safety-critical nodes and explicitly-positioned ones.** Two rules from
+the `medui-authoring` skill, stated here because ADR-012 depends on the same predicate: a
+`@safety_critical` node emits an entry, and **any** node with an explicit `position:` emits a
+`Bounds` entry whether annotated or not, because a declared position is a safety-relevant claim by
+itself. A node matching both rules emits exactly one merged entry with deduplicated `cv_checks`,
+never two. #196 implements this and ADR-012's `goldens.json` carries the result.
+
+Concretely:
+
+1. **The compiler is host-only.** It lives under `tools/medui/`, is registered on a host-tools
+   target, and is deliberately not declared governed — the same arrangement as `mdux-shaderbake`,
+   `mdux-mlbake` and `mdux-textbake`. It parses untrusted input and may throw and allocate freely,
+   because nothing it contains reaches a device.
+
+2. **The schema is governed and shared.** A single `mdux.medui.schema` module defines the compiled
+   screen, imported by both the host compiler that writes one and the device runtime that reads
+   one. This is ADR-008 decision 1 applied to screens: not a discipline that two implementations be
+   kept in step, but one definition that cannot drift from itself. #197 builds the module; no such
+   module is in the tree today, and ADR-012 decision 3 records what it must satisfy.
+
+3. **The compiled screen is `constexpr`-constructible over spans, and contains no parser.** It is
+   the shape `mdux.ml.schema`'s `ModelPackage` already has, for the same reason — a device with no
+   filesystem must be able to hold one in `.rodata` and validate it at compile time.
+
+4. **The governed runtime's whole job is `compiled screen + scratch storage -> DrawList`.** It
+   allocates nothing, throws nothing, and reads no file. It is `mdux.ml.runtime`'s `predict()` in a
+   different domain, and #199 builds it into `MduXCore` so that `mdux-governed-lint` and
+   `governed.noThrow.symbolScan` cover it without a second registration.
+
+5. **The language is restricted so that the budget is computable.** Loops, conditionals, recursion
+   and runtime scripting are rejected by the parser with a diagnostic, because each of them makes
+   the number of primitives depend on something the compiler cannot see, and a `DrawBudget` that
+   cannot be computed exactly is not a budget. Nested `Row` is rejected too, but for a different
+   reason and it should not be defended with this one: its depth is fully visible to the compiler
+   and the primitive count stays exact either way. It is excluded to keep the layout solver a
+   single flattening pass over a known structure — a solver argument, not a budget one — and the
+   `medui-authoring` skill already publishes the restriction.
+
+6. **Layout arithmetic is integer-only.** The compiled output is committed and byte-compared across
+   toolchains under ADR-007, so a float in the solver would make the artifact a property of the
+   compiler's code generator. `mdux.text.raster` took this position for the same reason and it held.
+
+## Alternatives Considered
+
+### 1. Interpret `.medui` on the device (Rejected)
+**Pros:** A screen could be replaced without rebuilding; one artifact instead of a compile step;
+matches how the deleted HTML/CSS path was shaped.
+**Cons:** Puts a parser over untrusted input inside the governed zone. An interpreter's usual shape
+— throwing on malformed input, allocating an AST — is rejected outright by `mdux-governed-lint`
+since issue #116; the shape that would survive the lint is rejected on the argument the next
+alternative makes. Makes memory use a function of document content, so `DrawBudget`
+stops being knowable ahead of time and the bounded-storage design of `mdux.draw` has no basis.
+Moves every check this ADR pulls forward — locale coverage, text budgets, unknown colour tokens —
+into runtime failures on a device.
+
+### 2. Compile at build time, but ship the result as data a governed parser reads (Rejected)
+**Pros:** One committed artifact; no generated source in the build; a screen could in principle be
+swapped without recompiling the application.
+**Cons:** "Parser" is the operative word — a JSON or binary reader in the governed zone is still a
+reader over external input, with the failure modes and the verification burden that implies. It is
+also the arrangement #153 was opened to *undo* for ML packages, where the device currently links a
+host-tools module to parse `package.json` at startup. Adopting for screens the shape ML is trying
+to leave would be a decision made twice in opposite directions.
+
+Note that this is rejected as the *only* mechanism, not as a capability. ADR-012 keeps a canonical
+JSON package as the committed evidence artifact; what is rejected is a device reading it.
+
+### 3. A general-purpose language subset rather than a restricted grammar (Rejected)
+**Pros:** Familiar to authors; expresses data-dependent screens directly; less compiler work to
+say no to things.
+**Cons:** A conditional or a loop makes the primitive count depend on data the compiler does not
+have, so the budget becomes an upper bound someone has to guess. Guessed budgets are either wasteful
+or wrong, and a wrong one fails on the frame that exceeds it — on a device, in the field. The
+restriction is what makes the guarantee exact rather than probable.
+
+### 4. Generate C++ only, with no schema module shared with the runtime (Rejected)
+**Pros:** Fewer modules; the generated source can be shaped freely for each screen.
+**Cons:** The runtime would need its own definition of what a screen is, and two definitions of the
+same structure drift — quietly, and in the direction that the tests happen not to cover. ADR-008
+made the opposite choice for ML kernels and the golden vectors exist to detect the case where it
+fails; there is no reason to relitigate it here.
+
+## Consequences
+
+### Positive
+- `DrawBudget` becomes computable exactly, which is what `mdux.draw`'s bounded storage was designed
+  against and has so far only been supplied by hand.
+- Locale coverage, text overflow, unknown colour tokens and missing `requirement:` fields become
+  build failures. Each is a class of defect that currently has no mechanism at all.
+- A device build links no compiler, no parser, and no host-tools module for screens. The trust-zone
+  claim is structural rather than conventional.
+- The compiled screen is byte-comparable across toolchains, so it can carry the same
+  two-toolchain evidence argument the shader, model and font packages already carry.
+
+### Negative
+- **No hot reload, and no field-editable screens.** Changing a screen requires recompiling and
+  redeploying the application. The deleted HTML/CSS path had a file watcher; nothing here replaces
+  it, and nothing is planned to. This is the price of the budget guarantee and it is accepted
+  knowingly.
+- **Data-dependent structure cannot be expressed.** A screen showing a variable number of rows must
+  be authored with the maximum number and hide the unused ones. That is more work for an author and
+  it wastes budget in the common case.
+- **Authoring feedback requires a build**, until #200's `mdux-medui-check` gives a single-file path.
+  Until then a typo in a colour token is found by a compile rather than by an editor.
+
+### Risks
+- **The restriction is worked around rather than accepted** — for instance by generating `.medui`
+  from a script, reintroducing data-dependence one level up. *Mitigation*: none mechanical, and
+  stated plainly here rather than implied. A generated `.medui` is still compiled and still budgeted,
+  so the guarantee holds; what is lost is the reviewability of the authored source, which is a
+  review concern rather than a runtime one.
+- **The governed runtime grows toward being an interpreter** as components accumulate in #17.
+  *Mitigation*: `mdux-governed-lint` rejects allocation and filesystem access in governed source,
+  and the rule to apply in review is that the runtime may compute vertices from a compiled screen
+  and may not compute *structure*. Neither of those is a bound on work, which is the next item.
+- **Nothing yet bounds the runtime's frame cost, and no test would catch it if that changed.**
+  Raised in review of this ADR, and worth stating precisely because the neighbouring guarantees
+  make it easy to assume otherwise: a no-heap test proves the runtime does not allocate, which is
+  not termination and not a bound on iteration.
+
+  The *invariant* is available and follows from the decision above: a compiled screen has a fixed
+  node count and a `DrawBudget` whose `maxVertices`, `maxIndices` and `maxCommands` are computed at
+  build time, and every `DrawList` operation fails closed once a budget is exhausted. A runtime that
+  iterates only over the package's nodes and only writes through `DrawList` therefore performs work
+  bounded by numbers that are known before the device runs, and the restriction on loops and
+  recursion in the source language is what keeps those numbers finite.
+
+  What does not exist is any mechanism holding the runtime to that invariant. It is not enforced by
+  the schema, and no test asserts a maximum frame cost. *Owner*: #199, which builds the runtime, and
+  which should either encode the bound in the schema — a declared maximum work figure the runtime
+  asserts against — or record that it did not. This ADR does not decide which; it records that the
+  guarantee is currently an argument rather than a check, so that #199 cannot inherit it as settled.
+  If #199 takes the schema route, the field belongs to #197: `mdux.medui.schema` is #197's module
+  and `package.json` is a committed, byte-compared artifact, so adding a field afterwards is a
+  schema version bump and a rebake of every screen. #197 should reserve it or decline it knowingly.
+- **Two definitions of a screen appear anyway**, one in the emitter and one in the schema.
+  *Mitigation*: #197 requires a test that compiles both emitted forms in one binary and asserts they
+  describe the same screen, which is what `shader_spec` already does for shaders.
+
+## Implementation Notes
+
+- Module names follow the existing dotted-lowercase convention: `mdux.medui.schema` (governed),
+  `mdux.medui.screen` (governed runtime, #199), `mdux.tools.meduic` (host compiler, #198).
+- The compiler's diagnostics use the shared envelope from #118 and the code registry from #191.
+- Nothing in this ADR is implemented at the time it is accepted. It is written first deliberately —
+  #190 is the first child of #15 — so that the stages that follow are applications of a recorded
+  decision rather than a decision assembled from whatever the code turned out to do. Every
+  mechanism named above is marked with the issue that will build it; none of them exists yet.
+
+## References
+- ADR-004: Trust zones in C++ — the governed/adapter/host-tools boundary this decision is scoped by
+- ADR-005: Error handling and exceptions policy — why a parser cannot live in the governed zone
+- ADR-007: Evidence pipeline doctrine — the committed-artifact model ADR-012 applies to screens
+- ADR-008: Zero-SOUP ML inference — decision 1, the shared-schema pattern this reuses
+- ADR-010: No on-device text shaping — the text half of the same boundary
+- [TrustSC ADR-001 through ADR-003](https://github.com/ambroise-leclerc/TrustSC/tree/main/docs/adr) — the sibling project's compiled-screen model
+- Issue #15 and its children #190-#201
+
+## Approval
+- **Decision Date**: 2026-08-11
+- **Approved By**: Project maintainer
+- **Review Date**: when #201 lands the first end-to-end screen — the first point at which this
+  boundary has been exercised rather than only described

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -20,8 +20,11 @@ storage sized from that budget and never grown. A compiler that could not comput
 build time would leave that type with no way to be used as designed.
 
 **Text shaping is already forbidden on device.** ADR-010 settled that static text bakes to
-positioned glyph runs and dynamic text is restricted to a validated charset. A `.medui` runtime
-that resolved `t("STR-KEY")` itself would reopen the question ADR-010 closed.
+positioned glyph runs and dynamic text is restricted to a validated charset. A `.medui` runtime that
+*shaped* `t("STR-KEY")` — chose glyphs, applied substitutions, measured — would reopen the question
+ADR-010 closed. Looking a key up to find the run ADR-010 already baked does not: the shaping
+happened on the build machine either way, and the lookup is a bounded scan of a fixed table. That
+distinction is what lets the Decision below keep keys in the package rather than baked runs.
 
 **The governed zone is a hostile place to put a parser.** ADR-004 keeps `MduXCore` on `std` alone,
 and issue #116 made ADR-005's no-throwing rule mechanical — `mdux-governed-lint` rejects
@@ -40,7 +43,8 @@ consumes. That choice determines whether a device build links a parser at all.
 ## Medical Device Considerations
 
 ### IEC 62304 implications (software lifecycle)
-- **Verification moves left.** A screen whose layout, text budgets and colour tokens are resolved at
+- **Verification moves left.** A screen whose layout is solved, whose text budgets are checked and
+  whose colour tokens and text keys are *validated* at
   build time can be rejected by a build, and a build failure is an artifact of the development
   process rather than a field observation. A screen resolved at runtime can only be verified by
   running it, on every input that changes it.
@@ -71,30 +75,56 @@ device runtime performs none of them, and turns that layout into vertices.**
 | Stage | Where | Zone |
 |---|---|---|
 | Lex, parse, build AST | build machine | host tools |
-| Resolve theme tokens to literal RGBA8, and text keys to baked glyph runs | build machine | host tools |
+| Validate theme tokens and text keys against every approved locale | build machine | host tools |
 | Solve layout, flatten `Row`, compute absolute rectangles | build machine | host tools |
 | Validate text budgets against every approved locale | build machine | host tools |
 | Compute the `DrawBudget` | build machine | host tools |
 | Emit golden references (see rule below) | build machine | host tools |
 | **Build a `DrawList` from a compiled screen** | **device** | **governed** |
 
-*Layout*, not *geometry*: the compiler produces rectangles, colours and budgets, and the runtime
-produces vertices and indices from them. ADR-012 decision 2 explains why the vertex data cannot be
-baked. Both records use the word this way, and neither uses "geometry" for the compiled form.
+*Layout*, not *geometry*: the compiler produces rectangles, budgets and the validated token and key
+*names* each node draws with, and the runtime produces vertices and indices from them. ADR-012
+decision 2 explains why the vertex data cannot be baked. Both records use the word this way, and
+neither uses "geometry" for the compiled form.
 
-**Resolved means literal, not looked up.** A `Theme.Colors.<Token>` becomes an RGBA8 value in the
-package, not a token name the runtime resolves against a table; a `t("STR-KEY")` becomes the baked
-glyph run for that locale, not a key the runtime looks up. The authoring names are retained
-*alongside* the resolved values — for diff readability, for the golden references, and for
-diagnostics — but nothing on the device reads them to decide what to draw. A runtime holding an
-unresolved token would be performing the last step of a resolution this ADR places on the build
-machine, which is the boundary being drawn rather than a detail of it.
+**Resolution is validated at build time; the last substitution is a bounded table lookup.** A
+`Theme.Colors.<Token>` and a `t("STR-KEY")` are both *checked* by the compiler — an unknown token
+is a compile error, and a key missing from any approved locale is a compile error naming the locale
+— and both are then carried into the package **as names**, resolved on device against a governed
+table.
 
-Baking the glyph runs makes *which locale* a property of the artifact rather than of the running
-device, and this ADR does not settle whether one compiled screen carries every approved locale or
-whether there is one per locale. Colours have no such multiplicity; text does, because the budget
-row above validates against every approved locale. ADR-012 decision 1 owns the file layout and
-records the question against #197 and #198.
+An earlier draft of this ADR required the opposite: RGBA8 values and baked glyph runs in the screen
+package, on the argument that a runtime holding a token would be "performing the last step of a
+resolution this ADR places on the build machine". That argument was definitional rather than
+consequential, and it is withdrawn. What this boundary exists to keep off the device is *parsing*
+and *unbounded work*; a lookup in a fixed, governed table is neither. The sibling project reached
+this conclusion first — `resolve_color_token()` and `THEME_COLORS` are in TrustSC's governed
+`trustsc-ui` crate, and its `CompiledScreenPackage` carries `text_key` and `color_token` — and the
+parity programme's direction is MduX moving toward it.
+
+**A compiled screen is locale-free.** It carries no locale field and no glyph runs. Per-locale
+glyph runs stay in the text package where ADR-010 already put them, and the two are joined on device
+by looking each node's `text_key` up for the running locale. TrustSC does exactly this in
+`ScreenTextLayout::from_screen(screen, package, locale)`.
+
+The consequence that decides it: **adding an approved locale touches no screen artifact at all.**
+The alternative — one screen package per locale, carrying baked runs — would add a file and an
+`evidence.screen.<id>` per locale, and would rebake every screen when a translation changed.
+Translations change far more often than layouts, and coupling the two makes the frequent change
+rewrite the stable artifact.
+
+**The cost of choosing this way, stated as a cost.** A locale-free screen does not know which locale
+it will be paired with, so its `DrawBudget` has to cover the widest approved translation — and a
+device shipping only `en-US` carries the German or Finnish ceiling in its buffers. Per-locale
+packages would size each budget to its own locale, and that is their one real advantage; it is
+given up deliberately. Buffer headroom is cheap and recoverable, while a translation update that
+rewrites every screen's digest is neither.
+
+Two things this does *not* relax. The compiler still validates every key against every approved
+locale, and still validates text budgets against the widest approved translation (#195) — that work
+does not move to the device just because the substitution does. And the lookup must be a bounded
+scan of a fixed table with a `Result` on miss, never an allocation or a throw; `mdux-governed-lint`
+and `governed.noThrow.symbolScan` hold the runtime to that.
 
 **Golden references cover safety-critical nodes and explicitly-positioned ones.** Two rules from
 the `medui-authoring` skill, stated here because ADR-012 depends on the same predicate: a

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -6,7 +6,7 @@ Accepted (2026-08-11)
 ## Shared decision identity
 
 This record is MduX's C++ and evidence-format realization of
-[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
+[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/d5136a8518bd499760ecff2aad215d3721329f20/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
 and `MEDUI-DEC-004`. The shared records define meaning; this ADR remains authoritative for
 canonical JSON, generated C++ modules/headers, and MduX's committed artifact layout.
 

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -1,0 +1,238 @@
+# ADR-012: What a compiled screen emits, and which parts are committed
+
+## Status
+Accepted (2026-08-11)
+
+## Context
+
+[ADR-011](ADR-011-deterministic-medui-compile-boundary.md) fixes *where* the work happens: every
+stage from `.medui` source to positioned, budgeted layout runs on the build machine, and the
+governed runtime only turns a compiled screen into a `DrawList`. This record fixes *what crosses
+that boundary* — the files the compiler writes, which of them are committed and byte-compared, and
+what the generated C++ contains.
+
+Three precedents already exist in the tree and the question is largely whether screens differ from
+them.
+
+**Bakes commit, emissions do not.** `cmake/MduXShaderEmit.cmake` states the rule its way: a bake
+produces a committed artifact and gets a byte-comparison test; an emission produces a build artifact
+and gets none, "because the bytes it renders are already byte-compared as `package.json` and
+`shaders.spv`." Registering an emission as a bake "would claim a second, redundant piece of
+evidence." All three existing packages follow the bake half — `generated/<kind>/<id>/` holds
+`package.json`, `report.json` and a payload. Only shaders follow the emit half:
+`mdux_emit_shader_package()` is the tree's one emitter, and the `.cppm`/`.hpp` rendering it
+produces lands in the build tree only. Model and font have no generated-source rendering yet — the
+ML example still links a host-tools module to parse `package.json` at startup, which is the
+arrangement #153 is open to undo. Screens take the shader shape from the start rather than
+arriving at it.
+
+**The two-form emitter is settled.** `<binary>/mdux_generated/<kind>/<identifier>.cppm` plus a
+`.hpp` carrying the same data, for consumers that cannot import a named module.
+
+**Canonical JSON is settled.** ADR-007 encodes floats as bit patterns because decimal float text is
+not byte-identical across MSVC, glibc and libc++, and the pipeline crosses all three.
+
+What is genuinely open for screens, and what this ADR therefore has to decide rather than inherit:
+whether the baked payload is *geometry* or *layout*, and where the golden references for
+safety-critical nodes live.
+
+## Medical Device Considerations
+
+### IEC 62304 implications (software lifecycle)
+- A committed, byte-compared screen package is a configuration item with a digest. "Which screen was
+  in this build" becomes answerable from the repository rather than from a build log.
+- The bake report records `toolVersion` — the project's semantic version, bumped deliberately and
+  manually (ADR-007 decision 5) — so a screen regenerated after a deliberate release of the
+  compiler tooling is visible as a diff rather than as identical bytes with a different provenance.
+  It deliberately does not record the host C++ compiler or a commit hash: ADR-007 decision 6
+  requires MSVC, GCC and Clang to produce the same bytes, so build-dependent provenance inside a
+  byte-compared artifact would fail `evidence.screen.<id>` on one leg.
+
+### Risk management
+- The golden references this ADR places in a committed sidecar are the input to #16's rendered-truth
+  verification. Committing them means the *expected* position and tint of safety-critical content is
+  reviewable in a pull request, not derived at verification time from the same source that produced
+  the thing being verified.
+
+### Traceability
+- `requirement:` strings resolved by the compiler appear in the committed package, so the
+  requirement-to-node mapping is diffable.
+
+## Decision
+
+### 1. Three files per screen, under `generated/screen/<id>/`
+
+| File | Committed | Contents |
+|---|---|---|
+| `package.json` | yes | the compiled screen: resolved nodes, absolute rectangles, `DrawBudget`, literal RGBA8 colours, baked glyph runs, requirement ids — plus the authoring names each resolved value came from |
+| `goldens.json` | yes | one golden reference per node matching ADR-011's predicate: `@safety_critical`, or an explicit `position:`, or both merged into one entry (#196). Always written, as `[]` when a screen matches no node |
+| `report.json` | yes | the ADR-007 bake report: inputs, digests, tool version |
+
+The colour and text columns are **resolved values, not lookups** — ADR-011 fixes that boundary, and
+the distinction matters here because a package carrying only a token name would oblige the runtime
+to resolve it. The authoring names ride along beside the resolved values so that a diff is readable
+and a golden reference can name what an author wrote, but nothing on the device reads them.
+
+Canonical JSON throughout, written through `mdux.evidence.json`. Registered via
+`mdux_bake_artifact()`, so each screen gets a build-tree bake, an `-update` target and an
+`evidence.screen.<id>` byte-comparison test on both toolchain legs. Two consequences of registering
+that way, both binding on #198:
+
+- **All three files are unconditional outputs.** `mdux_bake_artifact()` declares each entry as an
+  `add_custom_command` OUTPUT, so a baker that skips `goldens.json` for a screen with nothing to
+  pin breaks the build and the comparison test. Hence the empty array above rather than no file.
+- **`<id>` is a slug, not the screen name.** `mdux_bake_artifact()` `FATAL_ERROR`s unless the kind
+  and id match `^[a-z0-9][a-z0-9-]*$` (`cmake/MduXBake.cmake:95-100`), while a screen's identity in
+  the grammar is CamelCase — `Screen NeuroSense500`. The compiler therefore derives the directory
+  slug from the screen name rather than using it, and the mapping has to be injective and recorded
+  in the recipe, since two screens differing only in case would otherwise collide.
+
+**Open: whether locales multiply this layout.** Since the package carries baked glyph runs rather
+than text keys, one screen with three approved locales is either one package holding all three or
+three packages. The layout above assumes the former and does not argue for it; `mdux.text.schema`'s
+`TextPackage` took the latter shape — a single `locale` field, "the runtime reads no others"
+(`include/mdux/text/Schema.cppm:145`). #197 settles it when it defines the schema and #198 when it
+lays out `generated/screen/`; whichever is chosen, the `evidence.screen.<id>` id has to stay unique,
+which is the constraint that makes this a layout question rather than a schema detail.
+
+### 2. The payload is **layout, not geometry**
+
+The package carries resolved rectangles, the budget, and the identity of what each node draws. It
+does **not** carry vertices and indices.
+
+This is the one place screens genuinely differ from shaders, models and fonts, all of which bake a
+finished binary payload. A screen cannot: `NumericDisplay`, `SignalTrace`, `StatusIndicator` and
+`Clock` all draw from live data, so their geometry does not exist until the frame does. Baking
+vertices would mean baking only the static subset and computing the rest anyway — two mechanisms
+where one suffices, and a budget split across both.
+
+What is fixed at compile time is everything that makes the runtime's job bounded: *where* each node
+is, *how much* it may draw, and *which* atlas entries it may use — in the resolved form decision 1
+fixes, so the colours are RGBA8 values rather than tokens awaiting a lookup. Turning that into
+vertices is arithmetic over a known bound, which is exactly what a governed, allocation-free
+runtime can do.
+
+### 3. Generated C++ is emitted, never committed
+
+`<binary>/mdux_generated/screen/<identifier>.cppm` and `.hpp`, produced from the committed
+`package.json` by the same two-form arrangement `mdux_emit_shader_package()` uses, and covered by
+the same argument: the reviewed artifact is the JSON, and a few thousand lines of generated
+initialisers under review is noise that hides signal.
+
+The generated source contains `static_assert(screen.validate().has_value())`, so a malformed screen
+is a compile error rather than a startup failure. That requires `mdux.medui.schema` to be
+header-only and fully `constexpr`, which is a property #197 has to deliver rather than one that
+exists — no such module is in the tree. `mdux.ml.schema` is the precedent that it is achievable:
+`tests/ml/SchemaTests.cpp:126` already `static_assert`s a reference package validating at compile
+time, and #197 should carry the equivalent for screens, built from `constexpr`-compatible types
+throughout. The owning `TextPackage` shape is explicitly *not* the model to copy here, since it
+holds `std::string` and `std::vector` and so cannot appear in a `static_assert`.
+
+### 4. Goldens are a sidecar, not a section of the package
+
+They have a different consumer (#16's verifier, not the runtime), a different lifetime, and a
+different review audience — a reviewer checking that a safety-critical node's expected bounds
+changed deliberately should not have to find that hunk inside the whole screen. A separate file also
+gets its own digest in `report.json`, so a goldens-only change is visible as one.
+
+### 5. One recipe per screen, under `recipes/screen/<id>.toml`
+
+Following the existing bakers: the recipe names the `.medui` source, the approved locales, the font
+package to measure against, and the theme token table. Every resolved knob is recorded in the
+report, per ADR-007's rule that a silently changed default must not leave every report looking
+unchanged.
+
+## Alternatives Considered
+
+### 1. Commit the generated C++ as well (Rejected)
+**Pros:** A consumer could build without running the emitter; the exact source compiled into a
+device build would be in the repository.
+**Cons:** It is a mechanical rendering of bytes that are already committed and already byte-compared.
+Committing it claims a second piece of evidence that adds nothing, and puts generated initialisers
+in front of reviewers who cannot meaningfully check them. `MduXShaderEmit.cmake` made this argument
+first and nothing about screens weakens it.
+
+### 2. Bake vertices and indices (Rejected)
+**Pros:** The runtime's job shrinks to memcpy; the artifact is a finished payload like the other
+three; byte-identity covers the geometry itself.
+**Cons:** Only correct for wholly static screens. Every dynamic component would need a second path,
+so the runtime would have to build geometry regardless — and then the baked vertices are a
+partial duplicate whose budget has to be reconciled with the dynamic one. Worse, it fixes text
+*rendering* at bake time, which is fine for static runs and wrong for a `NumericDisplay` whose value
+changes.
+
+### 3. Fold the goldens into `package.json` (Rejected)
+**Pros:** One artifact, one `validate()`, one digest.
+**Cons:** Couples the rendered-truth verifier to the runtime's schema, so #16 would have to parse a
+structure most of which it does not use. Makes a goldens-only diff invisible inside a package-wide
+one, at exactly the review moment where visibility matters most.
+
+### 4. Emit a binary package rather than JSON (Rejected)
+**Pros:** Smaller, faster to load, no text encoding questions.
+**Cons:** Not reviewable in a pull request, which is most of why the committed artifacts are
+committed. ADR-007 already settled canonical JSON for the package and a binary payload only for
+opaque bulk (`shaders.spv`, `weights.bin`, `atlas.bin`); a screen's package is precisely the part a
+human should read.
+
+## Consequences
+
+### Positive
+- A screen becomes a reviewable configuration item: a layout change shows up as a rectangle moving
+  in a diff, and a safety-critical node's expected bounds change in a file of their own.
+- The `evidence.screen.<id>` test extends the existing two-toolchain byte-identity argument to
+  screens at no additional conceptual cost.
+- A device build links no host-tools module and parses nothing at startup, because the generated
+  C++ is `constexpr` and lands in `.rodata`.
+- `static_assert` moves malformed-screen detection from startup to compile.
+
+### Negative
+- **A fourth artifact kind to maintain**, with its own recipe schema, baker and update target.
+- **Layout diffs are verbose.** Moving a container by eight pixels rewrites every descendant's
+  absolute rectangle in `package.json`. The alternative — storing relative offsets and resolving on
+  device — is the layout solving ADR-011 forbids, so this is accepted rather than solved.
+- **Two files must stay consistent.** A node in `goldens.json` names a node in `package.json`;
+  nothing in the format prevents them diverging. The check cannot live in the governed
+  `validate()`: decision 4 puts the goldens outside the schema precisely because the runtime never
+  reads them, so the `static_assert` in §3 sees only `package.json` and has no ids to compare
+  against. The mitigation is host-side — the baker writes both files from one AST, and #197 owns
+  the test.
+
+  That test compares **sets, not references**. Applying ADR-011's predicate to the nodes in
+  `package.json` yields exactly the ids `goldens.json` must contain, so the test derives that set
+  and requires equality: an id in the goldens with no node behind it fails, and — the direction
+  that matters more — a node the predicate selects with no golden fails too. Checking only that
+  listed ids resolve would accept the dangerous case silently, since a safety-critical node whose
+  golden was dropped looks exactly like a screen with fewer safety-critical nodes. #16's verifier
+  derives its expectations the same way rather than trusting the file to be complete.
+
+### Risks
+- **The package grows to carry things the runtime does not need**, because it is the convenient
+  place to put them. *Mitigation*: the rule to apply is that `package.json` holds what the runtime
+  reads; anything read only by a tool belongs in a sidecar, as the goldens do.
+- **A regenerated screen differs on a second toolchain** despite the integer-only layout rule.
+  *Mitigation*: `evidence.screen.<id>` runs on both legs, which is the check that would catch it;
+  ADR-011's integer-only rule is what makes it expected to pass.
+
+## Implementation Notes
+
+- Directory kind is `screen` (`generated/screen/<id>/`, `recipes/screen/<id>.toml`), consistent with
+  `shader`, `model` and `font`.
+- Nothing here is implemented at the time this ADR is accepted. The schema and emitters are #197,
+  the CMake integration and `mdux-meduic` are #198, the goldens are #196. This record is written
+  first so that those are applications of a decision rather than a decision reconstructed from
+  whatever they produced.
+
+## References
+- ADR-004: Trust zones in C++ — why the compiler is host-only
+- ADR-007: Evidence pipeline doctrine — the committed-artifact model, canonical JSON, bake reports
+- ADR-008: Zero-SOUP ML inference — decision 2, the constexpr-package end state #153 pursues
+- ADR-010: No on-device text shaping — why text is resolved before the device sees it
+- ADR-011: The deterministic `.medui` compile boundary — the decision this one details
+- `cmake/MduXShaderEmit.cmake` and `tools/shader/Emit.cppm` — the bake-versus-emit argument in full
+- Issues #196, #197, #198 and #16
+
+## Approval
+- **Decision Date**: 2026-08-11
+- **Approved By**: Project maintainer
+- **Review Date**: when #197 lands the emitters — the first point at which the file layout decided
+  here is exercised by something that has to produce it

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -3,6 +3,13 @@
 ## Status
 Accepted (2026-08-11)
 
+## Shared decision identity
+
+This record is MduX's C++ and evidence-format realization of
+[`MEDUI-DEC-003`](https://github.com/Compliatory/MedUI/blob/c8cc45ecec2f2dfd84940b9efc17c613e691cc0d/decisions/MEDUI-DEC-003-compiled-screen-semantics.md)
+and `MEDUI-DEC-004`. The shared records define meaning; this ADR remains authoritative for
+canonical JSON, generated C++ modules/headers, and MduX's committed artifact layout.
+
 ## Context
 
 [ADR-011](ADR-011-deterministic-medui-compile-boundary.md) fixes *where* the work happens: every

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -81,6 +81,12 @@ device performs the substitution by a bounded lookup in a governed table. Carryi
 values is also what makes the package readable in a diff: a reviewer sees
 `Theme.Colors.ScoreDigits`, not `[33, 184, 107, 255]`.
 
+**All three files spell their members in camelCase**, as the committed font, shader and model
+packages do (`byteLength`, `occupancyPercent`, `advanceWidth`). The one file that could have differed is
+`goldens.json`, whose entry ADR-011 originally spelled in snake_case; that amendment explains why it
+does not. One directory, one vocabulary, and #16's verifier - which reads two of these three files -
+carries one set of member names rather than two.
+
 Canonical JSON throughout, written through `mdux.evidence.json`. Registered via
 `mdux_bake_artifact()`, so each screen gets a build-tree bake, an `-update` target and an
 `evidence.screen.<id>` byte-comparison test on both toolchain legs. Two consequences of registering

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -64,14 +64,15 @@ safety-critical nodes live.
 
 | File | Committed | Contents |
 |---|---|---|
-| `package.json` | yes | the compiled screen: resolved nodes, absolute rectangles, `DrawBudget`, literal RGBA8 colours, baked glyph runs, requirement ids — plus the authoring names each resolved value came from |
+| `package.json` | yes | the compiled screen: compiled nodes, absolute rectangles, `DrawBudget`, requirement ids, and the validated `Theme.Colors.<Token>` and `t("STR-KEY")` names each node draws with. **No locale field, no glyph runs, no RGBA8** |
 | `goldens.json` | yes | one golden reference per node matching ADR-011's predicate: `@safety_critical`, or an explicit `position:`, or both merged into one entry (#196). Always written, as `[]` when a screen matches no node |
 | `report.json` | yes | the ADR-007 bake report: inputs, digests, tool version |
 
-The colour and text columns are **resolved values, not lookups** — ADR-011 fixes that boundary, and
-the distinction matters here because a package carrying only a token name would oblige the runtime
-to resolve it. The authoring names ride along beside the resolved values so that a diff is readable
-and a golden reference can name what an author wrote, but nothing on the device reads them.
+The colour and text columns are **validated names, not baked values** — ADR-011 fixes that boundary.
+The compiler proves every token exists and every key is present in every approved locale, and the
+device performs the substitution by a bounded lookup in a governed table. Carrying names rather than
+values is also what makes the package readable in a diff: a reviewer sees
+`Theme.Colors.ScoreDigits`, not `[33, 184, 107, 255]`.
 
 Canonical JSON throughout, written through `mdux.evidence.json`. Registered via
 `mdux_bake_artifact()`, so each screen gets a build-tree bake, an `-update` target and an
@@ -87,13 +88,17 @@ that way, both binding on #198:
   slug from the screen name rather than using it, and the mapping has to be injective and recorded
   in the recipe, since two screens differing only in case would otherwise collide.
 
-**Open: whether locales multiply this layout.** Since the package carries baked glyph runs rather
-than text keys, one screen with three approved locales is either one package holding all three or
-three packages. The layout above assumes the former and does not argue for it; `mdux.text.schema`'s
-`TextPackage` took the latter shape — a single `locale` field, "the runtime reads no others"
-(`include/mdux/text/Schema.cppm:145`). #197 settles it when it defines the schema and #198 when it
-lays out `generated/screen/`; whichever is chosen, the `evidence.screen.<id>` id has to stay unique,
-which is the constraint that makes this a layout question rather than a schema detail.
+**Locales do not multiply this layout.** One screen, one directory, whatever the approved locale
+count — because ADR-011 keeps the package locale-free and leaves the per-locale glyph runs in the
+text package. `mdux.text.schema`'s `TextPackage` already carries a single `locale` field and "the
+runtime reads no others" (`include/mdux/text/Schema.cppm:145`), so a device pairs one screen package
+with the text package for the locale it is running.
+
+This question was recorded as open in an earlier revision, on the assumption that the screen carried
+baked glyph runs. It closes with that assumption. The reason to prefer it, stated as a consequence
+rather than a preference: **adding an approved locale rewrites no screen artifact**, so a translation
+update cannot change the digest of a screen whose layout nobody touched. In a byte-compared evidence
+pipeline that is the difference between re-verifying one artifact and re-verifying all of them.
 
 ### 2. The payload is **layout, not geometry**
 
@@ -107,10 +112,9 @@ vertices would mean baking only the static subset and computing the rest anyway 
 where one suffices, and a budget split across both.
 
 What is fixed at compile time is everything that makes the runtime's job bounded: *where* each node
-is, *how much* it may draw, and *which* atlas entries it may use — in the resolved form decision 1
-fixes, so the colours are RGBA8 values rather than tokens awaiting a lookup. Turning that into
-vertices is arithmetic over a known bound, which is exactly what a governed, allocation-free
-runtime can do.
+is, *how much* it may draw, and *which* validated token and key it draws with. Turning that into
+vertices is a bounded table lookup followed by arithmetic over a known bound, which is exactly what
+a governed, allocation-free runtime can do.
 
 ### 3. Generated C++ is emitted, never committed
 
@@ -226,7 +230,8 @@ human should read.
 - ADR-004: Trust zones in C++ — why the compiler is host-only
 - ADR-007: Evidence pipeline doctrine — the committed-artifact model, canonical JSON, bake reports
 - ADR-008: Zero-SOUP ML inference — decision 2, the constexpr-package end state #153 pursues
-- ADR-010: No on-device text shaping — why text is resolved before the device sees it
+- ADR-010: No on-device text shaping — why text is *shaped* before the device sees it; the
+  key-to-run lookup this record leaves on device is not shaping
 - ADR-011: The deterministic `.medui` compile boundary — the decision this one details
 - `cmake/MduXShaderEmit.cmake` and `tools/shader/Emit.cppm` — the bake-versus-emit argument in full
 - Issues #196, #197, #198 and #16

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -129,6 +129,13 @@ is, *how much* it may draw, and *which* validated token and key it draws with. T
 vertices is a bounded table lookup followed by arithmetic over a known bound, which is exactly what
 a governed, allocation-free runtime can do.
 
+**A node's payload is typed per component.** The package carries one spec type per dictionary entry
+behind a `std::variant`, not a single record with every field on it. The flat form was tried first
+and was lossy: it had nowhere to put a `Clock`'s format, a `NumericDisplay`'s template and source, a
+`StatusIndicator`'s state keys and per-state tints, a `CriticalButton`'s `on_press`, or a
+`VulkanViewport`'s stream, so a device could not have rendered four of the eleven components. Every
+field remains a validated *name* rather than a resolved value, which keeps the boundary ADR-011 fixes.
+
 ### 3. Generated C++ is emitted, never committed
 
 `<binary>/mdux_generated/screen/<identifier>.cppm` and `.hpp`, produced from the committed
@@ -151,6 +158,35 @@ They have a different consumer (#16's verifier, not the runtime), a different li
 different review audience — a reviewer checking that a safety-critical node's expected bounds
 changed deliberately should not have to find that hunk inside the whole screen. A separate file also
 gets its own digest in `report.json`, so a goldens-only change is visible as one.
+
+**This is a deliberate divergence from TrustSC, recorded as one.** Its `CompiledScreenPackage`
+carries `golden_references` as a field, and `trustsc-ui-verify::verify_frame()` walks them straight
+out of the compiled screen; the field is not feature-gated, so a shipped binary carries expectations
+only a verifier reads. MduX keeps them outside the package for the reasons above — the runtime never
+reads them, the review audience differs, and the sidecar gets its own digest — and pays for that with
+a verifier that opens two files instead of walking one structure. That is a driver-shaped cost, not
+an evidence-shaped one, and it is the trade this decision accepts knowingly rather than by omission.
+
+**Completeness is guaranteed by construction, not by comparing the two files.** The predicate has
+one implementation - `collectGoldens()` (#196) - and the baker applies it once, in the same pass that
+writes the compiled nodes. That is TrustSC's arrangement: its DSL compiler pushes a golden at the
+moment it compiles a selected node, from the AST it already holds, and the guard is a set of unit
+tests over known screens rather than a check over the emitted artifact.
+
+An earlier revision of this decision required an artifact-level set comparison instead, and carried
+`NodeProvenance { safetyCritical, positioned }` in every compiled node so the expected id set could be
+re-derived from `package.json`. Both are withdrawn, for two reasons that point the same way:
+
+- **It could not catch the failure that matters.** Both files come from one AST in one pass, so a
+  comparison between them detects two writers disagreeing, never a predicate that is wrong. The
+  tests that *do* catch a wrong predicate already exist, with the predicate, in #196.
+- **It put data on a device that only a tool reads**, which is what this decision refuses two
+  paragraphs above. Two booleans is a small breach of a rule, and a rule breached for something small
+  is how the next thing gets in.
+
+What replaces the check is a constraint on the baker (#198): **it must call `collectGoldens()`, not
+re-apply the predicate.** A second implementation is the only way the two files can disagree once
+they are written in one pass, and it is the thing a reviewer should refuse.
 
 ### 5. One recipe per screen, under `recipes/screen/<id>.toml`
 
@@ -211,21 +247,24 @@ human should read.
   nothing in the format prevents them diverging. The check cannot live in the governed
   `validate()`: decision 4 puts the goldens outside the schema precisely because the runtime never
   reads them, so the `static_assert` in §3 sees only `package.json` and has no ids to compare
-  against. The mitigation is host-side — the baker writes both files from one AST, and #197 owns
+  against. The mitigation is host-side — the baker writes both files from one AST, and #198 owns
   the test.
 
-  That test compares **sets, not references**. Applying ADR-011's predicate to the nodes in
-  `package.json` yields exactly the ids `goldens.json` must contain, so the test derives that set
-  and requires equality: an id in the goldens with no node behind it fails, and — the direction
-  that matters more — a node the predicate selects with no golden fails too. Checking only that
-  listed ids resolve would accept the dangerous case silently, since a safety-critical node whose
-  golden was dropped looks exactly like a screen with fewer safety-critical nodes. #16's verifier
-  derives its expectations the same way rather than trusting the file to be complete.
+  The mitigation is structural rather than a comparison: one implementation of ADR-011's predicate,
+  called once, in the pass that writes both files. An earlier revision of this ADR required the baker
+  to derive the expected id set from `package.json` and assert set equality with `goldens.json`, and
+  decision 4 records why that was withdrawn — it cannot see a wrong predicate, and it needed
+  provenance on the device that only a tool would read. #16 derives its expectations from
+  `goldens.json` itself; what it must never do is re-apply the predicate, since a second
+  implementation is precisely what would let the two disagree.
 
 ### Risks
 - **The package grows to carry things the runtime does not need**, because it is the convenient
   place to put them. *Mitigation*: the rule to apply is that `package.json` holds what the runtime
-  reads; anything read only by a tool belongs in a sidecar, as the goldens do.
+  reads; anything read only by a tool belongs in a sidecar, as the goldens do. Decision 4 records one
+  attempt to breach this rule - two booleans of golden provenance - and why it was withdrawn rather
+  than granted an exception.
+
 - **A regenerated screen differs on a second toolchain** despite the integer-only layout rule.
   *Mitigation*: `evidence.screen.<id>` runs on both legs, which is the check that would catch it;
   ADR-011's integer-only rule is what makes it expected to pass.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,8 +17,10 @@ in the index below, numbers contiguous from ADR-001.
 | [ADR-008](ADR-008-zero-soup-ml-inference.md) | Zero-SOUP ML inference | Accepted | 2026-08-03 |
 | [ADR-009](ADR-009-in-repository-test-framework.md) | In-repository test framework, and SpecLab for BDD | Accepted | 2026-08-03 |
 | [ADR-010](ADR-010-no-on-device-text-shaping.md) | No on-device text shaping | Accepted | 2026-08-06 |
+| [ADR-011](ADR-011-deterministic-medui-compile-boundary.md) | The deterministic `.medui` compile boundary | Accepted | 2026-08-11 |
+| [ADR-012](ADR-012-compiled-screen-artifacts.md) | What a compiled screen emits, and which parts are committed | Accepted | 2026-08-11 |
 
-Every number from 001 to 010 appears exactly once. A superseded decision keeps its number and its
+Every number from 001 to 012 appears exactly once. A superseded decision keeps its number and its
 file — the trail is only useful if the abandoned turns are still visible.
 
 ## What is not here
@@ -52,7 +54,7 @@ decision record that lists only benefits documents an advertisement rather than 
 ## Writing a new ADR
 
 1. Copy [`template.md`](template.md).
-2. Take the next free number from the index above — currently **ADR-011**.
+2. Take the next free number from the index above — currently **ADR-013**.
 3. Name the file `ADR-NNN-short-description.md`, lowercase and hyphenated.
 4. Add a row to the index in this file. An ADR that is not indexed does not exist.
 5. If it supersedes an earlier decision, set that ADR's status to `Superseded by ADR-NNN`, link

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191) and parser (#192) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), and component/theme/locale semantic analyzer (#193) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | the replacement for the retired HTML/CSS path |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing and semantic validation are implemented; layout, packaging, and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); at S2 only the `MDX-E` diagnostic registry (#191) — the parser (#192), emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191) and parser (#192) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,6 @@ are ordinary `PRIVATE` sources.
 | `mdux.governance.compliance` | `include/mdux/governance/Compliance.cppm` | `src/governance/Compliance.cpp` |
 | `mdux.shader.schema` | `include/mdux/shader/Schema.cppm` | `src/shader/Schema.cpp` |
 | `mdux.text.schema` | `include/mdux/text/Schema.cppm` | `src/text/Schema.cpp` |
-| `mdux.text.raster` | `include/mdux/text/Raster.cppm` | `src/text/Raster.cpp` |
 | `mdux.font.schema` | `include/mdux/font/Schema.cppm` | `src/font/Schema.cpp` |
 | `mdux.text.draw` | `include/mdux/text/Draw.cppm` | `src/text/Draw.cpp` |
 | `mdux.draw` | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
@@ -89,10 +88,16 @@ performs no checking and confers no compliance.
 | `MduXToolsCommon` | `tools/common/` | TOML subset reader, CLI parser, shared diagnostic envelope |
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
-| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158) and `mdux.tools.atlaspacker` (the shelf packer, #160) |
+| `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
+
+`mdux.text.raster` was governed until [#116](https://github.com/ambroise-leclerc/MduX/issues/116).
+It allocates, and `std::vector` reports failure by throwing, so its `noexcept` entry point has to
+catch — which [ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md) forbids in governed
+code. It runs once per glyph at build time and never on a device, which is what made the host-tools
+zone the right home rather than a reason to rewrite it.
 
 ## The Vulkan boundary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), integer-only bounded layout solver (#194), and the text-budget check that measures resolved boxes against the widest approved translation (#195) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), integer-only bounded layout solver (#194), the text-budget check that measures resolved boxes against the widest approved translation (#195), and the golden references that say where safety-critical content must appear (#196) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, bounded layout, and text budgets are implemented; packaging and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, bounded layout, text budgets, and golden references are implemented; packaging and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,7 @@ recipes/<kind>/<id>.toml  ──[ mdux-<kind>bake ]──▶  generated/<kind>/<
                                                       <payload>.bin
 ```
 
-Five artifacts are committed today:
+Six artifacts are committed today:
 
 | Artifact | Baker | Payload |
 |---|---|---|
@@ -145,6 +145,18 @@ Five artifacts are committed today:
 | `generated/model/ecg-demo/` | `mdux-mlbake` | `weights.bin` |
 | `generated/model/ecg-demo-alt/` | `mdux-mlbake` | `weights.bin` |
 | `generated/font/dejavu-ui/` | `mdux-textbake` | `atlas.bin` |
+| `generated/screen/endoscope-monitor/` | `mdux-meduic` | `package.json` + `goldens.json` |
+
+The screen is the one entry whose payload is not opaque bytes, and ADR-012 explains why: a screen
+cannot bake vertices, because four of the eleven components in the dictionary — `NumericDisplay`,
+`SignalTrace`, `StatusIndicator` and `Clock` — draw from live data, and their geometry does not exist
+until the frame does. What `package.json` carries instead is layout: where each node is, how much it
+may draw, and which validated token and key it draws with.
+
+`goldens.json` is a sidecar with a different consumer — #16's frame verifier, not the runtime — and a
+different rule. ADR-011 puts **every `@safety_critical` node and every node with an explicit
+`position:`** in the golden set, which is why the committed screen has one entry: its `SignalTrace`
+is positioned, not annotated. Both files are reviewable as text, which is the point.
 
 Every baker registers through `mdux_bake_artifact()`
 ([`cmake/MduXBake.cmake`](../cmake/MduXBake.cmake)), which creates the bake target, an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), and integer-only bounded layout solver (#194) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), integer-only bounded layout solver (#194), and the text-budget check that measures resolved boxes against the widest approved translation (#195) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, and bounded layout are implemented; packaging and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, bounded layout, and text budgets are implemented; packaging and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,7 @@ are ordinary `PRIVATE` sources.
 | `mdux.ml.kernels` | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
 | `mdux.ml.runtime` | `include/mdux/ml/Runtime.cppm` | `src/ml/Runtime.cpp` |
 | `mdux.medui.schema` | `include/mdux/medui/Schema.cppm` | header-only |
+| `mdux.medui.screen` | `include/mdux/medui/Screen.cppm` | `src/medui/Screen.cpp` |
 
 `mdux.core.result` is a naming alias over `std::expected`, not a reimplementation
 ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)).
@@ -99,7 +100,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), integer-only bounded layout solver (#194), the text-budget check that measures resolved boxes against the widest approved translation (#195), and the golden references that say where safety-critical content must appear (#196) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), integer-only bounded layout solver (#194), the text-budget check that measures resolved boxes against the widest approved translation (#195), and the golden references that say where safety-critical content must appear (#196), the canonical package with its two C++ emitters (#197) and the compiler driver behind `mdux-meduic` (#198) |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,8 +32,17 @@ It is a *link-graph* property, checked mechanically.
 
 **What it is not:** it is not `#![forbid(unsafe_code)]`. It does not prove the absence of undefined
 behaviour, and no combination of C++ tooling here does. Governed modules are compiled without access
-to platform, graphics or OS headers, are covered by determinism and no-heap tests, and are held to
-an enforced warning set — that is the whole of the claim.
+to platform, graphics or OS headers, are checked at the source level by
+[`mdux-governed-lint`](../tools/governed-lint/) and at the object level by
+`governed.noThrow.symbolScan`, are covered by determinism and no-heap tests, and are held to an
+enforced warning set — that is the whole of the claim.
+
+Two things that claim deliberately does not include. Governed code can still reach libstdc++'s
+throwing helpers through ordinary `std::string` and `std::vector` use — 14 such references exist and
+the scan prints them on every run rather than implying otherwise. And `MduXCore` cannot be built
+with `-fno-exceptions`: `import std` and that flag are mutually exclusive on GCC, because the std
+BMI records its dialect and CMake synthesises one shared std target. Both are recorded in
+[ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md), "What is enforced".
 
 ## Modules
 
@@ -182,11 +191,25 @@ Labels select the evidence-bearing suites:
 | `evidence-unit` | unit tests of the evidence modules themselves |
 | `determinism` | the ML kernels produce the frozen bit patterns |
 | `noheap` | `predict()` performs no allocation |
+| `governed` | no governed object contains a throw expression — a gate on GCC/Clang, informational on MSVC ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)) |
 | `pixel` | rendered output matches expectations, under lavapipe |
 | `regulatory` | corpus indexes and schemas are current |
 
 The `evidence` / `evidence-unit` split is deliberate: a broken SHA-256 test and a drifted artifact
-must not produce the same CI signal.
+must not produce the same CI signal. `governed` is separate from `noheap` for the same reason: both
+run `cmake/MduXNoHeapScan.cmake`, but over different objects with different forbidden sets, and a
+CI leg selecting one should not silently start covering the other.
+
+`governed` includes a negative test on GCC/Clang. `governed.noThrow.symbolScan.negative` scans a
+deliberately non-conforming object (`tests/governed/ThrowFixture.cpp`) and passes only when the scan
+rejects it with the expected message — because a check that has only ever run against conforming
+code passes identically when it is working and when it is looking for the wrong thing.
+
+Neither test gates on MSVC, and the reason is worth knowing: the MSVC STL inlines its own throw
+sites, so `_CxxThrowException` in a governed object is the same symbol whether it came from a
+hand-written `throw` or from a `std::string` growth path. The scan reports there instead of
+failing, and [`mdux-governed-lint`](../tools/governed-lint/) — which reads source and is
+toolchain-independent — is what enforces the rule on Windows.
 
 ## Install and export
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,7 @@ are ordinary `PRIVATE` sources.
 | `mdux.ml.schema` | `include/mdux/ml/Schema.cppm` | header-only |
 | `mdux.ml.kernels` | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
 | `mdux.ml.runtime` | `include/mdux/ml/Runtime.cppm` | `src/ml/Runtime.cpp` |
+| `mdux.medui.schema` | `include/mdux/medui/Schema.cppm` | header-only |
 
 `mdux.core.result` is a naming alias over `std::expected`, not a reimplementation
 ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,7 +256,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, bounded layout, text budgets, and golden references are implemented; packaging and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | complete front to back: parsing, semantic validation, bounded layout, text budgets, golden references, the canonical package, both C++ emitters, `mdux-meduic`, `mdux-medui-check`, and a governed runtime that draws a compiled screen. One committed screen reaches pixels in `ScreenPixelTests`; what remains is the text package ([#235](https://github.com/ambroise-leclerc/MduX/issues/235)) and the components' own geometry (#17) |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |
@@ -269,7 +269,7 @@ tracking issue; the issue is authoritative for what remains.
 for the object's whole lifetime; it was removed rather than fixed.
 
 What replaces it is `mdux.draw` (a governed description of a frame) plus `mdux.render.vulkan` (the
-adapter that renders it). `.medui` will generate the former. **Do not reintroduce HTML/CSS parsing.**
+adapter that renders it). `.medui` generates the former today, through the chain in the previous section. **Do not reintroduce HTML/CSS parsing.**
 
 ## Reading order
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ boundary between them enforced at configure time rather than by review:
 |---|---|---|---|
 | **Governed** | `MduXCore`, `MduX_warnings` | `std` only | never throws ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)) |
 | **Adapter** | `MduX` | governed + Vulkan | throws where Vulkan makes it unavoidable |
-| **Host tools** | `MduXToolsCommon`, `MduXShaderBakeLib`, `MduXMlBakeLib`, `MduXTextBakeLib` | anything | may throw freely; never linked into a device target |
+| **Host tools** | `MduXToolsCommon`, `MduXShaderBakeLib`, `MduXMlBakeLib`, `MduXTextBakeLib`, `MduXMeduiLib` | anything | may throw freely; never linked into a device target |
 
 `mdux_verify_trust_zones()` in [`cmake/MduXTrustZones.cmake`](../cmake/MduXTrustZones.cmake) walks
 the full link graph of every declared-governed target at the end of configure and fails on a
@@ -98,6 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); at S2 only the `MDX-E` diagnostic registry (#191) — the parser (#192), emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ performs no checking and confers no compliance.
 | `MduXShaderBakeLib` | `tools/shader/` | `mdux-shaderbake`, `mdux-shaderemit` |
 | `MduXMlBakeLib` | `tools/ml/` | `mdux-mlbake` |
 | `MduXTextBakeLib` | `tools/text/` | `mdux-textbake`; also hosts `mdux.tools.truetype` (the host-only glyf parser with cmap/hmtx, #158), `mdux.tools.atlaspacker` (the shelf packer, #160) and `mdux.text.raster` (the glyph rasteriser, #159) |
-| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), and component/theme/locale semantic analyzer (#193) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
+| `MduXMeduiLib` | `tools/medui/` | the `.medui` compiler (#15); the shared `MEDUI-E` diagnostic registry (#191), parser (#192), component/theme/locale semantic analyzer (#193), and integer-only bounded layout solver (#194) are implemented, while emitters (#197) and `mdux-meduic` (#198) land on this same target |
 
 Host tools parse untrusted input, so they are deliberately outside the governed zone. They are
 never linked into `MduXCore` or `MduX` and are absent from the install/export set.
@@ -242,7 +242,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing and semantic validation are implemented; layout, packaging, and emission remain |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | parsing, semantic validation, and bounded layout are implemented; packaging and emission remain |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/governance/schemas/diagnostic.schema.json
+++ b/docs/governance/schemas/diagnostic.schema.json
@@ -42,7 +42,7 @@
           },
           "code": {
             "type": "string",
-            "description": "Short stable identifier for the kind of finding, such as 'MDX-D011' or 'FB001'. This is the field an agent keys off, so its meaning must not change once published - reword the message instead. The empty string is permitted, and means the tool has not assigned a code to this finding; `mdux::tools::cli::render` omits the bracketed code from its text form in that case.",
+            "description": "Short stable identifier for the kind of finding, such as 'MDX-D011', 'MEDUI-E015', or 'FB001'. MedUI codes are owned by the pinned Compliatory/MedUI contract; other families remain local. This is the field an agent keys off, so its meaning must not change once published - reword the message instead. The empty string is permitted, and means the tool has not assigned a code to this finding; `mdux::tools::cli::render` omits the bracketed code from its text form in that case.",
             "pattern": "^([A-Za-z0-9][A-Za-z0-9-]*)?$"
           },
           "severity": {

--- a/docs/governance/soup-register.toml
+++ b/docs/governance/soup-register.toml
@@ -90,24 +90,24 @@ known_anomaly_tracking = "Tool qualification, and any anomaly found in a specifi
 [[entries]]
 component_id = "speclab"
 name = "SpecLab"
-version = "commit 84631c9f01f5309baf1d12618b2ef66c3512b511 (no tagged release upstream)"
+version = "v0.1.0, pinned by commit 37b51fcec"
 classification = "SOUP"
 supplier = "ambroise-leclerc / SpecLab contributors"
 repository = "https://github.com/ambroise-leclerc/SpecLab"
-license = "See upstream repository"
-usage = "Given/When/Then BDD scenarios in seven test executables (shader_spec, draw_spec, tools_spec, bridge_spec, ml_spec, ml_tools_spec, ml_noheap_spec), adapted to this project's CTest discovery contract by tests/framework/SpecLabBridge.hpp. Never linked into a library, an example, or the install/export set."
+license = "EUPL-1.2 (upstream LICENSE and LICENSING.md at commit 37b51fcec). Alternative commercial terms *may* be available from the project steward, and are granted only through a separate written agreement; upstream states that the notice does not itself grant commercial-licence rights. Recorded with that qualification because this register is consulted to answer what the project is entitled to rely on, and an unconditional reading would answer it wrongly. The same dual-licensing model this repository adopted in #185."
+usage = "Given/When/Then BDD scenarios in eleven test executables (bridge_spec, draw_spec, font_spec, medui_tools_spec, ml_noheap_spec, ml_spec, ml_tools_spec, shader_spec, text_spec, text_tools_spec, tools_spec), adapted to this project's CTest discovery contract by tests/framework/SpecLabBridge.hpp. Never linked into a library, an example, or the install/export set."
 trust_zone = "tests"
 integration_path = "tests/CMakeLists.txt (CPMAddPackage NAME SpecLab, pinned by commit); linked only into test executables"
 pinned_by = ["tests/CMakeLists.txt"]
 runtime_deployment = false
-support_model = "Single-maintainer open-source project with no tagged release and no support agreement. Pinned by commit rather than by branch or tag precisely because a moving reference would make the build non-reproducible, which the evidence pipeline (ADR-007) cannot tolerate."
-boundary_rationale = "Test-only. No library target links it, it is absent from the install/export set, and mdux_verify_trust_zones() would reject it on a governed target. A defect in it cannot reach a device; its risk is false confidence in test results, not patient harm - see ADR-009."
+support_model = "Single-maintainer open-source project with no support agreement. Tagged releases began with v0.1.0; this entry read 'no tagged release' until then. Pinned by commit rather than by tag or branch, because a moving reference would make the build non-reproducible, which the evidence pipeline (ADR-007) cannot tolerate - and observed supplier practice is that the tag does move: v0.1.0 was repointed from ea7f2e363 to 37b51fcec within an hour of publication to pick up a release-packaging fix. The tag name is recorded beside the commit in tests/CMakeLists.txt as documentation, not as the pin."
+boundary_rationale = "Test-only. No library target links it, it is absent from the install/export set, and mdux_verify_trust_zones() would reject it on a governed target. What that establishes is narrow and worth stating narrowly: no code from this dependency is executed on a device. It does not establish that a defect here is harmless. A test framework that reports a passing result for failing code lets a real defect through verification, and verification is what release decisions rest on - so the risk is to the integrity of verification rather than to runtime behaviour, which is a different thing from no risk. See ADR-009."
 risk_controls = [
-    "Pinned to an immutable commit, so a rebuild uses the same source or fails outright.",
+    "Pinned to an immutable commit: a rebuild fetches that exact tree, or the fetch fails because the commit is unreachable. There is no third outcome in which it silently builds something else. Deliberately not pinned to the release tag, which upstream has already moved once.",
     "bridge_spec exists solely to test the SpecLab integration, so a broken adapter fails with a name that says so rather than looking like a failure in the code under test.",
-    "Nine further test executables use the in-repository MduXTest framework instead, so a SpecLab regression cannot silence the whole suite.",
+    "Nine further test executables use the in-repository MduXTest framework instead (verified: eleven SpecLab, nine MduXTest), so a SpecLab *runtime* regression cannot silence the whole suite. This does not extend to configure, compile or module-BMI failures, which block the build before any executable runs - the GCC 16.2.0 anomaly below did exactly that and left no tests running at all. Independent coverage begins only after a successful build.",
 ]
-known_anomaly_tracking = "A defect found in this dependency is recorded as a ProblemReport (mdux.governance.compliance, issue #35) with this component_id in its description; none open as of this entry. Note this dependency is also why the project's GCC floor is 16: GCC 15 cannot build it."
+known_anomaly_tracking = "A defect found in this dependency is recorded as a ProblemReport (mdux.governance.compliance, issue #35) with this component_id in its description; none open as of this entry. Note this dependency is also why the project's GCC floor is 16: GCC 15 cannot build it, and upstream dropped GCC 15 support before v0.1.0. One toolchain anomaly is known and shared: GCC 16.2.0 corrupts the module BMIs for speclab.core.testsuite and speclab.runners.testrunner, which turned this repository's develop red (MduX #205) and upstream's CI too (ambroise-leclerc/SpecLab#15). Both projects pin gcc:16.1.0; a working 16.2.x is tracked as ambroise-leclerc/SpecLab#17. Upstream issue numbers are written in full here because a bare #15 or #17 in this repository names the .medui compiler and Content components epics."
 
 [[entries]]
 name = "DejaVu Sans"

--- a/docs/iec62304/03-development-process.md
+++ b/docs/iec62304/03-development-process.md
@@ -100,5 +100,15 @@ software item, its known anomalies, and the configuration it was built from. Mdu
 pipeline ([ADR-007](../adr/ADR-007-evidence-pipeline-doctrine.md)) is the mechanism most directly
 relevant here: a `report.json` records exactly which recipe, inputs, and resolved options produced
 a given artifact, and CI re-derives the artifact from those to confirm the record is accurate before
-anything is considered final. There is no product release yet for this to apply to; the mechanism
-exists ahead of the need, which is the order issue #12 was deliberately built in.
+anything is considered final.
+
+[`docs/release-process.md`](../release-process.md) is the procedure that turns those mechanisms into
+a release, and three of its steps answer this sub-clause directly: every committed artifact is
+re-derived after the version moves and its diff reviewed, so the configuration released is the one
+the sources produce; the changelog entry carries the limits known at the time, which is this
+sub-clause's "known anomalies"; and the tag is annotated on `master`, so the composition has an
+identifier with an author and a date rather than a moving branch name.
+
+The distinction this document should keep is between a *library* release, which MduX has cut five of,
+and a *product* release by a manufacturer incorporating it — the second is out of scope here, and
+none of the five carries that claim.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -132,10 +132,15 @@ Skipping this is how `master` accumulates commits `develop` does not have. As of
 `origin/master...origin/develop` is `1 32` — master carries one commit develop does not, which is
 exactly the drift this step prevents.
 
-### 9. Update the roadmap
+### 9. Update the roadmap — on the release branch, with the rest
 
-The wave line moves from "in progress" to "shipped vX.Y.Z", and the next wave opens. That file is the
-programme's own account of what shipped when, and the CHANGELOG's earlier entries rest on it.
+The wave line moves from "in progress" to "shipped vX.Y.Z", the counts move, and the next wave opens.
+That file is the programme's own account of what shipped when, and the CHANGELOG's earlier entries
+rest on it.
+
+This belongs in the release branch rather than after the tag, which is what cutting v0.6.0 taught:
+the tagged tree should describe itself. A roadmap updated afterwards leaves the tag pointing at a
+tree that still calls its own wave "in progress".
 
 ## What is deliberately not automated
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -68,10 +68,24 @@ in [`roadmap.md`](roadmap.md) and has an open child issue is a release note that
 $ git switch -c release/v0.6.0
 ```
 
-### 3. Move the version, in the one place it lives
+### 3. Move the version, in the one place it is *defined* and the three that assert it
 
-`CMakeLists.txt`'s `project(MduX VERSION X.Y.Z ...)` is the single source. `MDUX_TOOL_VERSION` flows
-from it into every baker, and therefore into every `report.json`; nothing else needs editing.
+`CMakeLists.txt`'s `project(MduX VERSION X.Y.Z ...)` is the single source: `MDUX_TOOL_VERSION` flows
+from it into every baker and therefore into every `report.json`, and `mdux::Version` from it into
+every consumer.
+
+Three tests then assert the value, and they have to move with it:
+
+```console
+$ grep -rn 'Version::minor ==\|Version::getString() ==' tests/
+tests/TestVersion.cpp:               2 assertions
+tests/TestRegulatoryCompliance.cpp:  1 assertion
+```
+
+They hard-code the number on purpose, and should keep doing so. `IEC 62304 Version Traceability`
+exists to check that the version a build *reports* is the version the project *declares*; derived
+from the same macro it would assert nothing. An earlier revision of this document said "nothing else
+needs editing" — cutting v0.6.0 found that out, three red tests into a green-looking release.
 
 ### 4. Re-bake every artifact, and read the diff
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -15,10 +15,15 @@ mechanisms into a release.
 ## The branch topology
 
 ```text
-  feature/NNN-slug ──▶ develop ──▶ release/vX.Y.Z ──▶ master  (tagged vX.Y.Z)
-                          ▲                              │
-                          └───────────── back-merge ─────┘
+  NNN-slug ──▶ develop ──▶ release/vX.Y.Z ──▶ master  (tagged vX.Y.Z)
+                  ▲                              │
+                  └───────────── back-merge ─────┘
 ```
+
+A working branch is `<issue-number>-<slug>` — the scheme GitHub's "create a branch for this issue"
+button generates, and the one every workflow's `branches:` filter matches (`'[0-9]+-*'`, plus
+`'feat/**'` for branches that predate the convention). A branch named anything else gets **no checks
+at all**, silently, which is worse than a failing one.
 
 - **`develop`** integrates. Every change arrives by pull request, and a stack of PRs is based on its
   predecessor rather than on `develop` — see [`AGENTS.md`](../AGENTS.md) and issue `#117`.
@@ -106,6 +111,27 @@ $ git diff generated/ | grep '^[-+]' | grep -v toolVersion | grep -v '^[-+][-+]'
 
 That command should print nothing.
 
+#### When you cannot run the bake
+
+This tree requires GCC 16 or MSVC with `import std`, and a preparer may have neither. The fallback is
+**bounded, and only this**: when the release changes no recipe, no input and no option — a pure
+version bump — the expected bytes are derivable by inspection, because `toolVersion` is the only
+field that moves. Write it, and let the release be gated on `evidence.<kind>.<id>` passing on **both**
+toolchain legs, which re-bakes every artifact from its recipe and byte-compares.
+
+Two things about that are worth being precise on, because it is a deviation from "run the baker":
+
+- **It is verification, not trust.** Two independent toolchains re-deriving the same bytes is a
+  stronger check than one unverified local bake. ADR-007 anticipated the case: it lists a hand-edited
+  file under `generated/` as a risk whose mitigation is that "re-baking overwrites the edit while the
+  byte-comparison fails the PR" — which is exactly the gate this leans on.
+- **It does not extend to anything else.** If any recipe, source or resolved option changed, the
+  bytes are not derivable by inspection and this fallback does not apply: find a supported toolchain.
+  A release that used it for more than a version bump would be asserting an artifact nobody derived.
+
+Record in the release PR that the fallback was used, so the next reviewer knows which of the two
+paths produced the bytes they are looking at.
+
 ### 5. Finish the changelog entry
 
 [`CHANGELOG.md`](../CHANGELOG.md)'s top entry moves from `unreleased` to the date. Its **known
@@ -113,7 +139,18 @@ limits** section is not optional: §5.8 asks for the anomalies known at release,
 that omits them describes a different release. If a limit was discovered after the entry was
 drafted, it goes in now.
 
-### 6. Run the full suite locally if you can, and let CI decide
+### 6. Update the roadmap
+
+The wave line moves from "in progress" to "shipped vX.Y.Z", the counts move, and the next wave opens.
+So do the provenance header and footer, which name the commit the status was verified at — a tagged
+roadmap whose banner names an older baseline contradicts itself in the one document a reader consults
+to find out what shipped.
+
+This is on the release branch, before the merge, and the ordering is the point: a roadmap updated
+after the tag leaves the tag pointing at a tree that still calls its own wave "in progress", and
+fixing it afterwards means re-tagging.
+
+### 7. Run the full suite locally if you can, and let CI decide
 
 ```console
 $ ctest --preset <your-preset> -L evidence      # the byte comparisons, both legs in CI
@@ -123,7 +160,7 @@ $ ctest --preset <your-preset>
 The `evidence` label is the one that matters here: it is the mechanical answer to "is the committed
 artifact the one this source produces".
 
-### 7. Merge to `master` and tag there
+### 8. Merge to `master` and tag there
 
 ```console
 $ gh pr create --base master --head release/v0.6.0 --title "Release v0.6.0"
@@ -136,7 +173,7 @@ $ git push origin v0.6.0
 The tag is annotated, and it names the commit on `master`. A lightweight tag records no author and no
 date of its own, which is a poor fit for a document that is meant to identify a configuration.
 
-### 8. Back-merge, so the histories do not drift
+### 9. Back-merge, so the histories do not drift
 
 ```console
 $ git switch develop && git merge --no-ff master && git push
@@ -145,16 +182,6 @@ $ git switch develop && git merge --no-ff master && git push
 Skipping this is how `master` accumulates commits `develop` does not have. As of this writing
 `origin/master...origin/develop` is `1 32` — master carries one commit develop does not, which is
 exactly the drift this step prevents.
-
-### 9. Update the roadmap — on the release branch, with the rest
-
-The wave line moves from "in progress" to "shipped vX.Y.Z", the counts move, and the next wave opens.
-That file is the programme's own account of what shipped when, and the CHANGELOG's earlier entries
-rest on it.
-
-This belongs in the release branch rather than after the tag, which is what cutting v0.6.0 taught:
-the tagged tree should describe itself. A roadmap updated afterwards leaves the tag pointing at a
-tree that still calls its own wave "in progress".
 
 ## What is deliberately not automated
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,161 @@
+# Releasing MduX
+
+How a version gets cut, and why each step is a step rather than a habit. Written because the
+procedure was inferable from the repository and nowhere stated — `v0.5.0` peels to `origin/master`'s
+tip, so tags evidently land on `master`, but nothing said who moves the version, in what order, or
+what must be true before the tag exists.
+
+For a medical-device SDK a release is not a convenience. IEC 62304 §5.8 asks a manufacturer to know
+precisely what is being released — every included item, its known anomalies, and the configuration it
+was built from — and §8.3 asks that changes to that composition be controlled. This repository can
+answer both mechanically, because every baked artifact carries a `report.json` recording its inputs
+by digest and CI re-derives it on two toolchains. What follows is the procedure that turns those
+mechanisms into a release.
+
+## The branch topology
+
+```text
+  feature/NNN-slug ──▶ develop ──▶ release/vX.Y.Z ──▶ master  (tagged vX.Y.Z)
+                          ▲                              │
+                          └───────────── back-merge ─────┘
+```
+
+- **`develop`** integrates. Every change arrives by pull request, and a stack of PRs is based on its
+  predecessor rather than on `develop` — see [`AGENTS.md`](../AGENTS.md) and issue `#117`.
+- **`release/vX.Y.Z`** exists so that release-only changes are reviewable as a diff. It is where the
+  version moves and the artifacts are re-baked, both of which touch files no feature branch should.
+- **`master`** carries releases and nothing else. Its tip is the most recent tag.
+
+A release branch rather than tagging `develop` directly, for one reason that is specific to this
+repository: **the version bump changes committed artifacts**, so it needs review like any other
+change to `generated/`. Tagging `develop` would put that change in the same commit stream as feature
+work.
+
+## The step that surprises everyone once
+
+`report.json` records `toolVersion`, which is the project version the baker was built from. Six
+artifacts carry it today:
+
+```console
+$ grep -rl toolVersion generated/ | wc -l
+6
+```
+
+So **bumping the version in `CMakeLists.txt` invalidates every committed artifact**. Until they are
+re-baked, every `evidence.<kind>.<id>` test fails on both toolchain legs — not because anything is
+wrong, but because the reports describe a baker that no longer exists.
+
+That is the ordering constraint the whole procedure turns on: bump, re-bake, review the artifact
+diff, *then* tag. Re-baking before the bump produces reports that are stale the moment the version
+moves.
+
+## The procedure
+
+### 1. Confirm `develop` is releasable
+
+```console
+$ git switch develop && git pull
+$ gh pr list --state open --base develop      # nothing half-landed
+$ gh run list --branch develop --limit 1      # green on both toolchain legs
+```
+
+Every epic the release claims must be closed on GitHub, not merely merged. A wave that reads "12/12"
+in [`roadmap.md`](roadmap.md) and has an open child issue is a release note that overstates.
+
+### 2. Open the release branch
+
+```console
+$ git switch -c release/v0.6.0
+```
+
+### 3. Move the version, in the one place it lives
+
+`CMakeLists.txt`'s `project(MduX VERSION X.Y.Z ...)` is the single source. `MDUX_TOOL_VERSION` flows
+from it into every baker, and therefore into every `report.json`; nothing else needs editing.
+
+### 4. Re-bake every artifact, and read the diff
+
+```console
+$ cmake --preset <your-preset>
+$ cmake --build --preset <your-preset> --target mdux-bake-update
+$ git diff --stat generated/
+```
+
+**Every changed file must differ only in `toolVersion`.** Anything else — a digest, a payload byte,
+a member — means the release is carrying an unreviewed change to a baked artifact, and the release
+stops until that is explained. This is the check §8.3 asks for, in the form this repository can
+actually perform.
+
+```console
+$ git diff generated/ | grep '^[-+]' | grep -v toolVersion | grep -v '^[-+][-+]'
+```
+
+That command should print nothing.
+
+### 5. Finish the changelog entry
+
+[`CHANGELOG.md`](../CHANGELOG.md)'s top entry moves from `unreleased` to the date. Its **known
+limits** section is not optional: §5.8 asks for the anomalies known at release, and a release note
+that omits them describes a different release. If a limit was discovered after the entry was
+drafted, it goes in now.
+
+### 6. Run the full suite locally if you can, and let CI decide
+
+```console
+$ ctest --preset <your-preset> -L evidence      # the byte comparisons, both legs in CI
+$ ctest --preset <your-preset>
+```
+
+The `evidence` label is the one that matters here: it is the mechanical answer to "is the committed
+artifact the one this source produces".
+
+### 7. Merge to `master` and tag there
+
+```console
+$ gh pr create --base master --head release/v0.6.0 --title "Release v0.6.0"
+# after review and a green run:
+$ git switch master && git pull
+$ git tag -a v0.6.0 -m "MduX v0.6.0"
+$ git push origin v0.6.0
+```
+
+The tag is annotated, and it names the commit on `master`. A lightweight tag records no author and no
+date of its own, which is a poor fit for a document that is meant to identify a configuration.
+
+### 8. Back-merge, so the histories do not drift
+
+```console
+$ git switch develop && git merge --no-ff master && git push
+```
+
+Skipping this is how `master` accumulates commits `develop` does not have. As of this writing
+`origin/master...origin/develop` is `1 32` — master carries one commit develop does not, which is
+exactly the drift this step prevents.
+
+### 9. Update the roadmap
+
+The wave line moves from "in progress" to "shipped vX.Y.Z", and the next wave opens. That file is the
+programme's own account of what shipped when, and the CHANGELOG's earlier entries rest on it.
+
+## What is deliberately not automated
+
+No workflow cuts this release. Three of the steps above are judgement calls a script cannot make:
+whether an epic is genuinely closed, whether an artifact diff that is not only `toolVersion` is
+acceptable, and whether the known-limits section is honest. A release button that skipped them would
+be recording a decision nobody made.
+
+What *is* automated is everything mechanical: the byte comparisons, the trust-zone check, the
+governed-source lints, the no-heap scans and the pixel tests all run on every pull request, including
+the release one.
+
+## Two things in this history that will confuse you
+
+**`v0.2.0` is not an ancestor of `v0.3.0`.** The symmetric difference is 462 commits against 475.
+That is not a mistake: issue `#23` purged reproduced normative text from git history, so everything
+before the rewrite sits on a line the current history does not contain. Tooling that walks tag ranges
+has to special-case that boundary; every later one is linear.
+
+**Check `origin/master`, never a local `master`.** A local `master` in a long-lived clone can predate
+the purge and sit hundreds of commits from the real one. An earlier revision of
+[`roadmap.md`](roadmap.md) claimed "develop is 668 commits ahead of master" for exactly that reason —
+a real number about the wrong pair of refs.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,11 +11,12 @@ what the build actually produces. Track C's authoring story is what remains: #14
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
 that generates the screens it draws. Eight of its twelve children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
-golden references, and the canonical package with its C++ emitters — so the compiler now reads a
-`.medui` file, resolves it to a bounded box tree, refuses a box that cannot hold its widest approved
-translation, says where safety-critical content must appear, and writes the result as both a
-byte-compared artifact and `constexpr` C++ a device links without a parser. #198 is next: the CMake
-integration and the `mdux-meduic` host tool that runs all of it from a recipe.
+golden references, the canonical package with its C++ emitters, and the `mdux-meduic` compiler with
+its CMake registration — so the compiler now reads a `.medui` file, resolves it to a bounded box
+tree, refuses a box that cannot hold its widest approved translation, says where safety-critical
+content must appear, and writes the result as a byte-compared artifact and as `constexpr` C++ a
+device links without a parser. The first compiled screen is committed under
+`generated/screen/endoscope-monitor/`. #199 is next: the allocation-free runtime that draws one.
 
 | Metric | Count |
 |---|---|
@@ -59,7 +60,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S8 done · S9 next)
+Wave 5 · in progress        #15 (S1–S9 done · S10 next)
 Wave 6                      #16  #17
 ```
 
@@ -239,7 +240,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 8/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 9/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -261,8 +262,8 @@ happened to read.
 - #195 S6 Text-budget validation against every approved locale · _closed_
 - #196 S7 Golden references for safety-critical nodes · _closed_
 - #197 S8 Canonical package and C++ emitters · _closed (PRs #220, #221)_
-- #198 S9 CMake integration and the `mdux-meduic` host tool · **next**
-- #199 S10 Allocation-free screen runtime
+- #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #231)_
+- #199 S10 Allocation-free screen runtime · **next**
 - #200 S11 `mdux-medui-check`
 - #201 S12 First end-to-end screen
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 16 August 2026
-> Verified against `develop` @ `d3efe11` · 16 August 2026 · `#15` current through `#195`
+> Backlog · ambroise-leclerc/MduX · updated 17 August 2026
+> Verified against `develop` @ `163371b` · 17 August 2026 · `#15` current through `#196`
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
@@ -9,10 +9,11 @@ backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draw
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. Six of its twelve children have landed — the ADRs,
-the diagnostic registry, the front end, semantic analysis, bounded layout, and per-locale text
-budgets — so the compiler now reads a `.medui` file, resolves it to a bounded box tree, and refuses
-a box that cannot hold its widest approved translation. #196 is next.
+that generates the screens it draws. Seven of its twelve children have landed — the ADRs,
+the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
+and golden references — so the compiler now reads a `.medui` file, resolves it to a bounded box
+tree, refuses a box that cannot hold its widest approved translation, and says where safety-critical
+content must appear. #197 is next: the emitters that write all of it down.
 
 | Metric | Count |
 |---|---|
@@ -25,13 +26,13 @@ a box that cannot hold its widest approved translation. #196 is next.
 
 ### Where the two diverge
 
-Re-verified against `develop` on 16 August 2026. Eight of the nine rows have closed since
+Re-verified against `develop` on 17 August 2026. Eight of the nine rows have closed since
 this table was first written; the one that remains is the `.medui` authoring story, which is
 the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler's front end has landed — lexer, parser, AST, semantic analysis, bounded layout and per-locale text budgets, all host-only and conformance-tested against the shared MedUI spec. What is still ahead is the back end: goldens, the emitters, and the runtime that consumes them. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler's front end has landed — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec. What is still ahead is the back end: the emitters, and the runtime that consumes them. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Five artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
@@ -56,7 +57,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S6 done · S7 next)
+Wave 5 · in progress        #15 (S1–S7 done · S8 next)
 Wave 6                      #16  #17
 ```
 
@@ -236,14 +237,15 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 6/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 7/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
 Rust shares types across the crate boundary; C++ can do better.
 
 The front end is in the tree and conformance-tested against the shared MedUI spec
-(`medui-conformance.toml`, capabilities `syntax`, `semantics`, `layout`). ADR-011 and
+(`medui-conformance.toml`, capabilities `syntax`, `semantics`, `layout`, `safety` — the last claimed
+with #196, which is what made the pinned `MEDUI-E070` case executable rather than skipped). ADR-011 and
 ADR-012 were amended by #203 before any code depended on them: the compiled screen is
 locale-free, so the per-locale text stays in the text package — which is why S6 measures every
 approved locale and reserves the worst of them, rather than sizing a box to the locale its author
@@ -255,8 +257,8 @@ happened to read.
 - #193 S4 Theme tokens and locale-checked strings · _closed_
 - #194 S5 Bounded layout and `Row` flattening · _closed (PR #212)_
 - #195 S6 Text-budget validation against every approved locale · _closed_
-- #196 S7 Golden references for safety-critical nodes · **next**
-- #197 S8 Canonical package and C++ emitters
+- #196 S7 Golden references for safety-critical nodes · _closed_
+- #197 S8 Canonical package and C++ emitters · **next**
 - #198 S9 CMake integration and the `mdux-meduic` host tool
 - #199 S10 Allocation-free screen runtime
 - #200 S11 `mdux-medui-check`
@@ -366,6 +368,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Verified at `develop` @ `d3efe11` · 16 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 6/12) · no enforcement gaps outstanding_
+_Verified at `develop` @ `163371b` · 17 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 7/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,16 +1,17 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 22 August 2026
-> Epic status verified against `develop` @ `06b2a59` · 22 August 2026 · `#15` current through `#201`.
+> Backlog · ambroise-leclerc/MduX · updated 23 August 2026
+> Epic status verified at the v0.6.0 release baseline, `develop` @ `acbe102` · 23 August 2026 ·
+> `#15` closed, all twelve children.
 > The divergence table below was last re-verified on 17 August 2026 and is not re-checked here.
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
-backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draws its first
-pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
-what the build actually produces. Track C's authoring story is what remains: #14 closed
-Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. All twelve of its children have landed — the ADRs,
+backlog that closes the gap. Five waves have shipped — the renderer draws its first
+pixel, zero-SOUP ML inference is in the tree, the documentation has been rebuilt from
+what the build actually produces, #14 closed Wave 4 with the font and text pipeline, and
+v0.6.0 closes Wave 5 with #15, the compiler that generates the screens it draws.
+All twelve of its children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
 golden references, the canonical package with its C++ emitters, and the `mdux-meduic` compiler with
 its CMake registration — so the compiler now reads a `.medui` file, resolves it to a bounded box
@@ -417,6 +418,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Epic status verified at `develop` @ `06b2a59` · 22 August 2026_
+_Epic status verified at the v0.6.0 baseline, `develop` @ `acbe102` · 23 August 2026_
 _13 epics · 10 delivered · Waves 1–5 shipped · Wave 6 open (#16, #17) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,8 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 17 August 2026
-> Verified against `develop` @ `163371b` · 17 August 2026 · `#15` current through `#196`
+> Backlog · ambroise-leclerc/MduX · updated 22 August 2026
+> Epic status verified against `develop` @ `45eecbe` · 22 August 2026 · `#15` current through `#199`.
+> The divergence table below was last re-verified on 17 August 2026 and is not re-checked here.
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
@@ -9,14 +10,15 @@ backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draw
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. Eight of its twelve children have landed — the ADRs,
+that generates the screens it draws. Ten of its twelve children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
 golden references, the canonical package with its C++ emitters, and the `mdux-meduic` compiler with
 its CMake registration — so the compiler now reads a `.medui` file, resolves it to a bounded box
 tree, refuses a box that cannot hold its widest approved translation, says where safety-critical
 content must appear, and writes the result as a byte-compared artifact and as `constexpr` C++ a
 device links without a parser. The first compiled screen is committed under
-`generated/screen/endoscope-monitor/`. #199 is next: the allocation-free runtime that draws one.
+`generated/screen/endoscope-monitor/`, and the governed runtime draws one without allocating. #200
+is next: `mdux-medui-check`, the authoring-side checker.
 
 | Metric | Count |
 |---|---|
@@ -35,9 +37,9 @@ the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler's front end has landed — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec. What is still ahead is the back end: the emitters, and the runtime that consumes them. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. What is still ahead is the authoring-side checker (#200) and the first end-to-end screen (#201), which is what the missing text package blocks. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
-| Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Five artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
+| Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Six artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
 | Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time, `mdux-governed-lint` rejects the banned construct at source level, and `governed.noThrow.symbolScan` rejects it in the emitted objects (#116). | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Closed (#8, #10). Five standards on real clause structure with per-clause indexes and JSON Schemas, plus the documentation architecture — README derived from real targets, a contiguous ADR index, and a CI lint for internal links and retired paths. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
@@ -60,9 +62,30 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S9 done · S10 next)
+Wave 5 · in progress        #15 (S1–S10 done · S11 next)
 Wave 6                      #16  #17
 ```
+
+#### When v0.6.0 gets cut
+
+**After #201, not before.** The convention above is one version per wave, and Wave 5 is #15 alone.
+Cutting a version at 10/12 would break the pattern the last four releases followed, and would ship a
+compiler whose runtime draws one component kind and whose text half is missing: no text package is
+baked in this tree, so no screen carrying `t("STR-KEY")` compiles at all. Both gaps close in #201, and
+a 0.6.0 released before them would need its notes to explain that it cannot draw a label.
+
+If a version has to be cut sooner than that, the line *after* #199 is the one to take rather than the
+line before it. Today's `develop` is a compiler producing artifacts nothing on a device consumes;
+#199 is what makes a device able to draw one, so it is the better boundary of the two.
+
+Two things worth settling before the tag rather than during it:
+
+- **There is no CHANGELOG and no release workflow.** What shipped in each of v0.2.0 through v0.5.0 is
+  recoverable only from this document's prose. If a release is two issues away, that gap costs least
+  to close now.
+- **`v0.5.0` is an ancestor of neither `develop` nor `master`**, and `develop` is 668 commits ahead of
+  `master`. Whatever the release ritual is, it is not readable from the repository - worth knowing
+  before 0.6.0 rather than at the moment of cutting it.
 
 ## The backlog
 
@@ -240,7 +263,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 9/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 10/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -263,8 +286,8 @@ happened to read.
 - #196 S7 Golden references for safety-critical nodes · _closed_
 - #197 S8 Canonical package and C++ emitters · _closed (PRs #220, #221)_
 - #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #231)_
-- #199 S10 Allocation-free screen runtime · **next**
-- #200 S11 `mdux-medui-check`
+- #199 S10 Allocation-free screen runtime · _closed (PR #232)_
+- #200 S11 `mdux-medui-check` · **next**
 - #201 S12 First end-to-end screen
 
 _Blocks #16, #17_
@@ -371,6 +394,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Verified at `develop` @ `163371b` · 17 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 7/12) · no enforcement gaps outstanding_
+_Epic status verified at `develop` @ `45eecbe` · 22 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 10/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 4 August 2026
-> Verified against `develop @ d1329da` · 4 August 2026
+> Backlog · ambroise-leclerc/MduX · updated 11 August 2026
+> Verified against `v0.5.0` · 11 August 2026
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
@@ -14,9 +14,9 @@ generates the screens it draws.
 | Metric | Count |
 |---|---|
 | Epics | 13 |
-| Delivered | 7 |
-| Remaining | 6 |
-| Waves shipped | 3 |
+| Delivered | 9 |
+| Remaining | 4 |
+| Waves shipped | 4 |
 
 ## The thesis
 
@@ -32,10 +32,10 @@ the whole of Track C.
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Five artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
-| Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time. | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
+| Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time, `mdux-governed-lint` rejects the banned construct at source level, and `governed.noThrow.symbolScan` rejects it in the emitted objects (#116). | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Closed (#8, #10). Five standards on real clause structure with per-clause indexes and JSON Schemas, plus the documentation architecture — README derived from real targets, a contiguous ADR index, and a CI lint for internal links and retired paths. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
 | Copyright | Closed (#7). Reproduced text removed from the tree and from history, with `mdux-docs-lint` in CI to keep it out. | Reproducing normative text is forbidden outright; original prose only. |
-| Tests | Closed. 436 tests on `develop`, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
+| Tests | Closed. 438 tests on `develop`, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification, governed-zone no-throw (`governed`, #116, with a negative fixture) and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
 | Packaging | Closed (#11). Install/export restored; MSVC, GCC and Clang presets, with MSVC and GCC 16 both green in CI. | Workspace builds `--locked` on Linux and in containers. |
 
 ## Dependency order
@@ -44,10 +44,12 @@ the whole of Track C.
 
 An epic opens when every epic it depends on has closed. Four waves have shipped
 (v0.2.0, v0.3.0, v0.4.0, v0.5.0), one epic per wave closing the dependency it held.
-Wave 5 is open now: #15's blockers were #12 and #14, both closed. #19 spans waves by design; its S3–S6 follow #15.
+Wave 5 is open now: #15's blockers were #12 and #14, both closed. #11 closed ahead of it with
+`#116` and `#117`, so no enforcement gap carries into the largest epic of the programme.
+#19 spans waves by design; its S3–S6 follow #15.
 
 ```text
-Wave 1 · shipped v0.2.0     #7 (done)   #11 (open · #116, #117)  #19 (S4–S6 open)
+Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
@@ -136,16 +138,27 @@ _All nine closed in PR #154. `#65` also closes the S1 child of #19_
 
 ### Track B · Load-bearing foundations
 
-#### #11 — Foundations & trust-zone skeleton · **Open · Wave 2 enforcement gaps**
+#### #11 — Foundations & trust-zone skeleton · **Done**
 
 A new `MduXCore` that never receives Vulkan's include directories — so
-`#include <vulkan/vulkan.h>` in governed code is a compile error on every platform. Plus
+`#include <vulkan/vulkan.h>` in governed code is rejected on every platform. Plus
 the prerequisites that produce no demo and block everything.
 
 The foundations shipped in Wave 1: `MduXCore` split, link-graph verification, the test
 framework, presets, install/export, and `#48` (GCC 16 CI green; the Clang CI leg stays
-disabled, an honesty scope pinned in ADR-007). The epic stays open for the two enforcement
-gaps that postdate v0.2.0 and were folded back in.
+disabled, an honesty scope pinned in ADR-007). The two enforcement gaps that postdate
+v0.2.0 closed before Wave 5 opened, which closes the epic.
+
+`#116` found the gap it was written for to be live rather than theoretical. ADR-005
+asserted in the present tense a governed-source lint that had never been written, and
+`src/text/Raster.cpp` — governed, shipped in v0.5.0 — contained `try` and three `catch`
+clauses. The intended fix, `-fno-exceptions` on `MduXCore`, turned out to be unavailable:
+GCC records the language dialect in every module BMI and CMake synthesises one shared
+`std` target, so `import std` and `-fno-exceptions` are mutually exclusive. Enforcement
+landed instead as `mdux-governed-lint` over the source and `governed.noThrow.symbolScan`
+over the emitted objects; the rasteriser moved to the host-tools zone; and ADR-004 and
+ADR-005 were rewritten to describe only mechanisms CI runs, including what they still
+cannot claim.
 
 - #40 ADR: trust zones in C++
 - #41 ADR: error handling and exceptions
@@ -159,7 +172,15 @@ gaps that postdate v0.2.0 and were folded back in.
 - #116 S10 — Enforce governed-zone source and exception policy
 - #117 S11 — Stack-safe PR integration and post-merge policy
 
-_Remaining: `#116`, `#117`. Downstream epics are no longer blocked_
+_All eleven closed. `#117`'s PR template and merge-ordering policy land ahead of Wave 5,
+which is the most stacked epic of the programme_
+
+> **Closure depends on two independent merges**, and this line exists so that a reader can check
+> rather than assume: `#116` closes with PR #189 (the last of a three-PR stack behind #188 and
+> #187), and `#117` closes with PR #186, which targets `develop` on its own. Neither gates the
+> other in GitHub. If you are reading this and #186 is still open, the "Done" above is ahead of
+> the tree — which is precisely the kind of unearned status `#116` existed to remove, so say so
+> rather than working around it.
 
 #### #12 — Evidence kernel · **Done v0.3.0**
 
@@ -336,6 +357,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Verified at `v0.5.0` · 9 August 2026_
-_13 epics · 8 delivered · Waves 1–4 shipped · Wave 5 open · #11 enforcement open_
+_Verified at `v0.5.0` · 11 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 open · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,12 +91,23 @@ until the content filled in would be waiting on #17, which is a wave of its own.
 
 Two things worth settling before the tag rather than during it:
 
-- **There is no CHANGELOG and no release workflow.** What shipped in each of v0.2.0 through v0.5.0 is
-  recoverable only from this document's prose. If a release is two issues away, that gap costs least
-  to close now.
-- **`v0.5.0` is an ancestor of neither `develop` nor `master`**, and `develop` is 668 commits ahead of
-  `master`. Whatever the release ritual is, it is not readable from the repository - worth knowing
-  before 0.6.0 rather than at the moment of cutting it.
+- **There is now a [CHANGELOG](../CHANGELOG.md), and still no release workflow.** The 0.6.0 entry is
+  written from the merges it contains; the four earlier ones are summarised from this document's own
+  wave record, and the file says so, because two of the four tags are not ancestors of `develop` and
+  a reader checking them with `git log` would find that out the hard way.
+- **The release ritual is inferable but not written down.** Checked rather than assumed, and an
+  earlier revision of this bullet got both facts wrong: `v0.5.0` peels to exactly `origin/master`'s
+  tip, so **tags land on `master`**, and `origin/master...origin/develop` is `1 32` — master carries
+  one commit develop does not, develop carries 32. (The "668" this bullet used to claim came from a
+  stale *local* `master`, 462 commits divergent from the real one, and was a total-history count
+  mislabelled as an ahead count.)
+
+  The procedure that was missing is now [`release-process.md`](release-process.md): a release
+  branch off `develop`, the version moved in `CMakeLists.txt`, **every committed artifact re-baked**
+  because each `report.json` records the `toolVersion` it was baked by, the artifact diff reviewed
+  for anything that is not that field, then a merge to `master` and an annotated tag there. One
+  non-linear boundary exists — `v0.2.0` is not an ancestor of `v0.3.0` — and it has a documented
+  cause: #23 purged normative text from git history.
 
 ## The backlog
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,11 +9,13 @@ backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draw
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. Seven of its twelve children have landed — the ADRs,
+that generates the screens it draws. Eight of its twelve children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
-and golden references — so the compiler now reads a `.medui` file, resolves it to a bounded box
-tree, refuses a box that cannot hold its widest approved translation, and says where safety-critical
-content must appear. #197 is next: the emitters that write all of it down.
+golden references, and the canonical package with its C++ emitters — so the compiler now reads a
+`.medui` file, resolves it to a bounded box tree, refuses a box that cannot hold its widest approved
+translation, says where safety-critical content must appear, and writes the result as both a
+byte-compared artifact and `constexpr` C++ a device links without a parser. #198 is next: the CMake
+integration and the `mdux-meduic` host tool that runs all of it from a recipe.
 
 | Metric | Count |
 |---|---|
@@ -57,7 +59,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S7 done · S8 next)
+Wave 5 · in progress        #15 (S1–S8 done · S9 next)
 Wave 6                      #16  #17
 ```
 
@@ -237,7 +239,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 7/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 8/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -258,8 +260,8 @@ happened to read.
 - #194 S5 Bounded layout and `Row` flattening · _closed (PR #212)_
 - #195 S6 Text-budget validation against every approved locale · _closed_
 - #196 S7 Golden references for safety-critical nodes · _closed_
-- #197 S8 Canonical package and C++ emitters · **next**
-- #198 S9 CMake integration and the `mdux-meduic` host tool
+- #197 S8 Canonical package and C++ emitters · _closed (PRs #220, #221)_
+- #198 S9 CMake integration and the `mdux-meduic` host tool · **next**
 - #199 S10 Allocation-free screen runtime
 - #200 S11 `mdux-medui-check`
 - #201 S12 First end-to-end screen

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,9 +29,9 @@ still awaits the rendered one ADR-012 describes, which is #16 over content #17 t
 | Metric | Count |
 |---|---|
 | Epics | 13 |
-| Delivered | 9 |
-| Remaining | 4 |
-| Waves shipped | 4 |
+| Delivered | 10 |
+| Remaining | 3 |
+| Waves shipped | 5 |
 
 ## The thesis
 
@@ -57,25 +57,26 @@ the whole of Track C.
 
 ### Six waves
 
-An epic opens when every epic it depends on has closed. Four waves have shipped
-(v0.2.0, v0.3.0, v0.4.0, v0.5.0), one epic per wave closing the dependency it held.
-Wave 5 is in progress: #15's blockers were #12 and #14, both closed. #11 closed ahead of it with
-`#116` and `#117`, so no enforcement gap carries into the largest epic of the programme.
-#19 spans waves by design; its S3–S6 follow #15.
+An epic opens when every epic it depends on has closed. Five waves have shipped
+(v0.2.0, v0.3.0, v0.4.0, v0.5.0, v0.6.0), one epic per wave closing the dependency it held.
+Wave 5 was #15, the largest epic of the programme, and it closed at 12/12. Wave 6 is open: #16 and
+#17 were blocked on it and are not any more. #19 spans waves by design; its S3–S6 follow #15.
 
 ```text
 Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S12 done · epic closing)
+Wave 5 · shipped v0.6.0     #15 (done)
 Wave 6                      #16  #17
 ```
 
 #### When v0.6.0 gets cut
 
-**Now.** The convention above is one version per wave, Wave 5 is #15 alone, and #201 closed it at
-12/12: an authored `.medui` file reaches compared pixels through every stage.
+**Cut, on 23 August 2026.** The convention above is one version per wave, Wave 5 was #15 alone, and
+#201 closed it at 12/12: an authored `.medui` file reaches compared pixels through every stage. What
+follows is the reasoning as it stood before the tag, kept because the next release faces the same
+question.
 
 This recommendation was written at 10/12 and said the two content gaps — no baked text package, a
 runtime that draws one component kind — would close in #201. **They did not, and that expectation was
@@ -285,7 +286,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 12/12**
+#### #15 — `.medui` compiler & build integration · **Done v0.6.0**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -417,5 +418,5 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 ---
 
 _Epic status verified at `develop` @ `06b2a59` · 22 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 12/12) · no enforcement gaps outstanding_
+_13 epics · 10 delivered · Waves 1–5 shipped · Wave 6 open (#16, #17) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # MduX → TrustSC parity roadmap
 
 > Backlog · ambroise-leclerc/MduX · updated 22 August 2026
-> Epic status verified against `develop` @ `a5cc41f` · 22 August 2026 · `#15` current through `#200`.
+> Epic status verified against `develop` @ `06b2a59` · 22 August 2026 · `#15` current through `#201`.
 > The divergence table below was last re-verified on 17 August 2026 and is not re-checked here.
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
@@ -10,7 +10,7 @@ backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draw
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. Eleven of its twelve children have landed — the ADRs,
+that generates the screens it draws. All twelve of its children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
 golden references, the canonical package with its C++ emitters, and the `mdux-meduic` compiler with
 its CMake registration — so the compiler now reads a `.medui` file, resolves it to a bounded box
@@ -19,8 +19,12 @@ content must appear, and writes the result as a byte-compared artifact and as `c
 device links without a parser. The first compiled screen is committed under
 `generated/screen/endoscope-monitor/`, the governed runtime draws one without allocating, and
 `mdux-medui-check` validates a single file while naming the two checks a file on its own cannot
-cover. #201 is next, and last: the first end-to-end screen, which is what the missing text package
-blocks.
+cover. With #201 the chain reaches pixels: `ScreenPixelTests` renders the committed screen through
+the governed runtime and compares the frame pixel by pixel under lavapipe. What the epic leaves for
+its successors is content rather than path: no text package is baked yet (#235), so a screen carrying
+`t("STR-KEY")` cannot be compiled, and the runtime draws a `Panel` while counting every other
+component as deferred (#17). The golden sidecar gains a static consumer in `ScreenPixelTests` and
+still awaits the rendered one ADR-012 describes, which is #16 over content #17 teaches to draw.
 
 | Metric | Count |
 |---|---|
@@ -39,7 +43,7 @@ the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build. What is still ahead is the first end-to-end screen (#201), which is what the missing text package blocks. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build, and an authored screen reaches pixels through the governed runtime in `ScreenPixelTests` (#201). What is still ahead is content rather than path: the text package, and the components' own geometry (#17). | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Six artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
@@ -64,21 +68,26 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S11 done · S12 next)
+Wave 5 · in progress        #15 (S1–S12 done · epic closing)
 Wave 6                      #16  #17
 ```
 
 #### When v0.6.0 gets cut
 
-**After #201, not before.** The convention above is one version per wave, and Wave 5 is #15 alone.
-Cutting a version at 10/12 would break the pattern the last four releases followed, and would ship a
-compiler whose runtime draws one component kind and whose text half is missing: no text package is
-baked in this tree, so no screen carrying `t("STR-KEY")` compiles at all. Both gaps close in #201, and
-a 0.6.0 released before them would need its notes to explain that it cannot draw a label.
+**Now.** The convention above is one version per wave, Wave 5 is #15 alone, and #201 closed it at
+12/12: an authored `.medui` file reaches compared pixels through every stage.
 
-If a version has to be cut sooner than that, the line *after* #199 is the one to take rather than the
-line before it. Today's `develop` is a compiler producing artifacts nothing on a device consumes;
-#199 is what makes a device able to draw one, so it is the better boundary of the two.
+This recommendation was written at 10/12 and said the two content gaps — no baked text package, a
+runtime that draws one component kind — would close in #201. **They did not, and that expectation was
+mine rather than the issue's.** #201's acceptance asked for an end-to-end screen exercising a
+safety-critical node, and that is what it delivered; nothing in it promised the text half. So the
+gaps outlive the wave and belong to its successors: the text package to whoever bakes one, the
+components' own geometry to #17.
+
+That does not argue for delaying the tag. What v0.6.0 ships is a complete *path* — authored file,
+byte-compared artifact, `constexpr` C++, governed runtime, compared pixel — and the honest release
+note says exactly that: the chain is built and the content is one rectangle. A version held back
+until the content filled in would be waiting on #17, which is a wave of its own.
 
 Two things worth settling before the tag rather than during it:
 
@@ -265,7 +274,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 11/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 12/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -290,7 +299,7 @@ happened to read.
 - #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #231)_
 - #199 S10 Allocation-free screen runtime · _closed (PR #232)_
 - #200 S11 `mdux-medui-check` · _closed (PR #233)_
-- #201 S12 First end-to-end screen · **next**
+- #201 S12 First end-to-end screen · _closed (PR #234)_
 
 _Blocks #16, #17_
 
@@ -396,6 +405,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Epic status verified at `develop` @ `a5cc41f` · 22 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 11/12) · no enforcement gaps outstanding_
+_Epic status verified at `develop` @ `06b2a59` · 22 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 12/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,15 +1,18 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 11 August 2026
-> Verified against `v0.5.0` · 11 August 2026
+> Backlog · ambroise-leclerc/MduX · updated 16 August 2026
+> Verified against `develop` @ `d3efe11` · 16 August 2026 · `#15` current through `#195`
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
 SDK with IEC 62304 Class B/C compliance modelling built in. This is the dependency-ordered
 backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draws its first
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
-Wave 4 with the font and text pipeline, and #15 opens Wave 5 with the compiler that
-generates the screens it draws.
+Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
+that generates the screens it draws. Six of its twelve children have landed — the ADRs,
+the diagnostic registry, the front end, semantic analysis, bounded layout, and per-locale text
+budgets — so the compiler now reads a `.medui` file, resolves it to a bounded box tree, and refuses
+a box that cannot hold its widest approved translation. #196 is next.
 
 | Metric | Count |
 |---|---|
@@ -22,20 +25,20 @@ generates the screens it draws.
 
 ### Where the two diverge
 
-Re-verified against `develop` on 9 August 2026. Eight of the nine rows have closed since
+Re-verified against `develop` on 16 August 2026. Eight of the nine rows have closed since
 this table was first written; the one that remains is the `.medui` authoring story, which is
 the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The `.medui` compiler that generates it is still ahead — this is Track C, Wave 5. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler's front end has landed — lexer, parser, AST, semantic analysis, bounded layout and per-locale text budgets, all host-only and conformance-tested against the shared MedUI spec. What is still ahead is the back end: goldens, the emitters, and the runtime that consumes them. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Five artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
 | Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time, `mdux-governed-lint` rejects the banned construct at source level, and `governed.noThrow.symbolScan` rejects it in the emitted objects (#116). | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Closed (#8, #10). Five standards on real clause structure with per-clause indexes and JSON Schemas, plus the documentation architecture — README derived from real targets, a contiguous ADR index, and a CI lint for internal links and retired paths. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
 | Copyright | Closed (#7). Reproduced text removed from the tree and from history, with `mdux-docs-lint` in CI to keep it out. | Reproducing normative text is forbidden outright; original prose only. |
-| Tests | Closed. 438 tests on `develop`, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification, governed-zone no-throw (`governed`, #116, with a negative fixture) and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
+| Tests | Closed. 438 tests at `v0.5.0`, and more since, across the in-repository `MduXTest` and SpecLab BDD scenarios. Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification, governed-zone no-throw (`governed`, #116, with a negative fixture) and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
 | Packaging | Closed (#11). Install/export restored; MSVC, GCC and Clang presets, with MSVC and GCC 16 both green in CI. | Workspace builds `--locked` on Linux and in containers. |
 
 ## Dependency order
@@ -44,7 +47,7 @@ the whole of Track C.
 
 An epic opens when every epic it depends on has closed. Four waves have shipped
 (v0.2.0, v0.3.0, v0.4.0, v0.5.0), one epic per wave closing the dependency it held.
-Wave 5 is open now: #15's blockers were #12 and #14, both closed. #11 closed ahead of it with
+Wave 5 is in progress: #15's blockers were #12 and #14, both closed. #11 closed ahead of it with
 `#116` and `#117`, so no enforcement gap carries into the largest epic of the programme.
 #19 spans waves by design; its S3–S6 follow #15.
 
@@ -53,7 +56,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · open now           #15
+Wave 5 · in progress        #15 (S1–S6 done · S7 next)
 Wave 6                      #16  #17
 ```
 
@@ -175,12 +178,11 @@ cannot claim.
 _All eleven closed. `#117`'s PR template and merge-ordering policy land ahead of Wave 5,
 which is the most stacked epic of the programme_
 
-> **Closure depends on two independent merges**, and this line exists so that a reader can check
-> rather than assume: `#116` closes with PR #189 (the last of a three-PR stack behind #188 and
-> #187), and `#117` closes with PR #186, which targets `develop` on its own. Neither gates the
-> other in GitHub. If you are reading this and #186 is still open, the "Done" above is ahead of
-> the tree — which is precisely the kind of unearned status `#116` existed to remove, so say so
-> rather than working around it.
+> **Closure depended on two independent merges**, and this line stays so that a reader can check
+> rather than assume: `#116` closed with PR #189 (the last of a three-PR stack behind #188 and
+> #187), and `#117` closed with PR #186, which targeted `develop` on its own. All four merged on
+> 11 August 2026, so the "Done" above is behind the tree rather than ahead of it — which is the
+> only direction this status line is allowed to be wrong in.
 
 #### #12 — Evidence kernel · **Done v0.3.0**
 
@@ -234,24 +236,31 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **Ready · opens Wave 5**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 6/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
 Rust shares types across the crate boundary; C++ can do better.
 
-- S1 ADRs: DSL boundary and generated artifacts
-- S2 Diagnostics and the code registry
-- S3 Lexer, parser, AST
-- S4 Theme tokens and locale-checked strings
-- S5 Layout and row flattening
-- S6 Text-budget validation
-- S7 Golden references for safety-critical nodes
-- S8 JSON and C++ emitters
-- S9 CMake integration and host tools
-- S10 Allocation-free screen runtime
-- S11 `mdux-medui-check`
-- S12 First end-to-end screen
+The front end is in the tree and conformance-tested against the shared MedUI spec
+(`medui-conformance.toml`, capabilities `syntax`, `semantics`, `layout`). ADR-011 and
+ADR-012 were amended by #203 before any code depended on them: the compiled screen is
+locale-free, so the per-locale text stays in the text package — which is why S6 measures every
+approved locale and reserves the worst of them, rather than sizing a box to the locale its author
+happened to read.
+
+- #190 S1 ADRs: DSL boundary and generated artifacts · _closed_
+- #191 S2 Diagnostics and the MDX-E code registry · _closed_
+- #192 S3 Lexer, parser, AST and the fixture corpus · _closed_
+- #193 S4 Theme tokens and locale-checked strings · _closed_
+- #194 S5 Bounded layout and `Row` flattening · _closed (PR #212)_
+- #195 S6 Text-budget validation against every approved locale · _closed_
+- #196 S7 Golden references for safety-critical nodes · **next**
+- #197 S8 Canonical package and C++ emitters
+- #198 S9 CMake integration and the `mdux-meduic` host tool
+- #199 S10 Allocation-free screen runtime
+- #200 S11 `mdux-medui-check`
+- #201 S12 First end-to-end screen
 
 _Blocks #16, #17_
 
@@ -357,6 +366,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Verified at `v0.5.0` · 11 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 open · no enforcement gaps outstanding_
+_Verified at `develop` @ `d3efe11` · 16 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 6/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # MduX → TrustSC parity roadmap
 
 > Backlog · ambroise-leclerc/MduX · updated 22 August 2026
-> Epic status verified against `develop` @ `45eecbe` · 22 August 2026 · `#15` current through `#199`.
+> Epic status verified against `develop` @ `a5cc41f` · 22 August 2026 · `#15` current through `#200`.
 > The divergence table below was last re-verified on 17 August 2026 and is not re-checked here.
 
 MduX (C++23 / Vulkan) and TrustSC (Rust) target the same problem — a medical-device UI
@@ -10,15 +10,17 @@ backlog that closes the gap. Waves 1, 2 and 3 have shipped — the renderer draw
 pixel, zero-SOUP ML inference is in the tree, and the documentation has been rebuilt from
 what the build actually produces. Track C's authoring story is what remains: #14 closed
 Wave 4 with the font and text pipeline, and #15 is underway in Wave 5 with the compiler
-that generates the screens it draws. Ten of its twelve children have landed — the ADRs,
+that generates the screens it draws. Eleven of its twelve children have landed — the ADRs,
 the diagnostic registry, the front end, semantic analysis, bounded layout, per-locale text budgets,
 golden references, the canonical package with its C++ emitters, and the `mdux-meduic` compiler with
 its CMake registration — so the compiler now reads a `.medui` file, resolves it to a bounded box
 tree, refuses a box that cannot hold its widest approved translation, says where safety-critical
 content must appear, and writes the result as a byte-compared artifact and as `constexpr` C++ a
 device links without a parser. The first compiled screen is committed under
-`generated/screen/endoscope-monitor/`, and the governed runtime draws one without allocating. #200
-is next: `mdux-medui-check`, the authoring-side checker.
+`generated/screen/endoscope-monitor/`, the governed runtime draws one without allocating, and
+`mdux-medui-check` validates a single file while naming the two checks a file on its own cannot
+cover. #201 is next, and last: the first end-to-end screen, which is what the missing text package
+blocks.
 
 | Metric | Count |
 |---|---|
@@ -37,7 +39,7 @@ the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. What is still ahead is the authoring-side checker (#200) and the first end-to-end screen (#201), which is what the missing text package blocks. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build. What is still ahead is the first end-to-end screen (#201), which is what the missing text package blocks. | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Six artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
@@ -62,7 +64,7 @@ Wave 1 · shipped v0.2.0     #7 (done)   #11 (done)  #19 (S4–S6 open)
 Wave 2 · shipped v0.3.0     #8 (done)   #9 (done)   #12 (done)
 Wave 3 · shipped v0.4.0     #10 (done)  #13 (done)  #18 (done)
 Wave 4 · shipped v0.5.0     #14 (done)
-Wave 5 · in progress        #15 (S1–S10 done · S11 next)
+Wave 5 · in progress        #15 (S1–S11 done · S12 next)
 Wave 6                      #16  #17
 ```
 
@@ -263,7 +265,7 @@ charset table — and the compiler rejects any format that could escape it, whic
 
 _Unblocks #15_
 
-#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 10/12**
+#### #15 — `.medui` compiler & build integration · **In progress · Wave 5 · 11/12**
 
 The schema module is imported by both the device runtime and the host compiler — one
 definition, shared. The runtime never sees the parser, which lives in a host-only tool.
@@ -287,8 +289,8 @@ happened to read.
 - #197 S8 Canonical package and C++ emitters · _closed (PRs #220, #221)_
 - #198 S9 CMake integration and the `mdux-meduic` host tool · _closed (PRs #225, #231)_
 - #199 S10 Allocation-free screen runtime · _closed (PR #232)_
-- #200 S11 `mdux-medui-check` · **next**
-- #201 S12 First end-to-end screen
+- #200 S11 `mdux-medui-check` · _closed (PR #233)_
+- #201 S12 First end-to-end screen · **next**
 
 _Blocks #16, #17_
 
@@ -394,6 +396,6 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Epic status verified at `develop` @ `45eecbe` · 22 August 2026_
-_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 10/12) · no enforcement gaps outstanding_
+_Epic status verified at `develop` @ `a5cc41f` · 22 August 2026_
+_13 epics · 9 delivered · Waves 1–4 shipped · Wave 5 in progress (#15 at 11/12) · no enforcement gaps outstanding_
 _All epics on GitHub_

--- a/generated/font/dejavu-ui/report.json
+++ b/generated/font/dejavu-ui/report.json
@@ -39,5 +39,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-textbake",
-  "toolVersion": "0.5.0"
+  "toolVersion": "0.6.0"
 }

--- a/generated/model/ecg-demo-alt/report.json
+++ b/generated/model/ecg-demo-alt/report.json
@@ -30,5 +30,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-mlbake",
-  "toolVersion": "0.5.0"
+  "toolVersion": "0.6.0"
 }

--- a/generated/model/ecg-demo/report.json
+++ b/generated/model/ecg-demo/report.json
@@ -30,5 +30,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-mlbake",
-  "toolVersion": "0.5.0"
+  "toolVersion": "0.6.0"
 }

--- a/generated/screen/endoscope-monitor/goldens.json
+++ b/generated/screen/endoscope-monitor/goldens.json
@@ -1,0 +1,15 @@
+[
+  {
+    "bounds": {
+      "height": 128,
+      "width": 1280,
+      "x": 0,
+      "y": 592
+    },
+    "colorToken": "Theme.Colors.Nominal",
+    "cvChecks": [
+      "Bounds"
+    ],
+    "nodeId": "ecg-lead-ii"
+  }
+]

--- a/generated/screen/endoscope-monitor/goldens.json
+++ b/generated/screen/endoscope-monitor/goldens.json
@@ -1,6 +1,20 @@
 [
   {
     "bounds": {
+      "height": 96,
+      "width": 1280,
+      "x": 0,
+      "y": 496
+    },
+    "colorToken": "Theme.Colors.ScoreDigits",
+    "cvChecks": [
+      "Bounds",
+      "ColorHash"
+    ],
+    "nodeId": "insufflation-pressure"
+  },
+  {
+    "bounds": {
       "height": 128,
       "width": 1280,
       "x": 0,

--- a/generated/screen/endoscope-monitor/package.json
+++ b/generated/screen/endoscope-monitor/package.json
@@ -35,7 +35,7 @@
     },
     {
       "bounds": {
-        "height": 520,
+        "height": 424,
         "width": 1280,
         "x": 0,
         "y": 72
@@ -44,6 +44,22 @@
       "kind": "VulkanViewport",
       "spec": {
         "streamSource": "ENDOSCOPE_PRIMARY"
+      }
+    },
+    {
+      "bounds": {
+        "height": 96,
+        "width": 1280,
+        "x": 0,
+        "y": 496
+      },
+      "id": "insufflation-pressure",
+      "kind": "NumericDisplay",
+      "spec": {
+        "colorToken": "Theme.Colors.ScoreDigits",
+        "requirement": "REQ-EM-001",
+        "source": "INSUFFLATION_PRESSURE",
+        "templateId": "TPL-PRESSURE-MMHG"
       }
     },
     {

--- a/generated/screen/endoscope-monitor/package.json
+++ b/generated/screen/endoscope-monitor/package.json
@@ -1,0 +1,67 @@
+{
+  "budget": {
+    "maxCommands": 64,
+    "maxIndices": 6144,
+    "maxVertices": 4096
+  },
+  "id": "endoscope-monitor",
+  "kind": "screen",
+  "nodes": [
+    {
+      "bounds": {
+        "height": 72,
+        "width": 1280,
+        "x": 0,
+        "y": 0
+      },
+      "id": "topbar-background",
+      "kind": "Panel",
+      "spec": {
+        "colorToken": "Theme.Colors.TopbarBackground"
+      }
+    },
+    {
+      "bounds": {
+        "height": 72,
+        "width": 240,
+        "x": 0,
+        "y": 0
+      },
+      "id": "brand-mark",
+      "kind": "Image",
+      "spec": {
+        "source": "IMG-BRAND-MARK"
+      }
+    },
+    {
+      "bounds": {
+        "height": 520,
+        "width": 1280,
+        "x": 0,
+        "y": 72
+      },
+      "id": "endoscope-view",
+      "kind": "VulkanViewport",
+      "spec": {
+        "streamSource": "ENDOSCOPE_PRIMARY"
+      }
+    },
+    {
+      "bounds": {
+        "height": 128,
+        "width": 1280,
+        "x": 0,
+        "y": 592
+      },
+      "id": "ecg-lead-ii",
+      "kind": "SignalTrace",
+      "spec": {
+        "colorToken": "Theme.Colors.Nominal",
+        "streamSource": "ECG_LEAD_II"
+      }
+    }
+  ],
+  "schemaVersion": 1,
+  "surfaceHeight": 720,
+  "surfaceWidth": 1280
+}

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -35,5 +35,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-meduic",
-  "toolVersion": "0.5.0"
+  "toolVersion": "0.6.0"
 }

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -1,0 +1,39 @@
+{
+  "inputs": [
+    {
+      "path": "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui",
+      "sha256": "7edbb61c9e6e196bb8f38b9a1339491cf2b2abbf51e47515c9fb37b0df8f32ae"
+    }
+  ],
+  "options": {
+    "budget": {
+      "maxCommands": 64,
+      "maxIndices": 6144,
+      "maxVertices": 4096
+    },
+    "dynamicText": [],
+    "fontPackage": "",
+    "id": "endoscope-monitor",
+    "source": "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui",
+    "surfaceHeight": 720,
+    "surfaceWidth": 1280,
+    "textPackages": []
+  },
+  "outputs": [
+    {
+      "path": "goldens.json",
+      "sha256": "d287cf21560be2891a0ab11ba6bcf197cd2295fc20ed900d95ea931aef3bdf4c"
+    },
+    {
+      "path": "package.json",
+      "sha256": "c0aa463ba4f87185729aaa99870e2497012c4e3506eb5a101fbc166e54433cef"
+    }
+  ],
+  "recipe": {
+    "path": "recipes/screen/endoscope-monitor.toml",
+    "sha256": "098afa4645afdb85dcf238c511c062bebedebf1148e8a565383df905db761af5"
+  },
+  "schemaVersion": 1,
+  "tool": "mdux-meduic",
+  "toolVersion": "0.5.0"
+}

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -2,7 +2,7 @@
   "inputs": [
     {
       "path": "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui",
-      "sha256": "7edbb61c9e6e196bb8f38b9a1339491cf2b2abbf51e47515c9fb37b0df8f32ae"
+      "sha256": "c35fd66ae804cb6ac14ea691914f52b3690355fd32a361a14bc46058f257642c"
     }
   ],
   "options": {
@@ -22,11 +22,11 @@
   "outputs": [
     {
       "path": "goldens.json",
-      "sha256": "d287cf21560be2891a0ab11ba6bcf197cd2295fc20ed900d95ea931aef3bdf4c"
+      "sha256": "60c555cbeceb4e897e5a4302c0d667aaca84dd72d28ef2c13d96178d86eb1a2a"
     },
     {
       "path": "package.json",
-      "sha256": "c0aa463ba4f87185729aaa99870e2497012c4e3506eb5a101fbc166e54433cef"
+      "sha256": "72066d6b6ef6a80c974a99b807a3e5fe7e40aba08fa0d0885eff67e2348554f0"
     }
   ],
   "recipe": {

--- a/generated/shader/mdux-ui/report.json
+++ b/generated/shader/mdux-ui/report.json
@@ -37,5 +37,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-shaderbake",
-  "toolVersion": "0.5.0"
+  "toolVersion": "0.6.0"
 }

--- a/generated/shader/triangle/report.json
+++ b/generated/shader/triangle/report.json
@@ -37,5 +37,5 @@
   },
   "schemaVersion": 1,
   "tool": "mdux-shaderbake",
-  "toolVersion": "0.5.0"
+  "toolVersion": "0.6.0"
 }

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -524,19 +524,23 @@ static_assert(std::variant_size_v<NodePayload> == 11, "an alternative was added 
  * function a traceability export walks rather than a field every node pretends to have.
  */
 [[nodiscard]] constexpr std::string_view requirementOf(const CompiledNode& node) noexcept {
-    if (const auto* spec = std::get_if<ButtonSpec>(&node.payload)) {
+    // Copied for the reason `validatePayload()` documents at length: `std::get_if` over a subobject
+    // of an `inline` variable is refused as a constant expression under `-fsanitize=undefined`, and
+    // a traceability export walking a generated screen at compile time would hit exactly that.
+    const NodePayload payload = node.payload;
+    if (const auto* spec = std::get_if<ButtonSpec>(&payload)) {
         return spec->requirement;
     }
-    if (const auto* spec = std::get_if<CriticalButtonSpec>(&node.payload)) {
+    if (const auto* spec = std::get_if<CriticalButtonSpec>(&payload)) {
         return spec->requirement;
     }
-    if (const auto* spec = std::get_if<NumericDisplaySpec>(&node.payload)) {
+    if (const auto* spec = std::get_if<NumericDisplaySpec>(&payload)) {
         return spec->requirement;
     }
-    if (const auto* spec = std::get_if<StatusIndicatorSpec>(&node.payload)) {
+    if (const auto* spec = std::get_if<StatusIndicatorSpec>(&payload)) {
         return spec->requirement;
     }
-    if (const auto* spec = std::get_if<TextInputSpec>(&node.payload)) {
+    if (const auto* spec = std::get_if<TextInputSpec>(&payload)) {
         return spec->requirement;
     }
     return {};
@@ -627,6 +631,23 @@ struct ScreenPackage {
  *
  * Optional fields are checked when present and ignored when empty, because "absent" is a legal
  * value the dictionary allows for `requirement` on a `Button` or `charset` on a `TextInput`.
+ *
+ * ## Why the payload is taken by value
+ *
+ * Not an oversight, and not a style preference. `std::get_if` takes the address of its argument, and
+ * GCC 16.1 under `-fsanitize=undefined` refuses `&object != nullptr` - the comparison inside
+ * `get_if` - as a constant expression when `object` is a subobject of an `inline` variable with
+ * external linkage. That is exactly the shape #197's generated screens have, and exactly what their
+ * `static_assert(screen.validate().has_value())` evaluates, so the sanitizer leg failed to compile a
+ * screen every other configuration accepted.
+ *
+ * The standard is not ambiguous here: the address of an object with static storage duration is a
+ * core constant expression whatever instruments the translation unit, so this is a compiler defect
+ * rather than a rule anyone should design around. Copying into a parameter gives `get_if` an
+ * automatic object to point at, which every configuration accepts. The copy costs nothing that
+ * matters - every alternative is trivially copyable, so it neither allocates nor throws - and
+ * `medui-schema-inline-screen-validates` in the schema suite pins the property so a later
+ * simplification back to a reference does not quietly break the sanitizer leg again.
  */
 [[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> requireColor(std::string_view token) noexcept {
     if (const auto named = require(token); !named.has_value()) {
@@ -635,7 +656,7 @@ struct ScreenPackage {
     return checkColor(token);
 }
 
-[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> validatePayload(const NodePayload& payload) noexcept {
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> validatePayload(NodePayload payload) noexcept {
     if (const auto* spec = std::get_if<PanelSpec>(&payload)) {
         // A Panel exists because a Row declared a background, so it always has one.
         return requireColor(spec->colorToken);

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -46,24 +46,27 @@
  * survives the widest approved translation. That is what #195 measures, and why the budget below
  * cannot be derived from the node count.
  *
- * ## The colour table lives here, and its contents do not
+ * ## The colour table, and why its contents are here rather than supplied
  *
  * ADR-011 puts the *resolution* of `Theme.Colors.<Token>` on the device, as a bounded scan of a
  * governed table - TrustSC's `THEME_COLORS` and `resolve_color_token()` are the reference, and both
- * live in its governed crate. So `ThemeColor` and `resolveColorToken()` are here, beside the package
- * that carries the names: a consumer holding this schema holds the whole device-side contract, and
- * #199 inherits a resolver rather than writing a second one.
+ * live in its governed crate. So `themeColors`, `ThemeColor` and `resolveColorToken()` are here,
+ * beside the package that carries the names: a consumer holding this schema holds the whole
+ * device-side contract, and #199 inherits a resolver rather than writing a second one.
  *
- * What is deliberately *not* here is a palette. Which colours a device shows is a clinical and
- * regulatory decision belonging to the product, exactly as the theme names semantic analysis
- * validates against are an input rather than a constant (#193). MduX owns the representation and the
- * lookup; the table is supplied.
+ * The table's *contents* are here for the same reason, and it is worth stating because the opposite
+ * is defensible in isolation: a palette looks like a product decision, and the theme names semantic
+ * analysis validates against are indeed a compiler input (#193). But the parity programme's purpose
+ * is that one `.medui` screen means the same thing in both projects, and it does not if a token
+ * renders one colour here and another there. TrustSC settles this in its governed crate; MduX
+ * matches it entry for entry, and a change to the palette is a change to make in both projects at
+ * once.
  *
  * ## What `validate()` checks, and what it deliberately does not
  *
  * It checks what a consumer is entitled to assume without looking: an identified screen, a positive
- * surface, nodes with unique ids and rectangles that lie inside that surface, colour tokens that are
- * names rather than values, and a budget the index width can address.
+ * surface, nodes with unique ids and rectangles that lie inside that surface, colour tokens the
+ * governed table actually defines, and a budget the index width can address.
  *
  * It does **not** check that the budget is large enough for what the screen draws. That number is
  * not derivable from anything here: a `Label` draws one rectangle per glyph of the widest approved
@@ -79,7 +82,6 @@ export module mdux.medui.schema;
 
 import std;
 import mdux.core.result;
-import mdux.core.units;
 import mdux.draw;
 import mdux.evidence.report;
 
@@ -101,6 +103,7 @@ enum class SchemaError : std::uint8_t {
     DegenerateBounds,          ///< a rectangle with no extent, which `DrawList` refuses to record
     BoundsOutsideSurface,      ///< a rectangle the declared surface does not contain
     MalformedColorToken,       ///< a colour that is not a `Theme.Colors.<Token>` name
+    UnknownColorToken,         ///< a well-formed name the governed table does not define
     EmptyBudget,               ///< a screen with nodes whose budget can hold no primitive
     BudgetExceedsIndexWidth,   ///< more vertices than a 16-bit index can address
 };
@@ -123,6 +126,8 @@ enum class SchemaError : std::uint8_t {
             return "a node's rectangle leaves the declared surface";
         case SchemaError::MalformedColorToken:
             return "a colour is not a Theme.Colors.<Token> name";
+        case SchemaError::UnknownColorToken:
+            return "a colour names a token the governed table does not define";
         case SchemaError::EmptyBudget:
             return "the screen has nodes and a budget that can hold no primitive";
         case SchemaError::BudgetExceedsIndexWidth:
@@ -132,17 +137,23 @@ enum class SchemaError : std::uint8_t {
 }
 
 /**
- * @brief One entry of the governed colour table: a name a screen may carry, and what it resolves to.
+ * @brief One entry of the governed token to RGBA table: a name a screen may carry, and its colour.
  *
  * The device side of ADR-011's boundary. A compiled screen carries `Theme.Colors.<Token>` as a
- * *name*, and the runtime turns it into a colour by scanning a table like this one - a bounded scan
- * over fixed data, which is neither parsing nor unbounded work, and therefore not what the compile
- * boundary exists to keep off a device. TrustSC reached this arrangement first: `THEME_COLORS` and
- * `resolve_color_token()` live in its governed `trustsc-ui` crate, and this is the same shape.
+ * *name*, and the runtime turns it into a colour by scanning this table - a bounded scan over fixed
+ * data, which is neither parsing nor unbounded work, and therefore not what the compile boundary
+ * exists to keep off a device.
+ *
+ * **Linear RGBA, straight alpha, in 0..1**, and `float` rather than the `ColorRgba8` a vertex
+ * carries. Both are parity decisions rather than local preferences: TrustSC's `THEME_COLORS` is
+ * `&[(&str, [f32; 4])]` and its `resolve_color_token()` returns `Option<[f32; 4]>`, so this is the
+ * same value in the same space. Converting to the `R8G8B8A8_UNORM` form `mdux.draw` records is the
+ * adapter's step, and is deliberately not folded in here - a table that stored bytes would have
+ * chosen a rounding rule that the two projects could then disagree about silently.
  */
 struct ThemeColor {
-    std::string_view       token;  ///< the full name, e.g. `Theme.Colors.ScoreDigits`
-    mdux::core::ColorRgba8 value{};
+    std::string_view     token;    ///< the full name, e.g. `Theme.Colors.ScoreDigits`
+    std::array<float, 4> value{};  ///< linear RGBA, straight alpha, each channel in 0..1
 
     [[nodiscard]] constexpr bool operator==(const ThemeColor&) const noexcept = default;
 };
@@ -163,17 +174,43 @@ enum class ThemeError : std::uint8_t {
 }
 
 /**
+ * @brief The governed token to RGBA table: the single approved source of truth for what a name
+ *        renders as.
+ *
+ * Entry for entry, and value for value, TrustSC's `THEME_COLORS` (its ADR-014). That is the point
+ * rather than an implementation detail: the parity programme's purpose is that one `.medui` screen
+ * means the same thing in both projects, and a screen means a different thing if the same token
+ * renders a different colour. A rendered-truth check (#16) comparing a tint against this table is
+ * comparing against the same numbers TrustSC's verifier uses.
+ *
+ * Consequently this table is **not** a product input. An earlier revision of this module left the
+ * contents to the caller on the argument that a palette is a clinical decision; TrustSC settles it
+ * the other way, in its governed crate, and the parity criterion decides between the two. A product
+ * that needs a different palette is a change to make in both projects at once, not one to make here
+ * by supplying a different span.
+ */
+inline constexpr std::array<ThemeColor, 8> themeColors{
+    ThemeColor{.token = "Theme.Colors.TopbarBackground", .value = {0.82F, 0.84F, 0.86F, 1.0F}},
+    ThemeColor{           .token = "Theme.Colors.Title", .value = {0.10F, 0.12F, 0.16F, 1.0F}},
+    ThemeColor{     .token = "Theme.Colors.ScoreDigits", .value = {0.13F, 0.72F, 0.42F, 1.0F}},
+    ThemeColor{         .token = "Theme.Colors.Nominal", .value = {0.13F, 0.72F, 0.42F, 1.0F}},
+    ThemeColor{           .token = "Theme.Colors.Alert", .value = {0.95F, 0.65F, 0.15F, 1.0F}},
+    ThemeColor{           .token = "Theme.Colors.Fault", .value = {0.86F, 0.20F, 0.18F, 1.0F}},
+    ThemeColor{         .token = "Theme.Colors.Neutral", .value = {0.62F, 0.66F, 0.70F, 1.0F}},
+    ThemeColor{   .token = "Theme.Colors.PrimaryAction", .value = {0.16F, 0.44F, 0.86F, 1.0F}}
+};
+
+/**
  * @brief Whether `token` has the shape a colour name must have.
  *
  * The prefix, then a non-empty suffix of the characters an identifier may contain - ASCII letters,
  * digits, `_` and `-` - with `.` admitted between segments, because the parser builds a dotted path
- * and a product may legitimately name `Theme.Colors.Status.Ok`. No empty segment: a trailing dot or
- * a `..` names nothing.
+ * and a name such as `Theme.Colors.Status.Ok` is expressible. No empty segment: a trailing dot or a
+ * `..` names nothing.
  *
- * Shape is not existence. A well-formed token may still be absent from a product's table, which is
- * what `resolveColorToken()` reports and what the compiler already checks against the theme names it
- * was given (#193). Keeping the two separate is what lets `validate()` reject a malformed name
- * without holding a table it was never handed.
+ * Shape is not existence. A well-formed token may still be absent from the governed table, which is
+ * what `resolveColorToken()` reports separately - and the distinction matters, because a malformed
+ * name is an emitter defect while an absent one is a table that does not define it.
  */
 [[nodiscard]] constexpr bool isColorToken(std::string_view token) noexcept {
     if (!token.starts_with(colorTokenPrefix) || token.size() == colorTokenPrefix.size()) {
@@ -200,26 +237,22 @@ enum class ThemeError : std::uint8_t {
 }
 
 /**
- * @brief Resolves a name a compiled screen carries against a product's governed colour table.
+ * @brief Resolves a name a compiled screen carries against the governed table.
  *
  * A bounded scan with a `Result` on miss - never an allocation, never a throw, as ADR-011 requires
- * and as `mdux-governed-lint` and `governed.noThrow.symbolScan` hold this module to. Linear rather
- * than a binary search: a palette holds tens of entries, and requiring the table to be sorted would
- * add an invariant a product's generated table could silently break, in exchange for a saving no
- * frame would notice.
+ * and as `mdux-governed-lint` and `governed.noThrow.symbolScan` hold this module to. Linear, like
+ * TrustSC's `resolve_color_token()`, over a table of eight entries.
  *
- * **The table's contents are the product's, not this library's.** MduX defines the representation
- * and the lookup; a palette is a clinical and regulatory decision belonging to the device it ships
- * on, exactly as the theme names semantic analysis validates against are an input rather than a
- * constant (#193). So there is no default table here to inherit, and a caller supplying an empty one
- * gets `UnknownToken` for every name rather than a colour nobody approved.
+ * Two errors rather than one, which is where this parts from the sibling's `Option`: a name that is
+ * not a name at all is an emitter defect, and a well-formed name the table does not define is a
+ * screen compiled against a different palette. Both are misses to a caller that only asks whether
+ * it got a colour, and they need different people to fix them.
  */
-[[nodiscard]] constexpr mdux::core::Result<mdux::core::ColorRgba8, ThemeError> resolveColorToken(std::span<const ThemeColor> table,
-                                                                                                 std::string_view            token) noexcept {
+[[nodiscard]] constexpr mdux::core::Result<std::array<float, 4>, ThemeError> resolveColorToken(std::string_view token) noexcept {
     if (!isColorToken(token)) {
         return mdux::core::err(ThemeError::MalformedToken);
     }
-    for (const ThemeColor& entry : table) {
+    for (const ThemeColor& entry : themeColors) {
         if (entry.token == token) {
             return entry.value;
         }
@@ -340,12 +373,21 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
         if (!containedBy(node.bounds, surfaceWidth, surfaceHeight)) {
             return err(SchemaError::BoundsOutsideSurface);
         }
-        // The same shape rule the resolver applies, so a screen that validates here cannot fail the
-        // device lookup for a reason `validate()` could have seen. `Theme.Colors.` names nothing and
-        // `Theme.Colors.#` is not a name at all; both would otherwise pass the generated
-        // `static_assert` and fail only where nobody is watching.
-        if (!node.colorToken.empty() && !isColorToken(node.colorToken)) {
-            return err(SchemaError::MalformedColorToken);
+        // The resolver itself, rather than the shape rule alone, so a screen that validates here
+        // cannot fail the device lookup for any reason `validate()` could have seen. Shape was all
+        // this could check while the palette was a caller's input; now that the governed table is
+        // the approved source of token existence, a name absent from it is as certain a defect as a
+        // name that is not a name - and both would otherwise pass the generated `static_assert` and
+        // fail where nobody is watching.
+        //
+        // The two are kept apart because they are different people's defects: a malformed name is
+        // the emitter's, and an unknown one is a screen compiled against a palette this build does
+        // not have.
+        if (!node.colorToken.empty()) {
+            const auto resolved = resolveColorToken(node.colorToken);
+            if (!resolved.has_value()) {
+                return err(resolved.error() == ThemeError::MalformedToken ? SchemaError::MalformedColorToken : SchemaError::UnknownColorToken);
+            }
         }
     }
 

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -1,0 +1,364 @@
+/**
+ * @file Schema.cppm
+ * @brief Governed-zone compiled-screen types: what a `.medui` screen becomes once the compiler has
+ *        resolved it, in the form a device holds it.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Part of MduXCore, and canonical: the emitters (#197), the compiler driver (#198) and the
+ * allocation-free runtime (#199) import this rather than restating its records. Two files
+ * describing the same artifact disagree eventually, and the disagreement surfaces as a
+ * byte-comparison failure nobody can localise - the Wave 2 lesson, applied here before there is
+ * anything to re-learn it on.
+ *
+ * Header-only by design; there is no `src/medui/Schema.cpp`. Everything is `constexpr`, because
+ * ADR-012 decision 3 puts `static_assert(package.validate().has_value())` in the generated source:
+ * a malformed screen has to be a compile error on the device build, not a startup failure in a
+ * theatre. `mdux.ml.schema` is the model followed here. `mdux.text.schema`'s `TextPackage`
+ * deliberately is not - it owns `std::string` and `std::vector`, so it could not appear in a
+ * `static_assert` at all.
+ *
+ * ## Non-owning, and what that costs the caller
+ *
+ * Every string is a `std::string_view` and the node list is a `std::span`. The generated
+ * translation unit owns the storage, statically, so a `ScreenPackage` is a handful of pointers that
+ * costs nothing to copy and needs no lifetime management. The cost is that a host tool assembling a
+ * screen cannot use this type as its accumulator - it builds an owning form and takes a view of it.
+ * That is the same split `mdux.ml.schema` makes with `mdux-mlbake`, and it is the price of a type a
+ * device can hold in `.rodata`.
+ *
+ * ## The package is locale-free, and that is load-bearing
+ *
+ * ADR-011, as amended by #203, carries `textKey` and `colorToken` as **validated names** rather than
+ * as glyph runs and RGBA8. The device resolves each against a governed table for the locale it is
+ * running - a bounded lookup, not a parse - and the per-locale glyph runs stay in the text package
+ * where ADR-010 put them.
+ *
+ * The consequence that decides the file layout: **adding an approved locale rewrites no screen
+ * artifact.** Translations change far more often than layouts, and a package carrying runs would
+ * make the frequent change rewrite the stable artifact - and its digest, and its review.
+ *
+ * The cost, stated as a cost: one rectangle serves every locale, so it must be the one that
+ * survives the widest approved translation. That is what #195 measures, and why the budget below
+ * cannot be derived from the node count.
+ *
+ * ## The colour table lives here, and its contents do not
+ *
+ * ADR-011 puts the *resolution* of `Theme.Colors.<Token>` on the device, as a bounded scan of a
+ * governed table - TrustSC's `THEME_COLORS` and `resolve_color_token()` are the reference, and both
+ * live in its governed crate. So `ThemeColor` and `resolveColorToken()` are here, beside the package
+ * that carries the names: a consumer holding this schema holds the whole device-side contract, and
+ * #199 inherits a resolver rather than writing a second one.
+ *
+ * What is deliberately *not* here is a palette. Which colours a device shows is a clinical and
+ * regulatory decision belonging to the product, exactly as the theme names semantic analysis
+ * validates against are an input rather than a constant (#193). MduX owns the representation and the
+ * lookup; the table is supplied.
+ *
+ * ## What `validate()` checks, and what it deliberately does not
+ *
+ * It checks what a consumer is entitled to assume without looking: an identified screen, a positive
+ * surface, nodes with unique ids and rectangles that lie inside that surface, colour tokens that are
+ * names rather than values, and a budget the index width can address.
+ *
+ * It does **not** check that the budget is large enough for what the screen draws. That number is
+ * not derivable from anything here: a `Label` draws one rectangle per glyph of the widest approved
+ * translation, and this package carries no glyph runs by design. The compiler computes the budget
+ * from the text packages it measured (#195) and the components' own draw shapes (#17); a rule
+ * invented here would be a second, weaker opinion about a number this type only carries. What it
+ * *can* say is that a screen with nodes and an empty budget draws nothing, and that a budget past
+ * `mdux::draw::maxIndexableVertices` cannot be indexed - both are refused.
+ */
+module;
+
+export module mdux.medui.schema;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.evidence.report;
+
+export namespace mdux::medui {
+
+/// The `<kind>` component of `generated/<kind>/<id>/`, and the value of a package's `kind` member.
+inline constexpr std::string_view packageKind = "screen";
+
+/// The prefix every colour a node draws with must carry, and which it must carry *something* after:
+/// the package holds names, never values, and `Theme.Colors.` on its own is not a name.
+inline constexpr std::string_view colorTokenPrefix = "Theme.Colors.";
+
+enum class SchemaError : std::uint8_t {
+    UnsupportedSchemaVersion,  ///< the package declares a version this module does not read
+    EmptyId,                   ///< the screen has no id, so no directory and no evidence entry
+    NonPositiveSurface,        ///< a surface with no extent cannot contain a rectangle
+    EmptyNodeId,               ///< a node with no id cannot be named by a golden or a requirement
+    DuplicateNodeId,           ///< two nodes share an id, so a golden could name either
+    DegenerateBounds,          ///< a rectangle with no extent, which `DrawList` refuses to record
+    BoundsOutsideSurface,      ///< a rectangle the declared surface does not contain
+    MalformedColorToken,       ///< a colour that is not a `Theme.Colors.<Token>` name
+    EmptyBudget,               ///< a screen with nodes whose budget can hold no primitive
+    BudgetExceedsIndexWidth,   ///< more vertices than a 16-bit index can address
+};
+
+[[nodiscard]] constexpr std::string_view describe(SchemaError error) noexcept {
+    switch (error) {
+        case SchemaError::UnsupportedSchemaVersion:
+            return "the package declares an unsupported schemaVersion";
+        case SchemaError::EmptyId:
+            return "the screen has no id";
+        case SchemaError::NonPositiveSurface:
+            return "the surface has no extent";
+        case SchemaError::EmptyNodeId:
+            return "a node has no id";
+        case SchemaError::DuplicateNodeId:
+            return "two nodes share an id";
+        case SchemaError::DegenerateBounds:
+            return "a node's rectangle has no extent";
+        case SchemaError::BoundsOutsideSurface:
+            return "a node's rectangle leaves the declared surface";
+        case SchemaError::MalformedColorToken:
+            return "a colour is not a Theme.Colors.<Token> name";
+        case SchemaError::EmptyBudget:
+            return "the screen has nodes and a budget that can hold no primitive";
+        case SchemaError::BudgetExceedsIndexWidth:
+            return "the vertex budget exceeds what a 16-bit index can address";
+    }
+    return "unknown schema error";
+}
+
+/**
+ * @brief One entry of the governed colour table: a name a screen may carry, and what it resolves to.
+ *
+ * The device side of ADR-011's boundary. A compiled screen carries `Theme.Colors.<Token>` as a
+ * *name*, and the runtime turns it into a colour by scanning a table like this one - a bounded scan
+ * over fixed data, which is neither parsing nor unbounded work, and therefore not what the compile
+ * boundary exists to keep off a device. TrustSC reached this arrangement first: `THEME_COLORS` and
+ * `resolve_color_token()` live in its governed `trustsc-ui` crate, and this is the same shape.
+ */
+struct ThemeColor {
+    std::string_view       token;  ///< the full name, e.g. `Theme.Colors.ScoreDigits`
+    mdux::core::ColorRgba8 value{};
+
+    [[nodiscard]] constexpr bool operator==(const ThemeColor&) const noexcept = default;
+};
+
+enum class ThemeError : std::uint8_t {
+    MalformedToken,  ///< the name is not of the form `Theme.Colors.<Token>`
+    UnknownToken,    ///< well-formed, but the governed table does not define it
+};
+
+[[nodiscard]] constexpr std::string_view describe(ThemeError error) noexcept {
+    switch (error) {
+        case ThemeError::MalformedToken:
+            return "the colour is not a Theme.Colors.<Token> name";
+        case ThemeError::UnknownToken:
+            return "the governed colour table does not define this token";
+    }
+    return "unknown theme error";
+}
+
+/**
+ * @brief Whether `token` has the shape a colour name must have.
+ *
+ * The prefix, then a non-empty suffix of the characters an identifier may contain - ASCII letters,
+ * digits, `_` and `-` - with `.` admitted between segments, because the parser builds a dotted path
+ * and a product may legitimately name `Theme.Colors.Status.Ok`. No empty segment: a trailing dot or
+ * a `..` names nothing.
+ *
+ * Shape is not existence. A well-formed token may still be absent from a product's table, which is
+ * what `resolveColorToken()` reports and what the compiler already checks against the theme names it
+ * was given (#193). Keeping the two separate is what lets `validate()` reject a malformed name
+ * without holding a table it was never handed.
+ */
+[[nodiscard]] constexpr bool isColorToken(std::string_view token) noexcept {
+    if (!token.starts_with(colorTokenPrefix) || token.size() == colorTokenPrefix.size()) {
+        return false;
+    }
+
+    bool segmentEmpty = true;
+    for (const char character : token.substr(colorTokenPrefix.size())) {
+        if (character == '.') {
+            if (segmentEmpty) {
+                return false;
+            }
+            segmentEmpty = true;
+            continue;
+        }
+        const bool admitted = (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')
+                              || character == '_' || character == '-';
+        if (!admitted) {
+            return false;
+        }
+        segmentEmpty = false;
+    }
+    return !segmentEmpty;
+}
+
+/**
+ * @brief Resolves a name a compiled screen carries against a product's governed colour table.
+ *
+ * A bounded scan with a `Result` on miss - never an allocation, never a throw, as ADR-011 requires
+ * and as `mdux-governed-lint` and `governed.noThrow.symbolScan` hold this module to. Linear rather
+ * than a binary search: a palette holds tens of entries, and requiring the table to be sorted would
+ * add an invariant a product's generated table could silently break, in exchange for a saving no
+ * frame would notice.
+ *
+ * **The table's contents are the product's, not this library's.** MduX defines the representation
+ * and the lookup; a palette is a clinical and regulatory decision belonging to the device it ships
+ * on, exactly as the theme names semantic analysis validates against are an input rather than a
+ * constant (#193). So there is no default table here to inherit, and a caller supplying an empty one
+ * gets `UnknownToken` for every name rather than a colour nobody approved.
+ */
+[[nodiscard]] constexpr mdux::core::Result<mdux::core::ColorRgba8, ThemeError> resolveColorToken(std::span<const ThemeColor> table,
+                                                                                                 std::string_view            token) noexcept {
+    if (!isColorToken(token)) {
+        return mdux::core::err(ThemeError::MalformedToken);
+    }
+    for (const ThemeColor& entry : table) {
+        if (entry.token == token) {
+            return entry.value;
+        }
+    }
+    return mdux::core::err(ThemeError::UnknownToken);
+}
+
+/**
+ * @brief One node's absolute rectangle, in integer surface pixels.
+ *
+ * Integer throughout, as ADR-011 decision 5 requires: the solver never divides into a fraction, so
+ * two toolchains cannot disagree about where a rectangle is. Signed rather than unsigned because
+ * `mdux::core::Px` is signed and a mixed-signedness comparison is a defect waiting for a reviewer.
+ */
+struct NodeRect {
+    std::int32_t x{0};
+    std::int32_t y{0};
+    std::int32_t width{0};
+    std::int32_t height{0};
+
+    [[nodiscard]] constexpr bool operator==(const NodeRect&) const noexcept = default;
+};
+
+/**
+ * @brief One compiled node: what it draws, where, and what it is traced to.
+ *
+ * `textKey` and `colorToken` are the validated *names* ADR-011 carries rather than the values they
+ * resolve to - the compiler has already proved the key exists in every approved locale (#193) and
+ * that the token is in the governed table, so the device performs a bounded lookup and no parse.
+ *
+ * `requirement` is empty for a node that declares none, and non-empty for every node that is
+ * safety-critical, because #196 refuses the annotation without it. Carrying it here is what makes
+ * the requirement-to-node mapping diffable in a committed artifact.
+ */
+struct CompiledNode {
+    std::string_view id;
+    std::string_view component;    ///< the dictionary name, e.g. `Label`
+    NodeRect         bounds{};
+    std::string_view textKey;      ///< empty when the node draws no static text
+    std::string_view colorToken;   ///< empty when the node declares no tint
+    std::string_view requirement;  ///< empty when the node declares none
+
+    [[nodiscard]] constexpr bool operator==(const CompiledNode&) const noexcept = default;
+};
+
+/**
+ * @brief A whole compiled screen as generated code exposes it and the runtime consumes it.
+ *
+ * Non-owning and `constexpr`-constructible throughout, so a generated translation unit can place one
+ * in read-only memory and `static_assert` that it validates.
+ */
+struct ScreenPackage {
+    std::string_view              id;
+    std::uint64_t                 schemaVersion{evidence::kSchemaVersion};
+    std::int32_t                  surfaceWidth{0};
+    std::int32_t                  surfaceHeight{0};
+    std::span<const CompiledNode> nodes;
+    mdux::draw::DrawBudget        budget{};
+
+    /// Checks every invariant a consumer is entitled to assume. See the module comment for the one
+    /// invariant it deliberately leaves to the compiler: whether the budget is *large enough*.
+    [[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> validate() const noexcept;
+
+    /// The node with this id, or nullptr. Linear: a screen holds tens of nodes, and a map would
+    /// cost more to build than every lookup it could serve - and could not be `constexpr` data.
+    [[nodiscard]] constexpr const CompiledNode* find(std::string_view nodeId) const noexcept {
+        for (const CompiledNode& node : nodes) {
+            if (node.id == nodeId) {
+                return &node;
+            }
+        }
+        return nullptr;
+    }
+};
+
+/// Whether `bounds` lies wholly inside a `width` x `height` surface.
+///
+/// Computed in 64-bit arithmetic: `x + width` on two `std::int32_t` at their extremes overflows,
+/// and an overflowed comparison would admit exactly the rectangle this is written to refuse.
+[[nodiscard]] constexpr bool containedBy(NodeRect bounds, std::int32_t width, std::int32_t height) noexcept {
+    if (bounds.x < 0 || bounds.y < 0) {
+        return false;
+    }
+    const std::int64_t right  = static_cast<std::int64_t>(bounds.x) + bounds.width;
+    const std::int64_t bottom = static_cast<std::int64_t>(bounds.y) + bounds.height;
+    return right <= width && bottom <= height;
+}
+
+constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const noexcept {
+    using mdux::core::err;
+
+    if (schemaVersion != evidence::kSchemaVersion) {
+        return err(SchemaError::UnsupportedSchemaVersion);
+    }
+    if (id.empty()) {
+        return err(SchemaError::EmptyId);
+    }
+    if (surfaceWidth <= 0 || surfaceHeight <= 0) {
+        return err(SchemaError::NonPositiveSurface);
+    }
+
+    for (std::size_t index = 0; index < nodes.size(); ++index) {
+        const CompiledNode& node = nodes[index];
+
+        if (node.id.empty()) {
+            return err(SchemaError::EmptyNodeId);
+        }
+        // Quadratic, and deliberately so: a screen holds tens of nodes, `constexpr` evaluation has
+        // no allocator, and a sorted copy would need one. The alternative is not checking.
+        for (std::size_t earlier = 0; earlier < index; ++earlier) {
+            if (nodes[earlier].id == node.id) {
+                return err(SchemaError::DuplicateNodeId);
+            }
+        }
+        if (node.bounds.width <= 0 || node.bounds.height <= 0) {
+            return err(SchemaError::DegenerateBounds);
+        }
+        if (!containedBy(node.bounds, surfaceWidth, surfaceHeight)) {
+            return err(SchemaError::BoundsOutsideSurface);
+        }
+        // The same shape rule the resolver applies, so a screen that validates here cannot fail the
+        // device lookup for a reason `validate()` could have seen. `Theme.Colors.` names nothing and
+        // `Theme.Colors.#` is not a name at all; both would otherwise pass the generated
+        // `static_assert` and fail only where nobody is watching.
+        if (!node.colorToken.empty() && !isColorToken(node.colorToken)) {
+            return err(SchemaError::MalformedColorToken);
+        }
+    }
+
+    if (budget.maxVertices > mdux::draw::maxIndexableVertices) {
+        return err(SchemaError::BudgetExceedsIndexWidth);
+    }
+    // A screen with nothing to draw may carry an empty budget; one with nodes may not, because the
+    // first rectangle it records would be refused and the frame would silently be blank.
+    if (!nodes.empty() && (budget.maxVertices == 0 || budget.maxIndices == 0 || budget.maxCommands == 0)) {
+        return err(SchemaError::EmptyBudget);
+    }
+
+    return {};
+}
+
+}  // namespace mdux::medui

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -104,6 +104,11 @@ enum class SchemaError : std::uint8_t {
     BoundsOutsideSurface,      ///< a rectangle the declared surface does not contain
     MalformedColorToken,       ///< a colour that is not a `Theme.Colors.<Token>` name
     UnknownColorToken,         ///< a well-formed name the governed table does not define
+    UnknownPayload,            ///< a payload this module cannot name, or one left valueless
+    EmptyRequiredName,         ///< a spec field the component dictionary requires is empty
+    NoStates,                  ///< a status indicator that can show nothing
+    StateColorCountMismatch,   ///< per-state tints that do not pair one-to-one with the states
+    NonPositiveMaxLength,      ///< a text input that can hold no character
     EmptyBudget,               ///< a screen with nodes whose budget can hold no primitive
     BudgetExceedsIndexWidth,   ///< more vertices than a 16-bit index can address
 };
@@ -128,6 +133,16 @@ enum class SchemaError : std::uint8_t {
             return "a colour is not a Theme.Colors.<Token> name";
         case SchemaError::UnknownColorToken:
             return "a colour names a token the governed table does not define";
+        case SchemaError::UnknownPayload:
+            return "a node carries a payload this module cannot name";
+        case SchemaError::EmptyRequiredName:
+            return "a name the component dictionary requires is empty";
+        case SchemaError::NoStates:
+            return "a status indicator declares no state to show";
+        case SchemaError::StateColorCountMismatch:
+            return "per-state colours do not pair one-to-one with the states";
+        case SchemaError::NonPositiveMaxLength:
+            return "a text input accepts no character";
         case SchemaError::EmptyBudget:
             return "the screen has nodes and a budget that can hold no primitive";
         case SchemaError::BudgetExceedsIndexWidth:
@@ -277,26 +292,255 @@ struct NodeRect {
 };
 
 /**
- * @brief One compiled node: what it draws, where, and what it is traced to.
+ * @brief What one component needs the device to know about it, one type per component.
  *
- * `textKey` and `colorToken` are the validated *names* ADR-011 carries rather than the values they
- * resolve to - the compiler has already proved the key exists in every approved locale (#193) and
- * that the token is in the governed table, so the device performs a bounded lookup and no parse.
+ * The dictionary is closed and each entry admits a different set of fields, so a single record with
+ * every field on it would carry a `format` for a `Label` and a `stateKeys` for a `Clock`. An earlier
+ * revision of this module did exactly that, and it was worse than untidy: it was **lossy**. A flat
+ * node had nowhere to put a `Clock`'s format, a `NumericDisplay`'s template and source, a
+ * `StatusIndicator`'s state keys and per-state tints, a `CriticalButton`'s `on_press`, or a
+ * `VulkanViewport`'s stream - so a device holding the package could not have rendered four of the
+ * eleven components at all.
  *
- * `requirement` is empty for a node that declares none, and non-empty for every node that is
- * safety-critical, because #196 refuses the annotation without it. Carrying it here is what makes
- * the requirement-to-node mapping diffable in a committed artifact.
+ * Every field is a **validated name**, never a resolved value, exactly as `colorToken` is. The
+ * compiler has already proved each one resolves - keys against every approved locale (#193), colour
+ * tokens against the governed table, named values against the tables a build supplies (#195) - so
+ * the device performs bounded lookups and no parsing.
+ *
+ * One consequence worth stating because it diverges from the sibling: `format`, `charset` and
+ * `onPress` stay `std::string_view` rather than becoming enumerations. TrustSC closes two of those
+ * three in its own crate (`ClockFormat`, `SystemEvent`) and leaves the third - a text input's glyph
+ * set - open, so the divergence is real and narrower than it looks.
+ *
+ * Closing them here was tried and withdrawn, and the reason is worth recording so the next attempt
+ * starts from it: the implemented front end accepts any identifier for `format:` and `on_press:`,
+ * #195's budget stage resolves a clock format through a product-supplied table, and the fixtures
+ * across three suites write names no two-value enumeration can hold. Closing the set in this module
+ * alone would leave the canonical type unable to represent a screen the compiler accepts. Doing it
+ * properly needs the semantic domains, the budget rule, the fixtures, the authoring skill and a
+ * diagnostic code for "a named value outside a closed set" - which the shared contract does not
+ * define today - to move together. That is a coordinated change with its own issue, not a paragraph
+ * of this one.
+ */
+// Every spec member carries a default initialiser. `-Wmissing-field-initializers` is an error in
+// this tree, and the emitter (#197) writes these initialisers from a screen - a type whose optional
+// fields still have to be spelled out at every site is a trap for generated code, and an empty name
+// is what "absent" means for all of them anyway.
+struct PanelSpec {
+    std::string_view colorToken{};  ///< the Row background that produced this synthetic node
+
+    [[nodiscard]] constexpr bool operator==(const PanelSpec&) const noexcept = default;
+};
+
+struct LabelSpec {
+    std::string_view textKey{};
+    std::string_view colorToken{};
+
+    [[nodiscard]] constexpr bool operator==(const LabelSpec&) const noexcept = default;
+};
+
+struct ClockSpec {
+    std::string_view format{};  ///< a named value the build's governed table defines
+
+    [[nodiscard]] constexpr bool operator==(const ClockSpec&) const noexcept = default;
+};
+
+struct ImageSpec {
+    std::string_view source{};  ///< the baked image package's id, from `img("ID")`
+
+    [[nodiscard]] constexpr bool operator==(const ImageSpec&) const noexcept = default;
+};
+
+struct VulkanViewportSpec {
+    std::string_view streamSource{};
+
+    [[nodiscard]] constexpr bool operator==(const VulkanViewportSpec&) const noexcept = default;
+};
+
+struct SignalTraceSpec {
+    std::string_view streamSource{};
+    std::string_view colorToken{};
+
+    [[nodiscard]] constexpr bool operator==(const SignalTraceSpec&) const noexcept = default;
+};
+
+struct ButtonSpec {
+    std::string_view labelKey{};
+    std::string_view colorToken{};
+    std::string_view source{};
+    std::string_view requirement{};  ///< optional on a Button; empty when it declares none
+
+    [[nodiscard]] constexpr bool operator==(const ButtonSpec&) const noexcept = default;
+};
+
+struct CriticalButtonSpec {
+    std::string_view requirement{};  ///< required by the dictionary, and by #196's annotation rule
+    std::string_view labelKey{};
+    std::string_view colorToken{};
+    std::string_view onPress{};
+
+    [[nodiscard]] constexpr bool operator==(const CriticalButtonSpec&) const noexcept = default;
+};
+
+struct NumericDisplaySpec {
+    std::string_view requirement{};
+    std::string_view templateId{};  ///< `template:` in the source; `template` is a keyword here
+    std::string_view source{};
+    std::string_view colorToken{};
+
+    [[nodiscard]] constexpr bool operator==(const NumericDisplaySpec&) const noexcept = default;
+};
+
+/**
+ * @brief A status indicator's states, and the tint each one shows.
+ *
+ * `stateKeys` and `colorTokens` are parallel spans over storage the generated translation unit owns.
+ * `colorTokens` is either empty - the component declares no per-state tint - or exactly as long as
+ * `stateKeys`, which `validate()` enforces, because a shorter list would leave a state with no tint
+ * and no way to say which.
+ *
+ * This is where per-state colour belongs, and settling it here answers the question #196 left open:
+ * a golden reference pins one tint, so it refuses `ColorHash` on a node whose tint varies. The
+ * variation lives in the node, not in the expectation.
+ */
+struct StatusIndicatorSpec {
+    std::string_view                  requirement{};
+    std::string_view                  source{};
+    std::span<const std::string_view> stateKeys{};
+    std::span<const std::string_view> colorTokens{};
+
+    [[nodiscard]] constexpr bool operator==(const StatusIndicatorSpec& other) const noexcept {
+        return requirement == other.requirement && source == other.source && std::ranges::equal(stateKeys, other.stateKeys)
+               && std::ranges::equal(colorTokens, other.colorTokens);
+    }
+};
+
+struct TextInputSpec {
+    std::string_view source{};
+    std::string_view colorToken{};
+    std::int64_t     maxLength{0};
+    std::string_view charset{};      ///< empty when the component narrows nothing
+    std::string_view requirement{};  ///< optional on a TextInput
+
+    [[nodiscard]] constexpr bool operator==(const TextInputSpec&) const noexcept = default;
+};
+
+/**
+ * @brief The payload of one compiled node: exactly one component's spec.
+ *
+ * `std::variant` rather than a hand-rolled union, and accessed only through `std::holds_alternative`
+ * and `std::get_if`. Both are `noexcept` and `constexpr`; `std::get` is deliberately never used
+ * anywhere in this module or its consumers, because it throws on the wrong alternative and ADR-005
+ * does not allow a governed type to have a throwing accessor as its natural spelling.
+ *
+ * The alternative order is *not* a wire contract. Nothing serialises the index: the emitter writes
+ * the component's dictionary name, which `kindName()` returns, so an alternative may be added
+ * without renumbering an artifact.
+ */
+using NodePayload = std::variant<PanelSpec,
+                                 LabelSpec,
+                                 ClockSpec,
+                                 ImageSpec,
+                                 VulkanViewportSpec,
+                                 SignalTraceSpec,
+                                 ButtonSpec,
+                                 CriticalButtonSpec,
+                                 NumericDisplaySpec,
+                                 StatusIndicatorSpec,
+                                 TextInputSpec>;
+
+/**
+ * @brief One compiled node: where it is, and everything the device needs to draw it.
+ *
+ * `id` and `bounds` are common to every component because a golden reference, a requirement trace
+ * and the layout solver all address a node the same way. Everything else is the component's own.
+ *
+ * Deliberately *not* here: whether the source carried `@safety_critical` or an explicit `position:`.
+ * A revision of this module carried both so that golden completeness could be re-derived from the
+ * committed package; ADR-012 decision 4 now takes TrustSC's arrangement instead - one pass applies
+ * the predicate once, and the tests that guard it live with the predicate (#196) rather than with the
+ * artifact. A device therefore carries nothing a verifier reads, which is what decision 4 said in the
+ * first place.
  */
 struct CompiledNode {
-    std::string_view id;
-    std::string_view component;    ///< the dictionary name, e.g. `Label`
+    std::string_view id{};
     NodeRect         bounds{};
-    std::string_view textKey;      ///< empty when the node draws no static text
-    std::string_view colorToken;   ///< empty when the node declares no tint
-    std::string_view requirement;  ///< empty when the node declares none
+    NodePayload      payload{PanelSpec{}};
 
     [[nodiscard]] constexpr bool operator==(const CompiledNode&) const noexcept = default;
 };
+
+/// The dictionary name of a node's component, e.g. `Label`. The spelling an emitter writes and a
+/// reader recognises; see `NodePayload` for why the variant's index is not that spelling.
+[[nodiscard]] constexpr std::string_view kindName(const CompiledNode& node) noexcept {
+    if (std::holds_alternative<PanelSpec>(node.payload)) {
+        return "Panel";
+    }
+    if (std::holds_alternative<LabelSpec>(node.payload)) {
+        return "Label";
+    }
+    if (std::holds_alternative<ClockSpec>(node.payload)) {
+        return "Clock";
+    }
+    if (std::holds_alternative<ImageSpec>(node.payload)) {
+        return "Image";
+    }
+    if (std::holds_alternative<VulkanViewportSpec>(node.payload)) {
+        return "VulkanViewport";
+    }
+    if (std::holds_alternative<SignalTraceSpec>(node.payload)) {
+        return "SignalTrace";
+    }
+    if (std::holds_alternative<ButtonSpec>(node.payload)) {
+        return "Button";
+    }
+    if (std::holds_alternative<CriticalButtonSpec>(node.payload)) {
+        return "CriticalButton";
+    }
+    if (std::holds_alternative<NumericDisplaySpec>(node.payload)) {
+        return "NumericDisplay";
+    }
+    if (std::holds_alternative<StatusIndicatorSpec>(node.payload)) {
+        return "StatusIndicator";
+    }
+    if (std::holds_alternative<TextInputSpec>(node.payload)) {
+        return "TextInput";
+    }
+    // An alternative this function does not know, or a valueless payload. Named as nothing rather
+    // than as the last kind checked: labelling an unknown component `TextInput` is how a package
+    // acquires a plausible wrong answer, and `validate()` refuses the same case outright.
+    return {};
+}
+
+// Adding an alternative to `NodePayload` without teaching `kindName()` and `validatePayload()` about
+// it would leave a node that names itself nothing and fails validation - which is fail-closed, but
+// only discovered at run time. This makes it a build failure at the point of the change instead.
+static_assert(std::variant_size_v<NodePayload> == 11, "an alternative was added or removed: update kindName() and validatePayload() to match");
+
+/**
+ * @brief The requirement a node is traced to, or empty when it declares none.
+ *
+ * Five components can carry one, and #196 refuses `@safety_critical` without it - so this is the
+ * function a traceability export walks rather than a field every node pretends to have.
+ */
+[[nodiscard]] constexpr std::string_view requirementOf(const CompiledNode& node) noexcept {
+    if (const auto* spec = std::get_if<ButtonSpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    if (const auto* spec = std::get_if<CriticalButtonSpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    if (const auto* spec = std::get_if<NumericDisplaySpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    if (const auto* spec = std::get_if<StatusIndicatorSpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    if (const auto* spec = std::get_if<TextInputSpec>(&node.payload)) {
+        return spec->requirement;
+    }
+    return {};
+}
 
 /**
  * @brief A whole compiled screen as generated code exposes it and the runtime consumes it.
@@ -341,6 +585,153 @@ struct ScreenPackage {
     return right <= width && bottom <= height;
 }
 
+/**
+ * @brief Checks one colour name through the resolver the device will use.
+ *
+ * The resolver rather than the shape rule alone, so a screen that validates cannot fail the device
+ * lookup for any reason `validate()` could have seen. The two errors stay apart because they are
+ * different people's defects: a malformed name is the emitter's, and an unknown one is a screen
+ * compiled against a palette this build does not have.
+ */
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> checkColor(std::string_view token) noexcept {
+    if (token.empty()) {
+        return {};
+    }
+    const auto resolved = resolveColorToken(token);
+    if (resolved.has_value()) {
+        return {};
+    }
+    return mdux::core::err(resolved.error() == ThemeError::MalformedToken ? SchemaError::MalformedColorToken : SchemaError::UnknownColorToken);
+}
+
+/// Requires a colour the dictionary marks required: present, and resolving through the table.
+///
+/// Worth separating from `checkColor()`, which permits an absent one. The dictionary makes `color`
+/// required on `Label`, `Button`, `CriticalButton`, `SignalTrace`, `NumericDisplay` and `TextInput`,
+/// and optional nowhere except `StatusIndicator`'s per-state list - a distinction the flat node this
+/// replaces could not express, since one shared field cannot be required for some components and
+/// absent for others.
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> requireColor(std::string_view token) noexcept;
+
+/// Requires a name the dictionary marks required.
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> require(std::string_view name) noexcept {
+    return name.empty() ? mdux::core::ResultVoid<SchemaError>{mdux::core::err(SchemaError::EmptyRequiredName)} : mdux::core::ResultVoid<SchemaError>{};
+}
+
+/**
+ * @brief Checks one node's payload against what its component's dictionary entry requires.
+ *
+ * Only what the dictionary already fixes, and nothing this module invents on its own: a name a
+ * component must declare is non-empty, every colour resolves, a status indicator has states to show,
+ * and its per-state tints - if it declares any - pair one-to-one with them.
+ *
+ * Optional fields are checked when present and ignored when empty, because "absent" is a legal
+ * value the dictionary allows for `requirement` on a `Button` or `charset` on a `TextInput`.
+ */
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> requireColor(std::string_view token) noexcept {
+    if (const auto named = require(token); !named.has_value()) {
+        return named;
+    }
+    return checkColor(token);
+}
+
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> validatePayload(const NodePayload& payload) noexcept {
+    if (const auto* spec = std::get_if<PanelSpec>(&payload)) {
+        // A Panel exists because a Row declared a background, so it always has one.
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<LabelSpec>(&payload)) {
+        if (const auto named = require(spec->textKey); !named.has_value()) {
+            return named;
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<ClockSpec>(&payload)) {
+        return require(spec->format);
+    }
+    if (const auto* spec = std::get_if<ImageSpec>(&payload)) {
+        return require(spec->source);
+    }
+    if (const auto* spec = std::get_if<VulkanViewportSpec>(&payload)) {
+        return require(spec->streamSource);
+    }
+    if (const auto* spec = std::get_if<SignalTraceSpec>(&payload)) {
+        if (const auto named = require(spec->streamSource); !named.has_value()) {
+            return named;
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<ButtonSpec>(&payload)) {
+        if (const auto named = require(spec->labelKey); !named.has_value()) {
+            return named;
+        }
+        if (const auto named = require(spec->source); !named.has_value()) {
+            return named;
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<CriticalButtonSpec>(&payload)) {
+        for (const std::string_view name : {spec->requirement, spec->labelKey, spec->onPress}) {
+            if (const auto named = require(name); !named.has_value()) {
+                return named;
+            }
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<NumericDisplaySpec>(&payload)) {
+        for (const std::string_view name : {spec->requirement, spec->templateId, spec->source}) {
+            if (const auto named = require(name); !named.has_value()) {
+                return named;
+            }
+        }
+        return requireColor(spec->colorToken);
+    }
+    if (const auto* spec = std::get_if<StatusIndicatorSpec>(&payload)) {
+        for (const std::string_view name : {spec->requirement, spec->source}) {
+            if (const auto named = require(name); !named.has_value()) {
+                return named;
+            }
+        }
+        if (spec->stateKeys.empty()) {
+            return mdux::core::err(SchemaError::NoStates);
+        }
+        for (const std::string_view key : spec->stateKeys) {
+            if (const auto named = require(key); !named.has_value()) {
+                return named;
+            }
+        }
+        // Empty is legal - the component declares no per-state tint. Anything else has to pair with
+        // the states one for one, because a shorter list leaves a state with no tint and no way to
+        // say which state that is.
+        if (!spec->colorTokens.empty() && spec->colorTokens.size() != spec->stateKeys.size()) {
+            return mdux::core::err(SchemaError::StateColorCountMismatch);
+        }
+        for (const std::string_view token : spec->colorTokens) {
+            if (const auto colour = requireColor(token); !colour.has_value()) {
+                return colour;
+            }
+        }
+        return {};
+    }
+    // Fail closed. An earlier revision returned success here, which made this a fail-open contract:
+    // a payload left valueless by an exceptional emplacement, or an alternative added without
+    // teaching this function about it, would have been accepted as a valid node by the one function
+    // consumers are entitled to trust. `std::visit` would give exhaustiveness, but it throws on a
+    // valueless variant, which ADR-005 does not allow here - so the residual case is named instead,
+    // and the `static_assert` above turns "an alternative was added" into a build failure.
+    const auto* spec = std::get_if<TextInputSpec>(&payload);
+    if (spec == nullptr) {
+        return mdux::core::err(SchemaError::UnknownPayload);
+    }
+    if (const auto named = require(spec->source); !named.has_value()) {
+        return named;
+    }
+    if (spec->maxLength <= 0) {
+        return mdux::core::err(SchemaError::NonPositiveMaxLength);
+    }
+    return requireColor(spec->colorToken);
+}
+
 constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const noexcept {
     using mdux::core::err;
 
@@ -373,21 +764,8 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
         if (!containedBy(node.bounds, surfaceWidth, surfaceHeight)) {
             return err(SchemaError::BoundsOutsideSurface);
         }
-        // The resolver itself, rather than the shape rule alone, so a screen that validates here
-        // cannot fail the device lookup for any reason `validate()` could have seen. Shape was all
-        // this could check while the palette was a caller's input; now that the governed table is
-        // the approved source of token existence, a name absent from it is as certain a defect as a
-        // name that is not a name - and both would otherwise pass the generated `static_assert` and
-        // fail where nobody is watching.
-        //
-        // The two are kept apart because they are different people's defects: a malformed name is
-        // the emitter's, and an unknown one is a screen compiled against a palette this build does
-        // not have.
-        if (!node.colorToken.empty()) {
-            const auto resolved = resolveColorToken(node.colorToken);
-            if (!resolved.has_value()) {
-                return err(resolved.error() == ThemeError::MalformedToken ? SchemaError::MalformedColorToken : SchemaError::UnknownColorToken);
-            }
+        if (const auto payload = validatePayload(node.payload); !payload.has_value()) {
+            return payload;
         }
     }
 

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -1,0 +1,131 @@
+/**
+ * @file Screen.cppm
+ * @brief The governed screen runtime: a compiled screen becomes draw commands, with no allocation,
+ *        no parsing and no work a device cannot bound before it runs.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Part of MduXCore, which is what puts it under `mdux-governed-lint` and
+ * `governed.noThrow.symbolScan` without either being told about it. The scratch is the caller's, the
+ * bound is the screen's own `DrawBudget`, and every refusal is a `Result`.
+ *
+ * ## What this runtime draws, and what it does not
+ *
+ * It draws a `Panel`: a filled rectangle in the colour its token resolves to. Every other component
+ * is visited, counted, and left undrawn - and that is a stated limit rather than an omission, so it
+ * is worth saying exactly why for each.
+ *
+ * - `Label`, `Button`, `CriticalButton`, `TextInput` draw **text**. A compiled screen carries a
+ *   `textKey`, not glyphs (ADR-011), so drawing them is a join with a baked text package for the
+ *   locale the device is running. No text package is baked in this repository yet, so the join has
+ *   nothing to join to; it belongs with #201, which lands the text half.
+ * - `Clock`, `NumericDisplay`, `SignalTrace`, `StatusIndicator` draw from **live data**. Their
+ *   geometry does not exist until the frame does - that is ADR-012's reason a screen bakes layout
+ *   rather than vertices - so what they paint is a function of a sample this module is not given.
+ * - `Image` draws a **baked image package**, which this repository does not yet produce.
+ *
+ * What is deliberately *not* claimed: that a `Label`'s box should be filled with its colour, or that
+ * a `Button` has a face in its. Those are per-component appearance decisions, and nothing in this
+ * project settles them today - not the ADRs, which stop at "where each node is and which validated
+ * token it draws with", and not the sibling, whose `render_frame` returns frame statistics rather
+ * than geometry (`crates/trustsc-ui/src/lib.rs:539`). Inventing them here would make this module
+ * authoritative over a question it has no evidence for, so it counts what it cannot decide and says
+ * so in `FrameStats::deferred`. A device integrator sees "eleven nodes, one drawn" rather than a
+ * screen that quietly renders less than it looks like it should.
+ *
+ * ## Bounded work, and the counter that proves it
+ *
+ * Work per frame is the node count times per-node work, both known before the device runs: the node
+ * count is fixed in the package, and per-node work is bounded by the `DrawBudget` every write fails
+ * closed against. The source language bans loops and recursion, so nothing can make either factor
+ * depend on data.
+ *
+ * `FrameStats::steps` counts each unit of per-node work this runtime performs, and three tests read
+ * it: identical screens rendered twice do identical work, *n* and *2n* nodes scale linearly, and -
+ * the one that carries the weight - two screens with the *same* node count but different geometry
+ * and different colours do the *same* work. That third case is what would catch work proportional to
+ * a rectangle's width; the first two would not, since duplicating identical nodes doubles any
+ * per-node cost whatever it depends on.
+ *
+ * What these tests establish is bounded, and the bound is worth stating rather than implying.
+ * `steps` is self-reported: a future inner loop that performed work without incrementing it would
+ * leave all three green. What they do establish is that the work this runtime performs does not vary
+ * with a node's payload or geometry at equal node count, and scales linearly with the node count.
+ * Making the per-node half a fact rather than a measurement needs a type-level cap - TrustSC does it
+ * with `TextRuntime::<MAX_GLYPH_COMMANDS_PER_RUN>` - and that belongs with the first component whose
+ * geometry is variable, which is #17's ground rather than this module's today.
+ *
+ * ## Two things this deliberately does not do
+ *
+ * **It does not validate the screen.** `ScreenPackage::validate()` is `constexpr` and generated code
+ * carries a `static_assert` over it, so validity is a property of the binary rather than of the
+ * frame. Re-checking per frame would pay a quadratic id comparison for something already proved.
+ * What this runtime still refuses is a colour token the governed table does not define, because a
+ * screen built by hand at run time never met that `static_assert`.
+ *
+ * **It does not leave a half-drawn frame.** A refused write rolls the list back to where the frame
+ * began, so a frame is whole or absent. A partial frame is the worst outcome available on a medical
+ * display: it looks like a reading.
+ */
+module;
+
+export module mdux.medui.screen;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.medui.schema;
+
+export namespace mdux::medui {
+
+/// Why a frame was refused. Every one leaves the draw list exactly as it was found.
+enum class ScreenError : std::uint8_t {
+    MalformedColorToken,  ///< a node's colour is not of the form `Theme.Colors.<Token>`
+    UnknownColorToken,    ///< well-formed, and the governed table does not define it
+    BudgetExhausted,      ///< a write would exceed a `DrawBudget` this frame is held to
+};
+
+// The two token failures are kept apart because the schema keeps them apart, and for its reason: a
+// malformed name is a defect in whatever emitted the screen, while an absent one is a table that
+// does not define it. Collapsing them would tell an integrator to look in the wrong place.
+
+[[nodiscard]] std::string_view describe(ScreenError error) noexcept;
+
+/**
+ * @brief What one frame did, and what it left undone.
+ *
+ * `deferred` is the honest half: it counts nodes this runtime visited and could not paint, for the
+ * reasons the module comment gives one by one. A caller that expects a screen to be fully drawn can
+ * assert it is zero; today, on any screen carrying text or live data, it will not be.
+ */
+struct FrameStats {
+    std::uint32_t nodes{0};     ///< nodes visited
+    std::uint32_t rects{0};     ///< rectangles recorded
+    std::uint32_t deferred{0};  ///< nodes visited and left undrawn
+    std::uint32_t steps{0};     ///< units of per-node work, for the bounded-work tests
+
+    [[nodiscard]] constexpr bool operator==(const FrameStats&) const noexcept = default;
+};
+
+/**
+ * @brief Records one frame of `screen` into `list`.
+ *
+ * @param screen a compiled screen, normally the `constexpr` one a generated translation unit holds
+ * @param list   a draw list the caller created over storage sized from `screen.budget`
+ *
+ * Allocation-free and `noexcept`: the list is the only storage written, and it was sized before the
+ * first frame. On any error the list is restored to its state at entry.
+ *
+ * Two budgets are in play and both are enforced. `DrawList` fails closed against the budget it was
+ * created with, and this function additionally holds the frame to `screen.budget` - the ceiling the
+ * screen itself declares - by measuring what it added. A list may legitimately be larger, because one
+ * list can carry several screens; without the second check the screen's declared budget would be
+ * decorative, and a mistake in a baked budget would be bypassed rather than observed.
+ */
+[[nodiscard]] mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list) noexcept;
+
+}  // namespace mdux::medui

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,7 +1,7 @@
 repository = "https://github.com/Compliatory/MedUI"
-version = "0.1.0-candidate"
-commit = "c8cc45ecec2f2dfd84940b9efc17c613e691cc0d"
-capabilities = ["syntax"]
+version = "0.1.0"
+commit = "d5136a8518bd499760ecff2aad215d3721329f20"
+capabilities = ["syntax", "semantics"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.
 positions = "full"

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,7 +1,7 @@
 repository = "https://github.com/Compliatory/MedUI"
 version = "0.1.0"
 commit = "d5136a8518bd499760ecff2aad215d3721329f20"
-capabilities = ["syntax", "semantics"]
+capabilities = ["syntax", "semantics", "layout"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.
 positions = "full"

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,7 +1,7 @@
 repository = "https://github.com/Compliatory/MedUI"
 version = "0.1.0"
 commit = "d5136a8518bd499760ecff2aad215d3721329f20"
-capabilities = ["syntax", "semantics", "layout"]
+capabilities = ["syntax", "semantics", "layout", "safety"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.
 positions = "full"

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,0 +1,7 @@
+repository = "https://github.com/Compliatory/MedUI"
+version = "0.1.0-candidate"
+commit = "c8cc45ecec2f2dfd84940b9efc17c613e691cc0d"
+capabilities = ["syntax"]
+# Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
+# byte columns, so every pinned position is matched in full.
+positions = "full"

--- a/recipes/screen/endoscope-monitor.toml
+++ b/recipes/screen/endoscope-monitor.toml
@@ -1,0 +1,43 @@
+# The endoscope monitor screen, compiled by mdux-meduic into generated/screen/endoscope-monitor/,
+# which is committed and byte-verified by `ctest -L evidence` on every active toolchain (ADR-007,
+# ADR-011, ADR-012).
+#
+# ## The id is the mapping ADR-012 asks to be recorded
+#
+# A screen's identity in the grammar is CamelCase - `Screen EndoscopeMonitor` - while an artifact id
+# must match `^[a-z0-9][a-z0-9-]*$` because it names a directory, a test and a generated C++
+# identifier. The recipe records the pairing rather than the compiler deriving it: a slug cannot be
+# derived injectively from a name, since names admit `-` and `_` and lowercasing is not injective
+# across case. What the compiler does check is that the two are the same word.
+#
+# ## Why this screen draws no text
+#
+# Not a simplification for its own sake. No text package is baked anywhere in this tree yet, so the
+# text-budget stage has nothing to measure against and a screen carrying `t("STR-KEY")` would be
+# refused - correctly - for declaring no approved locale. #201 lands the text half; this screen
+# proves the rest of the pipeline end to end in the meantime.
+#
+# To change the screen, edit the .medui source and run
+#
+#   cmake --build <build-dir> --target mdux-bake-update
+#
+# then review the diff to generated/screen/endoscope-monitor/.
+
+[package]
+id            = "endoscope-monitor"
+source        = "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui"
+
+# The panel this screen is drawn for. Declared here rather than taken from the source, so a screen
+# drawn for another panel is a diagnostic rather than a silently rescaled frame; the solver checks
+# the source's own `surface:` against these two numbers.
+surfaceWidth  = 1280
+surfaceHeight = 720
+
+# What the runtime may draw for this screen, declared by the product rather than computed. The cost
+# model that would let a compiler compute it belongs to the runtime (#199), and until then a declared
+# ceiling is the honest form: DrawList fails closed against these numbers at run time, and the schema
+# refuses an empty budget on a screen that has nodes.
+[budget]
+maxVertices = 4096
+maxIndices  = 6144
+maxCommands = 64

--- a/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
+++ b/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
@@ -29,8 +29,31 @@ Screen EndoscopeMonitor {
     VulkanViewport {
         id: endoscope-view;
         width: 1280px;
-        height: 520px;
+        height: 424px;
         stream_source: "ENDOSCOPE_PRIMARY";
+    }
+
+    // The safety-critical node, and the reason this screen has one: `goldens.json` should describe a
+    // real screen rather than only a test fixture. Annotated and traced, so the sidecar carries an
+    // entry saying where the insufflation reading must appear and in what tint - never what the
+    // number says, because the number is live.
+    //
+    // What that entry does *not* have yet is a verifier reading it against a frame. This component
+    // is deferred by the runtime, so there are no pixels to compare; the check ADR-012 describes
+    // arrives with #16, over content that #17 teaches to draw.
+    //
+    // A NumericDisplay deliberately: it is the one traceable component that carries no text key, so
+    // this screen exercises the annotation rules without needing the text package that does not
+    // exist yet (#201's remaining half, and the reason the runtime draws what it draws).
+    @safety_critical(cv_check: [Bounds, ColorHash])
+    NumericDisplay {
+        id: insufflation-pressure;
+        width: 1280px;
+        height: 96px;
+        requirement: "REQ-EM-001";
+        template: "TPL-PRESSURE-MMHG";
+        source: "INSUFFLATION_PRESSURE";
+        color: Theme.Colors.ScoreDigits;
     }
 
     // Positioned, so its rectangle is pinned by a golden reference: a waveform that drifts off its

--- a/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
+++ b/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
@@ -1,0 +1,46 @@
+// The first screen this repository compiles into a committed artifact (#198).
+//
+// It draws no text, and that is a deliberate limit rather than a design: no text package is baked
+// anywhere in this tree yet, so a screen carrying `t("STR-KEY")` cannot be compiled end to end until
+// #201 lands the text half. What this screen does exercise is everything that does not depend on
+// that - the Row background the solver synthesises, a live video surface, a live waveform, a baked
+// image, and an explicitly positioned node whose rectangle a golden reference pins.
+//
+// One property per line, matching TrustSC's own sources: its parser splits a component body line by
+// line, so a fixture written the portable way is evidence about a shared grammar rather than about
+// one implementation.
+Screen EndoscopeMonitor {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 1280px, 720px;
+
+    Row {
+        id: topbar;
+        height: 72px;
+        background: Theme.Colors.TopbarBackground;
+
+        Image {
+            id: brand-mark;
+            width: 240px;
+            height: 72px;
+            source: img("IMG-BRAND-MARK");
+        }
+    }
+
+    VulkanViewport {
+        id: endoscope-view;
+        width: 1280px;
+        height: 520px;
+        stream_source: "ENDOSCOPE_PRIMARY";
+    }
+
+    // Positioned, so its rectangle is pinned by a golden reference: a waveform that drifts off its
+    // band is the kind of regression a screenshot comparison catches and a unit test does not.
+    SignalTrace {
+        id: ecg-lead-ii;
+        width: 1280px;
+        height: 128px;
+        position: 0px, 592px;
+        stream_source: "ECG_LEAD_II";
+        color: Theme.Colors.Nominal;
+    }
+}

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -1,0 +1,128 @@
+/**
+ * @file Screen.cpp
+ * @brief Implementation of the governed screen runtime.
+ */
+
+module;
+
+module mdux.medui.screen;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.medui.schema;
+
+namespace mdux::medui {
+
+namespace {
+
+/// A linear channel as the byte a `R8G8B8A8_UNORM` vertex colour carries.
+///
+/// Quantisation and nothing else: the governed table stores linear RGBA, the vertex colour is read
+/// by the shader as a plain 0..1 UNORM value, so the byte is the linear value scaled. No transfer
+/// function is applied here, because whether the *swapchain* is sRGB is the renderer's decision and
+/// applying one in two places is how a colour ends up encoded twice.
+///
+/// The multiply and the add are separate statements so that neither the rounding nor the result
+/// depends on whether the compiler fuses them. `mdux_enforce_fp_determinism(MduXCore)` already turns
+/// contraction off for this target, and this is the belt to that pair of braces: a frame that is
+/// byte-compared across toolchains cannot afford a last-bit difference in a colour.
+[[nodiscard]] std::uint8_t quantise(float channel) noexcept {
+    const float clamped = channel < 0.0F ? 0.0F : (channel > 1.0F ? 1.0F : channel);
+    const float scaled  = clamped * 255.0F;
+    const float rounded = scaled + 0.5F;
+    return static_cast<std::uint8_t>(rounded);
+}
+
+[[nodiscard]] mdux::core::ColorRgba8 toColor(const std::array<float, 4>& linear) noexcept {
+    return mdux::core::ColorRgba8{.r = quantise(linear[0]), .g = quantise(linear[1]), .b = quantise(linear[2]), .a = quantise(linear[3])};
+}
+
+[[nodiscard]] mdux::core::Rect toRect(const NodeRect& bounds) noexcept {
+    return mdux::core::Rect{.x      = static_cast<mdux::core::Px>(bounds.x),
+                            .y      = static_cast<mdux::core::Px>(bounds.y),
+                            .width  = static_cast<mdux::core::Px>(bounds.width),
+                            .height = static_cast<mdux::core::Px>(bounds.height)};
+}
+
+}  // namespace
+
+std::string_view describe(ScreenError error) noexcept {
+    switch (error) {
+        case ScreenError::MalformedColorToken:
+            return "a node's colour token is not of the form Theme.Colors.<Token>";
+        case ScreenError::UnknownColorToken:
+            return "a node names a colour token the governed table does not define";
+        case ScreenError::BudgetExhausted:
+            return "the frame would exceed a draw budget it is held to";
+    }
+    // Unreachable for a value of the enumeration, and named rather than defaulted so that adding an
+    // enumerator without a case here is a warning at this switch instead of a blank string later.
+    return "unknown screen error";
+}
+
+mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list) noexcept {
+    // Taken before anything is recorded: every refusal below rolls back to here, so a frame is
+    // whole or absent. A half-drawn frame on a medical display is the worst outcome available,
+    // because it looks like a reading.
+    const mdux::draw::DrawList::Marker start = list.mark();
+
+    const auto refuse = [&list, &start](ScreenError error) {
+        // The rollback cannot fail for a marker this function took from this list moments ago; the
+        // result is discarded rather than checked because there is no second recovery to attempt,
+        // and the error being returned is the one the caller needs.
+        static_cast<void>(list.rollback(start));
+        return mdux::core::err(error);
+    };
+
+    // Where the list stood before this frame. The screen's own budget bounds what *this screen*
+    // draws, and `DrawList` can only enforce the budget it was created with - which may be larger,
+    // because one list may carry several screens. Without this the declared ceiling was decorative:
+    // a screen declaring room for one rectangle drew two whenever the caller passed a roomier list,
+    // and a mistake in the baked budget was silently bypassed instead of being observable.
+    const std::size_t vertexBase  = list.vertices().size();
+    const std::size_t indexBase   = list.indices().size();
+    const std::size_t commandBase = list.commands().size();
+
+    const auto withinScreenBudget = [&]() noexcept {
+        return list.vertices().size() - vertexBase <= screen.budget.maxVertices && list.indices().size() - indexBase <= screen.budget.maxIndices
+               && list.commands().size() - commandBase <= screen.budget.maxCommands;
+    };
+
+    FrameStats stats;
+
+    for (const CompiledNode& node : screen.nodes) {
+        ++stats.nodes;
+        ++stats.steps;
+
+        const auto* panel = std::get_if<PanelSpec>(&node.payload);
+        if (panel == nullptr) {
+            // Visited and left undrawn. The module comment says which components these are and why
+            // each one's appearance is not decidable from a compiled screen alone.
+            ++stats.deferred;
+            continue;
+        }
+
+        const auto colour = resolveColorToken(panel->colorToken);
+        if (!colour.has_value()) {
+            return refuse(colour.error() == ThemeError::MalformedToken ? ScreenError::MalformedColorToken : ScreenError::UnknownColorToken);
+        }
+
+        if (const auto recorded = list.addSolidRect(toRect(node.bounds), toColor(*colour)); !recorded.has_value()) {
+            return refuse(ScreenError::BudgetExhausted);
+        }
+        // Measured rather than predicted: a rectangle costs four vertices and six indices, and
+        // extends the current command or starts a new one depending on the clip. Reading the deltas
+        // keeps this from carrying a second copy of arithmetic `DrawList` already owns.
+        if (!withinScreenBudget()) {
+            return refuse(ScreenError::BudgetExhausted);
+        }
+        ++stats.rects;
+        ++stats.steps;
+    }
+
+    return stats;
+}
+
+}  // namespace mdux::medui

--- a/src/ml/Runtime.cpp
+++ b/src/ml/Runtime.cpp
@@ -89,7 +89,7 @@ mdux::core::Result<Classifier1D, MlError> Classifier1D::create(const ModelPackag
     //
     // Note the golden self-test below independently covers a *wrong* interpretation of these
     // bytes: if the weights were being read incorrectly, no golden vector would reproduce.
-    const auto blobAddress = reinterpret_cast<std::uintptr_t>(weights.data());
+    const auto blobAddress = reinterpret_cast<std::uintptr_t>(weights.data());  // mdux-governed-lint:allow
     if (!weights.empty() && blobAddress % alignof(float) != 0) {
         return err(MlError{.code = MlError::Code::WeightsUnaligned});
     }
@@ -107,7 +107,7 @@ mdux::core::Result<Classifier1D, MlError> Classifier1D::create(const ModelPackag
     classifier.outputLength_ = package.outputLength;
 
     // Resolve every tensor to a float span once, here, rather than per predict() call.
-    const float* base = weights.empty() ? nullptr : reinterpret_cast<const float*>(weights.data());
+    const float* base = weights.empty() ? nullptr : reinterpret_cast<const float*>(weights.data());  // mdux-governed-lint:allow
     for (std::size_t i = 0; i < package.layers.size(); ++i) {
         const LayerDesc& layer = package.layers[i];
         LayerTensors tensors;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -709,6 +709,7 @@ mdux_emit_screen_package(
 add_executable(medui_spec
     medui/MeduiSpecMain.cpp
     medui/SchemaTests.cpp
+    medui/ScreenRuntimeTests.cpp
     medui/GeneratedScreenTests.cpp
     medui/GeneratedScreenModuleConsumer.cpp
     medui/GeneratedScreenHeaderConsumer.cpp
@@ -959,6 +960,37 @@ endif()
 
 mdux_discover_tests(ml_noheap_spec)
 
+# Screen runtime no-heap suite (issue #199)
+#
+# Its own binary for the reason ml_noheap_spec has one: it replaces the global operator new family,
+# and that is a whole-program property. Keeping it out of medui_spec means those scenarios run
+# against the ordinary allocator, and a failure here names the no-heap property rather than
+# appearing as one line among two dozen unrelated ones.
+add_executable(medui_noheap_spec
+    medui/ScreenNoHeapSpecMain.cpp
+    medui/ScreenNoHeapTests.cpp
+)
+
+target_link_libraries(medui_noheap_spec PRIVATE MduX::Core speclab::speclab)
+target_include_directories(medui_noheap_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(medui_noheap_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(medui_noheap_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(medui_noheap_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(medui_noheap_spec)
+
 # No-heap verification, layer 2 (issue #63): object-file symbol scan.
 #
 # Catches an allocator reference at build time, in the PR that introduced it, rather than whenever
@@ -969,6 +1001,16 @@ set(mdux_ml_object_list "${CMAKE_CURRENT_BINARY_DIR}/ml_objects_$<CONFIG>.txt")
 file(GENERATE
     OUTPUT "${mdux_ml_object_list}"
     CONTENT "$<JOIN:$<FILTER:$<TARGET_OBJECTS:MduXCore>,INCLUDE,/ml/>,\n>"
+)
+
+# The same scan over the screen runtime's objects (issue #199). The profile is named `ml-noheap` for
+# historical reasons and what it forbids is not ML-specific - the allocation family and the throwing
+# operators - so it is reused rather than copied under a second name. Renaming it would touch the ML
+# wiring in a PR about screens; worth doing, separately.
+set(mdux_screen_object_list "${CMAKE_CURRENT_BINARY_DIR}/screen_objects_$<CONFIG>.txt")
+file(GENERATE
+    OUTPUT "${mdux_screen_object_list}"
+    CONTENT "$<JOIN:$<FILTER:$<TARGET_OBJECTS:MduXCore>,INCLUDE,/medui/>,\n>"
 )
 
 # The same mechanism over the whole governed target (issue #116), with the forbidden set narrowed
@@ -998,6 +1040,16 @@ else()
 endif()
 
 if(MDUX_SYMBOL_TOOL)
+    add_test(NAME screen.noheap.symbolScan
+        COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=ml-noheap
+            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_screen_object_list}
+            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+    )
+    set_tests_properties(screen.noheap.symbolScan PROPERTIES LABELS "noheap")
+
     add_test(NAME ml.noheap.symbolScan
         COMMAND ${CMAKE_COMMAND}
             -DMDUX_SCAN_PROFILE=ml-noheap

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -773,6 +773,10 @@ mdux_discover_tests(medui_spec)
 # ADR-011 fixes for golden references in one screen - including the node that matches both rules and
 # must therefore appear exactly once.
 #
+# CompileTests (#198) drives the compiler driver as calls rather than spawning mdux-meduic: what is
+# under test is the order the stages run in, the recipe being complete for the screen it names, and
+# the three artifacts a compile produces - none of which an exit status could report on.
+#
 # EmitTests (#197) covers everything that has to hold before a compiler sees the generated source:
 # among them the two ways a valid screen used to become invalid C++ - a name carrying a control
 # character the `.medui` lexer decodes, and the empty screen the schema permits, whose node table
@@ -795,6 +799,7 @@ add_executable(medui_tools_spec
     medui/GoldenTests.cpp
     medui/PackageTests.cpp
     medui/EmitTests.cpp
+    medui/CompileTests.cpp
     medui/SharedConformanceTests.cpp
 )
 
@@ -804,6 +809,14 @@ target_include_directories(medui_tools_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 # open rather than string literals - #200's mdux-medui-check will be pointed at the same corpus,
 # and a fixture that exists only inside a test cannot be reused by the tool that checks files.
 target_compile_definitions(medui_tools_spec PRIVATE MDUX_REPO_ROOT="${CMAKE_SOURCE_DIR}")
+
+# One scenario spawns the compiler rather than calling into it: `medui-compile-cli` is the only place
+# that can show main() rendering a diagnostic envelope and returning a status, rather than letting an
+# exception reach the terminate handler - which is the behaviour an author meets first when a recipe
+# is wrong. Everything else in this suite drives the calls, because a failing assertion then says
+# what was wrong instead of what the exit status was.
+add_dependencies(medui_tools_spec mdux-meduic)
+target_compile_definitions(medui_tools_spec PRIVATE MDUX_MEDUIC_PATH="$<TARGET_FILE:mdux-meduic>")
 
 # The build's own answers for mdux_screen_identifier(), written where EmitTests can read them and
 # compare against identifierForScreen() in the C++ emitter. Both halves are executed, for the reason

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,7 +674,7 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issues #191, #192, #193)
+# .medui compiler host-tools suite (issues #191, #192, #193, #194)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
 # completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
@@ -686,6 +686,7 @@ add_executable(medui_tools_spec
     medui/DiagnosticsTests.cpp
     medui/ParserTests.cpp
     medui/SemanticTests.cpp
+    medui/LayoutTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,7 +674,7 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issues #191, #192, #193, #194, #195)
+# .medui compiler host-tools suite (issues #191, #192, #193, #194, #195, #196)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
 # completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
@@ -686,6 +686,10 @@ mdux_discover_tests(text_tools_spec)
 # widest-approved-translation rule is only checkable when two locales differ by a width the test
 # chose. The packages are still validated by the schema modules that own their formats, so the
 # measurements are taken from artifacts that would be legal on disk.
+#
+# GoldenTests (#196) reads tests/medui/fixtures/accepted-goldens.medui, which carries every rule
+# ADR-011 fixes for golden references in one screen - including the node that matches both rules and
+# must therefore appear exactly once.
 add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
@@ -693,6 +697,7 @@ add_executable(medui_tools_spec
     medui/SemanticTests.cpp
     medui/LayoutTests.cpp
     medui/TextBudgetTests.cpp
+    medui/GoldenTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -725,6 +725,11 @@ mdux_discover_tests(medui_spec)
 # GoldenTests (#196) reads tests/medui/fixtures/accepted-goldens.medui, which carries every rule
 # ADR-011 fixes for golden references in one screen - including the node that matches both rules and
 # must therefore appear exactly once.
+#
+# PackageTests (#197) reads tests/medui/fixtures/accepted-every-component.medui, a screen carrying
+# all eleven compiled payloads, and round-trips it through canonical JSON. The writer and the reader
+# spell each member name separately, so the scenario executes both directions over one screen rather
+# than asserting either half - the shape of parity check this repository has got wrong before.
 add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
@@ -733,6 +738,7 @@ add_executable(medui_tools_spec
     medui/LayoutTests.cpp
     medui/TextBudgetTests.cpp
     medui/GoldenTests.cpp
+    medui/PackageTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -685,6 +685,7 @@ add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
     medui/ParserTests.cpp
+    medui/SharedConformanceTests.cpp
 )
 
 target_link_libraries(medui_tools_spec PRIVATE MduX::MeduiLib speclab::speclab)
@@ -706,7 +707,10 @@ if(TARGET __CMAKE::CXX23)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_compile_options(medui_tools_spec PRIVATE /experimental:module /std:c++latest)
+    # SharedConformanceTests uses getenv() only to read CI configuration. Suppress MSVC's
+    # blanket deprecation warning for that test at the target boundary instead of adding
+    # compiler-control macros and pragmas to the C++ source.
+    target_compile_options(medui_tools_spec PRIVATE /experimental:module /std:c++latest /wd4996)
 endif()
 
 mdux_discover_tests(medui_tools_spec)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -857,6 +857,44 @@ endif()
 
 mdux_discover_tests(medui_tools_spec)
 
+# mdux_compile_screen()'s recipe reading (issue #198)
+#
+# Script-mode CMake, because what is under test is a pure function of the recipe text: which
+# `[package]` keys the wrapper extracts, and whether it refuses a registration that names a different
+# screen than the recipe compiles. Configuring a fixture project to reach the same two functions
+# would be slower and would report a failure two layers from its cause.
+#
+# The negative cases match the message rather than the exit status, following
+# governed.noThrow.symbolScan.negative - and, as that test's comment records, PASS_REGULAR_EXPRESSION
+# must not be combined with WILL_FAIL, which would invert the verdict. A bare "it failed" would be
+# satisfied by a typo in the script.
+foreach(mdux_screen_recipe_case scoped identity-accepts committed)
+    add_test(NAME "screen.recipe.${mdux_screen_recipe_case}"
+        COMMAND ${CMAKE_COMMAND} -DCASE=${mdux_screen_recipe_case}
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+endforeach()
+
+add_test(NAME "screen.recipe.identity"
+    COMMAND ${CMAKE_COMMAND} -DCASE=identity
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+# Short fragments, on purpose: CMake wraps the text of a FATAL_ERROR to its own width, so a regex
+# spanning two clauses can straddle the line break it inserts. This one did - the message was right
+# and the test failed anyway - which is worth one line here to save the next person the same hunt.
+set_tests_properties("screen.recipe.identity" PROPERTIES
+    PASS_REGULAR_EXPRESSION "declares id 'real-screen'")
+
+add_test(NAME "screen.recipe.ambiguous"
+    COMMAND ${CMAKE_COMMAND} -DCASE=ambiguous
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+set_tests_properties("screen.recipe.ambiguous" PROPERTIES
+    PASS_REGULAR_EXPRESSION "declares .source. 2 times")
+
+add_test(NAME "screen.recipe.missing"
+    COMMAND ${CMAKE_COMMAND} -DCASE=missing
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompileScreenRecipeTest.cmake")
+set_tests_properties("screen.recipe.missing" PROPERTIES
+    PASS_REGULAR_EXPRESSION "has no .source")
+
 # ML host-tools suite (issue #60)
 #
 # Links MduX::MlBakeLib, the host-tools-zone target. Deliberately separate from ml_spec, which

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,7 +674,7 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issues #191, #192)
+# .medui compiler host-tools suite (issues #191, #192, #193)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
 # completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
@@ -685,6 +685,7 @@ add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
     medui/ParserTests.cpp
+    medui/SemanticTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -443,14 +443,35 @@ mdux_discover_tests(vulkansc_object_tests)
 # It is also the reason this project's GCC floor is 16. GCC 15 cannot build SpecLab at all -
 # reading a named module that transitively re-exports parts of `std` fails with "failed to load
 # pendings for 'std::_Sp_counted_ptr_inplace'", a defect in GCC's own std BMI.
-# Pinned to a commit, not to a branch. SpecLab has no tagged release yet, and a moving ref would
-# mean the test framework under a medical device library could change between two builds of the
-# same MduX commit - which is the same reproducibility argument ADR-007 makes about baked
-# artifacts. Bump this deliberately, in a reviewable diff.
+# Pinned to a commit, not to a tag or a branch. A moving ref would mean the test framework under a
+# medical device library could change between two builds of the same MduX commit - the same
+# reproducibility argument ADR-007 makes about baked artifacts. Bump this deliberately, in a
+# reviewable diff.
+#
+# The commit is SpecLab v0.1.0, its first release. Pinned by SHA and not by the tag name, and the
+# reason is not theoretical: this pin was written against `v0.1.0` while the tag pointed at
+# ea7f2e363, and within the hour the tag was moved to 37b51fcec to pick up a release-packaging fix
+# (ambroise-leclerc/SpecLab#18). Nothing in that commit affects this build - it makes SpecLab's project version a
+# cache variable and edits its own release workflow - but a reference that can change under a
+# frozen MduX commit is a moving reference whatever it is called, and ADR-007's reproducibility
+# argument does not distinguish between a branch and a retagged release.
+#
+# Read the tag name as documentation and the SHA as the pin. To bump, resolve the new tag to its
+# commit and change both, in a reviewable diff.
+#
+# That release is also what makes MduX's own gcc:16.1.0 pin (#206) coherent rather than a
+# workaround. SpecLab hit the same GCC 16.2 BMI corruption in its own CI
+# (ambroise-leclerc/SpecLab#15), diagnosed
+# it the same way, and pinned identically; its CMakeLists now enforces GCC 16.1+. A future working
+# 16.2.x bump is tracked upstream as ambroise-leclerc/SpecLab#17, and this repository's #205
+# follow-up depends on it. Upstream issue numbers are written in full: a bare #15 or #17 here names
+# MduX's .medui compiler and Content components epics, which is a confusing thing to mean by
+# accident in a comment about a different repository.
 CPMAddPackage(
     NAME SpecLab
     GITHUB_REPOSITORY ambroise-leclerc/SpecLab
-    GIT_TAG 84631c9f01f5309baf1d12618b2ef66c3512b511
+    # SpecLab v0.1.0
+    GIT_TAG 37b51fcec
     OPTIONS
         "SPECLAB_BUILD_TESTS OFF"
         "SPECLAB_BUILD_EXAMPLES OFF"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -684,13 +684,60 @@ mdux_discover_tests(text_tools_spec)
 # decision 3 puts `static_assert(package.validate().has_value())` in every generated screen, so
 # compile-time validation is a promise the device build depends on, and one no runtime test can
 # make on its behalf.
+# The emitted C++ for the test corpus screen (#197). Build-tree only, never committed - see
+# cmake/MduXScreenEmit.cmake. The package it renders is a fixture rather than an artifact under
+# generated/, because no screen is baked there until #198 registers one; the byte-comparison that
+# keeps the fixture honest is `medui-screen-emit-fixture-is-current` in medui_tools_spec, which
+# recompiles the source and compares.
+include(${CMAKE_SOURCE_DIR}/cmake/MduXScreenEmit.cmake)
+mdux_emit_screen_package(
+    ID every-component
+    PACKAGE tests/medui/fixtures/every-component-package.json
+    OUT_MODULE MDUX_EVERY_COMPONENT_SCREEN_MODULE
+    OUT_DIR MDUX_GENERATED_SCREEN_DIR
+)
+
+# The degenerate screen the schema permits: no nodes, empty budget. Emitted and compiled because an
+# empty C array is not valid C++, so this is the case where a screen validate() accepts could not be
+# consumed at all - see GeneratedEmptyScreenConsumer.cpp.
+mdux_emit_screen_package(
+    ID empty-screen
+    PACKAGE tests/medui/fixtures/empty-screen-package.json
+    OUT_MODULE MDUX_EMPTY_SCREEN_MODULE
+)
+
 add_executable(medui_spec
     medui/MeduiSpecMain.cpp
     medui/SchemaTests.cpp
+    medui/GeneratedScreenTests.cpp
+    medui/GeneratedScreenModuleConsumer.cpp
+    medui/GeneratedScreenHeaderConsumer.cpp
+    medui/GeneratedEmptyScreenConsumer.cpp
 )
 
+# Compiling both emitted forms in one binary is #197's acceptance criterion, not incidental. It
+# works because the module form is attached to a named module and the header form is not, so they
+# are distinct entities that can coexist; GeneratedScreenTests then asserts they describe one
+# screen. The generated module needs its own named file set, because the default CXX_MODULES set's
+# base directory is this source directory and a generated module lives in the build tree.
+target_sources(medui_spec
+    PRIVATE
+        FILE_SET generated_screen_modules
+            TYPE CXX_MODULES
+            BASE_DIRS ${MDUX_GENERATED_SCREEN_DIR}
+            FILES
+                ${MDUX_EVERY_COMPONENT_SCREEN_MODULE}
+                ${MDUX_EMPTY_SCREEN_MODULE}
+)
+add_dependencies(medui_spec emit-screen-every-component emit-screen-empty-screen)
+
+# MduX::Core and no host-tools module: a device build reaching a compiled screen through generated
+# code links no compiler and parses nothing, and this target linking is the evidence for it.
 target_link_libraries(medui_spec PRIVATE MduX::Core speclab::speclab)
-target_include_directories(medui_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(medui_spec PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${MDUX_GENERATED_SCREEN_DIR}
+)
 
 set_target_properties(medui_spec
     PROPERTIES
@@ -726,6 +773,14 @@ mdux_discover_tests(medui_spec)
 # ADR-011 fixes for golden references in one screen - including the node that matches both rules and
 # must therefore appear exactly once.
 #
+# EmitTests (#197) covers everything that has to hold before a compiler sees the generated source:
+# among them the two ways a valid screen used to become invalid C++ - a name carrying a control
+# character the `.medui` lexer decodes, and the empty screen the schema permits, whose node table
+# cannot be an empty C array.
+# that the committed fixture package is still what compiling its source produces, that both halves of
+# the filename rule agree, and that a malformed package is refused rather than rendered. The emitted
+# C++ itself is compiled and compared in medui_spec, which links MduX::Core only.
+#
 # PackageTests (#197) reads tests/medui/fixtures/accepted-every-component.medui, a screen carrying
 # all eleven compiled payloads, and round-trips it through canonical JSON. The writer and the reader
 # spell each member name separately, so the scenario executes both directions over one screen rather
@@ -739,6 +794,7 @@ add_executable(medui_tools_spec
     medui/TextBudgetTests.cpp
     medui/GoldenTests.cpp
     medui/PackageTests.cpp
+    medui/EmitTests.cpp
     medui/SharedConformanceTests.cpp
 )
 
@@ -748,6 +804,25 @@ target_include_directories(medui_tools_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 # open rather than string literals - #200's mdux-medui-check will be pointed at the same corpus,
 # and a fixture that exists only inside a test cannot be reused by the tool that checks files.
 target_compile_definitions(medui_tools_spec PRIVATE MDUX_REPO_ROOT="${CMAKE_SOURCE_DIR}")
+
+# The build's own answers for mdux_screen_identifier(), written where EmitTests can read them and
+# compare against identifierForScreen() in the C++ emitter. Both halves are executed, for the reason
+# the shader pair had to learn: a C++ assertion cannot observe a CMake regex, so asserting one half
+# and calling it consistent with the other let the two drift on the leading-digit rule.
+# Keywords are in the list because they are legal package slugs: `class` and `module` map to
+# identifiers a compiler rejects unless the rule prefixes them, and both implementations agreed on
+# that invalid answer until the prefix landed.
+set(mdux_screen_identifier_ids
+    "every-component" "empty-screen" "neurosense-500" "plain" "2d" "a.b-c" "already_fine" "ui.v2"
+    "class" "namespace" "module" "import" "int")
+set(mdux_screen_identifier_lines "")
+foreach(mdux_screen_identifier_id IN LISTS mdux_screen_identifier_ids)
+    mdux_screen_identifier(mdux_screen_identifier_value "${mdux_screen_identifier_id}")
+    string(APPEND mdux_screen_identifier_lines "${mdux_screen_identifier_id}\t${mdux_screen_identifier_value}\n")
+endforeach()
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/screen_identifier_parity.tsv" "${mdux_screen_identifier_lines}")
+target_compile_definitions(medui_tools_spec PRIVATE
+    MDUX_SCREEN_IDENTIFIER_PARITY_FILE="${CMAKE_CURRENT_BINARY_DIR}/screen_identifier_parity.tsv")
 
 set_target_properties(medui_tools_spec
     PROPERTIES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -548,9 +548,10 @@ mdux_discover_tests(ml_spec)
 #
 # Links MduX::Core only. mdux.text.schema is governed and contains no Vulkan handle, so a
 # scenario that needed MduX::MduX to build it would mean the trust-zone boundary had moved -
-# the same standing evidence shader_spec, draw_spec and ml_spec give. S1 ships the schema and a
-# no-run baker skeleton; the TrueType parser (#158), rasteriser (#159), atlas font baker (#160),
-# font schema (#161) and coverage draw path (#162) follow as their blockers close.
+# the same standing evidence shader_spec, draw_spec and ml_spec give. The suite covers the
+# governed half of the text pipeline: the schema (#157), the font schema (#161) and the coverage
+# draw path (#162). The host-only halves - the TrueType parser (#158), the rasteriser (#159) and
+# the atlas font baker (#160) - are covered by text_tools_spec instead.
 # Font schema suite (issue #161)
 #
 # Its own executable rather than cases inside text_spec, because a font package and a text package
@@ -587,7 +588,6 @@ mdux_discover_tests(font_spec)
 add_executable(text_spec
     text/TextSpecMain.cpp
     text/SchemaTests.cpp
-    text/RasterTests.cpp
     text/DrawTests.cpp
 )
 
@@ -619,11 +619,17 @@ mdux_discover_tests(text_spec)
 # `ml_tools_spec` and `shader_spec` follow: drive `parseRecipe()` / `run()` / `write()` / `verify()`
 # as calls so a failing assertion names the diagnostic code that failed rather than only an exit
 # status from a spawned process.
+#
+# RasterTests.cpp lives here rather than in text_spec since #116, because `mdux.text.raster` moved
+# to the host-tools zone. Moving the test with the module is not bookkeeping: text_spec links
+# MduX::Core alone, and that link line *is* the standing evidence above. Leaving raster cases there
+# would force MduX::TextBakeLib onto text_spec and destroy the very thing it exists to demonstrate.
 add_executable(text_tools_spec
     text/TextToolsSpecMain.cpp
     text/TextBakeTests.cpp
     text/TruetypeTests.cpp
     text/AtlasPackerTests.cpp
+    text/RasterTests.cpp
 )
 
 target_link_libraries(text_tools_spec PRIVATE MduX::TextBakeLib speclab::speclab)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,19 +674,25 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issues #191, #192, #193, #194)
+# .medui compiler host-tools suite (issues #191, #192, #193, #194, #195)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
 # completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
 # diagnose() produces - and the lexer and parser (#192), whose rejection cases assert the code and
 # the position rather than the message, since #191 published the codes as the contract and
 # messages are explicitly rewordable.
+#
+# TextBudgetTests (#195) builds its own font and text packages rather than reading generated/: the
+# widest-approved-translation rule is only checkable when two locales differ by a width the test
+# chose. The packages are still validated by the schema modules that own their formats, so the
+# measurements are taken from artifacts that would be legal on disk.
 add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
     medui/ParserTests.cpp
     medui/SemanticTests.cpp
     medui/LayoutTests.cpp
+    medui/TextBudgetTests.cpp
     medui/SharedConformanceTests.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -729,6 +729,19 @@ file(GENERATE
     CONTENT "$<JOIN:$<FILTER:$<TARGET_OBJECTS:MduXCore>,INCLUDE,/ml/>,\n>"
 )
 
+# The same mechanism over the whole governed target (issue #116), with the forbidden set narrowed
+# to the throw expression alone. No filter: every MduXCore object, module interfaces included.
+#
+# The allocator symbols cannot come along. mdux.evidence.json and mdux.governance allocate by
+# design - they build strings and vectors - so the ml-noheap forbidden set applied here would fail
+# on correct code. What generalises is the no-throwing half, which is a property ADR-005 asserts of
+# the whole governed zone rather than only of the ML modules.
+set(mdux_governed_object_list "${CMAKE_CURRENT_BINARY_DIR}/governed_objects_$<CONFIG>.txt")
+file(GENERATE
+    OUTPUT "${mdux_governed_object_list}"
+    CONTENT "$<JOIN:$<TARGET_OBJECTS:MduXCore>,\n>"
+)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     find_program(MDUX_SYMBOL_TOOL NAMES dumpbin)
     set(mdux_symbol_tool_kind "dumpbin")
@@ -745,16 +758,90 @@ endif()
 if(MDUX_SYMBOL_TOOL)
     add_test(NAME ml.noheap.symbolScan
         COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=ml-noheap
             -DMDUX_NOHEAP_OBJECT_LIST=${mdux_ml_object_list}
             -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
             -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
             -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
     )
     set_tests_properties(ml.noheap.symbolScan PROPERTIES LABELS "noheap")
+
+    # Issue #116. Labelled `governed` rather than `noheap`: it is not a no-heap check, and a CI leg
+    # selecting -L noheap should not silently start covering something else.
+    add_test(NAME governed.noThrow.symbolScan
+        COMMAND ${CMAKE_COMMAND}
+            -DMDUX_SCAN_PROFILE=governed-throw
+            -DMDUX_NOHEAP_OBJECT_LIST=${mdux_governed_object_list}
+            -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+            -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+            -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+    )
+    set_tests_properties(governed.noThrow.symbolScan PROPERTIES LABELS "governed")
+
+    # The negative fixture. See tests/governed/ThrowFixture.cpp for why a scan that only ever runs
+    # against conforming code is not yet evidence of anything.
+    #
+    # MSVC is excluded, and the reason is the same one that makes the positive scan
+    # report-only there: the MSVC STL inlines its own throw sites, so `_CxxThrowException` cannot
+    # distinguish a governed `throw` from an ordinary `std::string` growth path. The
+    # `governed-throw` profile therefore forbids nothing under dumpbin, and a negative test needs
+    # something to be forbidden before it can prove the rejection works. Registering it anyway
+    # would produce a test that fails on Windows for a reason unrelated to any defect - the kind of
+    # noise that trains a reader to ignore a red check.
+    #
+    # CXX_SCAN_FOR_MODULES OFF keeps this object out of the module dependency graph: it declares no
+    # module and imports none, and a fixture whose job is to be non-conforming has no business in
+    # anyone's dyndep.
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        message(STATUS
+            "governed.noThrow.symbolScan.negative not registered on MSVC - the governed-throw "
+            "profile forbids no symbol under dumpbin, so there is nothing for a negative test to "
+            "prove. mdux-governed-lint covers the rule on this toolchain.")
+    else()
+        add_library(mdux_throw_fixture OBJECT governed/ThrowFixture.cpp)
+        set_target_properties(mdux_throw_fixture
+            PROPERTIES
+                CXX_STANDARD 23
+                CXX_STANDARD_REQUIRED ON
+                CXX_EXTENSIONS OFF
+                CXX_SCAN_FOR_MODULES OFF
+        )
+
+        set(mdux_throw_fixture_object_list
+            "${CMAKE_CURRENT_BINARY_DIR}/throw_fixture_objects_$<CONFIG>.txt")
+        file(GENERATE
+            OUTPUT "${mdux_throw_fixture_object_list}"
+            CONTENT "$<JOIN:$<TARGET_OBJECTS:mdux_throw_fixture>,\n>"
+        )
+
+        add_test(NAME governed.noThrow.symbolScan.negative
+            COMMAND ${CMAKE_COMMAND}
+                -DMDUX_SCAN_PROFILE=governed-throw
+                -DMDUX_NOHEAP_OBJECT_LIST=${mdux_throw_fixture_object_list}
+                -DMDUX_NOHEAP_TOOL=${mdux_symbol_tool_kind}
+                -DMDUX_NOHEAP_COMMAND=${MDUX_SYMBOL_TOOL}
+                -P ${CMAKE_SOURCE_DIR}/cmake/MduXNoHeapScan.cmake
+        )
+        # PASS_REGULAR_EXPRESSION rather than WILL_FAIL, and the two must not be combined. When
+        # PASS_REGULAR_EXPRESSION is set CTest ignores the exit status and passes the test iff the
+        # regex matches, so it already accommodates the expected non-zero exit; adding WILL_FAIL
+        # then *inverts* that verdict and turns the correct outcome into a reported failure
+        # (observed).
+        #
+        # Matching the message rather than merely the exit status is what makes this a real
+        # negative test. A bare WILL_FAIL would be satisfied by a missing object, a misspelled
+        # profile or a bad path - every way of failing except the one being verified.
+        set_tests_properties(governed.noThrow.symbolScan.negative
+            PROPERTIES
+                PASS_REGULAR_EXPRESSION "Symbol scan violation \\(profile 'governed-throw'\\)"
+                LABELS "governed"
+        )
+    endif()
 else()
-    # Deliberately not silent. A missing tool means this layer is not running, and the other two
-    # layers do not cover what it covers.
+    # Deliberately not silent. A missing tool means these layers are not running, and nothing else
+    # covers what they cover.
     message(WARNING
-        "No symbol tool (nm/dumpbin) found - ml.noheap.symbolScan will not run, so issue #63's "
-        "layer 2 is unverified in this build.")
+        "No symbol tool (nm/dumpbin) found - ml.noheap.symbolScan and governed.noThrow.symbolScan "
+        "will not run, so issue #63's layer 2 and issue #116's object-level no-throw check are "
+        "both unverified in this build.")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,20 +674,25 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
-# .medui compiler host-tools suite (issue #191)
+# .medui compiler host-tools suite (issues #191, #192)
 #
-# Links MduX::MeduiLib. At S2 the library is the diagnostic code registry and nothing else, so this
-# suite is entirely registry invariants - completeness, uniqueness, identifier shape, ordering
-# against the retired list, and the envelope diagnose() produces. Those are the questions a
-# registry exists to answer mechanically; without them the module is a table of string literals
-# with extra steps.
+# Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -
+# completeness, uniqueness, identifier shape, ordering against the retired list, and the envelope
+# diagnose() produces - and the lexer and parser (#192), whose rejection cases assert the code and
+# the position rather than the message, since #191 published the codes as the contract and
+# messages are explicitly rewordable.
 add_executable(medui_tools_spec
     medui/MeduiToolsSpecMain.cpp
     medui/DiagnosticsTests.cpp
+    medui/ParserTests.cpp
 )
 
 target_link_libraries(medui_tools_spec PRIVATE MduX::MeduiLib speclab::speclab)
 target_include_directories(medui_tools_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+# The parser scenarios read tests/medui/fixtures/*.medui, which are real files an author could
+# open rather than string literals - #200's mdux-medui-check will be pointed at the same corpus,
+# and a fixture that exists only inside a test cannot be reused by the tool that checks files.
+target_compile_definitions(medui_tools_spec PRIVATE MDUX_REPO_ROOT="${CMAKE_SOURCE_DIR}")
 
 set_target_properties(medui_tools_spec
     PROPERTIES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -262,6 +262,7 @@ add_executable(offscreen_tests
     render/OffscreenTests.cpp
     render/PixelTests.cpp
     render/TextPixelTests.cpp
+    render/ScreenPixelTests.cpp
 )
 
 target_sources(offscreen_tests
@@ -271,12 +272,25 @@ target_sources(offscreen_tests
             TYPE CXX_MODULES
             BASE_DIRS ${MDUX_GENERATED_SHADER_DIR}
             FILES ${MDUX_UI_SHADER_MODULE}
+        # The emitted screen joins its own file set, because its base directory is the screen output
+        # directory rather than the shader one. ScreenPixelTests (#201) links it: the last link in
+        # the chain from an authored .medui file to a compared pixel.
+        FILE_SET generated_screen_modules
+            TYPE CXX_MODULES
+            BASE_DIRS ${MDUX_GENERATED_SCREEN_DIR}
+            FILES ${MDUX_ENDOSCOPE_SCREEN_MODULE}
 )
-add_dependencies(offscreen_tests emit-shader-mdux-ui)
+add_dependencies(offscreen_tests emit-shader-mdux-ui emit-screen-endoscope-monitor)
+
+# ScreenPixelTests reads the committed golden sidecar under generated/, a fixed location in the
+# source tree rather than anything the build produces. It reads only; the source-tree-cleanliness
+# gate in CI stays satisfied.
+target_compile_definitions(offscreen_tests PRIVATE MDUX_REPO_ROOT="${CMAKE_SOURCE_DIR}")
 target_link_libraries(offscreen_tests PRIVATE MduX::MduX)
 target_include_directories(offscreen_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${MDUX_GENERATED_SHADER_DIR}
+    ${MDUX_GENERATED_SCREEN_DIR}
 )
 
 set_target_properties(offscreen_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -674,6 +674,41 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
+# Governed compiled-screen schema (issue #197)
+#
+# Links MduX::Core only, and deliberately not MduX::MeduiLib. `mdux.medui.schema` is the one type a
+# device holds, so a scenario that needed the parser or the solver to build one would mean the
+# trust-zone boundary had moved - the same argument that keeps ml_spec apart from ml_tools_spec.
+#
+# The file's centre of gravity is a namespace-scope static_assert rather than a scenario: ADR-012
+# decision 3 puts `static_assert(package.validate().has_value())` in every generated screen, so
+# compile-time validation is a promise the device build depends on, and one no runtime test can
+# make on its behalf.
+add_executable(medui_spec
+    medui/MeduiSpecMain.cpp
+    medui/SchemaTests.cpp
+)
+
+target_link_libraries(medui_spec PRIVATE MduX::Core speclab::speclab)
+target_include_directories(medui_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(medui_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(medui_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(medui_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(medui_spec)
+
 # .medui compiler host-tools suite (issues #191, #192, #193, #194, #195, #196)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -653,6 +653,38 @@ endif()
 
 mdux_discover_tests(text_tools_spec)
 
+# .medui compiler host-tools suite (issue #191)
+#
+# Links MduX::MeduiLib. At S2 the library is the diagnostic code registry and nothing else, so this
+# suite is entirely registry invariants - completeness, uniqueness, identifier shape, ordering
+# against the retired list, and the envelope diagnose() produces. Those are the questions a
+# registry exists to answer mechanically; without them the module is a table of string literals
+# with extra steps.
+add_executable(medui_tools_spec
+    medui/MeduiToolsSpecMain.cpp
+    medui/DiagnosticsTests.cpp
+)
+
+target_link_libraries(medui_tools_spec PRIVATE MduX::MeduiLib speclab::speclab)
+target_include_directories(medui_tools_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(medui_tools_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(medui_tools_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(medui_tools_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(medui_tools_spec)
+
 # ML host-tools suite (issue #60)
 #
 # Links MduX::MlBakeLib, the host-tools-zone target. Deliberately separate from ml_spec, which

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -774,6 +774,11 @@ mdux_discover_tests(medui_spec)
 # ADR-011 fixes for golden references in one screen - including the node that matches both rules and
 # must therefore appear exactly once.
 #
+# CheckTests (#200) drives the single-file checker over the same rejection corpus the parser and
+# analyzer suites use by call, so a code that stops surfacing to an author stops a test. Two of its
+# scenarios spawn the tool, for the same reason CompileTests has one: nothing at call level shows
+# that the executable exits non-zero on a finding and zero on a run whose only output is notes.
+#
 # CompileTests (#198) drives the compiler driver as calls rather than spawning mdux-meduic: what is
 # under test is the order the stages run in, the recipe being complete for the screen it names, and
 # the three artifacts a compile produces - none of which an exit status could report on.
@@ -801,6 +806,7 @@ add_executable(medui_tools_spec
     medui/PackageTests.cpp
     medui/EmitTests.cpp
     medui/CompileTests.cpp
+    medui/CheckTests.cpp
     medui/SharedConformanceTests.cpp
 )
 
@@ -816,8 +822,10 @@ target_compile_definitions(medui_tools_spec PRIVATE MDUX_REPO_ROOT="${CMAKE_SOUR
 # exception reach the terminate handler - which is the behaviour an author meets first when a recipe
 # is wrong. Everything else in this suite drives the calls, because a failing assertion then says
 # what was wrong instead of what the exit status was.
-add_dependencies(medui_tools_spec mdux-meduic)
-target_compile_definitions(medui_tools_spec PRIVATE MDUX_MEDUIC_PATH="$<TARGET_FILE:mdux-meduic>")
+add_dependencies(medui_tools_spec mdux-meduic mdux-medui-check)
+target_compile_definitions(medui_tools_spec PRIVATE
+    MDUX_MEDUIC_PATH="$<TARGET_FILE:mdux-meduic>"
+    MDUX_MEDUI_CHECK_PATH="$<TARGET_FILE:mdux-medui-check>")
 
 # The build's own answers for mdux_screen_identifier(), written where EmitTests can read them and
 # compare against identifierForScreen() in the C++ emitter. Both halves are executed, for the reason

--- a/tests/TestRegulatoryCompliance.cpp
+++ b/tests/TestRegulatoryCompliance.cpp
@@ -12,7 +12,7 @@ import mdux.test;
 TEST_CASE("IEC 62304 Version Traceability", "regulatory") {
     // Verify version traceability (required by IEC 62304)
     CHECK(mdux::Version::major == 0);
-    CHECK(mdux::Version::minor == 5);
+    CHECK(mdux::Version::minor == 6);
     CHECK(mdux::Version::patch == 0);
     CHECK(!mdux::Version::getString().empty());
 }

--- a/tests/TestVersion.cpp
+++ b/tests/TestVersion.cpp
@@ -11,9 +11,9 @@ import mdux.test;
 
 TEST_CASE("Version Test") {
     CHECK(mdux::Version::major == 0);
-    CHECK(mdux::Version::minor == 5);
+    CHECK(mdux::Version::minor == 6);
     CHECK(mdux::Version::patch == 0);
-    CHECK(mdux::Version::getString() == "0.5.0");
+    CHECK(mdux::Version::getString() == "0.6.0");
 }
 
 TEST_CASE("Version Test Sections") {
@@ -25,13 +25,13 @@ TEST_CASE("Version Test Sections") {
     SECTION("major and minor") {
         sectionsRun += 1;
         CHECK(mdux::Version::major == 0);
-        CHECK(mdux::Version::minor == 5);
+        CHECK(mdux::Version::minor == 6);
     }
 
     SECTION("patch and string") {
         sectionsRun += 1;
         CHECK(mdux::Version::patch == 0);
-        CHECK(mdux::Version::getString() == "0.5.0");
+        CHECK(mdux::Version::getString() == "0.6.0");
     }
 
     CHECK(sectionsRun == 2);

--- a/tests/cmake/CompileScreenRecipeTest.cmake
+++ b/tests/cmake/CompileScreenRecipeTest.cmake
@@ -1,0 +1,85 @@
+# Configure-time checks for mdux_compile_screen()'s recipe reading (issue #198).
+#
+# Run as `cmake -DCASE=<case> -P tests/cmake/CompileScreenRecipeTest.cmake`. Each case is registered
+# as its own CTest entry in tests/CMakeLists.txt; the negative ones match the message rather than the
+# exit status, because a bare "it failed" would be satisfied by a typo in this file.
+#
+# Script mode rather than a fixture project: what is under test is the extraction and the identity
+# check, both of which are pure functions of the recipe text. Configuring a whole project to exercise
+# them would be slower and would report a failure two layers away from its cause.
+
+cmake_minimum_required(VERSION 4.0.0)
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/MduXCompileScreen.cmake")
+
+# A recipe carrying a decoy `source` in a table the compiler ignores, before the one it reads. This
+# is the shape that made an unscoped regex dangerous: CMake would take `decoy.png` as the dependency
+# while mdux-meduic compiled `real.medui`, so editing the screen would stop triggering a rebake.
+set(decoy_recipe
+"# a comment mentioning [package] and source = \"commented-out.medui\"
+[assets]
+source = \"decoy.png\"
+
+[package]
+id            = \"real-screen\"
+source        = \"recipes/screen/real-screen/RealScreen.medui\"
+surfaceWidth  = 400
+surfaceHeight = 300
+")
+
+if(CASE STREQUAL "scoped")
+    _mdux_screen_package_field(value "${decoy_recipe}" "source" "decoy.toml")
+    if(NOT value STREQUAL "recipes/screen/real-screen/RealScreen.medui")
+        message(FATAL_ERROR "expected the [package] source, got '${value}'")
+    endif()
+    _mdux_screen_package_field(id_value "${decoy_recipe}" "id" "decoy.toml")
+    if(NOT id_value STREQUAL "real-screen")
+        message(FATAL_ERROR "expected the [package] id, got '${id_value}'")
+    endif()
+    message(STATUS "scoped: OK")
+
+elseif(CASE STREQUAL "identity")
+    # The pair the wrapper must refuse: a recipe that compiles one screen, registered as another.
+    _mdux_screen_check_recipe("${decoy_recipe}" "decoy.toml" "another-screen" unused_source)
+    message(FATAL_ERROR "unreachable: a mismatched id was accepted")
+
+elseif(CASE STREQUAL "identity-accepts")
+    _mdux_screen_check_recipe("${decoy_recipe}" "decoy.toml" "real-screen" source_value)
+    if(NOT source_value STREQUAL "recipes/screen/real-screen/RealScreen.medui")
+        message(FATAL_ERROR "expected the [package] source, got '${source_value}'")
+    endif()
+    message(STATUS "identity-accepts: OK")
+
+elseif(CASE STREQUAL "ambiguous")
+    set(ambiguous
+"[package]
+id     = \"real-screen\"
+source = \"one.medui\"
+source = \"two.medui\"
+")
+    _mdux_screen_package_field(value "${ambiguous}" "source" "ambiguous.toml")
+    message(FATAL_ERROR "unreachable: two source keys were accepted")
+
+elseif(CASE STREQUAL "missing")
+    set(missing
+"[assets]
+source = \"decoy.png\"
+
+[package]
+id = \"real-screen\"
+")
+    _mdux_screen_package_field(value "${missing}" "source" "missing.toml")
+    message(FATAL_ERROR "unreachable: a [package] with no source was accepted")
+
+elseif(CASE STREQUAL "committed")
+    # The recipe this repository actually commits, read the way the wrapper reads it.
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/../../recipes/screen/endoscope-monitor.toml" committed)
+    _mdux_screen_check_recipe("${committed}" "recipes/screen/endoscope-monitor.toml" "endoscope-monitor" source_value)
+    if(NOT source_value STREQUAL "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui")
+        message(FATAL_ERROR "expected the committed screen's source, got '${source_value}'")
+    endif()
+    message(STATUS "committed: OK")
+
+else()
+    message(FATAL_ERROR "unknown CASE '${CASE}'")
+endif()

--- a/tests/framework/CountingAllocations.hpp
+++ b/tests/framework/CountingAllocations.hpp
@@ -1,0 +1,189 @@
+/**
+ * @file CountingAllocations.hpp
+ * @brief Replaces the global `operator new` family with counting versions, for the no-heap suites.
+ *
+ * Included by exactly one translation unit per binary, because replacing a global operator is a
+ * whole-program property: two definitions do not link, and a suite that shared a binary with an
+ * allocating one would measure the wrong program.
+ *
+ * Extracted from `tests/ml/NoHeapTests.cpp` when the screen runtime needed the same measurement
+ * (issue #199). It is subtle enough - over-aligned allocation by hand, a scoped GCC diagnostic for a
+ * mismatched-new-delete the compiler cannot see through - that a second copy would have been a
+ * second thing to keep right.
+ *
+ * What it catches and what it misses is the argument for the other two layers, and belongs with the
+ * suites that use it: this sees any allocation through the global `operator new` family, including
+ * one hidden inside a `std` call nobody expected to allocate. It does not see a direct
+ * `std::malloc`, a pool allocator, or anything else that bypasses those operators - the symbol scan
+ * covers those.
+ *
+ * A suite using this must include at least one scenario that allocates deliberately and asserts the
+ * counter moves. Without it the file would be a test that cannot fail: if the interposition ever
+ * stopped taking effect, every scenario would pass on a counter that never moved.
+ */
+#pragma once
+
+namespace {
+
+/// Bumped by every allocating operator below. Not atomic-by-necessity - the scenarios are
+/// single-threaded - but atomic anyway, so that a future threaded case cannot make this quietly
+/// unreliable.
+std::atomic<std::size_t> allocationCount{0};
+
+[[nodiscard]] std::size_t allocations() noexcept {
+    return allocationCount.load(std::memory_order_relaxed);
+}
+
+/**
+ * @brief Over-aligned allocation built on plain malloc, with no platform branch.
+ *
+ * Neither standard route works here. `std::aligned_alloc` does not exist on MSVC at all, and
+ * `_aligned_malloc` is declared in `<malloc.h>` - a header this translation unit cannot include,
+ * because it reaches the standard library through `import std;` and mixing the two is what the
+ * C5050 diagnostics elsewhere in this epic were about.
+ *
+ * So the alignment is done by hand: over-allocate, step the pointer up to the boundary, and stash
+ * the original just below it for the matching free. Portable, needs nothing but `std::malloc`, and
+ * keeps the counter covering over-aligned allocations - which matters, because leaving the aligned
+ * operators unreplaced would leave a path through which predict() could allocate uncounted.
+ */
+[[nodiscard]] void* allocateAligned(std::size_t size, std::size_t alignment) {
+    // The stash slot has to be addressable, so never align more loosely than a pointer.
+    const std::size_t effective = alignment < alignof(void*) ? alignof(void*) : alignment;
+    const std::size_t slack     = effective - 1 + sizeof(void*);
+
+    void* raw = std::malloc(size + slack);
+    if (raw == nullptr) {
+        return nullptr;
+    }
+
+    auto address  = reinterpret_cast<std::uintptr_t>(raw) + sizeof(void*);
+    address       = (address + effective - 1) & ~static_cast<std::uintptr_t>(effective - 1);
+    auto* aligned = reinterpret_cast<void*>(address);
+
+    // `aligned` is a multiple of effective >= alignof(void*), so the slot below it is aligned too.
+    *(reinterpret_cast<void**>(aligned) - 1) = raw;
+    return aligned;
+}
+
+void freeAligned(void* pointer) noexcept {
+    if (pointer == nullptr) {
+        return;
+    }
+    std::free(*(reinterpret_cast<void**>(pointer) - 1));
+}
+
+}  // namespace
+
+// Every allocating form is replaced, not just the common one. A partial replacement would leave a
+// path through which predict() could allocate uncounted, which is the failure this file exists to
+// make impossible.
+
+void* operator new(std::size_t size) {
+    allocationCount.fetch_add(1, std::memory_order_relaxed);
+    void* pointer = std::malloc(size == 0 ? 1 : size);
+    if (pointer == nullptr) {
+        throw std::bad_alloc{};
+    }
+    return pointer;
+}
+
+void* operator new[](std::size_t size) {
+    return ::operator new(size);
+}
+
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+    allocationCount.fetch_add(1, std::memory_order_relaxed);
+    return std::malloc(size == 0 ? 1 : size);
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+    return ::operator new(size, tag);
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment) {
+    allocationCount.fetch_add(1, std::memory_order_relaxed);
+    void* pointer = allocateAligned(size == 0 ? 1 : size, static_cast<std::size_t>(alignment));
+    if (pointer == nullptr) {
+        throw std::bad_alloc{};
+    }
+    return pointer;
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment) {
+    return ::operator new(size, alignment);
+}
+
+// The aligned nothrow pair. Absent from the first version of this file while its comment claimed
+// every allocating form was replaced - which left a path an allocation could take uncounted, in the
+// one file whose whole job is that no path is uncounted.
+void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+    allocationCount.fetch_add(1, std::memory_order_relaxed);
+    return allocateAligned(size == 0 ? 1 : size, static_cast<std::size_t>(alignment));
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment, const std::nothrow_t& tag) noexcept {
+    return ::operator new(size, alignment, tag);
+}
+
+// GCC's -Wmismatched-new-delete sees std::free() applied to a pointer that came from
+// `operator new` and reports a mismatch. It is right about the shape and wrong about the facts:
+// the operator new above *is* std::malloc, so free is the correct counterpart. The warning cannot
+// see that pairing because these are separate replaceable functions. Scoped to exactly the delete
+// family below, so the diagnostic keeps working everywhere else in this file.
+#if defined(__GNUC__) && !defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#endif
+
+void operator delete(void* pointer) noexcept {
+    std::free(pointer);
+}
+
+void operator delete[](void* pointer) noexcept {
+    std::free(pointer);
+}
+
+void operator delete(void* pointer, std::size_t) noexcept {
+    std::free(pointer);
+}
+
+void operator delete[](void* pointer, std::size_t) noexcept {
+    std::free(pointer);
+}
+
+void operator delete(void* pointer, const std::nothrow_t&) noexcept {
+    std::free(pointer);
+}
+
+void operator delete[](void* pointer, const std::nothrow_t&) noexcept {
+    std::free(pointer);
+}
+
+void operator delete(void* pointer, std::align_val_t, const std::nothrow_t&) noexcept {
+    freeAligned(pointer);
+}
+
+void operator delete[](void* pointer, std::align_val_t, const std::nothrow_t&) noexcept {
+    freeAligned(pointer);
+}
+
+void operator delete(void* pointer, std::align_val_t) noexcept {
+    freeAligned(pointer);
+}
+
+void operator delete[](void* pointer, std::align_val_t) noexcept {
+    freeAligned(pointer);
+}
+
+void operator delete(void* pointer, std::size_t, std::align_val_t) noexcept {
+    freeAligned(pointer);
+}
+
+void operator delete[](void* pointer, std::size_t, std::align_val_t) noexcept {
+    freeAligned(pointer);
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+    #pragma GCC diagnostic pop
+#endif

--- a/tests/framework/TemporaryDirectory.hpp
+++ b/tests/framework/TemporaryDirectory.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file TemporaryDirectory.hpp
+ * @brief A scratch directory a scenario owns for its own lifetime, and nobody else's.
+ *
+ * Extracted when the third copy appeared (#200). Three test files were carrying the same class, and
+ * all three carried the same defect with it: a fixed name directly under the system temporary
+ * directory, removed at construction *and* at destruction. Two concurrent `medui_tools_spec` runs -
+ * `ctest -j`, or two builds on one machine - would share the path, and either could delete files
+ * while the other process was using them. The failure that produces is an intermittent subprocess
+ * error with nothing to do with the code under test, which is the worst kind to debug and the
+ * easiest to blame on the tool being tested.
+ *
+ * The name now carries a random suffix, so two runs cannot collide however they are launched.
+ * `std::random_device` rather than a process id because it needs no platform header - this tree
+ * reaches the standard library through `import std`, and mixing that with `<unistd.h>` or
+ * `<process.h>` is what the C5050 diagnostics elsewhere in this epic were about.
+ */
+#pragma once
+
+namespace mdux::test {
+
+/// A directory this scenario owns, removed when it is done with it.
+class TemporaryDirectory {
+public:
+    explicit TemporaryDirectory(std::string_view name)
+        : path_{std::filesystem::temp_directory_path() / std::format("{}-{:08x}", name, std::random_device{}())} {
+        std::error_code code;
+        std::filesystem::create_directories(path_, code);
+    }
+
+    TemporaryDirectory(const TemporaryDirectory&)            = delete;
+    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
+
+    ~TemporaryDirectory() {
+        // Best effort, and deliberately not asserted: a scenario that has already failed should
+        // report why it failed rather than that its scratch could not be swept up afterwards.
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
+}  // namespace mdux::test

--- a/tests/governed/ThrowFixture.cpp
+++ b/tests/governed/ThrowFixture.cpp
@@ -1,0 +1,40 @@
+/**
+ * @file ThrowFixture.cpp
+ * @brief A deliberately non-conforming source, used to prove the governed no-throw scan fails.
+ *
+ * @compliance ADR-005 Error handling and exceptions policy
+ *
+ * This file is **not** part of `MduXCore` and is never linked into anything that ships. It exists
+ * so that `governed.noThrow.symbolScan.negative` has something to fail on.
+ *
+ * A check that only ever runs against conforming code proves very little: it passes identically
+ * when it is working and when it is scanning an empty list, matching no symbol, or reading the
+ * wrong objects. `MduXNoHeapScan.cmake` guards the empty-list and missing-object cases with its own
+ * `FATAL_ERROR`s. This covers the case those cannot - the scan running correctly over a real
+ * object and simply failing to recognise the thing it is looking for.
+ *
+ * The `throw` below is what the compiler turns into a `__cxa_throw` reference, the exact symbol
+ * the `governed-throw` profile forbids. Narrow that forbidden set or break the symbol matching and
+ * the scan stops rejecting this object, which CTest reports as a failure because the test carries
+ * `PASS_REGULAR_EXPRESSION` matching the violation message. Deliberately *not* `WILL_FAIL`: with a
+ * pass regex CTest already ignores the exit status, and adding `WILL_FAIL` inverts the verdict so
+ * the correct outcome is reported as a failure. `tests/CMakeLists.txt` carries the full reasoning.
+ *
+ * Only registered on GCC/Clang. The MSVC STL inlines its own throw sites, so the `governed-throw`
+ * profile forbids no symbol under `dumpbin` — and a negative test needs something to be forbidden
+ * before it can prove the rejection works.
+ *
+ * Plain includes rather than `import std`, and no module declaration: the fixture is compiled as
+ * an object library outside the module graph, so that a file whose entire purpose is to be
+ * non-conforming cannot participate in anyone's module dependency scan.
+ */
+#include <stdexcept>
+
+namespace mdux::test {
+
+/// Throws unconditionally. Never called; the reference in the emitted object is the whole point.
+[[noreturn]] void alwaysThrows() {
+    throw std::runtime_error{"this function exists to be found by a symbol scan"};
+}
+
+}  // namespace mdux::test

--- a/tests/medui/CheckTests.cpp
+++ b/tests/medui/CheckTests.cpp
@@ -1,0 +1,258 @@
+/**
+ * @file CheckTests.cpp
+ * @brief BDD scenarios for the single-file checker (issue #200).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Driven over the rejection corpus the parser and analyzer suites already use, which is the point of
+ * that corpus being real files rather than string literals: the tool #200 adds is pointed at exactly
+ * what those suites check by call, so a code that stops surfacing here has stopped surfacing to the
+ * author too.
+ *
+ * The scenarios that matter most are the two about what the checker *cannot* do. A checker whose
+ * clean run is silently partial is worse than no checker, because it converts "I did not look" into
+ * "nothing is wrong".
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.check;
+import mdux.tools.medui.diagnostics;
+
+#include "../framework/SpecLabBridge.hpp"
+#include "../framework/TemporaryDirectory.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+[[nodiscard]] std::filesystem::path fixturePath(std::string_view name) {
+    return std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+}
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    std::ifstream in{fixturePath(name), std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened", name), std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] bool carries(const md::CheckResult& result, std::string_view code) {
+    return std::ranges::any_of(result.diagnostics, [code](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == code;
+    });
+}
+
+[[nodiscard]] std::string codes(const md::CheckResult& result) {
+    std::string rendered;
+    for (const cli::Diagnostic& diagnostic : result.diagnostics) {
+        if (!rendered.empty()) {
+            rendered += ", ";
+        }
+        rendered += diagnostic.code.empty() ? std::string{"<none>"} : diagnostic.code;
+    }
+    return rendered.empty() ? std::string{"<nothing>"} : rendered;
+}
+
+
+/// One shell command line, spelled the way the platform's shell will actually read it.
+///
+/// `cmd.exe` strips the outer pair of quotes when a command line begins with one, and reads a
+/// leading `/` as a switch. Getting this wrong does not fail honestly - the process never starts and
+/// the exit status is non-zero for the wrong reason.
+[[nodiscard]] std::string shellCommand(std::string_view program, std::string_view arguments) {
+#ifdef _WIN32
+    std::string native{program};
+    std::ranges::replace(native, '/', '\\');
+    return std::format(R"(""{}" {}")", native, arguments);
+#else
+    return std::format(R"("{}" {})", program, arguments);
+#endif
+}
+
+[[nodiscard]] std::string contentsOf(const std::filesystem::path& path) {
+    std::ifstream in{path, std::ios::binary};
+    if (!in) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+}  // namespace
+
+const mdux::spec::Register aGoodScreenPassesWithItsGapsNamed{
+    "A screen that checks out says which checks did not run",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-check-accepts")
+            .Given("a screen the compiler accepts", [] {})
+            .When("it is checked on its own", [] {})
+            .Then("nothing of error severity is reported, and the uncovered checks are named",
+                  [] {
+                      mdux::spec::Checks    checks;
+                      const md::CheckResult result = md::checkScreen(fixture("accepted-textless.medui"), "accepted-textless.medui");
+
+                      checks.expect(result.ok(), std::format("a good screen passes, got {}", codes(result)));
+                      checks.expect(result.layoutChecked, "and its layout was resolved, since it declares a surface");
+
+                      // The property that makes a clean run trustworthy: it is visibly partial. A
+                      // checker that stayed silent here would convert "I did not look" into
+                      // "nothing is wrong", which is worse than not existing.
+                      checks.expect(!result.textChecked, "text keys were not checked without a recipe");
+                      checks.expect(carries(result, "MDC001"), std::format("and the run says so, got {}", codes(result)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyRejectionCodeSurfaces{"The rejection corpus surfaces through the checker", "evidence-unit", [] {
+                                                          return speclab::Test("medui-check-rejects")
+                                                              .Given("the fixtures the parser and analyzer suites drive by call", [] {})
+                                                              .When("the checker is pointed at each of them", [] {})
+                                                              .Then("each reports the code its name promises",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+
+                                                                        // Pointed at the same corpus rather than at strings of its own: a code that
+                                                                        // stops surfacing here has stopped surfacing to an author, and that is what
+                                                                        // the shared fixtures exist to make checkable.
+                                                                        const std::array<std::pair<std::string_view, std::string_view>, 4> cases{
+                                                                            {{"rejected-unterminated-string.medui", "MEDUI-E010"},
+                                                                             {"rejected-nested-row.medui", "MEDUI-E015"},
+                                                                             {"rejected-duplicate-id.medui", "MEDUI-E014"},
+                                                                             {"rejected-safety-without-requirement.medui", "MEDUI-E070"}}
+                                                                        };
+
+                                                                        for (const auto& [name, code] : cases) {
+                                                                            const md::CheckResult result = md::checkScreen(fixture(name), std::string{name});
+                                                                            checks.expect(!result.ok(), std::format("{} is rejected", name));
+                                                                            checks.expect(carries(result, code),
+                                                                                          std::format("{} reports {}, got {}", name, code, codes(result)));
+                                                                        }
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register aScreenWithoutASurfaceSaysWhatWasSkipped{
+    "A screen with no surface is checked as far as it can be, and says where that stopped",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-check-no-surface")
+            .Given("a screen that declares no `surface:`", [] {})
+            .When("it is checked", [] {})
+            .Then("it is not called malformed, and layout is reported as unchecked",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Not a finding about the file: the compiler takes the surface from the
+                      // recipe, so a screen without one is legitimate and simply cannot be resolved
+                      // to rectangles here.
+                      const std::string source = "Screen NoSurface {\n"
+                                                 "    layout: Vertical { spacing: 0px; padding: 0px; }\n"
+                                                 "\n"
+                                                 "    Clock {\n"
+                                                 "        id: wall-clock;\n"
+                                                 "        width: 200px;\n"
+                                                 "        height: 40px;\n"
+                                                 "        format: TimeSeconds;\n"
+                                                 "    }\n"
+                                                 "}\n";
+
+                      const md::CheckResult result = md::checkScreen(source, "no-surface.medui");
+                      checks.expect(result.ok(), std::format("a screen without a surface is not an error, got {}", codes(result)));
+                      checks.expect(!result.layoutChecked, "and its layout was not resolved");
+                      checks.expect(carries(result, "MDC002"), std::format("with the gap named, got {}", codes(result)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theCheckerStopsAtTheCause{"The checker stops at the first stage that rejects the screen", "evidence-unit", [] {
+                                                         return speclab::Test("medui-check-stops-at-the-cause")
+                                                             .Given("a file that does not parse", [] {})
+                                                             .When("it is checked", [] {})
+                                                             .Then("the parse error is reported alone, without consequences from later stages",
+                                                                   [] {
+                                                                       mdux::spec::Checks    checks;
+                                                                       const md::CheckResult result = md::checkScreen(
+                                                                           fixture("rejected-unterminated-string.medui"),
+                                                                           "rejected-unterminated-string.medui");
+
+                                                                       checks.expect(!result.ok(), "the file is rejected");
+                                                                       // A later stage reading a screen an earlier one rejected reports consequences
+                                                                       // rather than causes - and the notes about uncovered checks are not emitted
+                                                                       // either, since the run did not get far enough to have gaps worth naming.
+                                                                       checks.expect(!carries(result, "MDC001") && !carries(result, "MDC002"),
+                                                                                     std::format("no notes about later stages, got {}", codes(result)));
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};
+
+const mdux::spec::Register theToolExitsAndSpeaksTheSharedEnvelope{
+    "The tool exits non-zero on an error and prints the shared envelope",
+    "evidence-unit",  // the one scenario here that spawns mdux-medui-check rather than calling into it
+    [] {
+        return speclab::Test("medui-check-cli")
+            .Given("mdux-medui-check and a broken screen", [] {})
+            .When("it is run with --format=json", [] {})
+            .Then("it exits non-zero having printed the envelope every MduX tool emits",
+                  [] {
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-medui-check-cli"};
+
+                      const std::filesystem::path log     = scratch.path() / "stdout.txt";
+                      const std::string           broken  = fixturePath("rejected-safety-without-requirement.medui").generic_string();
+                      const std::string           command = shellCommand(MDUX_MEDUI_CHECK_PATH,
+                                                               std::format(R"("{}" --format=json > "{}")", broken, log.generic_string()));
+                      const int                   status  = std::system(command.c_str());
+                      checks.expect(status != 0, "a broken screen exits non-zero");
+
+                      const std::string envelope = contentsOf(log);
+                      // Asserted before the contents: an empty log means the process never ran, and
+                      // the status above was non-zero for a reason unrelated to the screen.
+                      checks.expect(!envelope.empty(), "the checker ran and printed something");
+                      checks.expect(envelope.contains("mdux-medui-check"), "the envelope names the tool");
+                      checks.expect(envelope.contains("MEDUI-E070"), std::format("and carries the finding, got:\n{}", envelope));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aCleanFileExitsZero{
+    "A file that checks out exits zero, notes and all",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-check-cli-clean")
+            .Given("a screen the compiler accepts", [] {})
+            .When("the tool is run over it", [] {})
+            .Then("it exits zero, because a note is not a failure",
+                  [] {
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-medui-check-clean"};
+
+                      // The half that would be easy to get wrong: the notes about uncovered checks
+                      // travel in the same envelope as findings, and an exit status keyed off the
+                      // presence of diagnostics rather than their severity would fail every clean
+                      // run.
+                      const std::filesystem::path log  = scratch.path() / "stdout.txt";
+                      const std::string           good = fixturePath("accepted-textless.medui").generic_string();
+                      const std::string command = shellCommand(MDUX_MEDUI_CHECK_PATH, std::format(R"("{}" --format=json > "{}")", good, log.generic_string()));
+                      const int         status  = std::system(command.c_str());
+                      checks.expect(status == 0, "a clean screen exits zero");
+
+                      const std::string envelope = contentsOf(log);
+                      checks.expect(envelope.contains("MDC001"), std::format("and still reports what it could not check, got:\n{}", envelope));
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -28,6 +28,7 @@ import mdux.tools.medui.parser;
 import mdux.tools.medui.textbudget;
 
 #include "../framework/SpecLabBridge.hpp"
+#include "../framework/TemporaryDirectory.hpp"
 
 namespace {
 
@@ -66,30 +67,6 @@ namespace cli = mdux::tools::cli;
     return *recipe;
 }
 
-/// A directory this scenario owns, removed when it is done with it.
-class TemporaryDirectory {
-public:
-    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-        std::filesystem::create_directories(path_, code);
-    }
-
-    TemporaryDirectory(const TemporaryDirectory&)            = delete;
-    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
-
-    ~TemporaryDirectory() {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-    }
-
-    [[nodiscard]] const std::filesystem::path& path() const noexcept {
-        return path_;
-    }
-
-private:
-    std::filesystem::path path_;
-};
 
 /// One shell command line, spelled the way the platform's shell will actually read it.
 ///
@@ -301,9 +278,9 @@ const mdux::spec::Register writingAndVerifyingAgree{
             .When("it is written, verified, and verified again after an edit", [] {})
             .Then("all three files appear, the untouched ones verify, and the edited one does not",
                   [] {
-                      mdux::spec::Checks           checks;
-                      std::vector<cli::Diagnostic> diagnostics;
-                      TemporaryDirectory           scratch{"mdux-meduic-write"};
+                      mdux::spec::Checks             checks;
+                      std::vector<cli::Diagnostic>   diagnostics;
+                      mdux::test::TemporaryDirectory scratch{"mdux-meduic-write"};
 
                       const md::Recipe  recipe     = textlessRecipe(diagnostics);
                       const std::string recipeText = fixture("textless-screen.toml");
@@ -539,8 +516,8 @@ const mdux::spec::Register theExecutableFailsLikeATool{
             .When("it is run with --format=json", [] {})
             .Then("it exits non-zero having printed a diagnostic envelope",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-meduic-cli"};
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-meduic-cli"};
 
                       // The one scenario that spawns the process rather than calling into the
                       // library. Everything else here drives the calls, which says more when it

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -1,0 +1,580 @@
+/**
+ * @file CompileTests.cpp
+ * @brief BDD scenarios for the `.medui` compiler driver (issue #198).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * The stages have their own suites; what is under test here is the driver's own contract - the order
+ * they run in, the recipe being complete for the screen it names, and the three artifacts a compile
+ * produces being exactly what the schema, the sidecar rule and the bake report require.
+ *
+ * The scenarios drive `run()`, `write()` and `verify()` as calls rather than spawning `mdux-meduic`,
+ * which is why the tool is split library-and-executable: an assertion on an exit status could only
+ * report that something was wrong, never what.
+ */
+
+import std;
+import speclab;
+import mdux.draw;
+import mdux.evidence.report;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.compile;
+import mdux.tools.medui.package;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.textbudget;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace ms  = mdux::medui;
+namespace cli = mdux::tools::cli;
+
+[[nodiscard]] std::filesystem::path repoRoot() {
+    return std::filesystem::path{MDUX_REPO_ROOT};
+}
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    std::ifstream in{repoRoot() / "tests" / "medui" / "fixtures" / name, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened", name), std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string& text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] std::string firstCode(std::span<const cli::Diagnostic> diagnostics) {
+    return diagnostics.empty() ? std::string{"<none>"} : diagnostics.front().code;
+}
+
+/// The fixture recipe, parsed. Every scenario that compiles starts here.
+[[nodiscard]] md::Recipe textlessRecipe(std::vector<cli::Diagnostic>& diagnostics) {
+    const std::optional<md::Recipe> recipe = md::parseRecipe(fixture("textless-screen.toml"), "tests/medui/fixtures/textless-screen.toml", diagnostics);
+    if (!recipe.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("the fixture recipe did not parse: {}", firstCode(diagnostics)), std::source_location::current());
+    }
+    return *recipe;
+}
+
+/// A directory this scenario owns, removed when it is done with it.
+class TemporaryDirectory {
+public:
+    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+        std::filesystem::create_directories(path_, code);
+    }
+
+    TemporaryDirectory(const TemporaryDirectory&)            = delete;
+    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
+
+    ~TemporaryDirectory() {
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
+/// One shell command line, spelled the way the platform's shell will actually read it.
+///
+/// `cmd.exe` strips the outer pair of quotes when a command line begins with one, so a quoted
+/// program path arrives mangled unless the whole line is wrapped in a second pair - and it reads a
+/// leading `/` as a switch, so the path needs native separators. Getting this wrong does not make a
+/// scenario fail honestly: the process never starts, the exit status is non-zero for the wrong
+/// reason, and only an assertion on what the process printed notices.
+[[nodiscard]] std::string shellCommand(std::string_view program, std::string_view arguments) {
+#ifdef _WIN32
+    std::string native{program};
+    std::ranges::replace(native, '/', '\\');
+    return std::format(R"(""{}" {}")", native, arguments);
+#else
+    return std::format(R"("{}" {})", program, arguments);
+#endif
+}
+
+[[nodiscard]] std::string contentsOf(const std::filesystem::path& path) {
+    std::ifstream in{path, std::ios::binary};
+    if (!in) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+}  // namespace
+
+const mdux::spec::Register everyRecipeKnobIsRequired{
+    "Every recipe knob is required, because a defaulted one would not appear in the report",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-recipe")
+            .Given("the fixture recipe, and copies with one knob removed", [] {})
+            .When("each is parsed", [] {})
+            .Then("the complete one resolves and each incomplete one is refused",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      const md::Recipe recipe = textlessRecipe(diagnostics);
+                      checks.expect(diagnostics.empty(), "the complete recipe parses without diagnostics");
+                      checks.expect(recipe.id == "textless-screen", std::format("the artifact slug, got '{}'", recipe.id));
+                      checks.expect(recipe.surfaceWidth == 400 && recipe.surfaceHeight == 300, "the declared surface");
+                      checks.expect(recipe.budget.maxVertices == 4096 && recipe.budget.maxCommands == 256, "the declared budget");
+                      checks.expect(recipe.fontPackage.empty() && recipe.textPackages.empty(), "a text-free screen names no locale inputs");
+
+                      // ADR-007's rule, checked rather than described: a knob with a default would
+                      // not appear in report.json, so a later change to that default would leave
+                      // every report looking unchanged.
+                      const std::string complete = fixture("textless-screen.toml");
+                      for (const std::string_view knob : {"id", "source", "surfaceWidth", "maxVertices", "maxIndices"}) {
+                          // Anchored to the start of a line, which is not fussiness: an unanchored
+                          // search for "id" finds "did" in the recipe's own commentary first, and
+                          // then this scenario deletes half a comment and asserts that a recipe
+                          // which is still complete was refused. It passed for four knobs and failed
+                          // for the one where the comment happened to come first.
+                          std::string       broken = complete;
+                          const std::size_t at     = broken.find("\n" + std::string{knob});
+                          if (at == std::string::npos) {
+                              checks.expect(false, std::format("the fixture declares {} at the start of a line", knob));
+                              continue;
+                          }
+                          const std::size_t lineEnd = broken.find('\n', at + 1);
+                          broken.erase(at, lineEnd - at);
+
+                          std::vector<cli::Diagnostic> refused;
+                          const auto                   parsed = md::parseRecipe(broken, "recipe.toml", refused);
+                          checks.expect(!parsed.has_value(), std::format("a recipe without {} is refused", knob));
+                          checks.expect(firstCode(refused) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(refused)));
+                      }
+
+                      std::vector<cli::Diagnostic> unparsed;
+                      const auto                   broken = md::parseRecipe("this is not TOML {{", "recipe.toml", unparsed);
+                      checks.expect(!broken.has_value(), "a recipe that is not TOML is refused");
+                      checks.expect(firstCode(unparsed) == "MEDUI-E001", std::format("reported as MEDUI-E001, got '{}'", firstCode(unparsed)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aCompileProducesThreeArtifacts{
+    "A compile produces the three artifacts ADR-012 fixes",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-artifacts")
+            .Given("a screen that draws no text", [] {})
+            .When("the compiler runs every stage over it", [] {})
+            .Then("the package validates, the goldens pin the positioned node, and the report records both",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      const md::Recipe  recipe     = textlessRecipe(diagnostics);
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "tests/medui/fixtures/textless-screen.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, std::format("the fixture screen compiles, first diagnostic '{}'", firstCode(diagnostics)));
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(diagnostics.empty(), "a clean compile reports nothing");
+
+                      // The package is read back through the reader rather than inspected as the
+                      // value that produced it, so this exercises the round trip a device's build
+                      // would take.
+                      const md::PackageReadResult read = md::readPackage(outputs->packageJson, "package.json");
+                      checks.expect(read.ok(), std::format("the emitted package reads back, first diagnostic '{}'", firstCode(read.diagnostics)));
+                      if (read.ok()) {
+                          const ms::ScreenPackage package = read.document.package();
+                          checks.expect(package.id == "textless-screen", "the package carries the artifact slug, not the screen name");
+                          checks.expect(package.nodes.size() == 4, std::format("four compiled nodes, got {}", package.nodes.size()));
+                          checks.expect(package.find("topbar-background") != nullptr, "the Row's synthetic background is compiled");
+                          checks.expect(package.validate().has_value(), "the compiled screen satisfies its schema");
+                      }
+
+                      // One golden, for the positioned SignalTrace. An empty array here would have
+                      // meant the sidecar proved nothing.
+                      checks.expect(outputs->goldenCount == 1, std::format("one golden reference, got {}", outputs->goldenCount));
+                      checks.expect(outputs->goldensJson.contains("\"nodeId\": \"ecg\""), "the positioned node is the one pinned");
+
+                      const auto report = mdux::evidence::BakeReport::parse(outputs->reportJson);
+                      checks.expect(report.has_value(), "the bake report parses");
+                      if (report.has_value()) {
+                          checks.expect(report->tool == "mdux-meduic", std::format("the report names the tool, got '{}'", report->tool));
+                          // Two outputs, not three: a file cannot carry its own digest, which is the
+                          // same reason ADR-007 gives for there being no commit SHA in a report.
+                          checks.expect(report->outputs.size() == 2, std::format("package.json and goldens.json are recorded, got {}", report->outputs.size()));
+                          checks.expect(report->inputs.size() == 1, std::format("the .medui source is the only input, got {}", report->inputs.size()));
+                          checks.expect(report->validate().has_value(), "the report satisfies its own schema");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aScreenThatDrawsTextNeedsItsLocales{
+    "A screen that draws text is refused when the recipe declares no locales",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-requires-locales")
+            .Given("a recipe with no [text] table, naming a screen full of text keys", [] {})
+            .When("the compiler runs", [] {})
+            .Then("it refuses rather than compiling a screen whose boxes nobody measured",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      // The hazard this rule closes: skipping the budget stage is safe only for a
+                      // screen with nothing to measure. A screen with text and no approved locale
+                      // would otherwise be certified against a set nobody approved - and the
+                      // omitted translation is exactly the one that overflows.
+                      md::Recipe recipe    = textlessRecipe(diagnostics);
+                      recipe.source        = "tests/medui/fixtures/accepted-every-component.medui";
+                      recipe.surfaceWidth  = 800;
+                      recipe.surfaceHeight = 700;
+
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      checks.expect(!outputs.has_value(), "a text-drawing screen with no locales is refused");
+                      checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
+
+                      // And the predicate that decides it, asked directly: the driver must not be
+                      // the second place that knows what counts as text.
+                      md::ParseResult drawsText = md::parse(fixture("accepted-every-component.medui"), "every.medui");
+                      md::ParseResult drawsNone = md::parse(fixture("accepted-textless.medui"), "textless.medui");
+                      checks.expect(drawsText.screen.has_value() && md::needsTextBudget(*drawsText.screen), "a screen with keys needs the budget stage");
+                      checks.expect(drawsNone.screen.has_value() && !md::needsTextBudget(*drawsNone.screen), "a screen without them does not");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aRejectedStageStopsTheCompile{
+    "A stage that rejects the screen stops the compile",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-stops-at-the-cause")
+            .Given("a recipe whose declared surface is not the one the screen was drawn for", [] {})
+            .When("the compiler runs", [] {})
+            .Then("it reports the disagreement and produces nothing",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      md::Recipe recipe   = textlessRecipe(diagnostics);
+                      recipe.surfaceWidth = 640;
+
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      checks.expect(!outputs.has_value(), "a screen drawn for another panel is refused");
+                      checks.expect(!diagnostics.empty(), "and the refusal is reported");
+                      // Diagnostics are not accumulated across stages: a later stage reading a screen
+                      // an earlier one rejected reports consequences rather than causes.
+                      checks.expect(diagnostics.size() == 1, std::format("one diagnostic, at the cause, got {}", diagnostics.size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register writingAndVerifyingAgree{
+    "What a compile writes is what verifying it accepts",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-write-verify")
+            .Given("a compiled screen", [] {})
+            .When("it is written, verified, and verified again after an edit", [] {})
+            .Then("all three files appear, the untouched ones verify, and the edited one does not",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+                      TemporaryDirectory           scratch{"mdux-meduic-write"};
+
+                      const md::Recipe  recipe     = textlessRecipe(diagnostics);
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, "the fixture screen compiles");
+                          checks.raise();
+                          return;
+                      }
+
+                      checks.expect(md::write(*outputs, scratch.path(), diagnostics), "writing succeeds");
+                      const std::filesystem::path package = scratch.path() / "package.json";
+                      const std::filesystem::path goldens = scratch.path() / "goldens.json";
+                      const std::filesystem::path report  = scratch.path() / "report.json";
+                      // All three unconditionally: ADR-012 declares each a build output, so a
+                      // compiler that skipped one would break the build rather than produce less.
+                      checks.expect(std::filesystem::exists(package) && std::filesystem::exists(goldens) && std::filesystem::exists(report),
+                                    "all three artifacts are written");
+                      checks.expect(contentsOf(goldens) == outputs->goldensJson, "the sidecar holds what the compile produced");
+
+                      std::vector<cli::Diagnostic> verified;
+                      checks.expect(md::verify(*outputs, package, goldens, report, verified), "the freshly written artifacts verify");
+                      checks.expect(verified.empty(), "and verifying reports nothing");
+
+                      std::ofstream tamper{goldens, std::ios::binary | std::ios::trunc};
+                      tamper << "[]\n";
+                      tamper.close();
+
+                      std::vector<cli::Diagnostic> mismatched;
+                      checks.expect(!md::verify(*outputs, package, goldens, report, mismatched), "a hand-edited artifact does not verify");
+                      checks.expect(!mismatched.empty(), "and the mismatch is reported");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theGovernedDynamicTextTableIsARecipeInput{
+    "The governed dynamic-text table comes from the recipe, not from the compiler",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-dynamic-text")
+            .Given("a recipe declaring what each named dynamic-text source can produce", [] {})
+            .When("it is parsed", [] {})
+            .Then("the rules resolve, and a malformed table is refused rather than half-read",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      // The names belong to a product's governed tables. A compiler shipping its own
+                      // list would be authoritative about a set it does not own - the same argument
+                      // that keeps the theme tokens and the approved locales out of the language.
+                      const std::string recipeText = "[package]\n"
+                                                     "id = \"clock\"\n"
+                                                     "source = \"tests/medui/fixtures/accepted-textless.medui\"\n"
+                                                     "surfaceWidth = 400\n"
+                                                     "surfaceHeight = 300\n"
+                                                     "[budget]\n"
+                                                     "maxVertices = 64\n"
+                                                     "maxIndices = 96\n"
+                                                     "maxCommands = 8\n"
+                                                     "[dynamicText]\n"
+                                                     "names = [\"TimeSeconds\", \"Ascii\"]\n"
+                                                     "firstCodePoints = [48, 32]\n"
+                                                     "lastCodePoints = [58, 126]\n";
+
+                      const auto recipe = md::parseRecipe(recipeText, "recipe.toml", diagnostics);
+                      checks.expect(recipe.has_value(), std::format("the recipe parses, first diagnostic '{}'", firstCode(diagnostics)));
+                      if (recipe.has_value()) {
+                          checks.expect(recipe->dynamicText.size() == 2, std::format("two rules, got {}", recipe->dynamicText.size()));
+                          if (recipe->dynamicText.size() == 2) {
+                              checks.expect(recipe->dynamicText[0].name == "TimeSeconds", "the first rule's name");
+                              checks.expect(recipe->dynamicText[0].produces.size() == 1 && recipe->dynamicText[0].produces[0].first == U'0'
+                                                && recipe->dynamicText[0].produces[0].last == U':',
+                                            "and the range a clock's digits and separator occupy");
+                          }
+                      }
+
+                      // Parallel arrays, so a length mismatch is a diagnostic rather than a silent
+                      // truncation to the shortest - the same rule the font recipe's charset has.
+                      std::vector<cli::Diagnostic> mismatched;
+                      const auto                   ragged = md::parseRecipe(std::string{recipeText}.replace(recipeText.find("lastCodePoints = [58, 126]"),
+                                                                                          std::string_view{"lastCodePoints = [58, 126]"}.size(),
+                                                                                          "lastCodePoints = [58]"),
+                                                          "recipe.toml",
+                                                          mismatched);
+                      checks.expect(!ragged.has_value(), "a ragged dynamic-text table is refused");
+                      checks.expect(firstCode(mismatched) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(mismatched)));
+
+                      // A range outside Unicode is named at the entry rather than left for the
+                      // charset walk to stop on.
+                      std::vector<cli::Diagnostic> outside;
+                      const auto                   beyond = md::parseRecipe(std::string{recipeText}.replace(recipeText.find("lastCodePoints = [58, 126]"),
+                                                                                          std::string_view{"lastCodePoints = [58, 126]"}.size(),
+                                                                                          "lastCodePoints = [58, 2000000]"),
+                                                          "recipe.toml",
+                                                          outside);
+                      checks.expect(!beyond.has_value(), "a range outside Unicode is refused");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theSlugAndTheScreenNameAreOneScreen{
+    "The artifact slug and the screen name have to be the same screen",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-identity")
+            .Given("recipes whose id is malformed, and whose id names another screen", [] {})
+            .When("each is compiled", [] {})
+            .Then("both are refused before anything is written",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const std::string            recipeText = fixture("textless-screen.toml");
+
+                      // The slug names a directory, an evidence test and a generated C++ identifier.
+                      // `mdux_bake_artifact()` refuses a non-slug at configure time; a compile run
+                      // directly would otherwise write `generated/screen/Textless/`, which no
+                      // registration could ever match.
+                      for (const std::string_view bad : {"Textless", "textless_screen", "-textless"}) {
+                          std::vector<cli::Diagnostic> refused;
+                          const auto                   parsed = md::parseRecipe(std::string{recipeText}.replace(recipeText.find("\"textless-screen\""),
+                                                                                              std::string_view{"\"textless-screen\""}.size(),
+                                                                                              std::format("\"{}\"", bad)),
+                                                              "recipe.toml",
+                                                              refused);
+                          checks.expect(!parsed.has_value(), std::format("the id '{}' is refused", bad));
+                          checks.expect(firstCode(refused) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(refused)));
+                      }
+
+                      // A well-formed slug naming a different screen: the registration would place
+                      // outputs in one directory while the package inside called itself something
+                      // else, and every later consumer would follow one name with nothing to say the
+                      // other exists.
+                      md::Recipe recipe  = textlessRecipe(diagnostics);
+                      recipe.id          = "another-screen";
+                      const auto outputs = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      checks.expect(!outputs.has_value(), "an id naming another screen is refused");
+                      checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
+
+                      // Hyphenation is the author's, the word is not: `TextlessScreen` may be
+                      // spelled `textless-screen` or `textlessscreen`, and nothing else.
+                      std::vector<cli::Diagnostic> accepted;
+                      md::Recipe                   renamed = textlessRecipe(accepted);
+                      renamed.id                           = "textlessscreen";
+                      const auto compiled                  = md::run(renamed, "recipe.toml", asBytes(recipeText), repoRoot(), accepted);
+                      checks.expect(compiled.has_value(), std::format("a differently hyphenated slug compiles, first diagnostic '{}'", firstCode(accepted)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aBudgetTheScreenCannotUseIsRefused{
+    "A budget the screen cannot use is a diagnostic, not a termination",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-budget-bounds")
+            .Given("a budget past the 16-bit index width, and an empty budget on a screen with nodes", [] {})
+            .When("each is compiled", [] {})
+            .Then("each is reported against the recipe that declared it",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string  recipeText = fixture("textless-screen.toml");
+
+                      // Both of these reach `ScreenPackage::validate()` if they are not caught here,
+                      // and `buildPackage()` treats a schema failure as a compiler bug and throws -
+                      // so an author's extra digit would terminate the tool rather than produce a
+                      // report.
+                      std::vector<cli::Diagnostic> tooWide;
+                      const auto                   wide = md::parseRecipe(std::string{recipeText}.replace(recipeText.find("maxVertices = 4096"),
+                                                                                        std::string_view{"maxVertices = 4096"}.size(),
+                                                                                        "maxVertices = 70000"),
+                                                        "recipe.toml",
+                                                        tooWide);
+                      checks.expect(!wide.has_value(), "a budget past the 16-bit index width is refused");
+                      checks.expect(firstCode(tooWide) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(tooWide)));
+
+                      std::vector<cli::Diagnostic> empty;
+                      md::Recipe                   recipe = textlessRecipe(empty);
+                      recipe.budget                       = mdux::draw::DrawBudget{};
+                      const auto outputs                  = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), empty);
+                      checks.expect(!outputs.has_value(), "an empty budget on a screen with nodes is refused");
+                      checks.expect(firstCode(empty) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(empty)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anInvertedDynamicRangeIsRefused{
+    "An inverted dynamic-text range is refused rather than read as empty",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-inverted-range")
+            .Given("a governed table whose entry descends", [] {})
+            .When("the recipe is parsed", [] {})
+            .Then("it is refused, because an empty range would check nothing",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      // Fail-open is the reason this one matters. `checkDynamicText()` deliberately
+                      // skips a range with `last < first`, so an inverted entry does not narrow the
+                      // charset - it removes the check, on the table that is the governed upper bound
+                      // for what a Clock or a TextInput can put on screen.
+                      const std::string recipeText = "[package]\n"
+                                                     "id = \"textless\"\n"
+                                                     "source = \"tests/medui/fixtures/accepted-textless.medui\"\n"
+                                                     "surfaceWidth = 400\n"
+                                                     "surfaceHeight = 300\n"
+                                                     "[budget]\n"
+                                                     "maxVertices = 64\n"
+                                                     "maxIndices = 96\n"
+                                                     "maxCommands = 8\n"
+                                                     "[dynamicText]\n"
+                                                     "names = [\"TimeSeconds\"]\n"
+                                                     "firstCodePoints = [58]\n"
+                                                     "lastCodePoints = [48]\n";
+
+                      const auto parsed = md::parseRecipe(recipeText, "recipe.toml", diagnostics);
+                      checks.expect(!parsed.has_value(), "a descending range is refused");
+                      checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theExecutableFailsLikeATool{
+    "A malformed recipe makes the executable exit with an envelope, not a crash",
+    "evidence-unit",  // the one scenario here that spawns mdux-meduic rather than calling into it
+    [] {
+        return speclab::Test("medui-compile-cli")
+            .Given("mdux-meduic and a recipe naming a screen that does not exist", [] {})
+            .When("it is run with --format=json", [] {})
+            .Then("it exits non-zero having printed a diagnostic envelope",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TemporaryDirectory scratch{"mdux-meduic-cli"};
+
+                      // The one scenario that spawns the process rather than calling into the
+                      // library. Everything else here drives the calls, which says more when it
+                      // fails - but nothing at call level can show that `main()` renders an envelope
+                      // and returns a status rather than letting an exception reach the terminate
+                      // handler, and that is exactly the behaviour an author sees first.
+                      const std::filesystem::path recipe = scratch.path() / "recipe.toml";
+                      std::ofstream               out{recipe, std::ios::binary | std::ios::trunc};
+                      out << "[package]\n"
+                             "id = \"missing-screen\"\n"
+                             "source = \"tests/medui/fixtures/no-such-screen.medui\"\n"
+                             "surfaceWidth = 400\n"
+                             "surfaceHeight = 300\n"
+                             "[budget]\n"
+                             "maxVertices = 64\n"
+                             "maxIndices = 96\n"
+                             "maxCommands = 8\n";
+                      out.close();
+
+                      const std::filesystem::path log       = scratch.path() / "stdout.txt";
+                      const std::string           arguments = std::format(R"(bake "{}" "{}" --format=json > "{}")",
+                                                                recipe.generic_string(),
+                                                                (scratch.path() / "out").generic_string(),
+                                                                log.generic_string());
+                      const int                   status    = std::system(shellCommand(MDUX_MEDUIC_PATH, arguments).c_str());
+                      checks.expect(status != 0, "a malformed recipe exits non-zero");
+
+                      const std::string envelope = contentsOf(log);
+                      // Asserted before the contents: an empty log means the process never ran, and the
+                      // status above was non-zero for a reason that has nothing to do with the recipe.
+                      checks.expect(!envelope.empty(), "the compiler ran and printed something");
+                      checks.expect(envelope.contains("mdux-meduic"), "the envelope names the tool");
+                      checks.expect(envelope.contains("MEDUI-E003"), std::format("and carries the unreadable-source code, got:\n{}", envelope));
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/DiagnosticsTests.cpp
+++ b/tests/medui/DiagnosticsTests.cpp
@@ -1,0 +1,284 @@
+/**
+ * @file DiagnosticsTests.cpp
+ * @brief BDD scenarios for the `.medui` diagnostic code registry (issue #191).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The registry's whole value is that questions about the *set* of codes are answerable
+ * mechanically. These are the questions, as tests. A registry nobody enumerates is a table of
+ * string literals with extra steps, so if these scenarios were deleted the module below would be
+ * worth deleting with them.
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+/// Every enumerator, so a scenario can walk the enum rather than the table it is checking against.
+///
+/// Written out rather than derived: C++ has no reflection over an enum, and a `Count` sentinel
+/// cast in a loop would assume contiguity this enum does not promise. The duplication is the point
+/// - adding an enumerator without adding it here fails `every code is registered`, which is the
+/// nudge that also gets it a table row.
+constexpr std::array<md::Code, 22> allCodes{
+    md::Code::RecipeUnreadable,
+    md::Code::RecipeUnparsed,
+    md::Code::RecipeMissingMember,
+    md::Code::SourceUnreadable,
+    md::Code::SourceNotUtf8,
+    md::Code::UnexpectedToken,
+    md::Code::UnknownComponent,
+    md::Code::MissingRequiredField,
+    md::Code::UnknownField,
+    md::Code::DuplicateNodeId,
+    md::Code::NestedRow,
+    md::Code::ForbiddenConstruct,
+    md::Code::HardcodedString,
+    md::Code::UnknownColorToken,
+    md::Code::UnknownTextKey,
+    md::Code::TextKeyMissingForLocale,
+    md::Code::TextBudgetExceeded,
+    md::Code::LayoutOverflow,
+    md::Code::SurfaceExceeded,
+    md::Code::CharsetEscape,
+    md::Code::SafetyCriticalWithoutRequirement,
+    md::Code::UnknownCvCheck,
+};
+
+[[nodiscard]] bool wellFormedId(std::string_view id) {
+    // `MDX-E` followed by exactly three digits. The schema's `code` pattern is looser - it admits
+    // the bakers' `TXT001` too - so this checks the narrower shape this tool committed to, which
+    // the schema alone would not catch.
+    if (id.size() != 8 || !id.starts_with("MDX-E")) {
+        return false;
+    }
+    return std::all_of(id.begin() + 5, id.end(),
+                       [](char c) { return c >= '0' && c <= '9'; });
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The questions a registry exists to answer.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register everyCodeIsRegistered{
+    "Every enumerator has exactly one registry row",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-complete")
+            .Given("the registry and the full enumerator list", [] {})
+            .When("each enumerator is looked up", [] {})
+            .Then("each resolves to a row carrying its own code, and the table has no extras",
+                  [] {
+                      mdux::spec::Checks checks;
+                      for (md::Code code : allCodes) {
+                          // tryInfo() rather than info(): a missing row must fail this scenario
+                          // with a named enumerator, not throw out of the loop and lose which one.
+                          const md::CodeInfo* row = md::tryInfo(code);
+                          checks.expect(row != nullptr,
+                                        std::format("enumerator {} has its own row",
+                                                    static_cast<int>(code)));
+                          if (row != nullptr) {
+                              checks.expect(row->code == code,
+                                            std::format("row for enumerator {} names it back",
+                                                        static_cast<int>(code)));
+                          }
+                      }
+                      checks.expect(md::registry().size() == allCodes.size(),
+                                    std::format("table has {} rows, one per enumerator (has {})",
+                                                allCodes.size(), md::registry().size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyIdIsUnique{
+    "No two codes share an identifier",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-unique")
+            .Given("the registry", [] {})
+            .When("its identifiers are collected", [] {})
+            .Then("each appears once", [] {
+                mdux::spec::Checks checks;
+                std::vector<std::string_view> ids;
+                for (const md::CodeInfo& row : md::registry()) {
+                    ids.push_back(row.id);
+                }
+                std::ranges::sort(ids);
+                const auto duplicate = std::ranges::adjacent_find(ids);
+                checks.expect(duplicate == ids.end(),
+                              duplicate == ids.end()
+                                  ? "identifiers are unique"
+                                  : std::format("'{}' is used twice", *duplicate));
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyIdIsWellFormed{
+    "Every identifier is MDX-E followed by three digits",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-shape")
+            .Given("the registry", [] {})
+            .When("each identifier is inspected", [] {})
+            .Then("it matches the published prefix and width", [] {
+                mdux::spec::Checks checks;
+                for (const md::CodeInfo& row : md::registry()) {
+                    checks.expect(wellFormedId(row.id),
+                                  std::format("'{}' is well formed", row.id));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyRowSaysWhatItMeans{
+    "Every row carries a non-empty summary",
+    "evidence-unit",
+    [] {
+        // fixHint is deliberately *not* required. The schema calls an empty hint "honest and
+        // common", and an invented one worse than none - so this asserts the summary, which is
+        // what a reader consults before reusing a code, and leaves the hint optional.
+        return speclab::Test("medui-diagnostics-summaries")
+            .Given("the registry", [] {})
+            .When("each row is inspected", [] {})
+            .Then("its summary is present", [] {
+                mdux::spec::Checks checks;
+                for (const md::CodeInfo& row : md::registry()) {
+                    checks.expect(!row.summary.empty(),
+                                  std::format("{} has a summary", row.id));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register idsAreOrderedAndUnretired{
+    "Identifiers ascend, and none collides with a retired number",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-order")
+            .Given("the registry and the retired list", [] {})
+            .When("the identifiers are read in table order", [] {})
+            .Then("they ascend, and no live code reuses a retired number", [] {
+                mdux::spec::Checks checks;
+                std::string_view previous;
+                for (const md::CodeInfo& row : md::registry()) {
+                    if (!previous.empty()) {
+                        checks.expect(previous < row.id,
+                                      std::format("{} follows {}", row.id, previous));
+                    }
+                    previous = row.id;
+                    const bool reused = std::ranges::find(md::retired(), row.id) != md::retired().end();
+                    checks.expect(!reused, std::format("{} is not a retired number", row.id));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// The envelope the codes travel in.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register diagnoseCarriesRegisteredIdentity{
+    "diagnose() stamps the registered id and severity onto the shared envelope",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-diagnose")
+            .Given("a code with a registered fix hint", [] {})
+            .When("a diagnostic is built without an explicit hint", [] {})
+            .Then("the registry's id, severity and hint are used", [] {
+                mdux::spec::Checks checks;
+                const cli::Diagnostic d = md::diagnose(md::Code::UnknownColorToken, "screen.medui",
+                                                       12, 5, "Theme.Colors.Wrong is not a token");
+                checks.expect(d.code == "MDX-E030", std::format("code is MDX-E030, got '{}'", d.code));
+                checks.expect(d.severity == cli::Severity::Error, "severity comes from the registry");
+                checks.expect(d.line == 12 && d.column == 5, "position is carried through");
+                checks.expect(!d.fixHint.empty(), "the registry's fix hint is used when none is given");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register callerHintWins{
+    "A caller-supplied fix hint overrides the registry's",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostics-hint-override")
+            .Given("a code whose registry hint is generic", [] {})
+            .When("a diagnostic is built with a specific hint", [] {})
+            .Then("the specific one survives", [] {
+                mdux::spec::Checks checks;
+                const cli::Diagnostic d =
+                    md::diagnose(md::Code::UnknownColorToken, "screen.medui", 1, 1, "unknown token",
+                                 "did you mean Theme.Colors.ScoreDigits?");
+                checks.expect(d.fixHint == "did you mean Theme.Colors.ScoreDigits?",
+                              std::format("caller hint kept, got '{}'", d.fixHint));
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register positionsMayBeAbsent{
+    "A finding about the whole file carries no position",
+    "evidence-unit",
+    [] {
+        // The envelope defines line and column as independent, 0 meaning "no precise position on
+        // this axis". A recipe that cannot be opened has neither, and inventing 1:1 would point a
+        // reader at a line that says nothing.
+        return speclab::Test("medui-diagnostics-no-position")
+            .Given("a whole-file failure", [] {})
+            .When("it is reported", [] {})
+            .Then("line and column are both zero", [] {
+                mdux::spec::Checks checks;
+                const cli::Diagnostic d = md::diagnose(md::Code::RecipeUnreadable, "recipe.toml", 0,
+                                                       0, "could not open recipe.toml");
+                checks.expect(d.line == 0 && d.column == 0, "no position invented");
+                checks.expect(d.code == "MDX-E000", "code is carried");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register unregisteredValuesFailLoudly{
+    "info() throws for a Code value no enumerator names",
+    "evidence-unit",
+    [] {
+        // `Code` has a fixed underlying type, so `static_cast<Code>(200)` is a well-formed value of
+        // the type - not undefined behaviour - and the completeness scenario above cannot reach it,
+        // because it walks the enumerators. An earlier revision returned the first row here, which
+        // would have attached MDX-E000's severity and fix hint to an unrelated failure. Two
+        // reviewers objected to that independently; this scenario is what keeps the objection
+        // answered.
+        return speclab::Test("medui-diagnostics-unregistered")
+            .Given("a Code value outside the enumerators", [] {})
+            .When("it is looked up", [] {})
+            .Then("tryInfo() reports the miss and info() throws", [] {
+                mdux::spec::Checks checks;
+                const auto stray = static_cast<md::Code>(200);
+                checks.expect(md::tryInfo(stray) == nullptr, "tryInfo() returns nullptr");
+
+                bool threw = false;
+                try {
+                    static_cast<void>(md::info(stray));
+                } catch (const std::logic_error&) {
+                    threw = true;
+                }
+                checks.expect(threw, "info() throws std::logic_error rather than returning a row");
+                checks.raise();
+            })
+            .Execute();
+    }};

--- a/tests/medui/DiagnosticsTests.cpp
+++ b/tests/medui/DiagnosticsTests.cpp
@@ -29,7 +29,7 @@ namespace cli = mdux::tools::cli;
 /// cast in a loop would assume contiguity this enum does not promise. The duplication is the point
 /// - adding an enumerator without adding it here fails `every code is registered`, which is the
 /// nudge that also gets it a table row.
-constexpr std::array<md::Code, 22> allCodes{
+constexpr std::array<md::Code, 23> allCodes{
     md::Code::RecipeUnreadable,
     md::Code::RecipeUnparsed,
     md::Code::RecipeMissingMember,
@@ -46,6 +46,7 @@ constexpr std::array<md::Code, 22> allCodes{
     md::Code::UnknownColorToken,
     md::Code::UnknownTextKey,
     md::Code::TextKeyMissingForLocale,
+    md::Code::FieldValueKind,
     md::Code::TextBudgetExceeded,
     md::Code::LayoutOverflow,
     md::Code::SurfaceExceeded,

--- a/tests/medui/DiagnosticsTests.cpp
+++ b/tests/medui/DiagnosticsTests.cpp
@@ -55,13 +55,13 @@ constexpr std::array<md::Code, 22> allCodes{
 };
 
 [[nodiscard]] bool wellFormedId(std::string_view id) {
-    // `MDX-E` followed by exactly three digits. The schema's `code` pattern is looser - it admits
+    // `MEDUI-E` followed by exactly three digits. The schema's `code` pattern is looser - it admits
     // the bakers' `TXT001` too - so this checks the narrower shape this tool committed to, which
     // the schema alone would not catch.
-    if (id.size() != 8 || !id.starts_with("MDX-E")) {
+    if (id.size() != 10 || !id.starts_with("MEDUI-E")) {
         return false;
     }
-    return std::all_of(id.begin() + 5, id.end(),
+    return std::all_of(id.begin() + 7, id.end(),
                        [](char c) { return c >= '0' && c <= '9'; });
 }
 
@@ -127,7 +127,7 @@ const mdux::spec::Register everyIdIsUnique{
     }};
 
 const mdux::spec::Register everyIdIsWellFormed{
-    "Every identifier is MDX-E followed by three digits",
+    "Every identifier is MEDUI-E followed by three digits",
     "evidence-unit",
     [] {
         return speclab::Test("medui-diagnostics-shape")
@@ -138,6 +138,25 @@ const mdux::spec::Register everyIdIsWellFormed{
                 for (const md::CodeInfo& row : md::registry()) {
                     checks.expect(wellFormedId(row.id),
                                   std::format("'{}' is well formed", row.id));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register legacyAliasesPreserveNumbers{
+    "The one-release MDX-E aliases preserve every diagnostic number",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-diagnostic-legacy-aliases")
+            .Given("the shared diagnostic registry", [] {})
+            .When("a legacy identifier is requested", [] {})
+            .Then("only the namespace changes", [] {
+                mdux::spec::Checks checks;
+                for (const md::CodeInfo& row : md::registry()) {
+                    const std::string alias = md::legacyId(row.code);
+                    checks.expect(alias == std::string{"MDX"} + std::string{row.id.substr(5)},
+                                  std::format("{} maps without changing its suffix", row.id));
                 }
                 checks.raise();
             })
@@ -204,7 +223,7 @@ const mdux::spec::Register diagnoseCarriesRegisteredIdentity{
                 mdux::spec::Checks checks;
                 const cli::Diagnostic d = md::diagnose(md::Code::UnknownColorToken, "screen.medui",
                                                        12, 5, "Theme.Colors.Wrong is not a token");
-                checks.expect(d.code == "MDX-E030", std::format("code is MDX-E030, got '{}'", d.code));
+                checks.expect(d.code == "MEDUI-E030", std::format("code is MEDUI-E030, got '{}'", d.code));
                 checks.expect(d.severity == cli::Severity::Error, "severity comes from the registry");
                 checks.expect(d.line == 12 && d.column == 5, "position is carried through");
                 checks.expect(!d.fixHint.empty(), "the registry's fix hint is used when none is given");
@@ -247,7 +266,7 @@ const mdux::spec::Register positionsMayBeAbsent{
                 const cli::Diagnostic d = md::diagnose(md::Code::RecipeUnreadable, "recipe.toml", 0,
                                                        0, "could not open recipe.toml");
                 checks.expect(d.line == 0 && d.column == 0, "no position invented");
-                checks.expect(d.code == "MDX-E000", "code is carried");
+                checks.expect(d.code == "MEDUI-E000", "code is carried");
                 checks.raise();
             })
             .Execute();
@@ -260,7 +279,7 @@ const mdux::spec::Register unregisteredValuesFailLoudly{
         // `Code` has a fixed underlying type, so `static_cast<Code>(200)` is a well-formed value of
         // the type - not undefined behaviour - and the completeness scenario above cannot reach it,
         // because it walks the enumerators. An earlier revision returned the first row here, which
-        // would have attached MDX-E000's severity and fix hint to an unrelated failure. Two
+        // would have attached MEDUI-E000's severity and fix hint to an unrelated failure. Two
         // reviewers objected to that independently; this scenario is what keeps the objection
         // answered.
         return speclab::Test("medui-diagnostics-unregistered")

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -1,0 +1,505 @@
+/**
+ * @brief BDD scenarios for the screen emitter (issue #197).
+ * @file EmitTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * The emitted C++ is compiled and compared in `GeneratedScreenTests.cpp`, which is where #197's
+ * acceptance criterion lives. What these scenarios cover is everything that has to hold before a
+ * compiler ever sees the output: that the fixture the emission reads is still what the compiler
+ * would produce, that the CMake and C++ halves of the filename rule agree, and that a malformed
+ * package is refused rather than rendered.
+ */
+
+import std;
+import speclab;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.emit;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.package;
+import mdux.tools.medui.parser;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+/// The budget the fixture package declares, and therefore the one a rebuild must reproduce.
+constexpr mdux::draw::DrawBudget fixtureBudget{.maxVertices = 4096, .maxIndices = 6144, .maxCommands = 256};
+
+[[nodiscard]] std::filesystem::path fixturePath(std::string_view name) {
+    return std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+}
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    std::ifstream in{fixturePath(name), std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened", name), std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+/// A directory this scenario owns, removed when it is done with it.
+class TemporaryDirectory {
+public:
+    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+    }
+
+    TemporaryDirectory(const TemporaryDirectory&)            = delete;
+    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
+
+    ~TemporaryDirectory() {
+        std::error_code code;
+        std::filesystem::remove_all(path_, code);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
+[[nodiscard]] std::string contentsOf(const std::filesystem::path& path) {
+    std::ifstream in{path, std::ios::binary};
+    if (!in) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+}  // namespace
+
+const mdux::spec::Register theEmittedFixtureIsWhatTheCompilerProduces{
+    "The committed fixture package is what compiling its source produces",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-fixture-is-current")
+            .Given("the screen source the fixture package was compiled from", [] {})
+            .When("it is compiled again", [] {})
+            .Then("the bytes match the committed package exactly",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The emission reads a committed package, so that package has to stay the
+                      // compiler's own answer. Without this scenario it would be a hand-maintained
+                      // file that drifts the first time the layout solver changes a rectangle - and
+                      // the drift would show up as generated C++ describing a screen nobody wrote.
+                      md::ParseResult parsed = md::parse(fixture("accepted-every-component.medui"), "every-component.medui");
+                      if (!parsed.screen || !parsed.diagnostics.empty()) {
+                          checks.expect(false, "the fixture source parses");
+                          checks.raise();
+                          return;
+                      }
+                      const md::LayoutResult layout = md::resolveLayout(*parsed.screen, "every-component.medui", {.surfaceWidth = 800, .surfaceHeight = 700});
+                      if (!layout.ok()) {
+                          checks.expect(false, std::format("the fixture source resolves: {}", layout.diagnostics.front().message));
+                          checks.raise();
+                          return;
+                      }
+
+                      const std::string produced = md::writePackage(md::buildPackage(layout, {.id = "every-component", .budget = fixtureBudget}).package());
+                      checks.expect(produced == fixture("every-component-package.json"), std::format("the committed package is current, got:\n{}", produced));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register bothHalvesOfTheFilenameRuleAgree{
+    "The CMake and C++ halves of the identifier rule agree",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-identifier-parity")
+            .Given("the identifiers mdux_screen_identifier() produced at configure time", [] {})
+            .When("identifierForScreen() is run over the same ids", [] {})
+            .Then("both halves answer the same for every id",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Both halves are executed and compared, rather than one being asserted and
+                      // called consistent with the other: a C++ assertion cannot observe a CMake
+                      // regex, which is how the shader pair drifted on the leading-digit rule.
+                      std::ifstream parity{MDUX_SCREEN_IDENTIFIER_PARITY_FILE, std::ios::binary};
+                      checks.expect(parity.is_open(), "the build wrote its identifier answers");
+
+                      std::size_t compared = 0;
+                      std::string line;
+                      while (std::getline(parity, line)) {
+                          if (line.empty()) {
+                              continue;
+                          }
+                          const std::size_t tab = line.find('\t');
+                          if (tab == std::string::npos) {
+                              checks.expect(false, std::format("parity line '{}' has two fields", line));
+                              continue;
+                          }
+                          const std::string id       = line.substr(0, tab);
+                          std::string       fromMake = line.substr(tab + 1);
+                          // CMake's file(WRITE) writes CRLF on Windows, and getline strips only the
+                          // newline. Without this the parity check fails on the MSVC leg alone, on a
+                          // carriage return rather than on a disagreement about the rule.
+                          if (!fromMake.empty() && fromMake.back() == '\r') {
+                              fromMake.pop_back();
+                          }
+                          const std::string fromCpp = md::identifierForScreen(id);
+                          checks.expect(fromCpp == fromMake, std::format("id '{}': CMake says '{}', C++ says '{}'", id, fromMake, fromCpp));
+                          ++compared;
+                      }
+                      checks.expect(compared > 0, "the parity file listed at least one id");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register bothFormsRenderFromOneScreen{
+    "The module and header forms render the same screen",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-two-forms")
+            .Given("a committed screen package", [] {})
+            .When("it is rendered", [] {})
+            .Then("both outputs carry one body, one static_assert, and every payload the screen holds",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      const auto outputs = md::renderScreen(fixturePath("every-component-package.json"), diagnostics);
+                      checks.expect(outputs.has_value(), "a valid package renders");
+                      if (!outputs.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      checks.expect(outputs->stem == "screen_every_component", std::format("the stem, got '{}'", outputs->stem));
+                      checks.expect(outputs->moduleName == "mdux.medui.generated.screen_every_component",
+                                    std::format("the module name, got '{}'", outputs->moduleName));
+                      checks.expect(outputs->moduleSource.contains("export module mdux.medui.generated.screen_every_component;"),
+                                    "the module form declares its module");
+                      checks.expect(outputs->headerSource.contains("#pragma once"), "the header form is include-guarded");
+                      checks.expect(!outputs->headerSource.contains("export module"), "the header form declares no module");
+
+                      // The two outputs share one rendering of the screen, so the body has to appear
+                      // in both. Compared as a whole rather than by sampling members: a shared body
+                      // is the property that makes them impossible to disagree.
+                      const std::size_t bodyStart = outputs->moduleSource.find("namespace mdux::medui::generated::");
+                      checks.expect(bodyStart != std::string::npos, "the module form carries the generated namespace");
+                      if (bodyStart != std::string::npos) {
+                          const std::string body = outputs->moduleSource.substr(bodyStart);
+                          checks.expect(outputs->headerSource.contains(body), "both forms carry the identical body");
+                      }
+
+                      checks.expect(outputs->moduleSource.contains("static_assert(screen.validate().has_value()"),
+                                    "the generated screen checks itself where it is defined");
+
+                      // All eleven payloads: what makes this an emitter rather than a renderer of
+                      // the components somebody happened to test with.
+                      for (const std::string_view spec : {"PanelSpec",
+                                                          "LabelSpec",
+                                                          "ClockSpec",
+                                                          "ImageSpec",
+                                                          "VulkanViewportSpec",
+                                                          "SignalTraceSpec",
+                                                          "ButtonSpec",
+                                                          "CriticalButtonSpec",
+                                                          "NumericDisplaySpec",
+                                                          "StatusIndicatorSpec",
+                                                          "TextInputSpec"}) {
+                          checks.expect(outputs->moduleSource.contains(spec), std::format("the rendering carries a {}", spec));
+                      }
+                      checks.expect(diagnostics.empty(), "a valid package renders without diagnostics");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aMalformedPackageIsNotRendered{
+    "A package the schema refuses is not rendered",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-refuses-malformed")
+            .Given("a package whose surface no longer contains its nodes", [] {})
+            .When("the emitter is pointed at it", [] {})
+            .Then("nothing is rendered and the reader's own diagnostic is reported",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TemporaryDirectory scratch{"mdux-screenemit-malformed"};
+                      std::error_code    code;
+                      std::filesystem::create_directories(scratch.path(), code);
+
+                      std::string       edited = fixture("every-component-package.json");
+                      const std::size_t at     = edited.find("\"surfaceWidth\": 800");
+                      checks.expect(at != std::string::npos, "the fixture declares its surface width");
+                      if (at != std::string::npos) {
+                          edited.replace(at, std::string_view{"\"surfaceWidth\": 800"}.size(), "\"surfaceWidth\": 100");
+                      }
+                      const std::filesystem::path path = scratch.path() / "package.json";
+                      std::ofstream               out{path, std::ios::binary | std::ios::trunc};
+                      out.write(edited.data(), static_cast<std::streamsize>(edited.size()));
+                      out.close();
+
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const auto                   outputs = md::renderScreen(path, diagnostics);
+                      checks.expect(!outputs.has_value(), "a screen the schema refuses is not rendered");
+                      checks.expect(
+                          !diagnostics.empty() && diagnostics.front().code == "SCP005",
+                          std::format("the reader's verdict is reported, got '{}'", diagnostics.empty() ? std::string{"<none>"} : diagnostics.front().code));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anUnreadablePackageIsReported{
+    "A package that cannot be read is reported, not assumed empty",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-unreadable")
+            .Given("a path where no package exists", [] {})
+            .When("the emitter is pointed at it", [] {})
+            .Then("it reports the file it could not read",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const auto                   outputs = md::renderScreen(fixturePath("no-such-screen-package.json"), diagnostics);
+                      checks.expect(!outputs.has_value(), "a missing package renders nothing");
+                      checks.expect(!diagnostics.empty() && diagnostics.front().code == "SCE001",
+                                    std::format("reported as SCE001, got '{}'", diagnostics.empty() ? std::string{"<none>"} : diagnostics.front().code));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register writingIsIdempotent{
+    "Writing the same screen twice leaves the same two files",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-write")
+            .Given("a rendered screen", [] {})
+            .When("it is written into an empty directory, then written again", [] {})
+            .Then("both files hold the rendering, unchanged by the second write",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+                      TemporaryDirectory           scratch{"mdux-screenemit-write"};
+
+                      const auto outputs = md::renderScreen(fixturePath("every-component-package.json"), diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, "the fixture package renders");
+                          checks.raise();
+                          return;
+                      }
+
+                      checks.expect(md::writeScreen(*outputs, scratch.path(), diagnostics), "the first write succeeds");
+                      const std::filesystem::path module = scratch.path() / "screen_every_component.cppm";
+                      const std::filesystem::path header = scratch.path() / "screen_every_component.hpp";
+                      checks.expect(contentsOf(module) == outputs->moduleSource, "the module file holds the rendering");
+                      checks.expect(contentsOf(header) == outputs->headerSource, "the header file holds the rendering");
+
+                      // A rebuild that changes nothing must not restamp these: every consumer of a
+                      // module interface recompiles when it changes.
+                      checks.expect(md::writeScreen(*outputs, scratch.path(), diagnostics), "the second write succeeds");
+                      checks.expect(contentsOf(module) == outputs->moduleSource, "the second write left the module file alone");
+                      checks.expect(diagnostics.empty(), "writing twice reports nothing");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aDecodedControlCharacterCannotEndTheLiteral{
+    "A name carrying a decoded control character is escaped, not embedded",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-escapes")
+            .Given("a screen whose requirement contains a source-legal escaped newline", [] {})
+            .When("it is compiled and rendered", [] {})
+            .Then("the generated literal carries an escape rather than a line break",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TemporaryDirectory scratch{"mdux-screenemit-escapes"};
+                      std::error_code    code;
+                      std::filesystem::create_directories(scratch.path(), code);
+
+                      // The lexer decodes `\n` inside a source string and the dictionary accepts an
+                      // unrestricted String for `requirement`, so this screen is legal, its package
+                      // is valid, and the decoded newline reaches the emitter. Rendered raw it would
+                      // end the C++ literal and let what follows be read as tokens.
+                      const std::string source = "Screen Escapes {\n"
+                                                 "    layout: Vertical { spacing: 0px; padding: 0px; }\n"
+                                                 "    surface: 200px, 100px;\n"
+                                                 "\n"
+                                                 "    NumericDisplay {\n"
+                                                 "        id: score;\n"
+                                                 "        width: 200px;\n"
+                                                 "        height: 40px;\n"
+                                                 "        requirement: \"REQ\\nHALT\";\n"
+                                                 "        template: \"TPL\\tSCORE\";\n"
+                                                 "        source: \"SCORE\";\n"
+                                                 "        color: Theme.Colors.ScoreDigits;\n"
+                                                 "    }\n"
+                                                 "}\n";
+
+                      md::ParseResult parsed = md::parse(source, "escapes.medui");
+                      if (!parsed.screen || !parsed.diagnostics.empty()) {
+                          checks.expect(false, "the escaped source parses");
+                          checks.raise();
+                          return;
+                      }
+                      const md::LayoutResult layout = md::resolveLayout(*parsed.screen, "escapes.medui", {.surfaceWidth = 200, .surfaceHeight = 100});
+                      if (!layout.ok()) {
+                          checks.expect(false, "the escaped source resolves");
+                          checks.raise();
+                          return;
+                      }
+
+                      const std::string           json = md::writePackage(md::buildPackage(layout, {.id = "escapes", .budget = fixtureBudget}).package());
+                      const std::filesystem::path path = scratch.path() / "package.json";
+                      std::ofstream               out{path, std::ios::binary | std::ios::trunc};
+                      out.write(json.data(), static_cast<std::streamsize>(json.size()));
+                      out.close();
+
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const auto                   outputs = md::renderScreen(path, diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, "a screen with an escaped name renders");
+                          checks.raise();
+                          return;
+                      }
+
+                      checks.expect(outputs->moduleSource.contains("REQ\\nHALT"), "the newline is emitted as an escape");
+                      checks.expect(outputs->moduleSource.contains("TPL\\tSCORE"), "and so is the tab");
+                      checks.expect(!outputs->moduleSource.contains("REQ\nHALT"), "no decoded newline reaches the generated source");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aScreenWithNoNodesRenders{
+    "A screen that resolves to no nodes renders as an empty span",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-empty")
+            .Given("the empty screen the schema permits", [] {})
+            .When("it is rendered", [] {})
+            .Then("its node table is an empty span rather than an empty array",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+
+                      const auto outputs = md::renderScreen(fixturePath("empty-screen-package.json"), diagnostics);
+                      checks.expect(outputs.has_value(), "the empty screen renders");
+                      if (!outputs.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      // `CompiledNode nodes[] = {}` cannot deduce a zero bound and is not valid C++,
+                      // so a screen validate() accepts could not be consumed in either form.
+                      // GeneratedEmptyScreenConsumer.cpp is where the compiler says so.
+                      checks.expect(outputs->moduleSource.contains("std::span<const mdux::medui::CompiledNode> nodes{}"), "the empty node table is a span");
+                      checks.expect(outputs->moduleSource.contains("static_assert(screen.validate().has_value()"), "the empty screen still checks itself");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aReservedIdentifierIsRefused{
+    "An id that maps to a reserved identifier is refused",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-reserved-identifier")
+            .Given("a package whose id carries two adjacent separators", [] {})
+            .When("it is rendered", [] {})
+            .Then("the emitter refuses rather than generating a reserved name",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TemporaryDirectory scratch{"mdux-screenemit-reserved"};
+                      std::error_code    code;
+                      std::filesystem::create_directories(scratch.path(), code);
+
+                      // `a--b` maps to `screen_a__b`, and `__` is reserved to the implementation
+                      // everywhere. Collapsing the run would fix the name and break injectivity, so
+                      // two screens could claim one filename; refusing keeps both properties.
+                      checks.expect(md::identifierForScreen("a--b") == "screen_a__b", "the mapping is one underscore per separator");
+                      checks.expect(md::identifierForScreen("class") == "screen_class", "a keyword id maps to a usable identifier");
+
+                      std::string       edited = fixture("empty-screen-package.json");
+                      const std::size_t at     = edited.find("\"empty-screen\"");
+                      checks.expect(at != std::string::npos, "the fixture carries its id");
+                      if (at != std::string::npos) {
+                          edited.replace(at, std::string_view{"\"empty-screen\""}.size(), "\"a--b\"");
+                      }
+                      const std::filesystem::path path = scratch.path() / "package.json";
+                      std::ofstream               out{path, std::ios::binary | std::ios::trunc};
+                      out.write(edited.data(), static_cast<std::streamsize>(edited.size()));
+                      out.close();
+
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const auto                   outputs = md::renderScreen(path, diagnostics);
+                      checks.expect(!outputs.has_value(), "a reserved identifier is refused");
+                      checks.expect(!diagnostics.empty() && diagnostics.front().code == "SCE003",
+                                    std::format("reported as SCE003, got '{}'", diagnostics.empty() ? std::string{"<none>"} : diagnostics.front().code));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aProvenanceCommentCannotBeEnded{
+    "An id carrying a newline cannot end the provenance comment",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-emit-comment-escapes")
+            .Given("a package whose id contains a control character", [] {})
+            .When("it is rendered", [] {})
+            .Then("the id appears escaped inside the comment, on one line",
+                  [] {
+                      mdux::spec::Checks checks;
+                      TemporaryDirectory scratch{"mdux-screenemit-comment"};
+                      std::error_code    code;
+                      std::filesystem::create_directories(scratch.path(), code);
+
+                      // The schema asks only that an id be non-empty, and canonical JSON carries a
+                      // control character as an escape, so this package is valid on both counts. A
+                      // `//` comment ends at a newline, so an unescaped id would have closed the
+                      // provenance comment and left `namespace` as generated source.
+                      std::string       edited = fixture("empty-screen-package.json");
+                      const std::size_t at     = edited.find("\"empty-screen\"");
+                      checks.expect(at != std::string::npos, "the fixture carries its id");
+                      if (at != std::string::npos) {
+                          edited.replace(at, std::string_view{"\"empty-screen\""}.size(), "\"a\\nnamespace\"");
+                      }
+                      const std::filesystem::path path = scratch.path() / "package.json";
+                      std::ofstream               out{path, std::ios::binary | std::ios::trunc};
+                      out.write(edited.data(), static_cast<std::streamsize>(edited.size()));
+                      out.close();
+
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const auto                   outputs = md::renderScreen(path, diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, "a package with a control character in its id renders");
+                          checks.raise();
+                          return;
+                      }
+
+                      const std::size_t marker = outputs->moduleSource.find("// Screen: ");
+                      checks.expect(marker != std::string::npos, "the provenance comment names the screen");
+                      if (marker != std::string::npos) {
+                          const std::size_t lineEnd = outputs->moduleSource.find('\n', marker);
+                          const std::string line    = outputs->moduleSource.substr(marker, lineEnd - marker);
+                          checks.expect(line == "// Screen: a\\nnamespace", std::format("the whole id stays on the comment line, got '{}'", line));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for the screen emitter (issue #197).
  * @file EmitTests.cpp
+ * @brief BDD scenarios for the screen emitter (issue #197).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -25,6 +25,7 @@ import mdux.tools.medui.package;
 import mdux.tools.medui.parser;
 
 #include "../framework/SpecLabBridge.hpp"
+#include "../framework/TemporaryDirectory.hpp"
 
 namespace {
 
@@ -48,29 +49,6 @@ constexpr mdux::draw::DrawBudget fixtureBudget{.maxVertices = 4096, .maxIndices 
     return buffer.str();
 }
 
-/// A directory this scenario owns, removed when it is done with it.
-class TemporaryDirectory {
-public:
-    explicit TemporaryDirectory(std::string_view name) : path_{std::filesystem::temp_directory_path() / name} {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-    }
-
-    TemporaryDirectory(const TemporaryDirectory&)            = delete;
-    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
-
-    ~TemporaryDirectory() {
-        std::error_code code;
-        std::filesystem::remove_all(path_, code);
-    }
-
-    [[nodiscard]] const std::filesystem::path& path() const noexcept {
-        return path_;
-    }
-
-private:
-    std::filesystem::path path_;
-};
 
 [[nodiscard]] std::string contentsOf(const std::filesystem::path& path) {
     std::ifstream in{path, std::ios::binary};
@@ -235,10 +213,8 @@ const mdux::spec::Register aMalformedPackageIsNotRendered{
             .When("the emitter is pointed at it", [] {})
             .Then("nothing is rendered and the reader's own diagnostic is reported",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-screenemit-malformed"};
-                      std::error_code    code;
-                      std::filesystem::create_directories(scratch.path(), code);
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-malformed"};
 
                       std::string       edited = fixture("every-component-package.json");
                       const std::size_t at     = edited.find("\"surfaceWidth\": 800");
@@ -291,9 +267,9 @@ const mdux::spec::Register writingIsIdempotent{
             .When("it is written into an empty directory, then written again", [] {})
             .Then("both files hold the rendering, unchanged by the second write",
                   [] {
-                      mdux::spec::Checks           checks;
-                      std::vector<cli::Diagnostic> diagnostics;
-                      TemporaryDirectory           scratch{"mdux-screenemit-write"};
+                      mdux::spec::Checks             checks;
+                      std::vector<cli::Diagnostic>   diagnostics;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-write"};
 
                       const auto outputs = md::renderScreen(fixturePath("every-component-package.json"), diagnostics);
                       if (!outputs.has_value()) {
@@ -327,10 +303,8 @@ const mdux::spec::Register aDecodedControlCharacterCannotEndTheLiteral{
             .When("it is compiled and rendered", [] {})
             .Then("the generated literal carries an escape rather than a line break",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-screenemit-escapes"};
-                      std::error_code    code;
-                      std::filesystem::create_directories(scratch.path(), code);
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-escapes"};
 
                       // The lexer decodes `\n` inside a source string and the dictionary accepts an
                       // unrestricted String for `requirement`, so this screen is legal, its package
@@ -423,10 +397,8 @@ const mdux::spec::Register aReservedIdentifierIsRefused{
             .When("it is rendered", [] {})
             .Then("the emitter refuses rather than generating a reserved name",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-screenemit-reserved"};
-                      std::error_code    code;
-                      std::filesystem::create_directories(scratch.path(), code);
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-reserved"};
 
                       // `a--b` maps to `screen_a__b`, and `__` is reserved to the implementation
                       // everywhere. Collapsing the run would fix the name and break injectivity, so
@@ -464,10 +436,8 @@ const mdux::spec::Register aProvenanceCommentCannotBeEnded{
             .When("it is rendered", [] {})
             .Then("the id appears escaped inside the comment, on one line",
                   [] {
-                      mdux::spec::Checks checks;
-                      TemporaryDirectory scratch{"mdux-screenemit-comment"};
-                      std::error_code    code;
-                      std::filesystem::create_directories(scratch.path(), code);
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-screenemit-comment"};
 
                       // The schema asks only that an id be non-empty, and canonical JSON carries a
                       // control character as an escape, so this package is valid on both counts. A

--- a/tests/medui/GeneratedEmptyScreenConsumer.cpp
+++ b/tests/medui/GeneratedEmptyScreenConsumer.cpp
@@ -1,0 +1,26 @@
+/**
+ * @file GeneratedEmptyScreenConsumer.cpp
+ * @brief Reaches the generated form of a screen that resolves to no nodes.
+ *
+ * The degenerate case, and it has to compile: `ScreenPackage::validate()` permits a screen with no
+ * nodes and an empty budget, and `medui-schema-budget` pins that. An earlier revision of the emitter
+ * rendered it as `CompiledNode nodes[] = {}`, which is not valid C++ - so a screen the schema calls
+ * valid could not be consumed in either emitted form. This translation unit compiling is what says
+ * that is no longer true.
+ *
+ * Only the module form is reached here. The two forms share one rendered body, which
+ * `medui-screen-emit-two-forms` asserts, so compiling one of them compiles the shape.
+ */
+import std;
+import mdux.medui.schema;
+import mdux.medui.generated.screen_empty_screen;
+
+#include "GeneratedScreenConsumers.hpp"
+
+namespace mdux::test::generated {
+
+mdux::medui::ScreenPackage emptyScreenFromModule() noexcept {
+    return mdux::medui::generated::screen_empty_screen::package();
+}
+
+}  // namespace mdux::test::generated

--- a/tests/medui/GeneratedScreenConsumers.hpp
+++ b/tests/medui/GeneratedScreenConsumers.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file GeneratedScreenConsumers.hpp
+ * @brief Declares the two ways of reaching the same generated screen.
+ *
+ * #197's acceptance is that both emitted forms describe one screen, and asserting it needs both in
+ * one binary. They cannot share a translation unit: the module form is attached to a named module
+ * and the header form is not, so a TU that both imported and included would hold two distinct sets
+ * of entities with the same names.
+ *
+ * So there are two thin translation units, one per form, each returning a `ScreenPackage`, and a
+ * third that compares them. Each of these files compiling is itself half the acceptance - the
+ * generated module must be importable, and the generated header includable, by an ordinary
+ * consumer that links no host-tools module.
+ */
+#pragma once
+
+namespace mdux::test::generated {
+
+/// The screen as reached through `import mdux.medui.generated.screen_every_component;`.
+[[nodiscard]] mdux::medui::ScreenPackage screenFromModule() noexcept;
+
+/// The screen as reached through `#include "screen_every_component.hpp"`.
+[[nodiscard]] mdux::medui::ScreenPackage screenFromHeader() noexcept;
+
+/// A screen that resolves to no nodes, which the schema permits and the emitter must render as an
+/// empty span rather than as an empty C array.
+[[nodiscard]] mdux::medui::ScreenPackage emptyScreenFromModule() noexcept;
+
+}  // namespace mdux::test::generated

--- a/tests/medui/GeneratedScreenHeaderConsumer.cpp
+++ b/tests/medui/GeneratedScreenHeaderConsumer.cpp
@@ -1,0 +1,24 @@
+/**
+ * @file GeneratedScreenHeaderConsumer.cpp
+ * @brief Reaches the generated screen through its header form.
+ *
+ * The other half of #197's acceptance. The header exists for a translation unit that cannot import
+ * a named module - a device's entry point may include Vulkan and platform headers before importing
+ * anything, precisely because mixing the two orders has produced GCC ICEs in this repository.
+ *
+ * Note the include order: `import std;` and `import mdux.medui.schema;` first, then the generated
+ * header, which assumes both. That is the contract the shader emitter's header form has too.
+ */
+import std;
+import mdux.medui.schema;
+
+#include "GeneratedScreenConsumers.hpp"
+#include "screen_every_component.hpp"
+
+namespace mdux::test::generated {
+
+mdux::medui::ScreenPackage screenFromHeader() noexcept {
+    return mdux::medui::generated::screen_every_component::package();
+}
+
+}  // namespace mdux::test::generated

--- a/tests/medui/GeneratedScreenModuleConsumer.cpp
+++ b/tests/medui/GeneratedScreenModuleConsumer.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file GeneratedScreenModuleConsumer.cpp
+ * @brief Reaches the generated screen through its module interface.
+ *
+ * This translation unit existing and compiling *is* half of #197's acceptance: the generated module
+ * form must be importable by an ordinary consumer, and the `static_assert` the generated source
+ * carries is evaluated here rather than on a device.
+ */
+import std;
+import mdux.medui.schema;
+import mdux.medui.generated.screen_every_component;
+
+#include "GeneratedScreenConsumers.hpp"
+
+namespace mdux::test::generated {
+
+mdux::medui::ScreenPackage screenFromModule() noexcept {
+    return mdux::medui::generated::screen_every_component::package();
+}
+
+}  // namespace mdux::test::generated

--- a/tests/medui/GeneratedScreenTests.cpp
+++ b/tests/medui/GeneratedScreenTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for the generated screen, in both emitted forms (issue #197).
  * @file GeneratedScreenTests.cpp
+ * @brief BDD scenarios for the generated screen, in both emitted forms (issue #197).
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/GeneratedScreenTests.cpp
+++ b/tests/medui/GeneratedScreenTests.cpp
@@ -1,0 +1,156 @@
+/**
+ * @brief BDD scenarios for the generated screen, in both emitted forms (issue #197).
+ * @file GeneratedScreenTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * This is where #197's acceptance criterion is met: both emitted forms are compiled into one binary
+ * and asserted to describe the same screen.
+ *
+ * Two properties are proved by this file existing at all, before any scenario runs. The generated
+ * source carries `static_assert(screen.validate().has_value())`, so **compiling** the consumers
+ * proves the emitted screen satisfies its schema - a malformed screen could not have got this far.
+ * And this target links `MduX::Core` and no host-tools module, so a device build reaching a compiled
+ * screen through generated code links no compiler and parses nothing at startup, which is the end
+ * state #153 is pursuing for every package kind.
+ */
+
+import std;
+import speclab;
+import mdux.medui.schema;
+
+#include "../framework/SpecLabBridge.hpp"
+#include "GeneratedScreenConsumers.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+namespace tg = mdux::test::generated;
+
+}  // namespace
+
+const mdux::spec::Register bothFormsDescribeOneScreen{
+    "The module form and the header form describe the same screen",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-generated-screen-forms-agree")
+            .Given("a screen emitted as a module interface and as a header", [] {})
+            .When("both are compiled into one binary and read", [] {})
+            .Then("they agree on the id, the surface, the budget and every node",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const ms::ScreenPackage fromModule = tg::screenFromModule();
+                      const ms::ScreenPackage fromHeader = tg::screenFromHeader();
+
+                      checks.expect(fromModule.id == fromHeader.id, "both forms name the same screen");
+                      checks.expect(fromModule.schemaVersion == fromHeader.schemaVersion, "both forms declare one schema version");
+                      checks.expect(fromModule.surfaceWidth == fromHeader.surfaceWidth && fromModule.surfaceHeight == fromHeader.surfaceHeight,
+                                    "both forms declare one surface");
+                      checks.expect(fromModule.budget == fromHeader.budget, "both forms declare one draw budget");
+                      checks.expect(fromModule.nodes.size() == fromHeader.nodes.size(),
+                                    std::format("both forms hold {} nodes, header holds {}", fromModule.nodes.size(), fromHeader.nodes.size()));
+
+                      for (std::size_t index = 0; index < std::min(fromModule.nodes.size(), fromHeader.nodes.size()); ++index) {
+                          checks.expect(fromModule.nodes[index] == fromHeader.nodes[index],
+                                        std::format("node '{}' is identical in both forms", fromModule.nodes[index].id));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theGeneratedScreenIsTheCompiledOne{
+    "The generated screen is the screen the compiler resolved",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-generated-screen-content")
+            .Given("the screen emitted from the committed package", [] {})
+            .When("its nodes are read through the schema", [] {})
+            .Then("every component's own fields are there, including the ones a flat node could not hold",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const ms::ScreenPackage screen = tg::screenFromModule();
+
+                      checks.expect(screen.id == "every-component", std::format("the screen id, got '{}'", screen.id));
+                      checks.expect(screen.nodes.size() == 11, std::format("eleven nodes, got {}", screen.nodes.size()));
+                      checks.expect(screen.validate().has_value(), "the generated screen validates at run time as well as at compile time");
+
+                      // The four components a flat node could not have held. Reading them back out
+                      // of generated code is what says the emitted form carries them, not just the
+                      // JSON the emitter read.
+                      const ms::CompiledNode* clock = screen.find("wall-clock");
+                      if (clock != nullptr) {
+                          const auto* spec = std::get_if<ms::ClockSpec>(&clock->payload);
+                          checks.expect(spec != nullptr && spec->format == "TimeSeconds", "the Clock's format survives emission");
+                      } else {
+                          checks.expect(false, "the generated screen holds the Clock");
+                      }
+
+                      const ms::CompiledNode* critical = screen.find("halt");
+                      if (critical != nullptr) {
+                          const auto* spec = std::get_if<ms::CriticalButtonSpec>(&critical->payload);
+                          checks.expect(spec != nullptr && spec->onPress == "TriggerHalt", "the CriticalButton's action survives emission");
+                          checks.expect(spec != nullptr && spec->requirement == "REQ-EC-002", "its requirement survives, for the trace");
+                      } else {
+                          checks.expect(false, "the generated screen holds the CriticalButton");
+                      }
+
+                      const ms::CompiledNode* status = screen.find("state");
+                      if (status != nullptr) {
+                          const auto* spec = std::get_if<ms::StatusIndicatorSpec>(&status->payload);
+                          // The spans are the interesting part: they view namespace-scope arrays the
+                          // emitter declared beside the node table, so this reads generated storage
+                          // rather than a copy.
+                          checks.expect(spec != nullptr && spec->stateKeys.size() == 2, "the StatusIndicator's states survive emission");
+                          checks.expect(spec != nullptr && !spec->colorTokens.empty() && spec->colorTokens.size() == spec->stateKeys.size(),
+                                        "its per-state tints pair with its states");
+                      } else {
+                          checks.expect(false, "the generated screen holds the StatusIndicator");
+                      }
+
+                      const ms::CompiledNode* viewport = screen.find("endoscope");
+                      if (viewport != nullptr) {
+                          const auto* spec = std::get_if<ms::VulkanViewportSpec>(&viewport->payload);
+                          checks.expect(spec != nullptr && spec->streamSource == "ENDOSCOPE", "the VulkanViewport's stream survives emission");
+                      } else {
+                          checks.expect(false, "the generated screen holds the VulkanViewport");
+                      }
+
+                      // A traceability export walks this, so it is worth reading out of the emitted
+                      // form rather than trusting that the schema function is shared.
+                      std::size_t traced = 0;
+                      for (const ms::CompiledNode& node : screen.nodes) {
+                          if (!ms::requirementOf(node).empty()) {
+                              ++traced;
+                          }
+                      }
+                      checks.expect(traced == 5, std::format("five nodes carry a requirement, got {}", traced));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anEmptyScreenIsConsumable{"A screen with no nodes is generated code a consumer can hold", "evidence-unit", [] {
+                                                         return speclab::Test("medui-generated-empty-screen")
+                                                             .Given("the degenerate screen the schema permits: no nodes, empty budget", [] {})
+                                                             .When("its generated form is compiled and read", [] {})
+                                                             .Then("it holds no nodes and still validates",
+                                                                   [] {
+                                                                       mdux::spec::Checks      checks;
+                                                                       const ms::ScreenPackage screen = tg::emptyScreenFromModule();
+
+                                                                       // The compiling of GeneratedEmptyScreenConsumer.cpp is the assertion that
+                                                                       // matters here; an emitter that rendered `CompiledNode nodes[] = {}` would
+                                                                       // have failed to build rather than failed this scenario.
+                                                                       checks.expect(screen.id == "empty-screen",
+                                                                                     std::format("the screen id, got '{}'", screen.id));
+                                                                       checks.expect(screen.nodes.empty(),
+                                                                                     std::format("no nodes, got {}", screen.nodes.size()));
+                                                                       checks.expect(screen.validate().has_value(),
+                                                                                     "an empty screen with an empty budget is valid");
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};

--- a/tests/medui/GoldenTests.cpp
+++ b/tests/medui/GoldenTests.cpp
@@ -1,0 +1,512 @@
+/**
+ * @brief BDD scenarios for golden references on safety-critical nodes (issue #196).
+ * @file GoldenTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * The predicate is the whole subject here: which nodes are selected, that a node matching both
+ * rules is selected exactly once, and that what a golden pins for dynamic content is where it
+ * appears rather than what it says. `accepted-goldens.medui` carries all of that in one screen an
+ * author could open, which is why it is a fixture rather than a string literal - #200's
+ * `mdux-medui-check` will be pointed at the same corpus.
+ */
+
+import std;
+import speclab;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+/// Reads one real authoring fixture from the repository corpus.
+[[nodiscard]] std::string fixture(std::string_view name) {
+    const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+    std::ifstream               in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened at {}", name, path.generic_string()),
+                                              std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] md::ast::Screen parseOrFail(std::string_view source) {
+    md::ParseResult parsed = md::parse(source, "goldens.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("golden test source did not parse", std::source_location::current());
+    }
+    return std::move(*parsed.screen);
+}
+
+/// Parses and resolves, failing the scenario rather than the assertion if the screen is malformed.
+[[nodiscard]] md::LayoutResult layoutOf(std::string_view source, std::int64_t width, std::int64_t height) {
+    const md::ast::Screen screen   = parseOrFail(source);
+    md::LayoutResult      resolved = md::resolveLayout(screen, "goldens.medui", {.surfaceWidth = width, .surfaceHeight = height});
+    if (!resolved.ok()) {
+        throw speclab::core::AssertionFailure("golden test source did not resolve", std::source_location::current());
+    }
+    return resolved;
+}
+
+/// Wraps a component body in a screen whose declared surface matches the build surface.
+[[nodiscard]] std::string screenWith(std::string_view body) {
+    return std::format("Screen Test {{\n"
+                       "    layout: Vertical {{ spacing: 0px; padding: 0px; }}\n"
+                       "    surface: 200px, 100px;\n"
+                       "{}"
+                       "}}\n",
+                       body);
+}
+
+/// One annotated Button, with the annotation argument the scenario is about.
+[[nodiscard]] std::string annotatedButton(std::string_view annotation) {
+    return screenWith(std::format("    {}\n"
+                                  "    Button {{ id: action; width: 100px; height: 40px; label: t(\"STR-ACTION\"); "
+                                  "color: Theme.Colors.PrimaryAction; source: \"ACTION\"; requirement: \"REQ-1\"; }}\n",
+                                  annotation));
+}
+
+/// Spelled as a predicate rather than as a projected `find`: the projection yields `std::string`
+/// and the needle is a `string_view`, and the range concepts do not owe us that comparison.
+[[nodiscard]] const md::GoldenReference* find(std::span<const md::GoldenReference> references, std::string_view nodeId) {
+    const auto found = std::ranges::find_if(references, [nodeId](const md::GoldenReference& reference) {
+        return reference.nodeId == nodeId;
+    });
+    return found == references.end() ? nullptr : &*found;
+}
+
+/// How many entries name `nodeId`. One is the whole point for a node matching both rules.
+[[nodiscard]] std::ptrdiff_t countFor(std::span<const md::GoldenReference> references, std::string_view nodeId) {
+    return std::ranges::count_if(references, [nodeId](const md::GoldenReference& reference) {
+        return reference.nodeId == nodeId;
+    });
+}
+
+[[nodiscard]] const cli::Diagnostic* find(const md::SafetyResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    });
+    return found == result.diagnostics.end() ? nullptr : &*found;
+}
+
+/// Renders a check list as `Bounds+ColorHash`, so a failure says what was emitted.
+[[nodiscard]] std::string describe(std::span<const md::CvCheck> checks) {
+    std::string rendered;
+    for (const md::CvCheck check : checks) {
+        if (!rendered.empty()) {
+            rendered += '+';
+        }
+        rendered += md::spell(check);
+    }
+    return rendered.empty() ? std::string{"<none>"} : rendered;
+}
+
+}  // namespace
+
+const mdux::spec::Register predicateSelectsTheRightNodes{
+    "The predicate selects annotated and positioned nodes, and nothing else",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-predicate")
+            .Given("a screen with an annotated node, a positioned node, one of each, and a plain one", [] {})
+            .When("the golden set is derived from the resolved screen", [] {})
+            .Then("four entries appear in source order and the plain node is absent",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300));
+
+                      const std::vector<std::string_view> expected{"action", "pinned", "score", "state"};
+                      checks.expect(references.size() == expected.size(), std::format("four nodes are pinned, got {}", references.size()));
+                      for (std::size_t index = 0; index < std::min(references.size(), expected.size()); ++index) {
+                          checks.expect(references[index].nodeId == expected[index],
+                                        std::format("entry {} is '{}', got '{}'", index, expected[index], references[index].nodeId));
+                      }
+                      checks.expect(find(references, "plain") == nullptr, "a node with neither an annotation nor a position is not pinned");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register positionAlonePinsBounds{
+    "A declared position pins bounds without an annotation, and an annotation pins what it names",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-position-and-annotation")
+            .Given("a positioned Label and an annotated Button naming only ColorHash", [] {})
+            .When("their entries are read", [] {})
+            .Then("the position yields Bounds and the annotation yields exactly what it asked for",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300));
+
+                      const md::GoldenReference* pinned = find(references, "pinned");
+                      checks.expect(pinned != nullptr, "the positioned node is pinned");
+                      if (pinned != nullptr) {
+                          checks.expect(pinned->cvChecks == std::vector{md::CvCheck::Bounds},
+                                        std::format("a declared position pins Bounds, got {}", describe(pinned->cvChecks)));
+                          checks.expect(pinned->bounds == md::LayoutRect{250, 0, 100, 40}, "the pinned rectangle is the resolved one");
+                          checks.expect(pinned->textKey == "STR-PINNED" && pinned->colorToken == "Theme.Colors.Title",
+                                        "a static Label pins its key and its tint");
+                      }
+
+                      const md::GoldenReference* action = find(references, "action");
+                      checks.expect(action != nullptr, "the annotated node is pinned");
+                      if (action != nullptr) {
+                          checks.expect(action->cvChecks == std::vector{md::CvCheck::ColorHash},
+                                        std::format("an unpositioned annotation pins only what it names, got {}", describe(action->cvChecks)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register bothRulesMergeIntoOneEntry{
+    "A node matching both rules is pinned exactly once, with the checks merged",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-merged-entry")
+            .Given("a NumericDisplay that is both @safety_critical(Bounds, ColorHash) and positioned", [] {})
+            .When("the golden set is derived", [] {})
+            .Then("there is one entry for it, with Bounds present once",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300));
+
+                      const std::ptrdiff_t count = countFor(references, "score");
+                      checks.expect(count == 1, std::format("one entry, never two, got {}", count));
+
+                      const md::GoldenReference* score = find(references, "score");
+                      if (score != nullptr) {
+                          checks.expect(score->cvChecks == std::vector{md::CvCheck::Bounds, md::CvCheck::ColorHash},
+                                        std::format("the automatic Bounds merges with the annotation, got {}", describe(score->cvChecks)));
+                          checks.expect(score->bounds == md::LayoutRect{250, 60, 120, 60}, "the merged entry keeps the resolved rectangle");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register dynamicContentPinsPlaceNotValue{
+    "Dynamic content pins where it appears and in what tint, never the value that varies",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-dynamic-content")
+            .Given("a NumericDisplay with a colour, and a StatusIndicator whose states and colours are lists", [] {})
+            .When("their entries are read", [] {})
+            .Then("neither pins a text key, and the one whose tint varies pins no colour either",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300));
+
+                      const md::GoldenReference* score = find(references, "score");
+                      if (score != nullptr) {
+                          checks.expect(score->textKey.empty(), "a numeric display pins no text");
+                          checks.expect(score->colorToken == "Theme.Colors.ScoreDigits", "its single declared tint is pinned");
+                      }
+
+                      const md::GoldenReference* state = find(references, "state");
+                      checks.expect(state != nullptr, "the positioned status indicator is pinned");
+                      if (state != nullptr) {
+                          checks.expect(state->textKey.empty(), "the state on screen is the varying part, so no key is pinned");
+                          checks.expect(state->colorToken.empty(), "its tint varies per state, so no colour is pinned");
+                          checks.expect(state->cvChecks == std::vector{md::CvCheck::Bounds}, "what remains checkable is where it appears");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register checksAreSortedAndDeduplicated{
+    "Check lists are sorted and deduplicated, so one screen has one serialisation",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-canonical-checks")
+            .Given("an annotation naming ColorHash before Bounds, and Bounds twice", [] {})
+            .When("the entry is derived", [] {})
+            .Then("the list reads Bounds, ColorHash exactly once each",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(
+                          layoutOf(annotatedButton("@safety_critical(cv_check: [ColorHash, Bounds, Bounds])"), 200, 100));
+
+                      checks.expect(references.size() == 1, "the annotated node is pinned");
+                      if (references.size() == 1) {
+                          checks.expect(references.front().cvChecks == std::vector{md::CvCheck::Bounds, md::CvCheck::ColorHash},
+                                        std::format("checks are canonical, got {}", describe(references.front().cvChecks)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register annotationWithoutChecksStillPinsBounds{
+    "An annotation naming no check still pins bounds rather than emitting an empty golden",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-annotation-without-checks")
+            .Given("@safety_critical with no cv_check argument", [] {})
+            .When("the entry is derived", [] {})
+            .Then("it pins Bounds, read from the rule that a declared position alone is enough",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         references = md::collectGoldens(layoutOf(annotatedButton("@safety_critical"), 200, 100));
+
+                      checks.expect(references.size() == 1, "the annotated node is pinned");
+                      if (references.size() == 1) {
+                          checks.expect(references.front().cvChecks == std::vector{md::CvCheck::Bounds},
+                                        std::format("an entry a verifier can act on, got {}", describe(references.front().cvChecks)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register annotatedContainerIsRejected{
+    "A component the dictionary gives no requirement cannot be safety-critical",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-annotated-row")
+            .Given("a Row carrying @safety_critical - Label, Clock and Image are in the same position", [] {})
+            .When("the annotation rules are validated", [] {})
+            .Then("MEDUI-E070 explains that the component takes no requirement at all",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The pinned component model gives Row only id, height, spacing and
+                      // background. It can therefore never carry a requirement:, so it can never
+                      // satisfy the annotation rule - which makes an annotated Row a screen that
+                      // does not compile rather than a golden over a container. An earlier revision
+                      // of this suite pinned the opposite behaviour by reaching collectGoldens()
+                      // without validating first; that path is unreachable in a real driver.
+                      //
+                      // Row is the clearest case rather than the only one: Label, Clock, Image,
+                      // SignalTrace and VulkanViewport take no requirement either, so the same
+                      // diagnostic answers an annotation on any of them.
+                      const std::string source = screenWith(
+                          "    @safety_critical(cv_check: [Bounds])\n"
+                          "    Row { id: topbar; height: 40px; background: Theme.Colors.Title;\n"
+                          "        Label { id: title; width: Fill; height: 40px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; }\n"
+                          "    }\n");
+                      const md::ast::Screen  screen = parseOrFail(source);
+                      const md::SafetyResult result = md::validateSafetyAnnotations(screen, "goldens.medui");
+
+                      const cli::Diagnostic* reported = find(result, md::Code::SafetyCriticalWithoutRequirement);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(reported != nullptr, "MEDUI-E070 is reported");
+                      checks.expect(reported != nullptr && reported->message.find("takes no requirement") != std::string::npos,
+                                    "the diagnostic names the real problem rather than asking for a field Row cannot have");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register onlyAuthoredNodesArePinned{"A Row's synthetic background is not a golden of its own", "evidence-unit", [] {
+                                                          return speclab::Test("medui-goldens-synthetic-nodes")
+                                                              .Given("a Row with a background and one positioned child", [] {})
+                                                              .When("the golden set is derived", [] {})
+                                                              .Then("the child is pinned and the synthetic background is not",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+                                                                        const std::string  source = screenWith(
+                                                                            "    Row { id: topbar; height: 40px; background: Theme.Colors.Title;\n"
+                                                                             "        Label { id: title; width: 60px; height: 20px; position: 10px, 10px; "
+                                                                             "text: t(\"STR-TITLE\"); color: Theme.Colors.Title; }\n"
+                                                                             "    }\n");
+                                                                        const auto references = md::collectGoldens(layoutOf(source, 200, 100));
+
+                                                                        checks.expect(find(references, "topbar-background") == nullptr,
+                                                                                      "a synthetic node describes nothing an author wrote");
+                                                                        checks.expect(find(references, "title") != nullptr, "the positioned child is pinned");
+                                                                        checks.expect(references.size() == 1,
+                                                                                      std::format("exactly one entry, got {}", references.size()));
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register blankRequirementIsNotTraceable{
+    "An empty requirement is no requirement, through the full analyze then validate order",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-blank-requirement")
+            .Given("a @safety_critical Button whose requirement is the empty string", [] {})
+            .When("semantic analysis accepts it and the annotation rules run", [] {})
+            .Then("MEDUI-E070 rejects it anyway, because there is nothing to trace",
+                  [] {
+                      mdux::spec::Checks    checks;
+                      const md::ast::Screen screen = parseOrFail(screenWith("    @safety_critical(cv_check: [Bounds])\n"
+                                                                            "    Button { id: action; width: 100px; height: 40px; label: t(\"STR-ACTION\"); "
+                                                                            "color: Theme.Colors.PrimaryAction; source: \"ACTION\"; requirement: \"\"; }\n"));
+
+                      // The gap this covers is that `requirement:` is a String field and the
+                      // semantic domain accepts every quoted string, `""` included - so the
+                      // analyze step below really does pass, and the safety rule is the only thing
+                      // standing between an empty requirement and a golden.
+                      const std::array<std::string_view, 1> themeTokens{"Theme.Colors.PrimaryAction"};
+                      mdux::text::TextPackage               package;
+                      package.header.id   = "goldens-en-US";
+                      package.atlasId     = "goldens-atlas";
+                      package.locale      = "en-US";
+                      package.sidecarPath = "runs.bin";
+                      package.runs.push_back(mdux::text::TextRun{.id = "STR-ACTION", .byteOffset = 0, .byteLength = 0, .sha256 = {}});
+                      const std::array textPackages{package};
+
+                      const md::SemanticResult semantic = md::analyze(screen,
+                                                                      "goldens.medui",
+                                                                      md::SemanticInputs{.themeTokens = themeTokens, .textPackages = textPackages});
+                      checks.expect(semantic.ok(),
+                                    std::format("semantic analysis accepts the empty requirement, got {} diagnostics", semantic.diagnostics.size()));
+
+                      const md::SafetyResult safety   = md::validateSafetyAnnotations(screen, "goldens.medui");
+                      const cli::Diagnostic* reported = find(safety, md::Code::SafetyCriticalWithoutRequirement);
+                      checks.expect(!safety.ok(), "the safety rule rejects it");
+                      checks.expect(reported != nullptr && reported->message.find("empty") != std::string::npos,
+                                    "the diagnostic says the requirement is empty rather than absent");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register colorHashNeedsATintToCompare{
+    "ColorHash is refused where no single declared tint exists",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-colorhash-needs-a-tint")
+            .Given("an annotated StatusIndicator whose colors: is a list, and a Clock with no colour", [] {})
+            .When("each annotation is validated", [] {})
+            .Then("MEDUI-E071 refuses the check rather than pinning one with nothing to compare against",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const md::ast::Screen indicator = parseOrFail(
+                          screenWith("    @safety_critical(cv_check: [Bounds, ColorHash])\n"
+                                     "    StatusIndicator { id: state; width: 120px; height: 40px; requirement: \"REQ-1\"; "
+                                     "source: \"STATE\"; states: [t(\"STR-OK\"), t(\"STR-ALARM\")]; "
+                                     "colors: [Theme.Colors.Title, Theme.Colors.ScoreDigits]; }\n"));
+                      const md::SafetyResult indicatorResult = md::validateSafetyAnnotations(indicator, "goldens.medui");
+                      const cli::Diagnostic* refused         = find(indicatorResult, md::Code::UnknownCvCheck);
+                      checks.expect(!indicatorResult.ok(), "a per-state tint is not one a golden can pin");
+                      checks.expect(refused != nullptr && refused->message.find("ColorHash") != std::string::npos, "the diagnostic names the check it refuses");
+
+                      const md::ast::Screen clock = parseOrFail(screenWith("    @safety_critical(cv_check: [ColorHash])\n"
+                                                                           "    Clock { id: now; width: 100px; height: 40px; format: HH_MM; }\n"));
+                      checks.expect(find(md::validateSafetyAnnotations(clock, "goldens.medui"), md::Code::UnknownCvCheck) != nullptr,
+                                    "a component with no colour field cannot be tint-checked either");
+
+                      // The control: a single declared token is exactly what ColorHash needs, and
+                      // the accepted fixture leans on that for both `action` and `score`.
+                      const md::ast::Screen  button       = parseOrFail(annotatedButton("@safety_critical(cv_check: [ColorHash])"));
+                      const md::SafetyResult buttonResult = md::validateSafetyAnnotations(button, "goldens.medui");
+                      checks.expect(buttonResult.ok(), std::format("one declared tint is enough, got {} diagnostics", buttonResult.diagnostics.size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register safetyCriticalNeedsARequirement{
+    "A @safety_critical node with no requirement is MEDUI-E070, reported at the annotation",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-missing-requirement")
+            .Given("the rejected-safety-without-requirement fixture", [] {})
+            .When("the annotation rules are validated", [] {})
+            .Then("MEDUI-E070 names the component and points at the '@'",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const md::ast::Screen  screen = parseOrFail(fixture("rejected-safety-without-requirement.medui"));
+                      const md::SafetyResult result = md::validateSafetyAnnotations(screen, "rejected-safety-without-requirement.medui");
+
+                      const cli::Diagnostic* reported = find(result, md::Code::SafetyCriticalWithoutRequirement);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(reported != nullptr, "MEDUI-E070 is reported");
+                      if (reported != nullptr) {
+                          checks.expect(reported->line == 11 && reported->column == 5,
+                                        std::format("the diagnostic points at the annotation, got {}:{}", reported->line, reported->column));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register acceptedFixturePassesValidation{
+    "Every annotation in the accepted fixture satisfies the rules",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-accepted-validates")
+            .Given("the accepted-goldens fixture", [] {})
+            .When("the annotation rules are validated", [] {})
+            .Then("nothing is reported, so the golden scenarios measure a legal screen",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const md::ast::Screen  screen = parseOrFail(fixture("accepted-goldens.medui"));
+                      const md::SafetyResult result = md::validateSafetyAnnotations(screen, "accepted-goldens.medui");
+                      checks.expect(result.ok(), std::format("the fixture validates, got {} diagnostics", result.diagnostics.size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unknownCvCheckIsRejected{
+    "A cv_check outside the closed set is MEDUI-E071, and a malformed one is MEDUI-E033",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-unknown-cv-check")
+            .Given("cv_check: [Bounds, Wobble] and cv_check: [\"Bounds\"]", [] {})
+            .When("each is validated", [] {})
+            .Then("the unknown name and the wrong value form are reported separately",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const md::ast::Screen  unknown       = parseOrFail(annotatedButton("@safety_critical(cv_check: [Bounds, Wobble])"));
+                      const md::SafetyResult unknownResult = md::validateSafetyAnnotations(unknown, "goldens.medui");
+                      const cli::Diagnostic* reported      = find(unknownResult, md::Code::UnknownCvCheck);
+                      checks.expect(reported != nullptr, "MEDUI-E071 is reported");
+                      checks.expect(reported != nullptr && reported->message.find("Wobble") != std::string::npos,
+                                    "the diagnostic names the check that does not exist");
+
+                      const md::ast::Screen  malformed       = parseOrFail(annotatedButton("@safety_critical(cv_check: [\"Bounds\"])"));
+                      const md::SafetyResult malformedResult = md::validateSafetyAnnotations(malformed, "goldens.medui");
+                      checks.expect(find(malformedResult, md::Code::FieldValueKind) != nullptr, "a quoted check is the wrong value form, not an unknown name");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register collectionAssumesValidation{
+    "Deriving goldens from an unvalidated screen throws rather than emitting one nobody can verify",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-goldens-gate-throws")
+            .Given("a screen whose cv_check names a verification this compiler does not emit", [] {})
+            .When("the golden set is derived without validating first", [] {})
+            .Then("it is std::logic_error, not a golden with a check the verifier cannot run",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const md::LayoutResult resolved = layoutOf(annotatedButton("@safety_critical(cv_check: [Wobble])"), 200, 100);
+
+                      bool threw = false;
+                      try {
+                          [[maybe_unused]] const auto ignored = md::collectGoldens(resolved);
+                      } catch (const std::logic_error&) {
+                          threw = true;
+                      }
+                      checks.expect(threw, "the validation gate is assumed, and its absence is a programming error");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/GoldenTests.cpp
+++ b/tests/medui/GoldenTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for golden references on safety-critical nodes (issue #196).
  * @file GoldenTests.cpp
+ * @brief BDD scenarios for golden references on safety-critical nodes (issue #196).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/LayoutTests.cpp
+++ b/tests/medui/LayoutTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for bounded integer `.medui` layout (issue #194).
  * @file LayoutTests.cpp
+ * @brief BDD scenarios for bounded integer `.medui` layout (issue #194).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/LayoutTests.cpp
+++ b/tests/medui/LayoutTests.cpp
@@ -1,0 +1,426 @@
+/**
+ * @brief BDD scenarios for bounded integer `.medui` layout (issue #194).
+ * @file LayoutTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.parser;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+static_assert(std::integral<decltype(md::LayoutRect::x)>);
+static_assert(std::integral<decltype(md::LayoutRect::y)>);
+static_assert(std::integral<decltype(md::LayoutRect::width)>);
+static_assert(std::integral<decltype(md::LayoutRect::height)>);
+
+/// Reads one real authoring fixture from the repository corpus.
+[[nodiscard]] std::string fixture(std::string_view name) {
+    const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+    std::ifstream               in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened at {}", name, path.generic_string()),
+                                              std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+/// Parses and resolves a test source against explicit build dimensions.
+[[nodiscard]] md::LayoutResult layout(std::string_view source, std::int64_t width, std::int64_t height) {
+    md::ParseResult parsed = md::parse(source, "layout.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("layout test source did not parse", std::source_location::current());
+    }
+    return md::resolveLayout(*parsed.screen, "layout.medui", {.surfaceWidth = width, .surfaceHeight = height});
+}
+
+/// Finds one registered diagnostic in a layout result.
+[[nodiscard]] const cli::Diagnostic* find(const md::LayoutResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    });
+    return found == result.diagnostics.end() ? nullptr : &*found;
+}
+
+/// Wraps component text in a minimal 100x100 Vertical screen by default.
+[[nodiscard]] std::string sourceWithBody(std::string_view body, std::int64_t width = 100, std::int64_t height = 100) {
+    return std::format("Screen Test {{\n"
+                       "    layout: Vertical {{ spacing: 0px; padding: 0px; }}\n"
+                       "    surface: {}px, {}px;\n"
+                       "{}"
+                       "}}\n",
+                       width,
+                       height,
+                       body);
+}
+
+}  // namespace
+
+const mdux::spec::Register handDerivedRectangles{
+    "Vertical and Row layout resolves to hand-derived absolute rectangles",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-hand-derived")
+            .Given("a 1280x720 screen with padding, spacing, fixed sizes and Fill", [] {})
+            .When("the single-level Row and vertical flow are resolved", [] {})
+            .Then("the Row is flat and every integer rectangle matches the derivation",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const md::LayoutResult result = layout(fixture("accepted-layout.medui"), 1280, 720);
+                      checks.expect(result.ok(), "layout succeeds");
+
+                      const std::vector<std::pair<std::string_view, md::LayoutRect>> expected{
+                          {"topbar-background",   {16, 16, 1248, 48}},
+                          {            "title",    {16, 16, 340, 48}},
+                          {            "clock",   {372, 16, 676, 48}},
+                          {           "status",  {1064, 16, 200, 48}},
+                          {            "score",  {16, 72, 1248, 120}},
+                          {         "viewport", {16, 200, 1248, 504}},
+                      };
+                      checks.expect(result.nodes.size() == expected.size(), std::format("six flat entries, got {}", result.nodes.size()));
+                      for (std::size_t index = 0; index < std::min(result.nodes.size(), expected.size()); ++index) {
+                          checks.expect(result.nodes[index].id == expected[index].first, std::format("entry {} id is {}", index, expected[index].first));
+                          checks.expect(result.nodes[index].bounds == expected[index].second,
+                                        std::format("{} has its hand-derived rectangle", expected[index].first));
+                          checks.expect(result.nodes[index].component != "Row", std::format("{} is not a Row container", expected[index].first));
+                      }
+                      if (!result.nodes.empty()) {
+                          checks.expect(result.nodes.front().component == "Panel" && result.nodes.front().synthetic,
+                                        "the Row background becomes a synthetic Panel underlay");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register positionedNodesLeaveFlow{"An explicitly positioned node does not advance the flow cursor", "evidence-unit", [] {
+                                                        return speclab::Test("medui-layout-positioned-out-of-flow")
+                                                            .Given("one positioned node followed by one ordinary flow node", [] {})
+                                                            .When("the vertical layout is resolved", [] {})
+                                                            .Then("the flow node still begins at the padded origin",
+                                                                  [] {
+                                                                      mdux::spec::Checks checks;
+                                                                      const std::string  source = sourceWithBody(
+                                                                          "    Label { id: pinned; width: 20px; height: 20px; position: 80px, 80px; "
+                                                                           "text: t(\"STR-PINNED\"); color: Theme.Colors.Title; }\n"
+                                                                           "    Label { id: flow; width: Fill; height: 20px; text: t(\"STR-FLOW\"); "
+                                                                           "color: Theme.Colors.Title; }\n");
+                                                                      const md::LayoutResult result = layout(source, 100, 100);
+                                                                      checks.expect(result.ok(), "layout succeeds");
+                                                                      checks.expect(result.nodes.size() == 2, "both leaves are emitted");
+                                                                      if (result.nodes.size() == 2) {
+                                                                          checks.expect(result.nodes[0].bounds == md::LayoutRect{80, 80, 20, 20},
+                                                                                        "the positioned rectangle is absolute");
+                                                                          checks.expect(result.nodes[1].bounds == md::LayoutRect{0, 0, 100, 20},
+                                                                                        "the flow cursor was not advanced by the positioned node");
+                                                                      }
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register positionedNodeMustFitSurface{"A positioned node must remain inside the content box", "evidence-unit", [] {
+                                                            return speclab::Test("medui-layout-positioned-surface-containment")
+                                                                .Given("a 20px node at 81px,80px on a 100px square surface", [] {})
+                                                                .When("the positioned rectangle is checked", [] {})
+                                                                .Then("MEDUI-E052 is fail-closed with no resolved nodes",
+                                                                      [] {
+                                                                          mdux::spec::Checks checks;
+                                                                          const std::string  source = sourceWithBody(
+                                                                              "    Label { id: outside; width: 20px; height: 20px; "
+                                                                               "position: 81px, 80px; text: t(\"STR-OUTSIDE\"); "
+                                                                               "color: Theme.Colors.Title; }\n");
+                                                                          const md::LayoutResult result = layout(source, 100, 100);
+                                                                          checks.expect(find(result, md::Code::SurfaceExceeded) != nullptr,
+                                                                                        "MEDUI-E052 is reported");
+                                                                          checks.expect(!result.ok() && result.nodes.empty(),
+                                                                                        "the rejected screen exposes no partial layout");
+                                                                          checks.raise();
+                                                                      })
+                                                                .Execute();
+                                                        }};
+
+const mdux::spec::Register positionedNodeMustHaveArea{"A positioned node cannot have a zero fixed dimension", "evidence-unit", [] {
+                                                          return speclab::Test("medui-layout-positioned-positive-size")
+                                                              .Given("a positioned node with width 0px", [] {})
+                                                              .When("dimension preflight runs", [] {})
+                                                              .Then("MEDUI-E051 rejects the degenerate rectangle",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+                                                                        const std::string  source = sourceWithBody(
+                                                                            "    Label { id: ghost; width: 0px; height: 20px; "
+                                                                             "position: 10px, 10px; text: t(\"STR-GHOST\"); "
+                                                                             "color: Theme.Colors.Title; }\n");
+                                                                        const md::LayoutResult result = layout(source, 100, 100);
+                                                                        checks.expect(find(result, md::Code::LayoutOverflow) != nullptr,
+                                                                                      "MEDUI-E051 is reported");
+                                                                        checks.expect(!result.ok() && result.nodes.empty(),
+                                                                                      "no zero-area rectangle is emitted");
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register rowPositionsAreSurfaceAbsolute{"A positioned Row child uses absolute surface coordinates", "evidence-unit", [] {
+                                                              return speclab::Test("medui-layout-row-position-absolute")
+                                                                  .Given("padding and a preceding flow item place a Row at y=35", [] {})
+                                                                  .When("a Row child is positioned at the Row's absolute origin", [] {})
+                                                                  .Then(
+                                                                      "the authored 10,35 coordinates are preserved",
+                                                                      [] {
+                                                                          mdux::spec::Checks     checks;
+                                                                          const std::string      source = "Screen Test {\n"
+                                                                                                          "    layout: Vertical { spacing: 5px; padding: 10px; }\n"
+                                                                                                          "    surface: 100px, 100px;\n"
+                                                                                                          "    Label { id: before; width: Fill; height: 20px; "
+                                                                                                          "text: t(\"STR-BEFORE\"); color: Theme.Colors.Title; }\n"
+                                                                                                          "    Row { id: row; height: 20px; Label { id: pinned; "
+                                                                                                          "width: 20px; height: 20px; position: 10px, 35px; "
+                                                                                                          "text: t(\"STR-PINNED\"); color: Theme.Colors.Title; } }\n"
+                                                                                                          "}\n";
+                                                                          const md::LayoutResult result = layout(source, 100, 100);
+                                                                          checks.expect(result.ok(), "the absolute Row position is contained");
+                                                                          checks.expect(result.nodes.size() == 2, "the Row itself is flattened away");
+                                                                          if (result.nodes.size() == 2) {
+                                                                              checks.expect(result.nodes[1].bounds == md::LayoutRect{10, 35, 20, 20},
+                                                                                            "the Row child keeps absolute surface coordinates");
+                                                                          }
+                                                                          checks.raise();
+                                                                      })
+                                                                  .Execute();
+                                                          }};
+
+const mdux::spec::Register paddingMustLeaveContent{"Padding exactly half the surface is rejected", "evidence-unit", [] {
+                                                       return speclab::Test("medui-layout-padding-content-box")
+                                                           .Given("an empty 100px square screen with padding 50px", [] {})
+                                                           .When("the padded content box is validated", [] {})
+                                                           .Then("MEDUI-E052 reports the zero-sized box at the layout",
+                                                                 [] {
+                                                                     mdux::spec::Checks     checks;
+                                                                     const std::string      source = "Screen Test {\n"
+                                                                                                     "    layout: Vertical { spacing: 0px; padding: 50px; }\n"
+                                                                                                     "    surface: 100px, 100px;\n"
+                                                                                                     "}\n";
+                                                                     const md::LayoutResult result = layout(source, 100, 100);
+                                                                     checks.expect(find(result, md::Code::SurfaceExceeded) != nullptr,
+                                                                                   "MEDUI-E052 is reported");
+                                                                     checks.expect(!result.ok() && result.nodes.empty(),
+                                                                                   "a zero-sized content box is not accepted");
+                                                                     checks.raise();
+                                                                 })
+                                                           .Execute();
+                                                   }};
+
+const mdux::spec::Register surfacePinMustMatchBuild{"An authored surface pin must match the build surface", "evidence-unit", [] {
+                                                        return speclab::Test("medui-layout-surface-pin")
+                                                            .Given("a source declaring 100x100 and a build selecting 101x100", [] {})
+                                                            .When("surface validation runs", [] {})
+                                                            .Then("MEDUI-E052 rejects the mismatch",
+                                                                  [] {
+                                                                      mdux::spec::Checks     checks;
+                                                                      const std::string      source = sourceWithBody("");
+                                                                      const md::LayoutResult result = layout(source, 101, 100);
+                                                                      checks.expect(find(result, md::Code::SurfaceExceeded) != nullptr,
+                                                                                    "MEDUI-E052 is reported");
+                                                                      checks.expect(!result.ok() && result.nodes.empty(),
+                                                                                    "the mismatched build cannot consume a layout");
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register fillSharesMatchReference{
+    "Fill uses equal integer shares like the reference implementation",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-fill-equal-shares")
+            .Given("two Fill children sharing a 101px Row", [] {})
+            .When("the indivisible remainder is resolved", [] {})
+            .Then("both receive 50px and the final pixel remains unused",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const std::string      source = sourceWithBody("    Row { id: row; height: 20px; "
+                                                                     "Label { id: first; width: Fill; height: 20px; "
+                                                                     "text: t(\"STR-FIRST\"); color: Theme.Colors.Title; } "
+                                                                     "Label { id: second; width: Fill; height: 20px; "
+                                                                     "text: t(\"STR-SECOND\"); color: Theme.Colors.Title; } }\n",
+                                                                101,
+                                                                100);
+                      const md::LayoutResult result = layout(source, 101, 100);
+                      checks.expect(result.ok() && result.nodes.size() == 2, "the Row resolves to two leaves");
+                      if (result.nodes.size() == 2) {
+                          checks.expect(result.nodes[0].bounds == md::LayoutRect{0, 0, 50, 20}, "the first Fill receives the equal integer share");
+                          checks.expect(result.nodes[1].bounds == md::LayoutRect{50, 0, 50, 20}, "the second Fill receives the same share");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register positionedFillIsRejected{"A positioned component cannot use Fill", "evidence-unit", [] {
+                                                        return speclab::Test("medui-layout-positioned-fill")
+                                                            .Given("a component whose exact position contradicts a Fill width", [] {})
+                                                            .When("layout preflight runs", [] {})
+                                                            .Then("MEDUI-E051 points at position rather than inventing a rectangle",
+                                                                  [] {
+                                                                      mdux::spec::Checks     checks;
+                                                                      const std::string      source     = sourceWithBody("    Label {\n"
+                                                                                                                         "        id: title;\n"
+                                                                                                                         "        width: Fill;\n"
+                                                                                                                         "        height: 20px;\n"
+                                                                                                                         "        position: 0px, 0px;\n"
+                                                                                                                         "        text: t(\"STR-TITLE\");\n"
+                                                                                                                         "        color: Theme.Colors.Title;\n"
+                                                                                                                         "    }\n");
+                                                                      const md::LayoutResult result     = layout(source, 100, 100);
+                                                                      const cli::Diagnostic* diagnostic = find(result, md::Code::LayoutOverflow);
+                                                                      checks.expect(!result.ok() && result.nodes.empty(), "no partial rectangle is returned");
+                                                                      checks.expect(diagnostic != nullptr, "MEDUI-E051 is reported");
+                                                                      if (diagnostic != nullptr) {
+                                                                          checks.expect(
+                                                                              diagnostic->line == 8 && diagnostic->column == 9,
+                                                                              std::format("position is 8:9, got {}:{}", diagnostic->line, diagnostic->column));
+                                                                      }
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register wideRowChildIsRejected{"A Row child wider than its parent is rejected rather than clamped", "evidence-unit", [] {
+                                                      return speclab::Test("medui-layout-wide-row-child")
+                                                          .Given("a 101px child in a 100px Row", [] {})
+                                                          .When("the Row axis is resolved", [] {})
+                                                          .Then("MEDUI-E051 is emitted and no rectangle is clamped",
+                                                                [] {
+                                                                    mdux::spec::Checks checks;
+                                                                    const std::string  source = sourceWithBody(
+                                                                        "    Row { id: row; height: 20px; background: Theme.Colors.TopbarBackground; "
+                                                                         "Label { id: title; width: 101px; "
+                                                                         "height: 20px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; } }\n");
+                                                                    const md::LayoutResult result = layout(source, 100, 100);
+                                                                    checks.expect(find(result, md::Code::LayoutOverflow) != nullptr, "MEDUI-E051 is reported");
+                                                                    checks.expect(result.nodes.empty(),
+                                                                                  "the failed Row returns neither its Panel nor a child rectangle");
+                                                                    checks.raise();
+                                                                })
+                                                          .Execute();
+                                                  }};
+
+const mdux::spec::Register fillWithoutRoomIsRejected{"Fill with no remaining pixels is rejected rather than resolved to zero", "evidence-unit", [] {
+                                                         return speclab::Test("medui-layout-fill-no-room")
+                                                             .Given("a fixed-height item consuming the entire surface before a Fill item", [] {})
+                                                             .When("the vertical axis is resolved", [] {})
+                                                             .Then("MEDUI-E051 is emitted before any partial layout",
+                                                                   [] {
+                                                                       mdux::spec::Checks checks;
+                                                                       const std::string  source = sourceWithBody(
+                                                                           "    Label { id: fixed; width: Fill; height: 100px; text: t(\"STR-FIXED\"); "
+                                                                            "color: Theme.Colors.Title; }\n"
+                                                                            "    Label { id: fill; width: Fill; height: Fill; text: t(\"STR-FILL\"); "
+                                                                            "color: Theme.Colors.Title; }\n");
+                                                                       const md::LayoutResult result = layout(source, 100, 100);
+                                                                       checks.expect(find(result, md::Code::LayoutOverflow) != nullptr,
+                                                                                     "MEDUI-E051 is reported");
+                                                                       checks.expect(result.nodes.empty(), "the failed axis produces no partial layout");
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};
+
+const mdux::spec::Register positionedOverlapIsRejected{
+    "An authored Panel name cannot bypass positioned overlap checks",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-positioned-overlap")
+            .Given("a directly-built AST naming an overlapping positioned leaf Panel", [] {})
+            .When("the flat layout is checked", [] {})
+            .Then("MEDUI-E051 rejects the overlap",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string  source = sourceWithBody("    Label { id: flow; width: Fill; height: 30px; text: t(\"STR-FLOW\"); "
+                                                                 "color: Theme.Colors.Title; }\n"
+                                                                 "    Label { id: pinned; width: 20px; height: 20px; position: 10px, 10px; "
+                                                                 "text: t(\"STR-PINNED\"); color: Theme.Colors.Title; }\n");
+                      md::ParseResult    parsed = md::parse(source, "layout.medui");
+                      if (!parsed.screen || parsed.screen->nodes.size() != 2) {
+                          checks.expect(false, "the overlap fixture parses to two nodes");
+                          checks.raise();
+                          return;
+                      }
+                      parsed.screen->nodes[1].component = "Panel";
+                      const md::LayoutResult result     = md::resolveLayout(*parsed.screen, "layout.medui", {.surfaceWidth = 100, .surfaceHeight = 100});
+                      checks.expect(find(result, md::Code::LayoutOverflow) != nullptr, "MEDUI-E051 is reported");
+                      checks.expect(!result.ok(), "overlap is not accepted as a compiled layout");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register syntheticIdsAreRechecked{
+    "Synthetic Row background IDs participate in uniqueness",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-synthetic-id-uniqueness")
+            .Given("an authored id colliding with <row-id>-background", [] {})
+            .When("the Row background Panel is synthesized", [] {})
+            .Then("MEDUI-E014 rejects the duplicate resolved id",
+                  [] {
+                      mdux::spec::Checks     checks;
+                      const std::string      source     = sourceWithBody("    Row { id: topbar; height: 20px; background: Theme.Colors.TopbarBackground; "
+                                                                         "Label { id: title; width: Fill; height: 20px; text: t(\"STR-TITLE\"); "
+                                                                         "color: Theme.Colors.Title; } }\n"
+                                                                         "    Label { id: topbar-background; width: Fill; height: 20px; "
+                                                                         "text: t(\"STR-OTHER\"); color: Theme.Colors.Title; }\n");
+                      const md::LayoutResult result     = layout(source, 100, 100);
+                      const cli::Diagnostic* diagnostic = find(result, md::Code::DuplicateNodeId);
+                      checks.expect(diagnostic != nullptr, "MEDUI-E014 is reported after synthesis");
+                      if (diagnostic != nullptr) {
+                          checks.expect(diagnostic->line == 5 && diagnostic->column == 13,
+                                        std::format("the authored colliding id is 5:13, got {}:{}", diagnostic->line, diagnostic->column));
+                      }
+                      checks.expect(!result.ok(), "the colliding flat node set is rejected");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register nestedRowInvariantIsChecked{
+    "The solver checks the parser's single-Row-level invariant",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-layout-nested-row-invariant")
+            .Given("a directly-mutated AST that bypasses the nested Row parser rejection", [] {})
+            .When("the layout boundary receives it", [] {})
+            .Then("it fails loudly in every build configuration",
+                  [] {
+                      mdux::spec::Checks checks;
+                      md::ParseResult    parsed = md::parse(fixture("accepted-layout.medui"), "accepted-layout.medui");
+                      bool               threw  = false;
+                      if (parsed.screen && !parsed.screen->nodes.empty() && !parsed.screen->nodes.front().children.empty()) {
+                          parsed.screen->nodes.front().children.front().component = "Row";
+                          try {
+                              static_cast<void>(md::resolveLayout(*parsed.screen, "accepted-layout.medui", {.surfaceWidth = 1280, .surfaceHeight = 720}));
+                          } catch (const std::logic_error&) {
+                              threw = true;
+                          }
+                      }
+                      checks.expect(threw, "a nested Row cannot silently reach the flattening pass");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/MeduiSpecMain.cpp
+++ b/tests/medui/MeduiSpecMain.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file MeduiSpecMain.cpp
+ * @brief Entry point for the governed `mdux.medui` SpecLab BDD executable.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Deliberately a separate binary from `medui_tools_spec`, which links the host-tools compiler.
+ * This one links MduX::Core only, so it is standing evidence that the compiled-screen schema - the
+ * one type a device holds - reaches nothing but `std`. A scenario here that needed the parser or
+ * the layout solver would mean the boundary had moved.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX MedUI Schema Spec");
+}

--- a/tests/medui/MeduiToolsSpecMain.cpp
+++ b/tests/medui/MeduiToolsSpecMain.cpp
@@ -1,0 +1,23 @@
+/**
+ * @file MeduiToolsSpecMain.cpp
+ * @brief Entry point for the .medui compiler host-tools SpecLab executable (issue #191).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Links MduX::MeduiLib, the host-tools-zone target. Separate from any governed medui suite for the
+ * reason text_tools_spec is separate from text_spec: keeping the two apart is what preserves the
+ * governed suite's standing evidence that it reaches nothing but std. There is no governed medui
+ * module yet - mdux.medui.schema is #197 and the runtime #199 - so today this suite is the only
+ * one, and it is named for the zone it links so that the split is already in place when the other
+ * arrives.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX MedUI Tools Spec");
+}

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -1,0 +1,478 @@
+/**
+ * @brief BDD scenarios for the compiled-screen document and its canonical JSON (issue #197).
+ * @file PackageTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine (canonical form, byte-identity)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Two properties carry most of these scenarios. The first is that the writer and the reader agree:
+ * they are separate code with a member name written on each side, so the round trip runs over a
+ * fixture carrying all eleven payloads and executes both directions rather than asserting one.
+ * The second is that the bytes are exactly determined - one scenario spells a whole small package
+ * out, because a byte-compared artifact's format is worth stating in a form a reviewer can read.
+ */
+
+import std;
+import speclab;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.package;
+import mdux.tools.medui.parser;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace ms  = mdux::medui;
+namespace cli = mdux::tools::cli;
+
+/// The budget every scenario compiles with. Declared rather than computed, as `PackageInputs` says.
+constexpr mdux::draw::DrawBudget testBudget{.maxVertices = 4096, .maxIndices = 6144, .maxCommands = 256};
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+    std::ifstream               in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(std::format("fixture {} could not be opened at {}", name, path.generic_string()),
+                                              std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] md::LayoutResult layoutOf(std::string_view source, std::int64_t width, std::int64_t height) {
+    md::ParseResult parsed = md::parse(source, "package.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("package test source did not parse", std::source_location::current());
+    }
+    md::LayoutResult resolved = md::resolveLayout(*parsed.screen, "package.medui", {.surfaceWidth = width, .surfaceHeight = height});
+    if (!resolved.ok()) {
+        throw speclab::core::AssertionFailure(std::format("package test source did not resolve: {}", resolved.diagnostics.front().message),
+                                              std::source_location::current());
+    }
+    return resolved;
+}
+
+/// The screen carrying all eleven payloads, compiled.
+[[nodiscard]] md::ScreenDocument everyComponent() {
+    return md::buildPackage(layoutOf(fixture("accepted-every-component.medui"), 800, 700), {.id = "every-component", .budget = testBudget});
+}
+
+/// One Label on a small surface: the screen the byte-exact scenario spells out.
+[[nodiscard]] std::string tinyScreen() {
+    return "Screen Tiny {\n"
+           "    layout: Vertical { spacing: 0px; padding: 0px; }\n"
+           "    surface: 200px, 100px;\n"
+           "\n"
+           "    Label {\n"
+           "        id: title;\n"
+           "        width: 200px;\n"
+           "        height: 40px;\n"
+           "        text: t(\"STR-TITLE\");\n"
+           "        color: Theme.Colors.Title;\n"
+           "    }\n"
+           "}\n";
+}
+
+[[nodiscard]] md::ScreenDocument tinyDocument() {
+    return md::buildPackage(layoutOf(tinyScreen(), 200, 100), {.id = "tiny", .budget = testBudget});
+}
+
+[[nodiscard]] const ms::CompiledNode& node(const ms::ScreenPackage& package, std::string_view id) {
+    const ms::CompiledNode* found = package.find(id);
+    if (found == nullptr) {
+        throw speclab::core::AssertionFailure(std::format("the compiled screen has no node '{}'", id), std::source_location::current());
+    }
+    return *found;
+}
+
+/// Replaces the first occurrence of `what`, failing the scenario if the bytes do not contain it -
+/// an edit that silently did nothing would make a rejection scenario pass for the wrong reason.
+[[nodiscard]] std::string editing(std::string text, std::string_view what, std::string_view with) {
+    const std::size_t at = text.find(what);
+    if (at == std::string::npos) {
+        throw speclab::core::AssertionFailure(std::format("the package bytes do not contain '{}'", what), std::source_location::current());
+    }
+    return text.replace(at, what.size(), with);
+}
+
+[[nodiscard]] std::string firstCode(const md::PackageReadResult& result) {
+    return result.diagnostics.empty() ? std::string{"<none>"} : result.diagnostics.front().code;
+}
+
+}  // namespace
+
+const mdux::spec::Register everyComponentCompilesToItsOwnPayload{
+    "Every component in the dictionary compiles to its own typed payload",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-payloads")
+            .Given("a screen carrying all ten authored components and a Row with a background", [] {})
+            .When("it is compiled to a screen package", [] {})
+            .Then("eleven nodes appear, each naming the component it came from",
+                  [] {
+                      mdux::spec::Checks       checks;
+                      const md::ScreenDocument document = everyComponent();
+                      const ms::ScreenPackage  package  = document.package();
+
+                      const std::vector<std::pair<std::string_view, std::string_view>> expected{
+                          {"topbar-background",           "Panel"},
+                          {            "title",           "Label"},
+                          {       "wall-clock",           "Clock"},
+                          {             "logo",           "Image"},
+                          {        "endoscope",  "VulkanViewport"},
+                          {              "ecg",     "SignalTrace"},
+                          {           "freeze",          "Button"},
+                          {             "halt",  "CriticalButton"},
+                          {   "sedation-index",  "NumericDisplay"},
+                          {            "state", "StatusIndicator"},
+                          {       "patient-id",       "TextInput"}
+                      };
+
+                      checks.expect(package.nodes.size() == expected.size(), std::format("eleven compiled nodes, got {}", package.nodes.size()));
+                      for (const auto& [id, kind] : expected) {
+                          const ms::CompiledNode* compiled = package.find(id);
+                          if (compiled == nullptr) {
+                              checks.expect(false, std::format("node '{}' is compiled", id));
+                              continue;
+                          }
+                          checks.expect(ms::kindName(*compiled) == kind, std::format("node '{}' is a {}, got '{}'", id, kind, ms::kindName(*compiled)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register fieldsReachTheirOwnSpecMembers{
+    "A component's fields reach the spec members the dictionary maps them to",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-spec-members")
+            .Given("components whose fields share spellings across different meanings", [] {})
+            .When("the screen is compiled", [] {})
+            .Then("each field lands on its own component's member, and a synthetic Panel carries the Row's background",
+                  [] {
+                      mdux::spec::Checks       checks;
+                      const md::ScreenDocument document = everyComponent();
+                      const ms::ScreenPackage  package  = document.package();
+
+                      // `text` on a Label and `label` on a Button are both a text key; `source` is a
+                      // data stream on one component and an image package on another. That mapping
+                      // is what a table keyed by field name could not express.
+                      if (const auto* label = std::get_if<ms::LabelSpec>(&node(package, "title").payload)) {
+                          checks.expect(label->textKey == "STR-TITLE", std::format("the Label's text key, got '{}'", label->textKey));
+                      } else {
+                          checks.expect(false, "the title node holds a Label spec");
+                      }
+                      if (const auto* button = std::get_if<ms::ButtonSpec>(&node(package, "freeze").payload)) {
+                          checks.expect(button->labelKey == "STR-FREEZE", std::format("the Button's label key, got '{}'", button->labelKey));
+                          checks.expect(button->source == "FREEZE", std::format("the Button's data source, got '{}'", button->source));
+                          checks.expect(button->requirement == "REQ-EC-001", "the Button's optional requirement is carried");
+                      } else {
+                          checks.expect(false, "the freeze node holds a Button spec");
+                      }
+                      if (const auto* image = std::get_if<ms::ImageSpec>(&node(package, "logo").payload)) {
+                          checks.expect(image->source == "IMG-LOGO", std::format("the Image's package id, got '{}'", image->source));
+                      } else {
+                          checks.expect(false, "the logo node holds an Image spec");
+                      }
+                      if (const auto* status = std::get_if<ms::StatusIndicatorSpec>(&node(package, "state").payload)) {
+                          checks.expect(status->stateKeys.size() == 2, std::format("two states, got {}", status->stateKeys.size()));
+                          checks.expect(status->colorTokens.size() == status->stateKeys.size(), "the per-state tints pair with the states");
+                      } else {
+                          checks.expect(false, "the state node holds a StatusIndicator spec");
+                      }
+                      if (const auto* input = std::get_if<ms::TextInputSpec>(&node(package, "patient-id").payload)) {
+                          checks.expect(input->maxLength == 16, std::format("the TextInput's length bound, got {}", input->maxLength));
+                          checks.expect(input->charset == "Ascii", std::format("the TextInput's charset, got '{}'", input->charset));
+                      } else {
+                          checks.expect(false, "the patient-id node holds a TextInput spec");
+                      }
+                      // The one payload no author can write: the solver synthesises it for a Row
+                      // that declares a background, and it carries that background.
+                      if (const auto* panel = std::get_if<ms::PanelSpec>(&node(package, "topbar-background").payload)) {
+                          checks.expect(panel->colorToken == "Theme.Colors.TopbarBackground", std::format("the Row's background, got '{}'", panel->colorToken));
+                      } else {
+                          checks.expect(false, "the synthetic background holds a Panel spec");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register writingAndReadingAgree{
+    "Canonical JSON round-trips every payload without loss",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-round-trip")
+            .Given("a compiled screen carrying all eleven payloads", [] {})
+            .When("it is written as canonical JSON and read back", [] {})
+            .Then("the screen read back equals the screen written, node for node",
+                  [] {
+                      mdux::spec::Checks       checks;
+                      const md::ScreenDocument original = everyComponent();
+                      const std::string        written  = md::writePackage(original.package());
+
+                      const md::PackageReadResult reread = md::readPackage(written, "package.json");
+                      checks.expect(reread.ok(), std::format("the written bytes read back, first diagnostic '{}'", firstCode(reread)));
+                      if (!reread.ok()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      const ms::ScreenPackage before = original.package();
+                      const ms::ScreenPackage after  = reread.document.package();
+                      checks.expect(after.id == before.id, "the package id survives");
+                      checks.expect(after.surfaceWidth == before.surfaceWidth && after.surfaceHeight == before.surfaceHeight, "the surface survives");
+                      checks.expect(after.budget == before.budget, "the draw budget survives");
+                      checks.expect(after.nodes.size() == before.nodes.size(),
+                                    std::format("{} nodes survive, got {}", before.nodes.size(), after.nodes.size()));
+                      for (std::size_t index = 0; index < std::min(before.nodes.size(), after.nodes.size()); ++index) {
+                          checks.expect(after.nodes[index] == before.nodes[index], std::format("node '{}' survives unchanged", before.nodes[index].id));
+                      }
+                      // Writing what was read gives the same bytes: a round trip that lost a member
+                      // would still compare equal if the reader dropped it on both sides.
+                      checks.expect(md::writePackage(after) == written, "writing the screen read back reproduces the bytes");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theBytesAreExactlyDetermined{
+    "A small screen has exactly these bytes",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-canonical-bytes")
+            .Given("a screen with one Label", [] {})
+            .When("it is written as canonical JSON", [] {})
+            .Then("the bytes are sorted, two-space indented, integer-only, and end with a newline",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string  written = md::writePackage(tinyDocument().package());
+
+                      const std::string expected = R"({
+  "budget": {
+    "maxCommands": 256,
+    "maxIndices": 6144,
+    "maxVertices": 4096
+  },
+  "id": "tiny",
+  "kind": "screen",
+  "nodes": [
+    {
+      "bounds": {
+        "height": 40,
+        "width": 200,
+        "x": 0,
+        "y": 0
+      },
+      "id": "title",
+      "kind": "Label",
+      "spec": {
+        "colorToken": "Theme.Colors.Title",
+        "textKey": "STR-TITLE"
+      }
+    }
+  ],
+  "schemaVersion": 1,
+  "surfaceHeight": 100,
+  "surfaceWidth": 200
+}
+)";
+                      checks.expect(written == expected, std::format("the package bytes are exactly as documented, got:\n{}", written));
+                      // A screen package holds no float, so ADR-007's `{"bits": N}` encoding - the
+                      // one thing that makes a float portable - never appears in one.
+                      checks.expect(written.find("\"bits\"") == std::string::npos, "no floating-point value appears in a screen package");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anUndefinedMemberIsRefused{"A member the format does not define is refused rather than ignored", "evidence-unit", [] {
+                                                          return speclab::Test("medui-package-unknown-member")
+                                                              .Given("committed bytes carrying a member no reader knows", [] {})
+                                                              .When("they are read", [] {})
+                                                              .Then("the read fails, naming the member",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+                                                                        const std::string  written = md::writePackage(tinyDocument().package());
+
+                                                                        // A misspelling is the realistic case, and the dangerous one: silently
+                                                                        // ignoring `colourToken` would leave a reviewer believing a tint was pinned.
+                                                                        const std::string edited = editing(written, "\"colorToken\"", "\"colourToken\"");
+                                                                        const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                                                                        checks.expect(!result.ok(), "an undefined member is refused");
+                                                                        checks.expect(firstCode(result) == "SCP003",
+                                                                                      std::format("reported as SCP003, got '{}'", firstCode(result)));
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register anUnknownComponentIsRefused{"A node naming a component outside the dictionary is refused", "evidence-unit", [] {
+                                                           return speclab::Test("medui-package-unknown-kind")
+                                                               .Given("committed bytes naming a component that does not exist", [] {})
+                                                               .When("they are read", [] {})
+                                                               .Then("the read fails with the code for an unknown kind",
+                                                                     [] {
+                                                                         mdux::spec::Checks checks;
+                                                                         const std::string  edited = editing(md::writePackage(tinyDocument().package()),
+                                                                                                            "\"Label\"",
+                                                                                                            "\"Marquee\"");
+                                                                         const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                                                                         checks.expect(!result.ok(), "an unknown component is refused");
+                                                                         checks.expect(firstCode(result) == "SCP004",
+                                                                                       std::format("reported as SCP004, got '{}'", firstCode(result)));
+                                                                         checks.raise();
+                                                                     })
+                                                               .Execute();
+                                                       }};
+
+const mdux::spec::Register aScreenTheSchemaRefusesIsRefused{
+    "A hand-edited screen the schema refuses fails at the read, not at the device",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-schema-refusal")
+            .Given("committed bytes whose surface no longer contains their nodes", [] {})
+            .When("they are read", [] {})
+            .Then("the read fails with the schema's own verdict",
+                  [] {
+                      mdux::spec::Checks checks;
+                      // Shrinking the surface leaves the file canonical and the members known: only
+                      // `validate()` can catch it, which is why the reader runs the same one a
+                      // device would rather than repeating the rules itself.
+                      const std::string edited = editing(md::writePackage(tinyDocument().package()), "\"surfaceWidth\": 200", "\"surfaceWidth\": 100");
+                      const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                      checks.expect(!result.ok(), "a screen the schema refuses is refused here");
+                      checks.expect(firstCode(result) == "SCP005", std::format("reported as SCP005, got '{}'", firstCode(result)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register nonCanonicalBytesAreRefused{"Bytes that are not canonical JSON are refused", "evidence-unit", [] {
+                                                           return speclab::Test("medui-package-non-canonical")
+                                                               .Given("a package whose integer was rewritten as a decimal", [] {})
+                                                               .When("it is read", [] {})
+                                                               .Then("the read fails before any member is interpreted",
+                                                                     [] {
+                                                                         mdux::spec::Checks checks;
+                                                                         // The canonical reader rejects any fraction or exponent outright: a decimal in
+                                                                         // a generated file means it was hand-edited or written by another tool.
+                                                                         const std::string edited = editing(md::writePackage(tinyDocument().package()),
+                                                                                                            "\"height\": 40",
+                                                                                                            "\"height\": 40.0");
+                                                                         const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                                                                         checks.expect(!result.ok(), "non-canonical bytes are refused");
+                                                                         checks.expect(firstCode(result) == "SCP001",
+                                                                                       std::format("reported as SCP001, got '{}'", firstCode(result)));
+                                                                         checks.raise();
+                                                                     })
+                                                               .Execute();
+                                                       }};
+
+const mdux::spec::Register goldensAreWrittenAsTheirOwnSidecar{
+    "The golden references are written as a sidecar, empty array included",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-goldens-sidecar")
+            .Given("a screen that pins safety-critical nodes, and one that pins none", [] {})
+            .When("the sidecar is written for each", [] {})
+            .Then("one carries the agreed member names and the other is an empty array",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const std::string pinned = md::writeGoldens(md::collectGoldens(layoutOf(fixture("accepted-goldens.medui"), 400, 300)));
+                      for (const std::string_view member : {"\"bounds\"", "\"colorToken\"", "\"cvChecks\"", "\"nodeId\"", "\"textKey\""}) {
+                          checks.expect(pinned.find(member) != std::string::npos, std::format("the sidecar spells {}", member));
+                      }
+                      checks.expect(pinned.find("node_id") == std::string::npos, "no snake_case member survives ADR-011's amendment");
+
+                      // ADR-012 makes all three outputs unconditional: a baker that skipped this
+                      // file for a screen with nothing to pin would break the build rather than
+                      // mean "this screen pins nothing".
+                      const std::string none = md::writeGoldens({});
+                      checks.expect(none == "[]\n", std::format("a screen pinning nothing writes an empty array, got '{}'", none));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aBypassedGateIsARefusalNotADiagnostic{
+    "Compiling a screen that did not resolve is a bypassed gate, not a diagnostic",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-bypassed-gate")
+            .Given("a layout result carrying a diagnostic", [] {})
+            .When("it is handed to the package stage anyway", [] {})
+            .Then("the stage throws rather than compiling half a screen",
+                  [] {
+                      mdux::spec::Checks checks;
+                      md::LayoutResult   unresolved;
+                      cli::Diagnostic    overflow;
+                      overflow.file = "package.medui";
+                      overflow.code = "MEDUI-E051";
+                      unresolved.diagnostics.push_back(std::move(overflow));
+
+                      bool threw = false;
+                      try {
+                          const md::ScreenDocument document = md::buildPackage(unresolved, {.id = "tiny", .budget = testBudget});
+                          checks.expect(document.package().nodes.empty(), "unreachable: the stage compiled a screen that did not resolve");
+                      } catch (const std::logic_error&) {
+                          threw = true;
+                      }
+                      checks.expect(threw, "an unresolved layout is refused as a bypassed gate");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aMovedDocumentStillOwnsItsText{
+    "A moved document still owns every name its package views",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-survives-a-move")
+            .Given("a compiled screen whose names are short enough to live inside their strings", [] {})
+            .When("the document is move-constructed and then move-assigned", [] {})
+            .Then("every name reads back unchanged through the package",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The small-string optimisation is the whole hazard: a name short enough to
+                      // live inside its `std::string` moves with the object, so this asserts what
+                      // the deque is chosen for rather than leaving it as an argument in a comment.
+                      // `writePackage()` reads every name and every span, so comparing the bytes
+                      // before and after a move exercises all of them at once.
+                      const std::string before = md::writePackage(everyComponent().package());
+
+                      // Initialising from the helper's return value would elide the move entirely
+                      // and assert nothing, so the source is named first and moved from explicitly.
+                      md::ScreenDocument source = everyComponent();
+                      md::ScreenDocument moved{std::move(source)};
+                      md::ScreenDocument assigned;
+                      assigned = std::move(moved);  // the operation readPackage() performs
+
+                      const ms::ScreenPackage package = assigned.package();
+                      checks.expect(package.validate().has_value(), "the moved screen still satisfies its schema");
+                      checks.expect(md::writePackage(package) == before, "every name and span survives both moves unchanged");
+
+                      // A state key list is a span into storage the document owns separately from
+                      // its text, so it is worth naming rather than trusting the byte comparison.
+                      if (const auto* status = std::get_if<ms::StatusIndicatorSpec>(&node(package, "state").payload)) {
+                          checks.expect(status->stateKeys.size() == 2 && status->stateKeys.front() == "STR-OK",
+                                        "the per-state keys still read back after the move");
+                      } else {
+                          checks.expect(false, "the state node holds a StatusIndicator spec");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for the compiled-screen document and its canonical JSON (issue #197).
  * @file PackageTests.cpp
+ * @brief BDD scenarios for the compiled-screen document and its canonical JSON (issue #197).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine (canonical form, byte-identity)

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -233,19 +233,19 @@ const mdux::spec::Register valuesKeepTheirKinds{
 // ---------------------------------------------------------------------------
 
 const mdux::spec::Register nestedRowRejected{
-    "A Row inside a Row is MDX-E015, at the inner Row",
+    "A Row inside a Row is MEDUI-E015, at the inner Row",
     "evidence-unit",
     [] {
         return speclab::Test("medui-reject-nested-row")
             .Given("a screen with a nested Row", [] {})
             .When("it is parsed", [] {})
-            .Then("MDX-E015 names the inner Row's position", [] {
+            .Then("MEDUI-E015 names the inner Row's position", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse(fixture("rejected-nested-row.medui"),
                                                     "rejected-nested-row.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::NestedRow);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E015 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E015 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 6, std::format("at line 6, got {}", d->line));
                     checks.expect(d->column == 9, std::format("at column 9, got {}", d->column));
@@ -257,19 +257,19 @@ const mdux::spec::Register nestedRowRejected{
     }};
 
 const mdux::spec::Register forbiddenConstructRejected{
-    "A control-flow keyword is MDX-E016",
+    "A control-flow keyword is MEDUI-E016",
     "evidence-unit",
     [] {
         return speclab::Test("medui-reject-forbidden")
             .Given("a screen containing 'if'", [] {})
             .When("it is parsed", [] {})
-            .Then("MDX-E016 names it at its position", [] {
+            .Then("MEDUI-E016 names it at its position", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse(fixture("rejected-forbidden-construct.medui"),
                                                     "rejected-forbidden-construct.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::ForbiddenConstruct);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E016 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 3, std::format("at line 3, got {}", d->line));
                     checks.expect(d->column == 5, std::format("at column 5, got {}", d->column));
@@ -282,19 +282,19 @@ const mdux::spec::Register forbiddenConstructRejected{
     }};
 
 const mdux::spec::Register duplicateIdRejected{
-    "A repeated node id is MDX-E014, pointing at the second one",
+    "A repeated node id is MEDUI-E014, pointing at the second one",
     "evidence-unit",
     [] {
         return speclab::Test("medui-reject-duplicate-id")
             .Given("two nodes sharing an id", [] {})
             .When("the screen is parsed", [] {})
-            .Then("MDX-E014 names the second and cites the first", [] {
+            .Then("MEDUI-E014 names the second and cites the first", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse(fixture("rejected-duplicate-id.medui"),
                                                     "rejected-duplicate-id.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::DuplicateNodeId);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E014 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E014 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 8, std::format("at the second id, line 8, got {}",
                                                             d->line));
@@ -309,19 +309,19 @@ const mdux::spec::Register duplicateIdRejected{
     }};
 
 const mdux::spec::Register unknownUnitRejected{
-    "A length in a unit other than px is MDX-E010",
+    "A length in a unit other than px is MEDUI-E010",
     "evidence-unit",
     [] {
         return speclab::Test("medui-reject-bad-unit")
             .Given("a width written as 10rem", [] {})
             .When("the screen is parsed", [] {})
-            .Then("MDX-E010 says what units exist", [] {
+            .Then("MEDUI-E010 says what units exist", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse(fixture("rejected-bad-unit.medui"),
                                                     "rejected-bad-unit.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E010 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E010 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 5, std::format("at line 5, got {}", d->line));
                     checks.expect(d->column == 18, std::format("at column 18, got {}", d->column));
@@ -389,7 +389,7 @@ const mdux::spec::Register commentsAreSkipped{
     }};
 
 const mdux::spec::Register invalidUtf8Rejected{
-    "A source that is not valid UTF-8 is rejected whole, with MDX-E004",
+    "A source that is not valid UTF-8 is rejected whole, with MEDUI-E004",
     "evidence-unit",
     [] {
         // Whole rather than at the byte: past an invalid sequence there are no defined character
@@ -397,13 +397,13 @@ const mdux::spec::Register invalidUtf8Rejected{
         return speclab::Test("medui-lex-bad-utf8")
             .Given("a source containing a lone continuation byte", [] {})
             .When("it is lexed", [] {})
-            .Then("MDX-E004 is reported and no tokens are produced", [] {
+            .Then("MEDUI-E004 is reported and no tokens are produced", [] {
                 mdux::spec::Checks checks;
                 std::string source = "Screen A { }\n";
                 source += '\x80';
                 const md::LexResult r = md::lex(source, "bad.medui");
                 checks.expect(has(r.diagnostics, md::Code::SourceNotUtf8),
-                              std::format("MDX-E004 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E004 reported, got {}", codesOf(r.diagnostics)));
                 checks.expect(r.tokens.empty(), "no tokens, so no invented positions");
                 checks.raise();
             })
@@ -431,7 +431,7 @@ const mdux::spec::Register severalProblemsInOneRun{
                     "}\n",
                     "two.medui");
                 const auto count = std::ranges::count_if(
-                    r.diagnostics, [](const cli::Diagnostic& d) { return d.code == "MDX-E010"; });
+                    r.diagnostics, [](const cli::Diagnostic& d) { return d.code == "MEDUI-E010"; });
                 checks.expect(count >= 2,
                               std::format("at least two findings, got {}",
                                           codesOf(r.diagnostics)));
@@ -487,7 +487,7 @@ const mdux::spec::Register trailingContentRejected{
                 const md::ParseResult two = md::parse("Screen A { }\nScreen B { }\n", "t.medui");
                 const cli::Diagnostic* d2 = find(two.diagnostics, md::Code::UnexpectedToken);
                 checks.expect(d2 != nullptr,
-                              std::format("MDX-E010 for a second Screen, got {}",
+                              std::format("MEDUI-E010 for a second Screen, got {}",
                                           codesOf(two.diagnostics)));
                 if (d2 != nullptr) {
                     checks.expect(d2->line == 2 && d2->column == 1,
@@ -498,7 +498,7 @@ const mdux::spec::Register trailingContentRejected{
                 const md::ParseResult junk = md::parse("Screen A { } garbage\n", "t.medui");
                 const cli::Diagnostic* dj = find(junk.diagnostics, md::Code::UnexpectedToken);
                 checks.expect(dj != nullptr,
-                              std::format("MDX-E010 for trailing junk, got {}",
+                              std::format("MEDUI-E010 for trailing junk, got {}",
                                           codesOf(junk.diagnostics)));
                 if (dj != nullptr) {
                     checks.expect(dj->line == 1 && dj->column == 14,
@@ -511,12 +511,12 @@ const mdux::spec::Register trailingContentRejected{
     }};
 
 const mdux::spec::Register annotatedChildOutsideRowRejected{
-    "An annotated child is rejected outside a Row, and a Row inside one is still MDX-E015",
+    "An annotated child is rejected outside a Row, and a Row inside one is still MEDUI-E015",
     "evidence-unit",
     [] {
         // Reported independently by three reviewers on #209. The unannotated path enforced
         // "only a Row has children"; the annotated path did not, so `Card { @x Label { } }`
-        // was accepted - and `Card { @x Row { } }` put a Row at depth two with no MDX-E015,
+        // was accepted - and `Card { @x Row { } }` put a Row at depth two with no MEDUI-E015,
         // because the annotated path also passed insideRow = false.
         return speclab::Test("medui-reject-annotated-child")
             .Given("an annotated child under a non-Row parent", [] {})
@@ -527,7 +527,7 @@ const mdux::spec::Register annotatedChildOutsideRowRejected{
                     md::parse("Screen A {\n Card {\n  @x Label { }\n }\n}\n", "a.medui");
                 const cli::Diagnostic* dc = find(child.diagnostics, md::Code::UnexpectedToken);
                 checks.expect(dc != nullptr,
-                              std::format("MDX-E010 for an annotated child, got {}",
+                              std::format("MEDUI-E010 for an annotated child, got {}",
                                           codesOf(child.diagnostics)));
                 if (dc != nullptr) {
                     checks.expect(dc->line == 3 && dc->column == 3,
@@ -537,21 +537,21 @@ const mdux::spec::Register annotatedChildOutsideRowRejected{
                 }
 
                 // A Row under a non-Row is rejected as a child, *not* as a nested Row: the parent
-                // is a Card, so MDX-E015 would be the wrong code. The nested-Row rule is asserted
+                // is a Card, so MEDUI-E015 would be the wrong code. The nested-Row rule is asserted
                 // separately below, where the parent really is a Row.
                 const md::ParseResult row =
                     md::parse("Screen A {\n Card {\n  @x Row { }\n }\n}\n", "a.medui");
                 checks.expect(find(row.diagnostics, md::Code::UnexpectedToken) != nullptr,
-                              std::format("MDX-E010 for an annotated Row under a Card, got {}",
+                              std::format("MEDUI-E010 for an annotated Row under a Card, got {}",
                                           codesOf(row.diagnostics)));
 
                 // An *annotated* Row inside a Row is the case the gate previously let through
-                // with no diagnostic at all. It must be MDX-E015, exactly as the unannotated form.
+                // with no diagnostic at all. It must be MEDUI-E015, exactly as the unannotated form.
                 const md::ParseResult nested =
                     md::parse("Screen A {\n Row {\n  @x Row { }\n }\n}\n", "a.medui");
                 const cli::Diagnostic* dn = find(nested.diagnostics, md::Code::NestedRow);
                 checks.expect(dn != nullptr,
-                              std::format("MDX-E015 for an annotated nested Row, got {}",
+                              std::format("MEDUI-E015 for an annotated nested Row, got {}",
                                           codesOf(nested.diagnostics)));
                 if (dn != nullptr) {
                     checks.expect(dn->line == 3 && dn->column == 6,
@@ -571,7 +571,7 @@ const mdux::spec::Register annotatedChildOutsideRowRejected{
     }};
 
 const mdux::spec::Register forbiddenWordInLayoutRejected{
-    "A control-flow keyword as a layout kind is MDX-E016",
+    "A control-flow keyword as a layout kind is MEDUI-E016",
     "evidence-unit",
     [] {
         // "Wherever an identifier may appear" did not include the layout kind, so `layout: if { }`
@@ -579,12 +579,12 @@ const mdux::spec::Register forbiddenWordInLayoutRejected{
         return speclab::Test("medui-reject-forbidden-layout")
             .Given("layout: if { }", [] {})
             .When("it is parsed", [] {})
-            .Then("MDX-E016 is reported", [] {
+            .Then("MEDUI-E016 is reported", [] {
                 mdux::spec::Checks checks;
                 const md::ParseResult r = md::parse("Screen A {\n layout: if { }\n}\n", "l.medui");
                 const cli::Diagnostic* d = find(r.diagnostics, md::Code::ForbiddenConstruct);
                 checks.expect(d != nullptr,
-                              std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                              std::format("MEDUI-E016 reported, got {}", codesOf(r.diagnostics)));
                 if (d != nullptr) {
                     checks.expect(d->line == 2 && d->column == 10,
                                   std::format("at 2:10, the 'if', got {}:{}", d->line, d->column));
@@ -599,7 +599,7 @@ const mdux::spec::Register onlyThemeColorsIsAColourToken{
     "evidence-unit",
     [] {
         // Every dotted path was classified ColorToken, so `Foo.Bar` would have reached #193's
-        // theme lookup and produced MDX-E030 "not in the governed table" for a value that never
+        // theme lookup and produced MEDUI-E030 "not in the governed table" for a value that never
         // claimed to name a colour.
         return speclab::Test("medui-value-colour-classification")
             .Given("three dotted paths", [] {})

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -1,0 +1,684 @@
+/**
+ * @file ParserTests.cpp
+ * @brief BDD scenarios for the `.medui` lexer and parser (issue #192).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The rejection scenarios assert on the **code**, not on the message, because #191 published the
+ * codes as the compiler's contract and messages are explicitly rewordable. They also assert the
+ * **position**, which #192 requires: a diagnostic that names the right problem at the wrong place
+ * costs an author as much time as one that names the wrong problem, and a lexer that dropped
+ * columns would make that impossible to notice from the code alone.
+ *
+ * Fixtures live in `fixtures/` as real `.medui` files rather than as string literals in this file.
+ * They are what an author would write, they can be opened in an editor, and #200's
+ * `mdux-medui-check` will be pointed at the same corpus - a fixture that only exists inside a test
+ * cannot be reused by the tool that exists to check files.
+ */
+
+import std;
+import speclab;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.lexer;
+import mdux.tools.medui.parser;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+[[nodiscard]] std::string fixture(std::string_view name) {
+    const std::filesystem::path path =
+        std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
+    std::ifstream in{path, std::ios::binary};
+    if (!in) {
+        throw speclab::core::AssertionFailure(
+            std::format("fixture {} could not be opened at {}", name, path.generic_string()),
+            std::source_location::current());
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+/// True when `code` appears among `diagnostics`.
+[[nodiscard]] bool has(const std::vector<cli::Diagnostic>& diagnostics, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    return std::ranges::any_of(diagnostics,
+                               [wanted](const cli::Diagnostic& d) { return d.code == wanted; });
+}
+
+[[nodiscard]] const cli::Diagnostic* find(const std::vector<cli::Diagnostic>& diagnostics,
+                                          md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto it = std::ranges::find_if(
+        diagnostics, [wanted](const cli::Diagnostic& d) { return d.code == wanted; });
+    return it == diagnostics.end() ? nullptr : &*it;
+}
+
+[[nodiscard]] std::string codesOf(const std::vector<cli::Diagnostic>& diagnostics) {
+    std::string out;
+    for (const cli::Diagnostic& d : diagnostics) {
+        if (!out.empty()) { out += ", "; }
+        out += std::format("{}@{}:{}", d.code, d.line, d.column);
+    }
+    return out.empty() ? "(none)" : out;
+}
+
+/// A node anywhere in the screen with `id: wanted`.
+[[nodiscard]] const md::ast::Node* nodeById(const md::ast::Screen& screen, std::string_view wanted) {
+    const md::ast::Node* found = nullptr;
+    const auto visit = [&](auto&& self, const md::ast::Node& node) -> void {
+        for (const md::ast::Field& f : node.fields) {
+            if (f.name == "id" && f.value != nullptr && f.value->text == wanted) {
+                found = &node;
+            }
+        }
+        for (const md::ast::Node& child : node.children) { self(self, child); }
+    };
+    for (const md::ast::Node& node : screen.nodes) { visit(visit, node); }
+    return found;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The corpus parses.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register acceptedScreenParses{
+    "The worked example from the authoring skill parses with no diagnostics",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-parse-accepted")
+            .Given("the published grammar example", [] {})
+            .When("it is parsed", [] {})
+            .Then("it yields a screen and nothing to report", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("accepted-neurosense.medui"),
+                                                    "accepted-neurosense.medui");
+                checks.expect(r.diagnostics.empty(),
+                              std::format("no diagnostics, got {}", codesOf(r.diagnostics)));
+                checks.expect(r.screen.has_value(), "a screen was produced");
+                if (r.screen) {
+                    checks.expect(r.screen->name == "NeuroSense500",
+                                  std::format("screen name, got '{}'", r.screen->name));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register acceptedScreenShape{
+    "The parsed AST carries layout, surface, annotations and a one-level Row",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-parse-shape")
+            .Given("the parsed example", [] {})
+            .When("its structure is inspected", [] {})
+            .Then("every construct survived with its position", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("accepted-neurosense.medui"),
+                                                    "accepted-neurosense.medui");
+                if (!r.screen) {
+                    checks.expect(false, "a screen was produced");
+                    checks.raise();
+                    return;
+                }
+                const md::ast::Screen& s = *r.screen;
+
+                checks.expect(s.layoutKind == "Vertical",
+                              std::format("layout kind, got '{}'", s.layoutKind));
+                checks.expect(s.layout.size() == 2, "layout carries spacing and padding");
+                checks.expect(s.surface.has_value() && s.surface->x == 1920 && s.surface->y == 1080,
+                              "surface is 1920x1080");
+                checks.expect(s.nodes.size() == 2, "two top-level nodes");
+
+                const md::ast::Node* display = nodeById(s, "sedation-index");
+                checks.expect(display != nullptr, "the NumericDisplay is present");
+                if (display != nullptr) {
+                    checks.expect(display->annotations.size() == 1, "it carries one annotation");
+                    if (!display->annotations.empty()) {
+                        checks.expect(display->annotations[0].name == "safety_critical",
+                                      "the annotation is @safety_critical");
+                    }
+                    // Position is asserted, not just presence: it is what a diagnostic three
+                    // stages later will quote back to the author.
+                    checks.expect(display->position.line == 11,
+                                  std::format("declared on line 11, got {}",
+                                              display->position.line));
+                }
+
+                const md::ast::Node* title = nodeById(s, "title");
+                checks.expect(title != nullptr, "the Row's child survived flattening-free parsing");
+
+                const md::ast::Node* row = nodeById(s, "topbar");
+                checks.expect(row != nullptr && row->children.size() == 1,
+                              "the Row holds exactly its one child");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register valuesKeepTheirKinds{
+    "Sizes, points, text keys and colour tokens parse to distinct value kinds",
+    "evidence-unit",
+    [] {
+        // The kinds are what #193 dispatches on. If `Fill` and `512px` collapsed to one kind, or a
+        // colour token arrived as a bare identifier, the next stage would have to re-lex strings.
+        return speclab::Test("medui-parse-values")
+            .Given("the parsed example", [] {})
+            .When("the NumericDisplay's fields are read", [] {})
+            .Then("each value kind is preserved and unresolved", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("accepted-neurosense.medui"),
+                                                    "accepted-neurosense.medui");
+                if (!r.screen) { checks.expect(false, "a screen was produced"); checks.raise(); return; }
+
+                const md::ast::Node* display = nodeById(*r.screen, "sedation-index");
+                const md::ast::Node* title = nodeById(*r.screen, "title");
+                if (display == nullptr || title == nullptr) {
+                    checks.expect(false, "both nodes present"); checks.raise(); return;
+                }
+                const auto fieldOf = [](const md::ast::Node& n, std::string_view name)
+                    -> const md::ast::Value* {
+                    for (const md::ast::Field& f : n.fields) {
+                        if (f.name == name) { return f.value.get(); }
+                    }
+                    return nullptr;
+                };
+
+                const md::ast::Value* width = fieldOf(*display, "width");
+                checks.expect(width != nullptr && width->kind == md::ast::ValueKind::Size &&
+                                  !width->size.fill && width->size.pixels == 512,
+                              "width is a 512px size");
+
+                const md::ast::Value* fill = fieldOf(*title, "width");
+                checks.expect(fill != nullptr && fill->kind == md::ast::ValueKind::Size &&
+                                  fill->size.fill,
+                              "Fill is a size, flagged fill");
+
+                const md::ast::Value* pos = fieldOf(*display, "position");
+                checks.expect(pos != nullptr && pos->kind == md::ast::ValueKind::Point &&
+                                  pos->point.x == 1392 && pos->point.y == 80,
+                              "position is a point");
+
+                const md::ast::Value* colour = fieldOf(*display, "color");
+                checks.expect(colour != nullptr && colour->kind == md::ast::ValueKind::ColorToken &&
+                                  colour->text == "Theme.Colors.ScoreDigits",
+                              "the colour token is carried whole and unresolved");
+
+                const md::ast::Value* text = fieldOf(*title, "text");
+                checks.expect(text != nullptr && text->kind == md::ast::ValueKind::TextKey &&
+                                  text->text == "STR-TITLE",
+                              "t(\"...\") is a text key, not a string");
+
+                const md::ast::Value* requirement = fieldOf(*display, "requirement");
+                checks.expect(requirement != nullptr &&
+                                  requirement->kind == md::ast::ValueKind::String &&
+                                  requirement->text == "REQ-NS-001",
+                              "a quoted literal stays a String, for #193 to accept or reject");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Rejections. Each asserts the code and the position.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register nestedRowRejected{
+    "A Row inside a Row is MDX-E015, at the inner Row",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-nested-row")
+            .Given("a screen with a nested Row", [] {})
+            .When("it is parsed", [] {})
+            .Then("MDX-E015 names the inner Row's position", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("rejected-nested-row.medui"),
+                                                    "rejected-nested-row.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::NestedRow);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E015 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 6, std::format("at line 6, got {}", d->line));
+                    checks.expect(d->column == 9, std::format("at column 9, got {}", d->column));
+                    checks.expect(!d->fixHint.empty(), "carries the registry's fix hint");
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register forbiddenConstructRejected{
+    "A control-flow keyword is MDX-E016",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-forbidden")
+            .Given("a screen containing 'if'", [] {})
+            .When("it is parsed", [] {})
+            .Then("MDX-E016 names it at its position", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("rejected-forbidden-construct.medui"),
+                                                    "rejected-forbidden-construct.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::ForbiddenConstruct);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 3, std::format("at line 3, got {}", d->line));
+                    checks.expect(d->column == 5, std::format("at column 5, got {}", d->column));
+                    checks.expect(d->message.find("if") != std::string::npos,
+                                  "the message names the offending word");
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register duplicateIdRejected{
+    "A repeated node id is MDX-E014, pointing at the second one",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-duplicate-id")
+            .Given("two nodes sharing an id", [] {})
+            .When("the screen is parsed", [] {})
+            .Then("MDX-E014 names the second and cites the first", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("rejected-duplicate-id.medui"),
+                                                    "rejected-duplicate-id.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::DuplicateNodeId);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E014 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 8, std::format("at the second id, line 8, got {}",
+                                                            d->line));
+                    checks.expect(d->column == 9, std::format("at column 9, got {}", d->column));
+                    // Naming only the duplicate would leave an author hunting for the original.
+                    checks.expect(d->message.find("line 4") != std::string::npos,
+                                  std::format("the message cites the first, got '{}'", d->message));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register unknownUnitRejected{
+    "A length in a unit other than px is MDX-E010",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-bad-unit")
+            .Given("a width written as 10rem", [] {})
+            .When("the screen is parsed", [] {})
+            .Then("MDX-E010 says what units exist", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(fixture("rejected-bad-unit.medui"),
+                                                    "rejected-bad-unit.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E010 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 5, std::format("at line 5, got {}", d->line));
+                    checks.expect(d->column == 18, std::format("at column 18, got {}", d->column));
+                    checks.expect(d->fixHint.find("Npx") != std::string::npos,
+                                  "the hint names the accepted form");
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register unterminatedStringRejected{
+    "An unterminated string is reported at its opening quote",
+    "evidence-unit",
+    [] {
+        // Reported where the string *started*, not where the line ended: the opening quote is
+        // where the author's mistake is, and a diagnostic at the newline points at the symptom.
+        return speclab::Test("medui-reject-unterminated-string")
+            .Given("a string with no closing quote", [] {})
+            .When("the source is lexed", [] {})
+            .Then("the diagnostic points at the opening quote", [] {
+                mdux::spec::Checks checks;
+                const md::LexResult r = md::lex(fixture("rejected-unterminated-string.medui"),
+                                                "rejected-unterminated-string.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(d != nullptr,
+                              std::format("a diagnostic was reported, got {}",
+                                          codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 5, std::format("at line 5, got {}", d->line));
+                    checks.expect(d->column == 22,
+                                  std::format("at the opening quote, column 22, got {}",
+                                              d->column));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Lexer properties the parser depends on.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register commentsAreSkipped{
+    "A // comment does not become a token",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-lex-comments")
+            .Given("a source with a trailing comment", [] {})
+            .When("it is lexed", [] {})
+            .Then("only the code tokens survive, with positions after the comment intact", [] {
+                mdux::spec::Checks checks;
+                const md::LexResult r = md::lex("// leading\nScreen A { } // trailing\n", "c.medui");
+                checks.expect(r.ok(), "no diagnostics");
+                checks.expect(r.tokens.size() == 5,
+                              std::format("Screen, A, {{, }}, EOF - got {}", r.tokens.size()));
+                if (r.tokens.size() >= 2) {
+                    checks.expect(r.tokens[0].line == 2,
+                                  std::format("the comment did not eat the newline, got line {}",
+                                              r.tokens[0].line));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register invalidUtf8Rejected{
+    "A source that is not valid UTF-8 is rejected whole, with MDX-E004",
+    "evidence-unit",
+    [] {
+        // Whole rather than at the byte: past an invalid sequence there are no defined character
+        // boundaries, so every column after it would be invented.
+        return speclab::Test("medui-lex-bad-utf8")
+            .Given("a source containing a lone continuation byte", [] {})
+            .When("it is lexed", [] {})
+            .Then("MDX-E004 is reported and no tokens are produced", [] {
+                mdux::spec::Checks checks;
+                std::string source = "Screen A { }\n";
+                source += '\x80';
+                const md::LexResult r = md::lex(source, "bad.medui");
+                checks.expect(has(r.diagnostics, md::Code::SourceNotUtf8),
+                              std::format("MDX-E004 reported, got {}", codesOf(r.diagnostics)));
+                checks.expect(r.tokens.empty(), "no tokens, so no invented positions");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register severalProblemsInOneRun{
+    "One run reports more than the first problem",
+    "evidence-unit",
+    [] {
+        // A compiler that stops at the first error makes fixing a screen an iterative guessing
+        // game, and #200 exists to hand an author everything at once.
+        return speclab::Test("medui-parse-recovery")
+            .Given("a screen with two independent bad fields", [] {})
+            .When("it is parsed", [] {})
+            .Then("both are reported", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse(
+                    "Screen A {\n"
+                    "  surface: 800px, 600px;\n"
+                    "  Label {\n"
+                    "    width: 10rem;\n"
+                    "    height: 20rem;\n"
+                    "  }\n"
+                    "}\n",
+                    "two.medui");
+                const auto count = std::ranges::count_if(
+                    r.diagnostics, [](const cli::Diagnostic& d) { return d.code == "MDX-E010"; });
+                checks.expect(count >= 2,
+                              std::format("at least two findings, got {}",
+                                          codesOf(r.diagnostics)));
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Regressions. Each of these parsed clean before review on #209.
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register columnsAreUtf8Bytes{
+    "A column counts UTF-8 bytes, not code points",
+    "evidence-unit",
+    [] {
+        // Raised by @coderabbitai: every other position scenario uses ASCII, so a lexer counting
+        // code points would pass all of them. The comment before "e" is 3 ASCII + one 2-byte
+        // character (U+00E9) + 1 ASCII = 6 bytes, so `Screen` starts at byte column 7 and at code
+        // point column 6. Asserting 7 is what pins the convention shared with mdux-docs-lint.
+        return speclab::Test("medui-lex-utf8-columns")
+            .Given("a line with a multi-byte character before a token", [] {})
+            .When("it is lexed", [] {})
+            .Then("the token's column is its byte offset", [] {
+                mdux::spec::Checks checks;
+                const md::LexResult r = md::lex("/*\u00e9*/Screen A { }\n", "u.medui");
+                // `/*` is not a comment in this grammar, so those are unexpected-character
+                // diagnostics; the token positions are what this scenario is about.
+                const auto screen = std::ranges::find_if(
+                    r.tokens, [](const md::Token& t) { return t.text == "Screen"; });
+                checks.expect(screen != r.tokens.end(), "the Screen token was produced");
+                if (screen != r.tokens.end()) {
+                    checks.expect(screen->column == 7,
+                                  std::format("byte column 7 (code-point column would be 6), got {}",
+                                              screen->column));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register trailingContentRejected{
+    "Content after the screen's closing brace is rejected",
+    "evidence-unit",
+    [] {
+        // Before review this parsed clean: the closing brace was consumed and nothing looked at
+        // what followed, so a second Screen or plain garbage produced ok() == true.
+        return speclab::Test("medui-reject-trailing")
+            .Given("two screens in one source, and a source with trailing junk", [] {})
+            .When("each is parsed", [] {})
+            .Then("both are rejected", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult two = md::parse("Screen A { }\nScreen B { }\n", "t.medui");
+                const cli::Diagnostic* d2 = find(two.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(d2 != nullptr,
+                              std::format("MDX-E010 for a second Screen, got {}",
+                                          codesOf(two.diagnostics)));
+                if (d2 != nullptr) {
+                    checks.expect(d2->line == 2 && d2->column == 1,
+                                  std::format("at 2:1, the second Screen keyword, got {}:{}",
+                                              d2->line, d2->column));
+                }
+
+                const md::ParseResult junk = md::parse("Screen A { } garbage\n", "t.medui");
+                const cli::Diagnostic* dj = find(junk.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(dj != nullptr,
+                              std::format("MDX-E010 for trailing junk, got {}",
+                                          codesOf(junk.diagnostics)));
+                if (dj != nullptr) {
+                    checks.expect(dj->line == 1 && dj->column == 14,
+                                  std::format("at 1:14, the junk token, got {}:{}",
+                                              dj->line, dj->column));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register annotatedChildOutsideRowRejected{
+    "An annotated child is rejected outside a Row, and a Row inside one is still MDX-E015",
+    "evidence-unit",
+    [] {
+        // Reported independently by three reviewers on #209. The unannotated path enforced
+        // "only a Row has children"; the annotated path did not, so `Card { @x Label { } }`
+        // was accepted - and `Card { @x Row { } }` put a Row at depth two with no MDX-E015,
+        // because the annotated path also passed insideRow = false.
+        return speclab::Test("medui-reject-annotated-child")
+            .Given("an annotated child under a non-Row parent", [] {})
+            .When("it is parsed", [] {})
+            .Then("it is rejected, as the unannotated form already was", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult child =
+                    md::parse("Screen A {\n Card {\n  @x Label { }\n }\n}\n", "a.medui");
+                const cli::Diagnostic* dc = find(child.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(dc != nullptr,
+                              std::format("MDX-E010 for an annotated child, got {}",
+                                          codesOf(child.diagnostics)));
+                if (dc != nullptr) {
+                    checks.expect(dc->line == 3 && dc->column == 3,
+                                  std::format("at 3:3, the '@', got {}:{}", dc->line, dc->column));
+                    checks.expect(dc->message.find("Card") != std::string::npos,
+                                  "the message names the offending parent");
+                }
+
+                // A Row under a non-Row is rejected as a child, *not* as a nested Row: the parent
+                // is a Card, so MDX-E015 would be the wrong code. The nested-Row rule is asserted
+                // separately below, where the parent really is a Row.
+                const md::ParseResult row =
+                    md::parse("Screen A {\n Card {\n  @x Row { }\n }\n}\n", "a.medui");
+                checks.expect(find(row.diagnostics, md::Code::UnexpectedToken) != nullptr,
+                              std::format("MDX-E010 for an annotated Row under a Card, got {}",
+                                          codesOf(row.diagnostics)));
+
+                // An *annotated* Row inside a Row is the case the gate previously let through
+                // with no diagnostic at all. It must be MDX-E015, exactly as the unannotated form.
+                const md::ParseResult nested =
+                    md::parse("Screen A {\n Row {\n  @x Row { }\n }\n}\n", "a.medui");
+                const cli::Diagnostic* dn = find(nested.diagnostics, md::Code::NestedRow);
+                checks.expect(dn != nullptr,
+                              std::format("MDX-E015 for an annotated nested Row, got {}",
+                                          codesOf(nested.diagnostics)));
+                if (dn != nullptr) {
+                    checks.expect(dn->line == 3 && dn->column == 6,
+                                  std::format("at 3:6, the inner Row, got {}:{}",
+                                              dn->line, dn->column));
+                }
+
+                // The unannotated form was always rejected; asserted so the two paths cannot
+                // drift apart again without a test noticing.
+                const md::ParseResult plain =
+                    md::parse("Screen A {\n Card {\n  Label { }\n }\n}\n", "a.medui");
+                checks.expect(find(plain.diagnostics, md::Code::UnexpectedToken) != nullptr,
+                              "the unannotated form stays rejected with the same code");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register forbiddenWordInLayoutRejected{
+    "A control-flow keyword as a layout kind is MDX-E016",
+    "evidence-unit",
+    [] {
+        // "Wherever an identifier may appear" did not include the layout kind, so `layout: if { }`
+        // parsed clean.
+        return speclab::Test("medui-reject-forbidden-layout")
+            .Given("layout: if { }", [] {})
+            .When("it is parsed", [] {})
+            .Then("MDX-E016 is reported", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse("Screen A {\n layout: if { }\n}\n", "l.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::ForbiddenConstruct);
+                checks.expect(d != nullptr,
+                              std::format("MDX-E016 reported, got {}", codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 2 && d->column == 10,
+                                  std::format("at 2:10, the 'if', got {}:{}", d->line, d->column));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register onlyThemeColorsIsAColourToken{
+    "A dotted path is a colour token only when it is Theme.Colors.<Token>",
+    "evidence-unit",
+    [] {
+        // Every dotted path was classified ColorToken, so `Foo.Bar` would have reached #193's
+        // theme lookup and produced MDX-E030 "not in the governed table" for a value that never
+        // claimed to name a colour.
+        return speclab::Test("medui-value-colour-classification")
+            .Given("three dotted paths", [] {})
+            .When("they are parsed as values", [] {})
+            .Then("only the qualified one is a ColorToken", [] {
+                mdux::spec::Checks checks;
+                const auto kindOf = [&](std::string_view value) {
+                    const md::ParseResult r = md::parse(
+                        std::format("Screen A {{\n L {{ c: {}; }}\n}}\n", value), "v.medui");
+                    if (!r.screen || r.screen->nodes.empty() ||
+                        r.screen->nodes[0].fields.empty() ||
+                        r.screen->nodes[0].fields[0].value == nullptr) {
+                        return md::ast::ValueKind::Number;  // a sentinel none of the cases expect
+                    }
+                    return r.screen->nodes[0].fields[0].value->kind;
+                };
+                checks.expect(kindOf("Theme.Colors.ScoreDigits") == md::ast::ValueKind::ColorToken,
+                              "Theme.Colors.ScoreDigits is a ColorToken");
+                checks.expect(kindOf("Foo.Bar") == md::ast::ValueKind::Identifier,
+                              "Foo.Bar is not a ColorToken");
+                checks.expect(kindOf("Theme.Colors") == md::ast::ValueKind::Identifier,
+                              "a truncated Theme.Colors is not a ColorToken");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register backslashAtLineEndDoesNotEatTheNewline{
+    "A backslash at end of line does not let a string span lines",
+    "evidence-unit",
+    [] {
+        // The escape branch consumed the next byte unconditionally, so a trailing backslash ate
+        // the newline and the string ran on - skewing every position after it, and reporting the
+        // unterminated string somewhere the author never wrote one.
+        return speclab::Test("medui-lex-backslash-eol")
+            .Given("a string with a trailing backslash", [] {})
+            .When("it is lexed", [] {})
+            .Then("it is unterminated, reported at its opening quote, and lines still line up", [] {
+                mdux::spec::Checks checks;
+                const md::LexResult r = md::lex("Screen A {\n r: \"ab\\\n cd\";\n}\n", "b.medui");
+                const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
+                checks.expect(d != nullptr,
+                              std::format("a diagnostic was reported, got {}",
+                                          codesOf(r.diagnostics)));
+                if (d != nullptr) {
+                    checks.expect(d->line == 2 && d->column == 5,
+                                  std::format("at the opening quote, 2:5, got {}:{}",
+                                              d->line, d->column));
+                }
+                // The token after the broken string must still be on line 3, which it cannot be if
+                // the newline was swallowed.
+                const auto brace = std::ranges::find_if(
+                    r.tokens, [](const md::Token& t) { return t.kind == md::TokenKind::RBrace; });
+                checks.expect(brace != r.tokens.end() && brace->line >= 3,
+                              "positions after the broken string are not skewed");
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register screenPositionIsTheKeyword{
+    "A screen's position is the Screen keyword, not its name",
+    "evidence-unit",
+    [] {
+        // Ast.cppm says a node carries the position of the token that introduced it, and
+        // parseLayout/parseSurface both capture before advancing. This one captured after.
+        return speclab::Test("medui-screen-position")
+            .Given("a screen declared at a known column", [] {})
+            .When("it is parsed", [] {})
+            .Then("the position is the keyword's", [] {
+                mdux::spec::Checks checks;
+                const md::ParseResult r = md::parse("Screen A { }\n", "s.medui");
+                checks.expect(r.screen.has_value(), "a screen was produced");
+                if (r.screen) {
+                    checks.expect(r.screen->position.column == 1,
+                                  std::format("column 1, the 'Screen' keyword, got {}",
+                                              r.screen->position.column));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};

--- a/tests/medui/ParserTests.cpp
+++ b/tests/medui/ParserTests.cpp
@@ -333,6 +333,47 @@ const mdux::spec::Register unknownUnitRejected{
             .Execute();
     }};
 
+const mdux::spec::Register outOfRangeIntegerRejected{
+    "A bare integer outside the AST's range is rejected during parsing",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-reject-out-of-range-integer")
+            .Given("a max_length larger than an int64 can represent", [] {})
+            .When("the bare integer is parsed", [] {})
+            .Then("MEDUI-E010 points at the number instead of producing a zero-valued AST node",
+                  [] {
+                      constexpr std::string_view source = R"(Screen IntegerRange {
+    TextInput { max_length: 999999999999999999999999; }
+})";
+                      const md::ParseResult r = md::parse(source, "integer-range.medui");
+                      const cli::Diagnostic* d = find(r.diagnostics, md::Code::UnexpectedToken);
+                      mdux::spec::Checks checks;
+                      checks.expect(d != nullptr,
+                                    std::format("MEDUI-E010 reported, got {}",
+                                                codesOf(r.diagnostics)));
+                      if (d != nullptr) {
+                          checks.expect(d->line == 2 && d->column == 29,
+                                        std::format("at the number, 2:29, got {}:{}",
+                                                    d->line, d->column));
+                          checks.expect(d->message.contains("integer") &&
+                                            d->message.contains("represent"),
+                                        "the diagnostic explains the integer range failure");
+                      }
+                      bool installed = false;
+                      if (r.screen && !r.screen->nodes.empty()) {
+                          installed = std::ranges::any_of(
+                              r.screen->nodes.front().fields,
+                              [](const md::ast::Field& field) {
+                                  return field.name == "max_length";
+                              });
+                      }
+                      checks.expect(!installed,
+                                    "the malformed max_length is not installed in the AST");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register unterminatedStringRejected{
     "An unterminated string is reported at its opening quote",
     "evidence-unit",

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -72,6 +72,44 @@ static_assert(std::get_if<ms::LabelSpec>(&constNodes[1].payload)->textKey == "ST
 static_assert(ms::requirementOf(constNodes[2]) == "REQ-NS-001", "a traced node yields its requirement");
 static_assert(ms::requirementOf(constNodes[1]).empty(), "and an untraced one yields nothing rather than a placeholder");
 
+}  // namespace
+
+/**
+ * @brief The same promise, in the shape generated code actually has.
+ *
+ * Deliberately **not** in the anonymous namespace above, and this is the whole point of the block:
+ * the defect it pins needs an `inline` variable with *external* linkage, and an `inline constexpr`
+ * in an anonymous namespace does not reproduce it. A pin written next to its neighbours would have
+ * asserted nothing while looking like it asserted something.
+ *
+ * What it holds: GCC 16.1 under `-fsanitize=undefined` refused `std::get_if` over a subobject of an
+ * `inline` variable as a constant expression, so a generated screen's own
+ * `static_assert(screen.validate().has_value())` failed to compile on the sanitizer leg alone. The
+ * schema answers it by taking payloads by value; this is what stops a later simplification back to a
+ * reference from breaking that leg again, without waiting for the emitter's output to notice.
+ */
+namespace mdux::test::medui::inlinescreen {
+
+inline constexpr std::array<ms::CompiledNode, 1> inlineNodes{
+    ms::CompiledNode{.id = "title", .bounds = {0, 0, 200, 40}, .payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"}}
+};
+
+inline constexpr ms::ScreenPackage inlinePackage{
+    .id            = "inline-screen",
+    .schemaVersion = mdux::evidence::kSchemaVersion,
+    .surfaceWidth  = 200,
+    .surfaceHeight = 100,
+    .nodes         = inlineNodes,
+    .budget        = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+};
+
+static_assert(inlinePackage.validate().has_value(), "an inline constexpr screen validates at compile time, as generated code is");
+static_assert(ms::requirementOf(inlineNodes[0]).empty(), "and a traceability walk over one is constant-evaluable too");
+
+}  // namespace mdux::test::medui::inlinescreen
+
+namespace {
+
 /**
  * @brief The palette transcribed from TrustSC's `THEME_COLORS`, by hand and independently.
  *

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief Scenarios for the governed compiled-screen schema (issue #197).
  * @file SchemaTests.cpp
+ * @brief Scenarios for the governed compiled-screen schema (issue #197).
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -16,7 +16,6 @@
 import std;
 import speclab;
 import mdux.core.result;
-import mdux.core.units;
 import mdux.draw;
 import mdux.evidence.report;
 import mdux.medui.schema;
@@ -36,7 +35,7 @@ constexpr std::array<ms::CompiledNode, 3> constNodes{
                      .component   = "Panel",
                      .bounds      = {0, 0, 400, 40},
                      .textKey     = {},
-                     .colorToken  = "Theme.Colors.Surface",
+                     .colorToken  = "Theme.Colors.TopbarBackground",
                      .requirement = {}          },
     ms::CompiledNode{            .id          = "title",
                      .component   = "Label",
@@ -68,16 +67,31 @@ static_assert(constPackage.validate().has_value(), "the reference screen must va
 static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
 static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
 
-// The governed table a product supplies. Two entries are enough to tell a hit from a miss, and
-// `constexpr` so the resolution below happens at compile time rather than at start-up.
-constexpr std::array<ms::ThemeColor, 2> constTheme{
-    ms::ThemeColor{      .token = "Theme.Colors.Title",   .value = {.r = 12, .g = 24, .b = 36, .a = 255}},
-    ms::ThemeColor{.token = "Theme.Colors.ScoreDigits", .value = {.r = 33, .g = 184, .b = 107, .a = 255}}
+/**
+ * @brief The palette transcribed from TrustSC's `THEME_COLORS`, by hand and independently.
+ *
+ * A second copy of data the module already holds, which this suite would normally refuse - and the
+ * exception is the point. The parity claim is that a token renders the same colour in both projects,
+ * so a check reading `themeColors` for both its input and its expectation would stay green while an
+ * entry drifted, which is the one failure this table exists to prevent. Compared against a
+ * transcription, a drift has to survive two edits in two files to go unnoticed.
+ */
+constexpr std::array<ms::ThemeColor, 8> expectedPalette{
+    ms::ThemeColor{.token = "Theme.Colors.TopbarBackground", .value = {0.82F, 0.84F, 0.86F, 1.0F}},
+    ms::ThemeColor{           .token = "Theme.Colors.Title", .value = {0.10F, 0.12F, 0.16F, 1.0F}},
+    ms::ThemeColor{     .token = "Theme.Colors.ScoreDigits", .value = {0.13F, 0.72F, 0.42F, 1.0F}},
+    ms::ThemeColor{         .token = "Theme.Colors.Nominal", .value = {0.13F, 0.72F, 0.42F, 1.0F}},
+    ms::ThemeColor{           .token = "Theme.Colors.Alert", .value = {0.95F, 0.65F, 0.15F, 1.0F}},
+    ms::ThemeColor{           .token = "Theme.Colors.Fault", .value = {0.86F, 0.20F, 0.18F, 1.0F}},
+    ms::ThemeColor{         .token = "Theme.Colors.Neutral", .value = {0.62F, 0.66F, 0.70F, 1.0F}},
+    ms::ThemeColor{   .token = "Theme.Colors.PrimaryAction", .value = {0.16F, 0.44F, 0.86F, 1.0F}}
 };
 
-static_assert(ms::resolveColorToken(constTheme, "Theme.Colors.ScoreDigits").has_value(), "a name the table defines resolves at compile time");
-static_assert(ms::resolveColorToken(constTheme, "Theme.Colors.ScoreDigits").value() == mdux::core::ColorRgba8{.r = 33, .g = 184, .b = 107, .a = 255},
-              "and resolves to the colour the table carries");
+// The governed table is the module's own, so there is no fixture to build here - only the promise
+// that a name resolves at compile time, which is what generated code and #16's verifier both rest on.
+static_assert(ms::resolveColorToken("Theme.Colors.ScoreDigits").has_value(), "a name the governed table defines resolves at compile time");
+static_assert(ms::resolveColorToken("Theme.Colors.ScoreDigits").value() == std::array<float, 4>{0.13F, 0.72F, 0.42F, 1.0F},
+              "and resolves to the colour TrustSC's THEME_COLORS carries for it");
 
 // ---------------------------------------------------------------------------
 // A mutable equivalent, so each rejection can change exactly one field
@@ -257,6 +271,15 @@ const mdux::spec::Register coloursAreNamesNotValues{
                       checks.expect(errorOf(bare) == ms::SchemaError::MalformedColorToken,
                                     std::format("a bare Theme.Colors. prefix names nothing and is refused, got {}", describe(errorOf(bare))));
 
+                      // The case the governed table makes checkable, and the reason this is worth
+                      // a rejection rather than a device-time miss: the name is well-formed, so
+                      // shape alone accepted it, and the generated `static_assert` would have
+                      // certified a screen whose colour lookup then fails on the device.
+                      Fixture undefined;
+                      undefined.nodes[1].colorToken = "Theme.Colors.DoesNotExist";
+                      checks.expect(errorOf(undefined) == ms::SchemaError::UnknownColorToken,
+                                    std::format("a name the governed table does not define is refused, got {}", describe(errorOf(undefined))));
+
                       Fixture untinted;
                       untinted.nodes[1].colorToken = {};
                       checks.expect(!errorOf(untinted).has_value(), "a node that declares no tint is legal");
@@ -321,42 +344,59 @@ const mdux::spec::Register sizingIsNotThisModulesClaim{
             .Execute();
     }};
 
-const mdux::spec::Register colourTokensResolveAgainstAGovernedTable{
-    "A carried name resolves against the product's table, and a miss is a Result rather than a guess",
+const mdux::spec::Register colourTokensResolveAgainstTheGovernedTable{
+    "Every governed token resolves, and everything else is refused with the error that fits",
     "evidence-unit",
     [] {
         return speclab::Test("medui-schema-colour-resolution")
-            .Given("a two-entry governed colour table", [] {})
-            .When("a defined name, an undefined one, and two malformed ones are resolved", [] {})
-            .Then("each answers with the colour or with the error that says which kind of failure it is",
+            .Given("the governed token to RGBA table", [] {})
+            .When("every entry, an undefined name and two malformed ones are resolved", [] {})
+            .Then("each answers with its colour or with the error that says whose defect it is",
                   [] {
                       mdux::spec::Checks checks;
 
-                      const auto hit = ms::resolveColorToken(constTheme, "Theme.Colors.Title");
-                      checks.expect(hit.has_value() && *hit == mdux::core::ColorRgba8{.r = 12, .g = 24, .b = 36, .a = 255},
-                                    "a defined name resolves to its colour");
+                      // The shape of TrustSC's own
+                      // `theme_color_table_resolves_every_entry_and_rejects_unknown_tokens`: walk
+                      // the table rather than spot-check it, so an entry that stops resolving -
+                      // a malformed token added to the table, say - fails here rather than on a
+                      // device.
+                      // Two different claims, and the second is the parity one. The first says the
+                      // resolver reaches every entry the table holds - a malformed token added to
+                      // the table would fail `isColorToken()` and be unreachable, and this catches
+                      // it. The second says the table holds what TrustSC holds, which reading the
+                      // table for both sides could never show.
+                      bool everyEntryResolves = true;
+                      for (const ms::ThemeColor& entry : ms::themeColors) {
+                          const auto resolved = ms::resolveColorToken(entry.token);
+                          everyEntryResolves  = everyEntryResolves && resolved.has_value() && *resolved == entry.value;
+                      }
+                      checks.expect(everyEntryResolves, "the resolver reaches every entry the table holds");
+
+                      checks.expect(ms::themeColors.size() == expectedPalette.size(),
+                                    std::format("the table carries TrustSC's eight entries, got {}", ms::themeColors.size()));
+                      checks.expect(std::ranges::equal(ms::themeColors, expectedPalette), "and carries them token for token, value for value");
+
+                      bool everyExpectedTokenResolves = true;
+                      for (const ms::ThemeColor& expected : expectedPalette) {
+                          const auto resolved        = ms::resolveColorToken(expected.token);
+                          everyExpectedTokenResolves = everyExpectedTokenResolves && resolved.has_value() && *resolved == expected.value;
+                      }
+                      checks.expect(everyExpectedTokenResolves, "and every name TrustSC defines resolves here to the colour it defines");
 
                       // A miss is not a colour. ADR-011 keeps the lookup bounded and fallible on
-                      // purpose: a fallback tint would render something nobody approved, which is
-                      // the failure mode a governed table exists to prevent.
-                      const auto miss = ms::resolveColorToken(constTheme, "Theme.Colors.Undefined");
+                      // purpose: a fallback tint would render something nobody approved.
+                      const auto miss = ms::resolveColorToken("Theme.Colors.DoesNotExist");
                       checks.expect(!miss.has_value() && miss.error() == ms::ThemeError::UnknownToken,
                                     "a name the table does not define is a miss, not a default");
 
-                      const auto malformed = ms::resolveColorToken(constTheme, "Theme.Colors.#");
+                      // The error matters as much as the failure: a malformed name is an emitter
+                      // defect, while an absent one is a screen compiled against another palette.
+                      const auto malformed = ms::resolveColorToken("Theme.Colors.#");
                       checks.expect(!malformed.has_value() && malformed.error() == ms::ThemeError::MalformedToken,
                                     "a name that is not a name is distinguished from one that is merely absent");
 
-                      const auto value = ms::resolveColorToken(constTheme, "#21B86B");
+                      const auto value = ms::resolveColorToken("#21B86B");
                       checks.expect(!value.has_value() && value.error() == ms::ThemeError::MalformedToken, "a colour value is refused where a name belongs");
-
-                      // The error matters as much as the failure: a well-formed name against an
-                      // empty table is *absent*, not malformed. Asserting only `!has_value()` would
-                      // pass if the resolver ever confused the two, which is the distinction this
-                      // scenario exists to draw.
-                      const auto emptyTable = ms::resolveColorToken({}, "Theme.Colors.Title");
-                      checks.expect(!emptyTable.has_value() && emptyTable.error() == ms::ThemeError::UnknownToken,
-                                    "an empty table answers a well-formed name with a miss, not a colour nobody approved");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -1,0 +1,393 @@
+/**
+ * @brief Scenarios for the governed compiled-screen schema (issue #197).
+ * @file SchemaTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * The `static_assert` below is the point of the file. ADR-012 decision 3 puts
+ * `static_assert(package.validate().has_value())` in every generated screen, so "this type can be
+ * validated at compile time" is a promise the device build depends on rather than a nicety - and a
+ * promise a runtime test cannot check, because a runtime test proves only that it also works at
+ * run time. The scenarios that follow cover the rejections, which a `static_assert` cannot express.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.evidence.report;
+import mdux.medui.schema;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+
+// ---------------------------------------------------------------------------
+// Compile-time evidence for the constexpr claim
+// ---------------------------------------------------------------------------
+
+constexpr std::array<ms::CompiledNode, 3> constNodes{
+    ms::CompiledNode{.id          = "topbar-background",
+                     .component   = "Panel",
+                     .bounds      = {0, 0, 400, 40},
+                     .textKey     = {},
+                     .colorToken  = "Theme.Colors.Surface",
+                     .requirement = {}          },
+    ms::CompiledNode{            .id          = "title",
+                     .component   = "Label",
+                     .bounds      = {8, 8, 200, 24},
+                     .textKey     = "STR-TITLE",
+                     .colorToken  = "Theme.Colors.Title",
+                     .requirement = {}          },
+    ms::CompiledNode{            .id          = "score",
+                     .component   = "NumericDisplay",
+                     .bounds      = {250, 60, 120, 60},
+                     .textKey     = {},
+                     .colorToken  = "Theme.Colors.ScoreDigits",
+                     .requirement = "REQ-NS-001"}
+};
+
+constexpr ms::ScreenPackage constPackage{
+    .id            = "neurosense",
+    .schemaVersion = mdux::evidence::kSchemaVersion,
+    .surfaceWidth  = 400,
+    .surfaceHeight = 300,
+    .nodes         = constNodes,
+    .budget        = mdux::draw::DrawBudget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16}
+};
+
+// The module promises a generated screen can be validated at compile time and placed in read-only
+// memory. This is that promise, mechanically checked - and it is what ADR-012's generated
+// `static_assert` rests on.
+static_assert(constPackage.validate().has_value(), "the reference screen must validate at compile time");
+static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
+static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
+
+// The governed table a product supplies. Two entries are enough to tell a hit from a miss, and
+// `constexpr` so the resolution below happens at compile time rather than at start-up.
+constexpr std::array<ms::ThemeColor, 2> constTheme{
+    ms::ThemeColor{      .token = "Theme.Colors.Title",   .value = {.r = 12, .g = 24, .b = 36, .a = 255}},
+    ms::ThemeColor{.token = "Theme.Colors.ScoreDigits", .value = {.r = 33, .g = 184, .b = 107, .a = 255}}
+};
+
+static_assert(ms::resolveColorToken(constTheme, "Theme.Colors.ScoreDigits").has_value(), "a name the table defines resolves at compile time");
+static_assert(ms::resolveColorToken(constTheme, "Theme.Colors.ScoreDigits").value() == mdux::core::ColorRgba8{.r = 33, .g = 184, .b = 107, .a = 255},
+              "and resolves to the colour the table carries");
+
+// ---------------------------------------------------------------------------
+// A mutable equivalent, so each rejection can change exactly one field
+// ---------------------------------------------------------------------------
+
+/// Owns what the package's spans point at, so a mutated fixture stays self-consistent.
+struct Fixture {
+    std::vector<ms::CompiledNode> nodes{constNodes.begin(), constNodes.end()};
+    std::string                   id{"neurosense"};
+    std::uint64_t                 schemaVersion{mdux::evidence::kSchemaVersion};
+    std::int32_t                  surfaceWidth{400};
+    std::int32_t                  surfaceHeight{300};
+    mdux::draw::DrawBudget        budget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
+
+    [[nodiscard]] ms::ScreenPackage package() const noexcept {
+        return ms::ScreenPackage{.id            = id,
+                                 .schemaVersion = schemaVersion,
+                                 .surfaceWidth  = surfaceWidth,
+                                 .surfaceHeight = surfaceHeight,
+                                 .nodes         = nodes,
+                                 .budget        = budget};
+    }
+};
+
+/// The error a mutated fixture reports, or nothing when it validates.
+[[nodiscard]] std::optional<ms::SchemaError> errorOf(const Fixture& fixture) {
+    const auto result = fixture.package().validate();
+    return result.has_value() ? std::nullopt : std::optional{result.error()};
+}
+
+[[nodiscard]] std::string describe(std::optional<ms::SchemaError> error) {
+    return error.has_value() ? std::string{ms::describe(*error)} : std::string{"accepted"};
+}
+
+}  // namespace
+
+const mdux::spec::Register referenceScreenValidates{"The reference screen validates, so every rejection below changes exactly one thing", "evidence-unit", [] {
+                                                        return speclab::Test("medui-schema-reference-validates")
+                                                            .Given("a three-node screen on a 400x300 surface", [] {})
+                                                            .When("it is validated", [] {})
+                                                            .Then("it is accepted, at run time as well as at compile time",
+                                                                  [] {
+                                                                      mdux::spec::Checks checks;
+                                                                      checks.expect(!errorOf(Fixture{}).has_value(),
+                                                                                    std::format("the fixture validates, got {}", describe(errorOf(Fixture{}))));
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register identityIsRequired{"A screen with no id and one with an unreadable version are both refused", "evidence-unit", [] {
+                                                  return speclab::Test("medui-schema-identity")
+                                                      .Given("the reference screen", [] {})
+                                                      .When("its id is emptied, and its schemaVersion moved past what this module reads", [] {})
+                                                      .Then("each is refused with the error that names it",
+                                                            [] {
+                                                                mdux::spec::Checks checks;
+
+                                                                Fixture unnamed;
+                                                                unnamed.id.clear();
+                                                                checks.expect(errorOf(unnamed) == ms::SchemaError::EmptyId,
+                                                                              std::format("an unnamed screen is refused, got {}", describe(errorOf(unnamed))));
+
+                                                                Fixture future;
+                                                                future.schemaVersion = mdux::evidence::kSchemaVersion + 1;
+                                                                checks.expect(
+                                                                    errorOf(future) == ms::SchemaError::UnsupportedSchemaVersion,
+                                                                    std::format("a version this module cannot read is refused rather than guessed at, got {}",
+                                                                                describe(errorOf(future))));
+                                                                checks.raise();
+                                                            })
+                                                      .Execute();
+                                              }};
+
+const mdux::spec::Register nodesAreAddressable{"Every node must be addressable, and addressable by exactly one id", "evidence-unit", [] {
+                                                   return speclab::Test("medui-schema-node-ids")
+                                                       .Given("the reference screen", [] {})
+                                                       .When("a node loses its id, and two nodes share one", [] {})
+                                                       .Then("both are refused, because a golden or a requirement could name either",
+                                                             [] {
+                                                                 mdux::spec::Checks checks;
+
+                                                                 Fixture anonymous;
+                                                                 anonymous.nodes[1].id = {};
+                                                                 checks.expect(errorOf(anonymous) == ms::SchemaError::EmptyNodeId,
+                                                                               std::format("an unnamed node is refused, got {}", describe(errorOf(anonymous))));
+
+                                                                 Fixture duplicated;
+                                                                 duplicated.nodes[2].id = duplicated.nodes[1].id;
+                                                                 checks.expect(errorOf(duplicated) == ms::SchemaError::DuplicateNodeId,
+                                                                               std::format("a shared id is refused, got {}", describe(errorOf(duplicated))));
+                                                                 checks.raise();
+                                                             })
+                                                       .Execute();
+                                               }};
+
+const mdux::spec::Register rectanglesStayInsideTheSurface{
+    "A rectangle with no extent, or one that leaves the surface, is refused",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-bounds")
+            .Given("the reference screen", [] {})
+            .When("a node is collapsed, moved past the right edge, and given a negative origin", [] {})
+            .Then("each is refused rather than clamped",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Fixture collapsed;
+                      collapsed.nodes[1].bounds.width = 0;
+                      checks.expect(errorOf(collapsed) == ms::SchemaError::DegenerateBounds,
+                                    std::format("a zero-width rectangle is refused, got {}", describe(errorOf(collapsed))));
+
+                      Fixture overflowing;
+                      overflowing.nodes[1].bounds.x = 201;  // 201 + 200 > 400
+                      checks.expect(errorOf(overflowing) == ms::SchemaError::BoundsOutsideSurface,
+                                    std::format("a rectangle past the right edge is refused, got {}", describe(errorOf(overflowing))));
+
+                      Fixture negative;
+                      negative.nodes[1].bounds.y = -1;
+                      checks.expect(errorOf(negative) == ms::SchemaError::BoundsOutsideSurface,
+                                    std::format("a negative origin is refused, got {}", describe(errorOf(negative))));
+
+                      // The containment arithmetic is 64-bit on purpose: at the type's extreme,
+                      // x + width wraps, and a wrapped comparison would admit exactly this.
+                      Fixture wrapping;
+                      wrapping.nodes[1].bounds.x     = std::numeric_limits<std::int32_t>::max();
+                      wrapping.nodes[1].bounds.width = 16;
+                      checks.expect(errorOf(wrapping) == ms::SchemaError::BoundsOutsideSurface,
+                                    std::format("a rectangle whose right edge overflows int32 is refused, got {}", describe(errorOf(wrapping))));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register surfaceMustHaveExtent{"A surface with no extent contains nothing", "evidence-unit", [] {
+                                                     return speclab::Test("medui-schema-surface")
+                                                         .Given("the reference screen", [] {})
+                                                         .When("its surface height is zeroed", [] {})
+                                                         .Then("the screen is refused before any rectangle is considered",
+                                                               [] {
+                                                                   mdux::spec::Checks checks;
+
+                                                                   Fixture flat;
+                                                                   flat.surfaceHeight = 0;
+                                                                   checks.expect(
+                                                                       errorOf(flat) == ms::SchemaError::NonPositiveSurface,
+                                                                       std::format("a surface with no extent is refused, got {}", describe(errorOf(flat))));
+                                                                   checks.raise();
+                                                               })
+                                                         .Execute();
+                                                 }};
+
+const mdux::spec::Register coloursAreNamesNotValues{
+    "A colour a node draws with is a governed name, never a value",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-colour-tokens")
+            .Given("the reference screen", [] {})
+            .When("a node carries an RGBA literal where its token belongs, and another carries none", [] {})
+            .Then("the literal is refused and the absent one is not",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // ADR-011 keeps values off the device side of the boundary: a package that
+                      // carried `[33, 184, 107, 255]` would have performed the substitution the
+                      // governed table exists to perform, and a reviewer would read numbers.
+                      Fixture literal;
+                      literal.nodes[1].colorToken = "#21B86B";
+                      checks.expect(errorOf(literal) == ms::SchemaError::MalformedColorToken,
+                                    std::format("a colour value is refused, got {}", describe(errorOf(literal))));
+
+                      // The prefix on its own resolves to nothing in the
+                      // governed table, so a screen carrying it would validate
+                      // at compile time and fail its lookup on the device.
+                      Fixture bare;
+                      bare.nodes[1].colorToken = ms::colorTokenPrefix;
+                      checks.expect(errorOf(bare) == ms::SchemaError::MalformedColorToken,
+                                    std::format("a bare Theme.Colors. prefix names nothing and is refused, got {}", describe(errorOf(bare))));
+
+                      Fixture untinted;
+                      untinted.nodes[1].colorToken = {};
+                      checks.expect(!errorOf(untinted).has_value(), "a node that declares no tint is legal");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register budgetMustBeIndexableAndNonEmpty{
+    "The budget must be addressable, and must not be empty for a screen that draws",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-budget")
+            .Given("the reference screen", [] {})
+            .When("its budget is emptied, and then set past the 16-bit index width", [] {})
+            .Then("both are refused, while an empty screen with an empty budget is not",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Fixture empty;
+                      empty.budget = mdux::draw::DrawBudget{};
+                      checks.expect(errorOf(empty) == ms::SchemaError::EmptyBudget,
+                                    std::format("a screen with nodes and no budget draws nothing, got {}", describe(errorOf(empty))));
+
+                      Fixture unindexable;
+                      unindexable.budget.maxVertices = mdux::draw::maxIndexableVertices + 1;
+                      checks.expect(errorOf(unindexable) == ms::SchemaError::BudgetExceedsIndexWidth,
+                                    std::format("more vertices than a 16-bit index can address is refused, got {}", describe(errorOf(unindexable))));
+
+                      // The one screen for which an empty budget is honest: it draws nothing.
+                      Fixture blank;
+                      blank.nodes.clear();
+                      blank.budget = mdux::draw::DrawBudget{};
+                      checks.expect(!errorOf(blank).has_value(), std::format("a screen with no nodes is legal, got {}", describe(errorOf(blank))));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register sizingIsNotThisModulesClaim{
+    "The schema carries the budget without claiming it is large enough",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-budget-sizing")
+            .Given("a three-node screen whose budget holds one rectangle", [] {})
+            .When("it is validated", [] {})
+            .Then("it is accepted, because sizing is the compiler's claim and not this type's",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Not an oversight, and worth a scenario so that nobody later "fixes" it into
+                      // a rule: the number of rectangles a screen draws depends on the widest
+                      // approved translation and on what each component draws, and this package
+                      // carries neither by design. A rule invented here would be a second, weaker
+                      // opinion about a number the compiler computes from the text packages (#195).
+                      Fixture tiny;
+                      tiny.budget = mdux::draw::DrawBudget{.maxVertices = 4, .maxIndices = 6, .maxCommands = 1};
+                      checks.expect(!errorOf(tiny).has_value(),
+                                    std::format("an undersized budget is not this module's to refuse, got {}", describe(errorOf(tiny))));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register colourTokensResolveAgainstAGovernedTable{
+    "A carried name resolves against the product's table, and a miss is a Result rather than a guess",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-colour-resolution")
+            .Given("a two-entry governed colour table", [] {})
+            .When("a defined name, an undefined one, and two malformed ones are resolved", [] {})
+            .Then("each answers with the colour or with the error that says which kind of failure it is",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const auto hit = ms::resolveColorToken(constTheme, "Theme.Colors.Title");
+                      checks.expect(hit.has_value() && *hit == mdux::core::ColorRgba8{.r = 12, .g = 24, .b = 36, .a = 255},
+                                    "a defined name resolves to its colour");
+
+                      // A miss is not a colour. ADR-011 keeps the lookup bounded and fallible on
+                      // purpose: a fallback tint would render something nobody approved, which is
+                      // the failure mode a governed table exists to prevent.
+                      const auto miss = ms::resolveColorToken(constTheme, "Theme.Colors.Undefined");
+                      checks.expect(!miss.has_value() && miss.error() == ms::ThemeError::UnknownToken,
+                                    "a name the table does not define is a miss, not a default");
+
+                      const auto malformed = ms::resolveColorToken(constTheme, "Theme.Colors.#");
+                      checks.expect(!malformed.has_value() && malformed.error() == ms::ThemeError::MalformedToken,
+                                    "a name that is not a name is distinguished from one that is merely absent");
+
+                      const auto value = ms::resolveColorToken(constTheme, "#21B86B");
+                      checks.expect(!value.has_value() && value.error() == ms::ThemeError::MalformedToken, "a colour value is refused where a name belongs");
+
+                      // The error matters as much as the failure: a well-formed name against an
+                      // empty table is *absent*, not malformed. Asserting only `!has_value()` would
+                      // pass if the resolver ever confused the two, which is the distinction this
+                      // scenario exists to draw.
+                      const auto emptyTable = ms::resolveColorToken({}, "Theme.Colors.Title");
+                      checks.expect(!emptyTable.has_value() && emptyTable.error() == ms::ThemeError::UnknownToken,
+                                    "an empty table answers a well-formed name with a miss, not a colour nobody approved");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register tokenShapeMatchesWhatTheParserAccepts{
+    "The shape rule admits what the language can write, and refuses what it cannot",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-colour-shape")
+            .Given("names the parser produces and names it cannot", [] {})
+            .When("each is checked for shape", [] {})
+            .Then("the rule tracks the grammar rather than a stricter guess at it",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The parser builds a dotted path from identifier tokens, and an identifier
+                      // may contain digits, `_` and `-`. A stricter rule here would reject screens
+                      // the compiler accepted, which is the worse direction to be wrong in.
+                      checks.expect(ms::isColorToken("Theme.Colors.ScoreDigits"), "the ordinary form");
+                      checks.expect(ms::isColorToken("Theme.Colors.Status-Ok"), "a hyphenated name");
+                      checks.expect(ms::isColorToken("Theme.Colors.Alarm_2"), "digits and an underscore");
+                      checks.expect(ms::isColorToken("Theme.Colors.Status.Ok"), "a nested path, which the parser can produce");
+
+                      checks.expect(!ms::isColorToken("Theme.Colors."), "the bare prefix names nothing");
+                      checks.expect(!ms::isColorToken("Theme.Colors.Status."), "a trailing dot leaves an empty segment");
+                      checks.expect(!ms::isColorToken("Theme.Colors..Ok"), "so does a doubled one");
+                      checks.expect(!ms::isColorToken("Theme.Colors.#"), "punctuation is not an identifier character");
+                      checks.expect(!ms::isColorToken("Palette.Title"), "another prefix is another table");
+                      checks.expect(!ms::isColorToken(""), "and nothing at all is not a name");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -30,25 +30,21 @@ namespace ms = mdux::medui;
 // Compile-time evidence for the constexpr claim
 // ---------------------------------------------------------------------------
 
+// Payloads named separately, so the node list stays one line per node. Inline, clang-format's
+// alignment of long designated initialisers pads the block into something no reviewer can scan -
+// the formatter is satisfied and the reader is not, which is the wrong trade in a fixture whose
+// job is to be read.
+constexpr ms::PanelSpec          topbarPanel{.colorToken = "Theme.Colors.TopbarBackground"};
+constexpr ms::LabelSpec          titleLabel{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"};
+constexpr ms::NumericDisplaySpec scoreDisplay{.requirement = "REQ-NS-001",
+                                              .templateId  = "TPL-SEDATION-INDEX-160",
+                                              .source      = "SEDATION_INDEX",
+                                              .colorToken  = "Theme.Colors.ScoreDigits"};
+
 constexpr std::array<ms::CompiledNode, 3> constNodes{
-    ms::CompiledNode{.id          = "topbar-background",
-                     .component   = "Panel",
-                     .bounds      = {0, 0, 400, 40},
-                     .textKey     = {},
-                     .colorToken  = "Theme.Colors.TopbarBackground",
-                     .requirement = {}          },
-    ms::CompiledNode{            .id          = "title",
-                     .component   = "Label",
-                     .bounds      = {8, 8, 200, 24},
-                     .textKey     = "STR-TITLE",
-                     .colorToken  = "Theme.Colors.Title",
-                     .requirement = {}          },
-    ms::CompiledNode{            .id          = "score",
-                     .component   = "NumericDisplay",
-                     .bounds      = {250, 60, 120, 60},
-                     .textKey     = {},
-                     .colorToken  = "Theme.Colors.ScoreDigits",
-                     .requirement = "REQ-NS-001"}
+    ms::CompiledNode{.id = "topbar-background",    .bounds = {0, 0, 400, 40},  .payload = topbarPanel},
+    ms::CompiledNode{            .id = "title",    .bounds = {8, 8, 200, 24},   .payload = titleLabel},
+    ms::CompiledNode{            .id = "score", .bounds = {250, 60, 120, 60}, .payload = scoreDisplay}
 };
 
 constexpr ms::ScreenPackage constPackage{
@@ -66,6 +62,15 @@ constexpr ms::ScreenPackage constPackage{
 static_assert(constPackage.validate().has_value(), "the reference screen must validate at compile time");
 static_assert(constPackage.find("score") != nullptr, "find() resolves a node at compile time");
 static_assert(constPackage.find("absent") == nullptr, "find() answers a miss without a runtime lookup");
+static_assert(ms::kindName(constNodes[1]) == "Label", "a node names its component at compile time");
+// `holds_alternative` for the claim, and a field read for the value. An earlier revision asserted
+// `get_if(...) != nullptr`, which GCC rejected under -Waddress and was right to: for a variant whose
+// alternative is known at compile time, the pointer can never be null, so the assertion asserted
+// nothing.
+static_assert(std::holds_alternative<ms::LabelSpec>(constNodes[1].payload), "a node's payload is its own component's type");
+static_assert(std::get_if<ms::LabelSpec>(&constNodes[1].payload)->textKey == "STR-TITLE", "and its fields are readable at compile time, without std::get");
+static_assert(ms::requirementOf(constNodes[2]) == "REQ-NS-001", "a traced node yields its requirement");
+static_assert(ms::requirementOf(constNodes[1]).empty(), "and an untraced one yields nothing rather than a placeholder");
 
 /**
  * @brief The palette transcribed from TrustSC's `THEME_COLORS`, by hand and independently.
@@ -259,7 +264,7 @@ const mdux::spec::Register coloursAreNamesNotValues{
                       // carried `[33, 184, 107, 255]` would have performed the substitution the
                       // governed table exists to perform, and a reviewer would read numbers.
                       Fixture literal;
-                      literal.nodes[1].colorToken = "#21B86B";
+                      literal.nodes[1].payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = "#21B86B"};
                       checks.expect(errorOf(literal) == ms::SchemaError::MalformedColorToken,
                                     std::format("a colour value is refused, got {}", describe(errorOf(literal))));
 
@@ -267,7 +272,7 @@ const mdux::spec::Register coloursAreNamesNotValues{
                       // governed table, so a screen carrying it would validate
                       // at compile time and fail its lookup on the device.
                       Fixture bare;
-                      bare.nodes[1].colorToken = ms::colorTokenPrefix;
+                      bare.nodes[1].payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = ms::colorTokenPrefix};
                       checks.expect(errorOf(bare) == ms::SchemaError::MalformedColorToken,
                                     std::format("a bare Theme.Colors. prefix names nothing and is refused, got {}", describe(errorOf(bare))));
 
@@ -276,13 +281,17 @@ const mdux::spec::Register coloursAreNamesNotValues{
                       // shape alone accepted it, and the generated `static_assert` would have
                       // certified a screen whose colour lookup then fails on the device.
                       Fixture undefined;
-                      undefined.nodes[1].colorToken = "Theme.Colors.DoesNotExist";
+                      undefined.nodes[1].payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.DoesNotExist"};
                       checks.expect(errorOf(undefined) == ms::SchemaError::UnknownColorToken,
                                     std::format("a name the governed table does not define is refused, got {}", describe(errorOf(undefined))));
 
+                      // The typed payload makes this checkable where the flat node could not: the
+                      // dictionary makes `color` required on a Label, and one shared field cannot be
+                      // required for some components and absent for others.
                       Fixture untinted;
-                      untinted.nodes[1].colorToken = {};
-                      checks.expect(!errorOf(untinted).has_value(), "a node that declares no tint is legal");
+                      untinted.nodes[1].payload = ms::LabelSpec{.textKey = "STR-TITLE", .colorToken = {}};
+                      checks.expect(errorOf(untinted) == ms::SchemaError::EmptyRequiredName,
+                                    std::format("a Label with no tint is refused, got {}", describe(errorOf(untinted))));
                       checks.raise();
                   })
             .Execute();
@@ -427,6 +436,165 @@ const mdux::spec::Register tokenShapeMatchesWhatTheParserAccepts{
                       checks.expect(!ms::isColorToken("Theme.Colors.#"), "punctuation is not an identifier character");
                       checks.expect(!ms::isColorToken("Palette.Title"), "another prefix is another table");
                       checks.expect(!ms::isColorToken(""), "and nothing at all is not a name");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyComponentNamesItself{
+    "Every payload names its component, and only the traced ones carry a requirement",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-payload-kinds")
+            .Given("one node of each of the eleven kinds", [] {})
+            .When("each is asked for its component name and its requirement", [] {})
+            .Then("the names are the dictionary's, and an untraced component yields nothing",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const std::array<std::string_view, 2>                              states{"STR-OK", "STR-ALARM"};
+                      const std::array<std::pair<ms::NodePayload, std::string_view>, 11> cases{
+                          std::pair{          ms::NodePayload{ms::PanelSpec{}},           std::string_view{"Panel"}},
+                          std::pair{          ms::NodePayload{ms::LabelSpec{}},           std::string_view{"Label"}},
+                          std::pair{          ms::NodePayload{ms::ClockSpec{}},           std::string_view{"Clock"}},
+                          std::pair{          ms::NodePayload{ms::ImageSpec{}},           std::string_view{"Image"}},
+                          std::pair{ ms::NodePayload{ms::VulkanViewportSpec{}},  std::string_view{"VulkanViewport"}},
+                          std::pair{    ms::NodePayload{ms::SignalTraceSpec{}},     std::string_view{"SignalTrace"}},
+                          std::pair{         ms::NodePayload{ms::ButtonSpec{}},          std::string_view{"Button"}},
+                          std::pair{ ms::NodePayload{ms::CriticalButtonSpec{}},  std::string_view{"CriticalButton"}},
+                          std::pair{ ms::NodePayload{ms::NumericDisplaySpec{}},  std::string_view{"NumericDisplay"}},
+                          std::pair{ms::NodePayload{ms::StatusIndicatorSpec{}}, std::string_view{"StatusIndicator"}},
+                          std::pair{      ms::NodePayload{ms::TextInputSpec{}},       std::string_view{"TextInput"}}
+                      };
+
+                      bool everyKindNamed = true;
+                      for (const auto& [payload, expected] : cases) {
+                          const ms::CompiledNode node{
+                              .id      = "n",
+                              .bounds  = {0, 0, 1, 1},
+                              .payload = payload
+                          };
+                          everyKindNamed = everyKindNamed && ms::kindName(node) == expected;
+                      }
+                      checks.expect(everyKindNamed, "every alternative names its component");
+                      checks.expect(cases.size() == std::variant_size_v<ms::NodePayload>,
+                                    "and the case list covers every alternative, so a new one cannot be added unnoticed");
+
+                      // Five components can be traced; the rest carry no requirement field at all,
+                      // which is the distinction the flat node had to fake with an empty string.
+                      const ms::CompiledNode traced{
+                          .id      = "score",
+                          .bounds  = {                     0,                 0,                   1,                 1},
+                          .payload = ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "STATE", .stateKeys = states, .colorTokens = {}}
+                      };
+                      const ms::CompiledNode untraced{
+                          .id      = "now",
+                          .bounds  = {0, 0, 1, 1},
+                          .payload = ms::ClockSpec{.format = "HH_MM"}
+                      };
+                      checks.expect(ms::requirementOf(traced) == "REQ-1", "a status indicator yields its requirement");
+                      checks.expect(ms::requirementOf(untraced).empty(), "a clock has none to yield");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register statesAndTheirTintsPairUp{
+    "A status indicator must have states, and per-state tints must pair with them",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-status-states")
+            .Given("a status indicator with two states", [] {})
+            .When("its states are emptied, and its tint list given the wrong length", [] {})
+            .Then("each is refused, while no tints at all is legal",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const std::array<std::string_view, 2> states{"STR-OK", "STR-ALARM"};
+                      const std::array<std::string_view, 2> tints{"Theme.Colors.Nominal", "Theme.Colors.Fault"};
+                      const std::array<std::string_view, 1> oneTint{"Theme.Colors.Nominal"};
+
+                      const auto packageWith = [](std::span<const ms::CompiledNode> storage) {
+                          return ms::ScreenPackage{
+                              .id            = "screen",
+                              .schemaVersion = mdux::evidence::kSchemaVersion,
+                              .surfaceWidth  = 400,
+                              .surfaceHeight = 300,
+                              .nodes         = storage,
+                              .budget        = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+                          };
+                      };
+
+                      const auto errorFor = [&](ms::NodePayload payload) -> std::optional<ms::SchemaError> {
+                          const std::array<ms::CompiledNode, 1> nodes{
+                              ms::CompiledNode{.id = "state", .bounds = {0, 0, 120, 40}, .payload = std::move(payload)}
+                          };
+                          const auto result = packageWith(nodes).validate();
+                          return result.has_value() ? std::nullopt : std::optional{result.error()};
+                      };
+
+                      checks.expect(
+                          !errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = states, .colorTokens = tints}).has_value(),
+                          "two states and two tints validate");
+                      checks.expect(
+                          !errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = states, .colorTokens = {}}).has_value(),
+                          "and declaring no tint at all is legal");
+                      checks.expect(errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = {}, .colorTokens = {}})
+                                        == ms::SchemaError::NoStates,
+                                    "an indicator that can show nothing is refused");
+
+                      // The failure this pairing rule exists for: one tint short leaves a state with
+                      // no colour and no way to say which state that is.
+                      checks.expect(errorFor(ms::StatusIndicatorSpec{.requirement = "REQ-1", .source = "S", .stateKeys = states, .colorTokens = oneTint})
+                                        == ms::SchemaError::StateColorCountMismatch,
+                                    "a short tint list is refused rather than padded");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unknownPayloadsAreRefused{
+    "A payload this module cannot name is refused rather than accepted",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-unknown-payload")
+            .Given("the closed set of payload alternatives", [] {})
+            .When("a node is validated and asked for its component name", [] {})
+            .Then("every alternative names itself, and the residual case fails closed",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Exhaustiveness is a build failure rather than a test: `variant_size_v` is
+                      // static_asserted in the module, so an alternative added without teaching
+                      // kindName() and validatePayload() about it stops the build at the change.
+                      // What a test can still show is that no alternative is silently misnamed.
+                      checks.expect(std::variant_size_v<ms::NodePayload> == 11, "the alternative set is the eleven components");
+
+                      const ms::CompiledNode textInput{
+                          .id      = "entry",
+                          .bounds  = {0, 0, 100, 20},
+                          .payload = ms::TextInputSpec{.source = "NOTE", .colorToken = "Theme.Colors.Title", .maxLength = 16}
+                      };
+                      checks.expect(ms::kindName(textInput) == "TextInput",
+                                    "the last alternative is named because it is that alternative, not because it is last");
+
+                      const ms::CompiledNode noSource{
+                          .id      = "entry",
+                          .bounds  = {0, 0, 100, 20},
+                          .payload = ms::TextInputSpec{.source = {}, .colorToken = "Theme.Colors.Title", .maxLength = 16}
+                      };
+                      const std::array<ms::CompiledNode, 1> nodes{noSource};
+                      const ms::ScreenPackage               package{
+                                        .id            = "screen",
+                                        .schemaVersion = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth  = 400,
+                                        .surfaceHeight = 300,
+                                        .nodes         = nodes,
+                                        .budget        = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+                      };
+                      const auto result = package.validate();
+                      checks.expect(!result.has_value() && result.error() == ms::SchemaError::EmptyRequiredName,
+                                    "and a required name it does declare is still enforced");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/ScreenNoHeapSpecMain.cpp
+++ b/tests/medui/ScreenNoHeapSpecMain.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file ScreenNoHeapSpecMain.cpp
+ * @brief Entry point for the screen runtime's no-heap executable (issue #199).
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ *
+ * Separate from medui_spec because this binary replaces the global `operator new` family, exactly as
+ * ml_noheap_spec is separate from ml_spec. Keeping the replacement out of the main suite means the
+ * other scenarios run against the ordinary allocator, and a failure here names the no-heap property
+ * rather than appearing as one line among two dozen unrelated ones.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX Screen Runtime No-Heap Spec");
+}

--- a/tests/medui/ScreenNoHeapTests.cpp
+++ b/tests/medui/ScreenNoHeapTests.cpp
@@ -1,0 +1,172 @@
+/**
+ * @file ScreenNoHeapTests.cpp
+ * @brief Layer 1 of issue #199: render() makes no `operator new` call, proved by interposition.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no allocation)
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * "The draw path does not allocate" is easy to claim and easy to break silently - a `std::vector` in
+ * a helper, a `std::string` on an error path, a `std::function` somebody found convenient. This
+ * binary replaces the global `operator new` family with counting versions and measures instead.
+ *
+ * The interposition is shared with the ML suite; `tests/framework/CountingAllocations.hpp` says what
+ * it catches and what it does not, and why the symbol scan is not redundant with it.
+ */
+
+import std;
+import speclab;
+import mdux.core.units;
+import mdux.evidence.report;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.medui.screen;
+
+#include "../framework/SpecLabBridge.hpp"
+
+// The interposition itself. Included by exactly one translation unit in this binary.
+#include "../framework/CountingAllocations.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+
+constexpr mdux::draw::DrawBudget budget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
+
+constexpr ms::PanelSpec panel{.colorToken = "Theme.Colors.TopbarBackground"};
+constexpr ms::LabelSpec label{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"};
+constexpr ms::ClockSpec clock{.format = "TimeSeconds"};
+
+// Every alternative the walk can take: one it draws, and two it defers. A screen of panels alone
+// would leave the deferred branch - the one that touches a variant it does not draw - unmeasured.
+constexpr std::array<ms::CompiledNode, 3> nodes{
+    ms::CompiledNode{ .id = "back",  .bounds = {0, 0, 400, 40}, .payload = panel},
+    ms::CompiledNode{.id = "title",  .bounds = {8, 8, 200, 24}, .payload = label},
+    ms::CompiledNode{.id = "clock", .bounds = {8, 40, 120, 24}, .payload = clock}
+};
+
+constexpr ms::ScreenPackage screen{.id            = "noheap",
+                                   .schemaVersion = mdux::evidence::kSchemaVersion,
+                                   .surfaceWidth  = 400,
+                                   .surfaceHeight = 300,
+                                   .nodes         = nodes,
+                                   .budget        = budget};
+
+static_assert(screen.validate().has_value(), "the screen under measurement must be one a device could hold");
+
+}  // namespace
+
+const mdux::spec::Register theCounterMoves{"The allocation counter moves when something allocates", "noheap", [] {
+                                               return speclab::Test("medui-screen-noheap-selftest")
+                                                   .Given("the interposed operator new", [] {})
+                                                   .When("a deliberate allocation is made", [] {})
+                                                   .Then("the counter records it",
+                                                         [] {
+                                                             mdux::spec::Checks checks;
+
+                                                             // Without this scenario the file would be a test that cannot fail: if the
+                                                             // interposition ever stopped taking effect - a linker change, a static
+                                                             // runtime, an inlined allocation - the counter would simply never move and
+                                                             // every scenario below would pass.
+                                                             const std::size_t before = allocations();
+                                                             auto*             leaked = new std::array<std::byte, 64>{};
+                                                             const std::size_t after  = allocations();
+                                                             delete leaked;
+
+                                                             checks.expect(after > before, std::format("the counter moved, {} then {}", before, after));
+                                                             checks.raise();
+                                                         })
+                                                   .Execute();
+                                           }};
+
+const mdux::spec::Register renderingAllocatesNothing{
+    "Rendering a frame allocates nothing",
+    "noheap",
+    [] {
+        return speclab::Test("medui-screen-noheap-render")
+            .Given("a screen and storage sized once from its budget", [] {})
+            .When("frames are recorded", [] {})
+            .Then("the allocation counter does not move",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Storage first, and outside the measurement: sizing it is the caller's job
+                      // and may allocate on a real device. What must not allocate is the frame.
+                      static std::array<mdux::draw::UiVertex, 512>   vertices{};
+                      static std::array<mdux::draw::Index, 768>      indices{};
+                      static std::array<mdux::draw::DrawCommand, 16> commands{};
+
+                      auto created = mdux::draw::DrawList::create(vertices, indices, commands, budget);
+                      if (!created.has_value()) {
+                          checks.expect(false, "the storage satisfies the budget");
+                          checks.raise();
+                          return;
+                      }
+                      mdux::draw::DrawList list = std::move(*created);
+
+                      const std::size_t before = allocations();
+                      for (int frame = 0; frame < 8; ++frame) {
+                          list.reset();
+                          const auto recorded = ms::render(screen, list);
+                          checks.expect(recorded.has_value(), "each frame is recorded");
+                      }
+                      const std::size_t after = allocations();
+
+                      // Eight frames rather than one, because a first frame could allocate once and
+                      // hide it as setup. A per-frame allocation would show up as eight.
+                      checks.expect(after == before, std::format("no allocation across eight frames, counter went {} to {}", before, after));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register refusingAFrameAllocatesNothing{
+    "Refusing a frame allocates nothing either",
+    "noheap",
+    [] {
+        return speclab::Test("medui-screen-noheap-refusal")
+            .Given("a screen naming a colour the governed table does not define", [] {})
+            .When("the frame is refused and rolled back", [] {})
+            .Then("the error path allocates nothing",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The path review misses. An error type carrying a message, or a diagnostic
+                      // assembled on the way out, allocates exactly where nobody is looking.
+                      static std::array<mdux::draw::UiVertex, 512>   vertices{};
+                      static std::array<mdux::draw::Index, 768>      indices{};
+                      static std::array<mdux::draw::DrawCommand, 16> commands{};
+
+                      auto created = mdux::draw::DrawList::create(vertices, indices, commands, budget);
+                      if (!created.has_value()) {
+                          checks.expect(false, "the storage satisfies the budget");
+                          checks.raise();
+                          return;
+                      }
+                      mdux::draw::DrawList list = std::move(*created);
+
+                      constexpr ms::PanelSpec                   unknown{.colorToken = "Theme.Colors.NotInTheTable"};
+                      constexpr std::array<ms::CompiledNode, 1> refusedNodes{
+                          ms::CompiledNode{.id = "wrong", .bounds = {0, 0, 400, 40}, .payload = unknown}
+                      };
+                      const ms::ScreenPackage refused{.id            = "refused",
+                                                      .schemaVersion = mdux::evidence::kSchemaVersion,
+                                                      .surfaceWidth  = 400,
+                                                      .surfaceHeight = 300,
+                                                      .nodes         = refusedNodes,
+                                                      .budget        = budget};
+
+                      const std::size_t before = allocations();
+                      const auto        frame  = ms::render(refused, list);
+                      const std::size_t after  = allocations();
+
+                      checks.expect(!frame.has_value(), "the frame is refused");
+                      if (!frame.has_value()) {
+                          // describe() is on the path a caller takes after a refusal, so it is
+                          // measured too: a string_view over a literal allocates nothing.
+                          checks.expect(!ms::describe(frame.error()).empty(), "the error describes itself");
+                      }
+                      checks.expect(after == before, std::format("the error path allocates nothing, counter went {} to {}", before, after));
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/ScreenRuntimeTests.cpp
+++ b/tests/medui/ScreenRuntimeTests.cpp
@@ -1,0 +1,476 @@
+/**
+ * @file ScreenRuntimeTests.cpp
+ * @brief BDD scenarios for the governed screen runtime (issue #199).
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
+ * @compliance ADR-005 Error handling and exceptions policy
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Two of these are #199's acceptance rather than ordinary coverage: the work a frame does must be a
+ * pure function of the package, and it must scale with the node count. Both are read off
+ * `FrameStats::steps`, which exists for them. A future component that looped until a condition, or
+ * whose work grew with its data, breaks one or the other - which is the point, since the bound
+ * otherwise holds only by argument.
+ */
+
+import std;
+import speclab;
+import mdux.core.units;
+import mdux.evidence.report;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.medui.screen;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+
+/// Storage a caller sizes once from a screen's budget, exactly as a device would.
+///
+/// A plain array rather than a vector: this suite links MduX::Core, and the scratch belongs where a
+/// device would put it rather than on a heap the path under test must never touch.
+struct Scratch {
+    std::array<mdux::draw::UiVertex, 512>   vertices{};
+    std::array<mdux::draw::Index, 768>      indices{};
+    std::array<mdux::draw::DrawCommand, 16> commands{};
+
+    [[nodiscard]] mdux::draw::DrawList list(const mdux::draw::DrawBudget& budget) {
+        auto created = mdux::draw::DrawList::create(vertices, indices, commands, budget);
+        if (!created.has_value()) {
+            throw speclab::core::AssertionFailure("the scratch does not satisfy the screen's budget", std::source_location::current());
+        }
+        return std::move(*created);
+    }
+};
+
+constexpr mdux::draw::DrawBudget testBudget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
+
+constexpr ms::PanelSpec topbar{.colorToken = "Theme.Colors.TopbarBackground"};
+constexpr ms::PanelSpec footer{.colorToken = "Theme.Colors.Neutral"};
+constexpr ms::LabelSpec title{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"};
+
+constexpr std::array<ms::CompiledNode, 3> mixedNodes{
+    ms::CompiledNode{.id = "topbar",   .bounds = {0, 0, 400, 40}, .payload = topbar},
+    ms::CompiledNode{ .id = "title",   .bounds = {8, 8, 200, 24},  .payload = title},
+    ms::CompiledNode{.id = "footer", .bounds = {0, 260, 400, 40}, .payload = footer}
+};
+
+constexpr ms::ScreenPackage mixedScreen{.id            = "mixed",
+                                        .schemaVersion = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth  = 400,
+                                        .surfaceHeight = 300,
+                                        .nodes         = mixedNodes,
+                                        .budget        = testBudget};
+
+/// The same screen with twice the nodes, for the scaling half of the bounded-work acceptance.
+constexpr std::array<ms::CompiledNode, 6> doubledNodes{
+    ms::CompiledNode{ .id = "topbar",   .bounds = {0, 0, 400, 40}, .payload = topbar},
+    ms::CompiledNode{  .id = "title",   .bounds = {8, 8, 200, 24},  .payload = title},
+    ms::CompiledNode{ .id = "footer", .bounds = {0, 260, 400, 40}, .payload = footer},
+    ms::CompiledNode{.id = "topbar2",  .bounds = {0, 40, 400, 40}, .payload = topbar},
+    ms::CompiledNode{ .id = "title2",  .bounds = {8, 88, 200, 24},  .payload = title},
+    ms::CompiledNode{.id = "footer2", .bounds = {0, 200, 400, 40}, .payload = footer}
+};
+
+constexpr ms::ScreenPackage doubledScreen{.id            = "doubled",
+                                          .schemaVersion = mdux::evidence::kSchemaVersion,
+                                          .surfaceWidth  = 400,
+                                          .surfaceHeight = 300,
+                                          .nodes         = doubledNodes,
+                                          .budget        = testBudget};
+
+static_assert(mixedScreen.validate().has_value(), "the reference screen must be one a device could hold");
+static_assert(doubledScreen.validate().has_value(), "and so must the doubled one");
+
+}  // namespace
+
+const mdux::spec::Register aFrameDrawsWhatItCanAndCountsTheRest{
+    "A frame draws the panels and counts what it cannot decide",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-frame")
+            .Given("a screen with two panels and a label", [] {})
+            .When("one frame is recorded", [] {})
+            .Then("the panels are drawn and the label is deferred, not silently skipped",
+                  [] {
+                      mdux::spec::Checks checks;
+                      Scratch            scratch;
+                      auto               list = scratch.list(testBudget);
+
+                      const auto frame = ms::render(mixedScreen, list);
+                      checks.expect(frame.has_value(), "the frame is recorded");
+                      if (!frame.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(frame->nodes == 3, std::format("three nodes visited, got {}", frame->nodes));
+                      checks.expect(frame->rects == 2, std::format("two rectangles, got {}", frame->rects));
+                      // The honest half: a Label carries a text key, not glyphs, so drawing it is a
+                      // join with a baked text package this repository does not have yet. Counted
+                      // rather than skipped, so an integrator sees what was left undone.
+                      checks.expect(frame->deferred == 1, std::format("one node deferred, got {}", frame->deferred));
+                      // The per-node cap this implementation actually has, asserted rather than
+                      // described: no node contributes more than one rectangle.
+                      checks.expect(frame->rects <= frame->nodes, "no node records more than one rectangle");
+                      checks.expect(list.vertices().size() == 8, std::format("two quads worth of vertices, got {}", list.vertices().size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theWorkIsAPureFunctionOfTheScreen{
+    "Rendering the same screen twice does the same work",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-work-is-pure")
+            .Given("one screen and two lists over separate storage", [] {})
+            .When("it is rendered twice", [] {})
+            .Then("the iteration count and the recorded bytes are identical",
+                  [] {
+                      mdux::spec::Checks checks;
+                      Scratch            first;
+                      Scratch            second;
+
+                      auto       listA  = first.list(testBudget);
+                      auto       listB  = second.list(testBudget);
+                      const auto frameA = ms::render(mixedScreen, listA);
+                      const auto frameB = ms::render(mixedScreen, listB);
+                      if (!frameA.has_value() || !frameB.has_value()) {
+                          checks.expect(false, "both frames are recorded");
+                          checks.raise();
+                          return;
+                      }
+
+                      // #199's first acceptance criterion: the work is a function of the package and
+                      // of nothing ambient. A component that looped until a condition would show up
+                      // here as a step count that moved between two identical renders.
+                      checks.expect(*frameA == *frameB, std::format("identical statistics, got steps {} then {}", frameA->steps, frameB->steps));
+
+                      const std::span<const mdux::draw::UiVertex> a = listA.vertices();
+                      const std::span<const mdux::draw::UiVertex> b = listB.vertices();
+                      checks.expect(a.size() == b.size(), "the same number of vertices");
+                      const bool sameBytes = a.size() == b.size()
+                                             && std::equal(reinterpret_cast<const std::byte*>(a.data()),
+                                                           reinterpret_cast<const std::byte*>(a.data()) + a.size_bytes(),
+                                                           reinterpret_cast<const std::byte*>(b.data()));
+                      checks.expect(sameBytes, "and the same bytes, which is what a cross-toolchain comparison rests on");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theWorkScalesWithTheNodeCount{"The work scales with the node count", "evidence-unit", [] {
+                                                             return speclab::Test("medui-screen-work-scales")
+                                                                 .Given("a screen and a second one with twice the nodes", [] {})
+                                                                 .When("both are rendered", [] {})
+                                                                 .Then("the iteration count doubles, so data-dependent work would be visible",
+                                                                       [] {
+                                                                           mdux::spec::Checks checks;
+                                                                           Scratch            small;
+                                                                           Scratch            large;
+
+                                                                           auto       listSmall = small.list(testBudget);
+                                                                           auto       listLarge = large.list(testBudget);
+                                                                           const auto n         = ms::render(mixedScreen, listSmall);
+                                                                           const auto twoN      = ms::render(doubledScreen, listLarge);
+                                                                           if (!n.has_value() || !twoN.has_value()) {
+                                                                               checks.expect(false, "both frames are recorded");
+                                                                               checks.raise();
+                                                                               return;
+                                                                           }
+
+                                                                           // #199's second criterion. An equality rather than a bound: work that grew
+                                                                           // with something other than the node count would land between the two, and a
+                                                                           // bound would let it pass.
+                                                                           checks.expect(
+                                                                               twoN->steps == n->steps * 2,
+                                                                               std::format("{} steps for twice the nodes of {}", twoN->steps, n->steps));
+                                                                           checks.expect(twoN->nodes == n->nodes * 2, "and twice the nodes visited");
+                                                                           checks.raise();
+                                                                       })
+                                                                 .Execute();
+                                                         }};
+
+const mdux::spec::Register aRefusedFrameLeavesNothingBehind{
+    "A refused frame leaves the list as it was found",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-fails-closed")
+            .Given("a screen whose second panel names a colour the governed table does not define", [] {})
+            .When("a frame is recorded after something else was already drawn", [] {})
+            .Then("the frame is refused and the earlier drawing survives untouched",
+                  [] {
+                      mdux::spec::Checks checks;
+                      Scratch            scratch;
+                      auto               list = scratch.list(testBudget);
+
+                      // Something the caller drew before the screen: a frame that rolled back too
+                      // far would take this with it.
+                      const auto before = list.addSolidRect(mdux::core::Rect{.x = 0, .y = 0, .width = 10, .height = 10},
+                                                            mdux::core::ColorRgba8{.r = 1, .g = 2, .b = 3, .a = 4});
+                      checks.expect(before.has_value(), "the caller's own rectangle is recorded");
+                      const std::size_t verticesBefore = list.vertices().size();
+
+                      constexpr ms::PanelSpec                   unknown{.colorToken = "Theme.Colors.NotInTheTable"};
+                      constexpr std::array<ms::CompiledNode, 2> nodes{
+                          ms::CompiledNode{ .id = "good",  .bounds = {0, 0, 400, 40},  .payload = topbar},
+                          ms::CompiledNode{.id = "wrong", .bounds = {0, 60, 400, 40}, .payload = unknown}
+                      };
+                      const ms::ScreenPackage screen{.id            = "unknown-token",
+                                                     .schemaVersion = mdux::evidence::kSchemaVersion,
+                                                     .surfaceWidth  = 400,
+                                                     .surfaceHeight = 300,
+                                                     .nodes         = nodes,
+                                                     .budget        = testBudget};
+
+                      const auto frame = ms::render(screen, list);
+                      checks.expect(!frame.has_value(), "a screen naming an unknown colour is refused");
+                      if (!frame.has_value()) {
+                          checks.expect(frame.error() == ms::ScreenError::UnknownColorToken,
+                                        std::format("reported as UnknownColorToken, got '{}'", ms::describe(frame.error())));
+                      }
+
+                      // A malformed name is a different failure from an absent one, and the schema
+                      // keeps them apart for a reason worth preserving here: one says the emitter is
+                      // broken, the other says the table does not define this colour.
+                      constexpr ms::PanelSpec                   malformed{.colorToken = "NotEvenAToken"};
+                      constexpr std::array<ms::CompiledNode, 1> malformedNodes{
+                          ms::CompiledNode{.id = "bad", .bounds = {0, 0, 40, 40}, .payload = malformed}
+                      };
+                      const ms::ScreenPackage malformedScreen{.id            = "malformed-token",
+                                                              .schemaVersion = mdux::evidence::kSchemaVersion,
+                                                              .surfaceWidth  = 400,
+                                                              .surfaceHeight = 300,
+                                                              .nodes         = malformedNodes,
+                                                              .budget        = testBudget};
+                      const auto              malformedFrame = ms::render(malformedScreen, list);
+                      checks.expect(!malformedFrame.has_value(), "a malformed colour is refused too");
+                      if (!malformedFrame.has_value()) {
+                          checks.expect(malformedFrame.error() == ms::ScreenError::MalformedColorToken,
+                                        std::format("and told apart from an unknown one, got '{}'", ms::describe(malformedFrame.error())));
+                      }
+                      // The first panel had already been recorded when the second failed. A frame is
+                      // whole or absent: a half-drawn one on a medical display looks like a reading.
+                      checks.expect(list.vertices().size() == verticesBefore,
+                                    std::format("the partial frame is gone, {} vertices remain of {}", list.vertices().size(), verticesBefore));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aBudgetTooSmallIsRefusedNotTruncated{
+    "A budget too small for the screen is refused rather than drawn in part",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-budget-exhausted")
+            .Given("a list created against a budget with room for one rectangle", [] {})
+            .When("a screen with two panels is rendered", [] {})
+            .Then("the frame is refused and nothing is left recorded",
+                  [] {
+                      mdux::spec::Checks checks;
+                      Scratch            scratch;
+
+                      constexpr mdux::draw::DrawBudget tight{.maxVertices = 4, .maxIndices = 6, .maxCommands = 1};
+                      auto                             list = scratch.list(tight);
+
+                      constexpr std::array<ms::CompiledNode, 2> nodes{
+                          ms::CompiledNode{.id = "one",  .bounds = {0, 0, 400, 40}, .payload = topbar},
+                          ms::CompiledNode{.id = "two", .bounds = {0, 60, 400, 40}, .payload = footer}
+                      };
+                      const ms::ScreenPackage screen{.id            = "too-tight",
+                                                     .schemaVersion = mdux::evidence::kSchemaVersion,
+                                                     .surfaceWidth  = 400,
+                                                     .surfaceHeight = 300,
+                                                     .nodes         = nodes,
+                                                     .budget        = tight};
+
+                      const auto frame = ms::render(screen, list);
+                      checks.expect(!frame.has_value(), "the frame is refused");
+                      if (!frame.has_value()) {
+                          checks.expect(frame.error() == ms::ScreenError::BudgetExhausted,
+                                        std::format("reported as BudgetExhausted, got '{}'", ms::describe(frame.error())));
+                      }
+                      checks.expect(list.vertices().empty(), std::format("nothing is left recorded, got {} vertices", list.vertices().size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theWorkDoesNotVaryWithTheData{
+    "Two screens with the same node count and different data do the same work",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-work-is-data-independent")
+            .Given("two screens of three nodes whose rectangles and colours differ entirely", [] {})
+            .When("both are rendered", [] {})
+            .Then("the iteration count is the same, so work proportional to the data would show",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The case that carries the weight. Rendering one screen twice proves only
+                      // determinism, and doubling identical nodes doubles any per-node cost whatever
+                      // it depends on - so neither would catch work proportional to a rectangle's
+                      // width. These two screens have the same node count and share nothing else.
+                      constexpr ms::PanelSpec alert{.colorToken = "Theme.Colors.Alert"};
+                      constexpr ms::PanelSpec fault{.colorToken = "Theme.Colors.Fault"};
+                      constexpr ms::LabelSpec other{.textKey = "STR-OTHER", .colorToken = "Theme.Colors.ScoreDigits"};
+
+                      constexpr std::array<ms::CompiledNode, 3> tinyNodes{
+                          ms::CompiledNode{.id = "a", .bounds = {0, 0, 2, 2}, .payload = alert},
+                          ms::CompiledNode{.id = "b", .bounds = {4, 4, 2, 2}, .payload = other},
+                          ms::CompiledNode{.id = "c", .bounds = {8, 8, 2, 2}, .payload = fault}
+                      };
+                      constexpr std::array<ms::CompiledNode, 3> hugeNodes{
+                          ms::CompiledNode{.id = "a",   .bounds = {0, 0, 400, 150}, .payload = fault},
+                          ms::CompiledNode{.id = "b", .bounds = {0, 150, 400, 100}, .payload = other},
+                          ms::CompiledNode{.id = "c",  .bounds = {0, 250, 400, 50}, .payload = alert}
+                      };
+
+                      const ms::ScreenPackage tiny{.id            = "tiny",
+                                                   .schemaVersion = mdux::evidence::kSchemaVersion,
+                                                   .surfaceWidth  = 400,
+                                                   .surfaceHeight = 300,
+                                                   .nodes         = tinyNodes,
+                                                   .budget        = testBudget};
+                      const ms::ScreenPackage huge{.id            = "huge",
+                                                   .schemaVersion = mdux::evidence::kSchemaVersion,
+                                                   .surfaceWidth  = 400,
+                                                   .surfaceHeight = 300,
+                                                   .nodes         = hugeNodes,
+                                                   .budget        = testBudget};
+
+                      Scratch small;
+                      Scratch large;
+                      auto    listTiny = small.list(testBudget);
+                      auto    listHuge = large.list(testBudget);
+
+                      const auto a = ms::render(tiny, listTiny);
+                      const auto b = ms::render(huge, listHuge);
+                      if (!a.has_value() || !b.has_value()) {
+                          checks.expect(false, "both frames are recorded");
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(a->steps == b->steps, std::format("the same work for the same node count, got {} and {}", a->steps, b->steps));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theEmittedBytesArePinned{
+    "One panel emits exactly these vertices on every toolchain",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-vertex-bytes")
+            .Given("a screen of one panel at a known rectangle in a known colour", [] {})
+            .When("a frame is recorded", [] {})
+            .Then("every field of every vertex is the value frozen here",
+                  [] {
+                      mdux::spec::Checks checks;
+                      Scratch            scratch;
+                      auto               list = scratch.list(testBudget);
+
+                      // Comparing two renders proves repeatability inside one binary, and both CI
+                      // legs would pass while emitting different bytes. The constants below are what
+                      // makes this a cross-toolchain comparison: MSVC and GCC check their output
+                      // against the same numbers, so a float conversion or a colour quantisation
+                      // that differed would fail on the leg that differed.
+                      constexpr std::array<ms::CompiledNode, 1> pinned{
+                          ms::CompiledNode{.id = "topbar", .bounds = {0, 0, 400, 40}, .payload = topbar}
+                      };
+                      const ms::ScreenPackage screen{.id            = "pinned",
+                                                     .schemaVersion = mdux::evidence::kSchemaVersion,
+                                                     .surfaceWidth  = 400,
+                                                     .surfaceHeight = 300,
+                                                     .nodes         = pinned,
+                                                     .budget        = testBudget};
+
+                      const auto frame = ms::render(screen, list);
+                      if (!frame.has_value()) {
+                          checks.expect(false, "the frame is recorded");
+                          checks.raise();
+                          return;
+                      }
+
+                      // `Theme.Colors.TopbarBackground` is {0.82, 0.84, 0.86, 1.0} linear, and this
+                      // runtime quantises without a transfer function - so these four bytes are the
+                      // quantisation, pinned. A change to either the table or the rounding shows up
+                      // here rather than as a slightly different frame nobody compares.
+                      const std::uint32_t expectedColor = mdux::draw::packColor(mdux::core::ColorRgba8{.r = 209, .g = 214, .b = 219, .a = 255});
+
+                      const std::span<const mdux::draw::UiVertex> vertices = list.vertices();
+                      checks.expect(vertices.size() == 4, std::format("one quad, got {} vertices", vertices.size()));
+                      if (vertices.size() != 4) {
+                          checks.raise();
+                          return;
+                      }
+
+                      // Corner order is top-left, top-right, bottom-right, bottom-left. Every field
+                      // of all four is named, and `UiVertex` is statically asserted to be exactly
+                      // 24 bytes with no padding, so "every field" is "every byte".
+                      const std::array<mdux::draw::UiVertex, 4> expected{
+                          mdux::draw::UiVertex{  .x = 0.0F,  .y = 0.0F, .u = 0.0F, .v = 0.0F, .color = expectedColor, .mode = 0},
+                          mdux::draw::UiVertex{.x = 400.0F,  .y = 0.0F, .u = 0.0F, .v = 0.0F, .color = expectedColor, .mode = 0},
+                          mdux::draw::UiVertex{.x = 400.0F, .y = 40.0F, .u = 0.0F, .v = 0.0F, .color = expectedColor, .mode = 0},
+                          mdux::draw::UiVertex{  .x = 0.0F, .y = 40.0F, .u = 0.0F, .v = 0.0F, .color = expectedColor, .mode = 0}
+                      };
+                      for (std::size_t index = 0; index < expected.size(); ++index) {
+                          checks.expect(vertices[index] == expected[index],
+                                        std::format("vertex {} matches the frozen value, got x={} y={} colour={}",
+                                                    index,
+                                                    vertices[index].x,
+                                                    vertices[index].y,
+                                                    vertices[index].color));
+                      }
+
+                      const std::array<mdux::draw::Index, 6>   expectedIndices{0, 1, 2, 0, 2, 3};
+                      const std::span<const mdux::draw::Index> indices = list.indices();
+                      checks.expect(std::ranges::equal(indices, expectedIndices), "and the two triangles are wound as pinned");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theScreensOwnBudgetBoundsTheFrame{
+    "The screen's declared budget bounds the frame, whatever the list allows",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-own-budget")
+            .Given("a two-panel screen declaring room for one rectangle, and a list far larger", [] {})
+            .When("it is rendered", [] {})
+            .Then("the frame is refused and rolled back rather than drawn to the list's limit",
+                  [] {
+                      mdux::spec::Checks checks;
+                      Scratch            scratch;
+
+                      // The inverse of the exhausted-list case, and the one that showed the declared
+                      // budget was decorative: `DrawList` can only enforce the budget it was created
+                      // with, so a roomier list let a screen draw past the ceiling it declares - and
+                      // a mistake in a baked budget would have been bypassed rather than observed.
+                      auto list = scratch.list(testBudget);
+
+                      constexpr mdux::draw::DrawBudget          oneRect{.maxVertices = 4, .maxIndices = 6, .maxCommands = 1};
+                      constexpr std::array<ms::CompiledNode, 2> nodes{
+                          ms::CompiledNode{.id = "one",  .bounds = {0, 0, 400, 40}, .payload = topbar},
+                          ms::CompiledNode{.id = "two", .bounds = {0, 60, 400, 40}, .payload = footer}
+                      };
+                      const ms::ScreenPackage screen{.id            = "declares-one-rect",
+                                                     .schemaVersion = mdux::evidence::kSchemaVersion,
+                                                     .surfaceWidth  = 400,
+                                                     .surfaceHeight = 300,
+                                                     .nodes         = nodes,
+                                                     .budget        = oneRect};
+
+                      const auto frame = ms::render(screen, list);
+                      checks.expect(!frame.has_value(), "the screen's own budget refuses the second rectangle");
+                      if (!frame.has_value()) {
+                          checks.expect(frame.error() == ms::ScreenError::BudgetExhausted,
+                                        std::format("reported as BudgetExhausted, got '{}'", ms::describe(frame.error())));
+                      }
+                      checks.expect(list.vertices().empty(), std::format("and nothing is left recorded, got {} vertices", list.vertices().size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/SemanticTests.cpp
+++ b/tests/medui/SemanticTests.cpp
@@ -1,0 +1,354 @@
+/**
+ * @file SemanticTests.cpp
+ * @brief BDD scenarios for `.medui` semantic analysis (issue #193).
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+
+import std;
+import speclab;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md  = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+
+[[nodiscard]] mdux::text::TextPackage package(std::string locale, std::initializer_list<std::string_view> keys) {
+    mdux::text::TextPackage result;
+    result.header.id   = std::format("semantic-fixture-{}", locale);
+    result.atlasId     = "semantic-fixture-atlas";
+    result.locale      = std::move(locale);
+    result.sidecarPath = "runs.bin";
+    for (std::string_view key : keys) {
+        result.runs.push_back(mdux::text::TextRun{.id = std::string{key}, .byteOffset = 0, .byteLength = 0, .sha256 = {}});
+    }
+    return result;
+}
+
+[[nodiscard]] md::SemanticResult analyze(std::string_view source, std::span<const std::string_view> themes, std::span<const mdux::text::TextPackage> packages) {
+    md::ParseResult parsed = md::parse(source, "semantic-test.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("semantic test source did not parse", std::source_location::current());
+    }
+    return md::analyze(*parsed.screen, "semantic-test.medui", md::SemanticInputs{.themeTokens = themes, .textPackages = packages});
+}
+
+[[nodiscard]] const cli::Diagnostic* find(const md::SemanticResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    });
+    return found == result.diagnostics.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] std::size_t count(const md::SemanticResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    return static_cast<std::size_t>(std::ranges::count_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    }));
+}
+
+constexpr std::string_view validNested = R"(Screen Valid {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Row {
+        id: header;
+        height: 32px;
+        background: Theme.Colors.Header;
+        Label {
+            id: title;
+            width: Fill;
+            height: 32px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+    }
+})";
+
+}  // namespace
+
+const mdux::spec::Register semanticNamesResolve{"Semantic analysis accepts known names recursively without substituting the AST", "evidence-unit", [] {
+                                                    return speclab::Test("medui-semantic-known-names")
+                                                        .Given("a Row child whose theme tokens and text key exist in two locales", [] {})
+                                                        .When("the unresolved parsed screen is analyzed", [] {})
+                                                        .Then("the recursive semantic pass accepts it",
+                                                              [] {
+                                                                  const std::array<std::string_view, 2> themes{"Theme.Colors.Header", "Theme.Colors.Title"};
+                                                                  const std::array<mdux::text::TextPackage, 2> packages{package("en-US", {"STR-TITLE"}),
+                                                                                                                        package("fr-FR", {"STR-TITLE"})};
+                                                                  const md::SemanticResult                     result = analyze(validNested, themes, packages);
+                                                                  mdux::spec::Checks                           checks;
+                                                                  checks.expect(result.ok(), "known recursive names produce no diagnostics");
+                                                                  checks.raise();
+                                                              })
+                                                        .Execute();
+                                                }};
+
+const mdux::spec::Register semanticDictionaryAccumulates{
+    "The closed component dictionary reports unknown components, fields, and missing fields",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-component-dictionary")
+            .Given("one unknown component and one incomplete Label with a misspelled field", [] {})
+            .When("both nodes are analyzed in one pass", [] {})
+            .Then("all dictionary findings carry their source positions",
+                  [] {
+                      constexpr std::string_view                   source = R"(Screen Dictionary {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Mystery {
+        id: unknown;
+    }
+    Label {
+        id: title;
+        width: 80px;
+        height: 20px;
+        text: t("STR-TITLE");
+        colour: Theme.Colors.Title;
+    }
+})";
+                      const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
+                      const md::SemanticResult                     result           = analyze(source, themes, packages);
+                      const cli::Diagnostic*                       unknownComponent = find(result, md::Code::UnknownComponent);
+                      const cli::Diagnostic*                       missingField     = find(result, md::Code::MissingRequiredField);
+                      const cli::Diagnostic*                       unknownField     = find(result, md::Code::UnknownField);
+
+                      mdux::spec::Checks checks;
+                      checks.expect(result.diagnostics.size() == 3, "three independent findings accumulate");
+                      checks.expect(unknownComponent != nullptr && unknownComponent->line == 3 && unknownComponent->column == 5,
+                                    "the unknown component points at its name");
+                      checks.expect(missingField != nullptr && missingField->line == 6 && missingField->column == 5,
+                                    "the missing color points at its component");
+                      checks.expect(unknownField != nullptr && unknownField->line == 11 && unknownField->column == 9, "the unknown field points at its name");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register semanticResolutionDistinguishesFailures{
+    "Theme and text resolution distinguish global absence from a locale-specific gap",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-resolution-diagnostics")
+            .Given("unknown theme/text names and a second key missing in two approved locales", [] {})
+            .When("the screen is analyzed against three locale packages", [] {})
+            .Then("E030, E031, and one E032 per missing locale are reported",
+                  [] {
+                      constexpr std::string_view                   source = R"(Screen Resolution {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Row {
+        id: content;
+        height: 40px;
+        Label {
+            id: unknown;
+            width: 100px;
+            height: 20px;
+            text: t("STR-UNKNOWN");
+            color: Theme.Colors.Unknown;
+        }
+        Label {
+            id: partial;
+            width: 100px;
+            height: 20px;
+            text: t("STR-PARTIAL");
+            color: Theme.Colors.Title;
+        }
+    }
+})";
+                      const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                      const std::array<mdux::text::TextPackage, 3> packages{package("en-US", {"STR-PARTIAL"}), package("fr-FR", {}), package("de-DE", {})};
+                      const md::SemanticResult                     result       = analyze(source, themes, packages);
+                      const cli::Diagnostic*                       unknownKey   = find(result, md::Code::UnknownTextKey);
+                      const cli::Diagnostic*                       unknownColor = find(result, md::Code::UnknownColorToken);
+
+                      mdux::spec::Checks checks;
+                      checks.expect(count(result, md::Code::UnknownTextKey) == 1, "a key absent everywhere produces one E031");
+                      checks.expect(count(result, md::Code::TextKeyMissingForLocale) == 2, "a partially present key produces one E032 per missing locale");
+                      checks.expect(count(result, md::Code::UnknownColorToken) == 1, "an absent theme token produces E030");
+                      checks.expect(unknownKey != nullptr && unknownKey->line == 10 && unknownKey->column == 19, "E031 points at t(KEY)");
+                      checks.expect(unknownColor != nullptr && unknownColor->line == 11 && unknownColor->column == 20, "E030 points at Theme.Colors.Token");
+                      checks.expect(std::ranges::any_of(result.diagnostics,
+                                                        [](const cli::Diagnostic& d) {
+                                                            return d.code == md::id(md::Code::TextKeyMissingForLocale) && d.message.contains("fr-FR");
+                                                        }),
+                                    "a missing-locale message names fr-FR");
+                      checks.expect(std::ranges::any_of(result.diagnostics,
+                                                        [](const cli::Diagnostic& d) {
+                                                            return d.code == md::id(md::Code::TextKeyMissingForLocale) && d.message.contains("de-DE");
+                                                        }),
+                                    "a missing-locale message names de-DE");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register semanticHardcodedTextPrecedence{"A literal in a text-bearing field is rejected as hardcoded text at its value", "evidence-unit", [] {
+                                                               return speclab::Test("medui-semantic-hardcoded-text")
+                                                                   .Given("a Label whose text is a literal string", [] {})
+                                                                   .When("the text field is analyzed", [] {})
+                                                                   .Then("E017 takes precedence over a generic value-shape finding",
+                                                                         [] {
+                                                                             constexpr std::string_view                   source = R"(Screen Literal {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Label {
+        id: title;
+        width: 100px;
+        height: 20px;
+        text: "Product Name";
+        color: Theme.Colors.Title;
+    }
+})";
+                                                                             const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                                                                             const std::array<mdux::text::TextPackage, 0> packages{};
+                                                                             const md::SemanticResult result  = analyze(source, themes, packages);
+                                                                             const cli::Diagnostic*   literal = find(result, md::Code::HardcodedString);
+                                                                             mdux::spec::Checks       checks;
+                                                                             checks.expect(result.diagnostics.size() == 1,
+                                                                                           "only the specific hardcoded-text finding is emitted");
+                                                                             checks.expect(literal != nullptr && literal->line == 7 && literal->column == 15,
+                                                                                           "E017 points at the literal value");
+                                                                             checks.raise();
+                                                                         })
+                                                                   .Execute();
+                                                           }};
+
+const mdux::spec::Register semanticFieldDomains{"Known fields reject syntactically valid values from the wrong semantic domain", "evidence-unit", [] {
+                                                    return speclab::Test("medui-semantic-field-domains")
+                                                        .Given("a Row and Label with three mismatched field value forms", [] {})
+                                                        .When("the field domains are analyzed", [] {})
+                                                        .Then("each mismatch is MEDUI-E033 at the value",
+                                                              [] {
+                                                                  constexpr std::string_view                   source = R"(Screen Domains {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Row {
+        id: content;
+        height: 40px;
+        spacing: Theme.Colors.Title;
+        Label {
+            id: t("STR-TITLE");
+            width: "120px";
+            height: 20px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+    }
+})";
+                                                                  const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                                                                  const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
+                                                                  const md::SemanticResult                     result = analyze(source, themes, packages);
+                                                                  mdux::spec::Checks                           checks;
+                                                                  checks.expect(count(result, md::Code::FieldValueKind) == 3,
+                                                                                "all three mismatches report E033");
+                                                                  checks.expect(result.diagnostics.size() == 3,
+                                                                                "domain mismatches do not cascade into name diagnostics");
+                                                                  if (result.diagnostics.size() == 3) {
+                                                                      checks.expect(result.diagnostics[0].line == 6 && result.diagnostics[0].column == 18,
+                                                                                    "Row spacing points at Theme.Colors.Title");
+                                                                      checks.expect(result.diagnostics[1].line == 8 && result.diagnostics[1].column == 17,
+                                                                                    "Label id points at t(\"STR-TITLE\")");
+                                                                      checks.expect(result.diagnostics[2].line == 9 && result.diagnostics[2].column == 20,
+                                                                                    "Label width points at the string literal");
+                                                                  }
+                                                                  checks.raise();
+                                                              })
+                                                        .Execute();
+                                                }};
+
+const mdux::spec::Register malformedColorIsSemanticOnly{
+    "A malformed colour path has one semantic-domain diagnostic and no syntax duplicate",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-malformed-color")
+            .Given("a Label color written as Theme.Color.Title", [] {})
+            .When("the source is parsed and analyzed", [] {})
+            .Then("only MEDUI-E033 is emitted",
+                  [] {
+                      constexpr std::string_view                   source = R"(Screen ColorPath {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Label {
+        id: title;
+        width: 120px;
+        height: 20px;
+        text: t("STR-TITLE");
+        color: Theme.Color.Title;
+    }
+})";
+                      const std::array<std::string_view, 0>        themes{};
+                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
+                      const md::SemanticResult                     result = analyze(source, themes, packages);
+                      mdux::spec::Checks                           checks;
+                      checks.expect(result.diagnostics.size() == 1, "the syntax and semantic phases do not duplicate the finding");
+                      checks.expect(count(result, md::Code::FieldValueKind) == 1, "the malformed path reports E033");
+                      if (result.diagnostics.size() == 1) {
+                          checks.expect(result.diagnostics[0].line == 8 && result.diagnostics[0].column == 16,
+                                        "E033 points at Theme.Color.Title");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register semanticSpecialValueForms{"Image references, positive integer limits, and dotted named values retain distinct forms",
+                                                     "evidence-unit",
+                                                     [] {
+                                                         return speclab::Test("medui-semantic-special-value-forms")
+                                                             .Given("valid Image, TextInput, Clock, and CriticalButton fields", [] {})
+                                                             .When("their component-specific domains are analyzed", [] {})
+                                                             .Then("the forms are accepted without weakening another field",
+                                                                   [] {
+                                                                       constexpr std::string_view                   source = R"(Screen Forms {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    Image { id: logo; width: 32px; height: 32px; source: img("LOGO"); }
+    TextInput { id: input; width: 120px; height: 20px; source: "NAME"; max_length: 16; color: Theme.Colors.Title; }
+    Clock { id: clock; width: 80px; height: 20px; format: TimeFormat.HoursMinutes; }
+    CriticalButton { id: stop; requirement: "REQ-1"; width: 80px; height: 24px; label: t("STR-STOP"); color: Theme.Colors.Title; on_press: SystemEvent.Stop; }
+})";
+                                                                       const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                                                                       const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};
+                                                                       const md::SemanticResult                     result = analyze(source, themes, packages);
+                                                                       mdux::spec::Checks                           checks;
+                                                                       checks.expect(result.ok(), "all declared value forms are accepted");
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};
+
+const mdux::spec::Register semanticHardcodedTextList{
+    "A literal inside a text-key list is reported as hardcoded text at that element",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-hardcoded-text-list")
+            .Given("a StatusIndicator states list mixing a literal and a governed key", [] {})
+            .When("the list is analyzed element by element", [] {})
+            .Then("the literal reports MEDUI-E017 without hiding valid keys",
+                  [] {
+                      constexpr std::string_view source = R"(Screen States {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    StatusIndicator {
+        id: state;
+        width: 100px;
+        height: 20px;
+        requirement: "REQ-STATE";
+        source: "STATE";
+        states: ["Ready", t("STR-STOP")];
+    }
+})";
+                      const std::array<std::string_view, 0> themes{};
+                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};
+                      const md::SemanticResult result = analyze(source, themes, packages);
+                      const cli::Diagnostic* literal = find(result, md::Code::HardcodedString);
+                      mdux::spec::Checks checks;
+                      checks.expect(result.diagnostics.size() == 1, "only the literal is rejected");
+                      checks.expect(literal != nullptr && literal->line == 9 && literal->column == 18,
+                                    "E017 points at the literal list element");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/SemanticTests.cpp
+++ b/tests/medui/SemanticTests.cpp
@@ -219,13 +219,16 @@ const mdux::spec::Register semanticHardcodedTextPrecedence{"A literal in a text-
                                                                    .Execute();
                                                            }};
 
-const mdux::spec::Register semanticFieldDomains{"Known fields reject syntactically valid values from the wrong semantic domain", "evidence-unit", [] {
-                                                    return speclab::Test("medui-semantic-field-domains")
-                                                        .Given("a Row and Label with three mismatched field value forms", [] {})
-                                                        .When("the field domains are analyzed", [] {})
-                                                        .Then("each mismatch is MEDUI-E033 at the value",
-                                                              [] {
-                                                                  constexpr std::string_view                   source = R"(Screen Domains {
+const mdux::spec::Register semanticFieldDomains{
+    "Known fields reject syntactically valid values from the wrong semantic domain",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-field-domains")
+            .Given("a Row and Label with three mismatched field value forms", [] {})
+            .When("the field domains are analyzed", [] {})
+            .Then("each mismatch is MEDUI-E033 at the value",
+                  [] {
+                      constexpr std::string_view                   source = R"(Screen Domains {
     layout: Vertical { spacing: 0px; padding: 0px; }
     Row {
         id: content;
@@ -240,26 +243,21 @@ const mdux::spec::Register semanticFieldDomains{"Known fields reject syntactical
         }
     }
 })";
-                                                                  const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
-                                                                  const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
-                                                                  const md::SemanticResult                     result = analyze(source, themes, packages);
-                                                                  mdux::spec::Checks                           checks;
-                                                                  checks.expect(count(result, md::Code::FieldValueKind) == 3,
-                                                                                "all three mismatches report E033");
-                                                                  checks.expect(result.diagnostics.size() == 3,
-                                                                                "domain mismatches do not cascade into name diagnostics");
-                                                                  if (result.diagnostics.size() == 3) {
-                                                                      checks.expect(result.diagnostics[0].line == 6 && result.diagnostics[0].column == 18,
-                                                                                    "Row spacing points at Theme.Colors.Title");
-                                                                      checks.expect(result.diagnostics[1].line == 8 && result.diagnostics[1].column == 17,
-                                                                                    "Label id points at t(\"STR-TITLE\")");
-                                                                      checks.expect(result.diagnostics[2].line == 9 && result.diagnostics[2].column == 20,
-                                                                                    "Label width points at the string literal");
-                                                                  }
-                                                                  checks.raise();
-                                                              })
-                                                        .Execute();
-                                                }};
+                      const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-TITLE"})};
+                      const md::SemanticResult                     result = analyze(source, themes, packages);
+                      mdux::spec::Checks                           checks;
+                      checks.expect(count(result, md::Code::FieldValueKind) == 3, "all three mismatches report E033");
+                      checks.expect(result.diagnostics.size() == 3, "domain mismatches do not cascade into name diagnostics");
+                      if (result.diagnostics.size() == 3) {
+                          checks.expect(result.diagnostics[0].line == 6 && result.diagnostics[0].column == 18, "Row spacing points at Theme.Colors.Title");
+                          checks.expect(result.diagnostics[1].line == 8 && result.diagnostics[1].column == 17, "Label id points at t(\"STR-TITLE\")");
+                          checks.expect(result.diagnostics[2].line == 9 && result.diagnostics[2].column == 20, "Label width points at the string literal");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
 
 const mdux::spec::Register malformedColorIsSemanticOnly{
     "A malformed colour path has one semantic-domain diagnostic and no syntax duplicate",
@@ -287,8 +285,7 @@ const mdux::spec::Register malformedColorIsSemanticOnly{
                       checks.expect(result.diagnostics.size() == 1, "the syntax and semantic phases do not duplicate the finding");
                       checks.expect(count(result, md::Code::FieldValueKind) == 1, "the malformed path reports E033");
                       if (result.diagnostics.size() == 1) {
-                          checks.expect(result.diagnostics[0].line == 8 && result.diagnostics[0].column == 16,
-                                        "E033 points at Theme.Color.Title");
+                          checks.expect(result.diagnostics[0].line == 8 && result.diagnostics[0].column == 16, "E033 points at Theme.Color.Title");
                       }
                       checks.raise();
                   })
@@ -320,16 +317,13 @@ const mdux::spec::Register semanticSpecialValueForms{"Image references, positive
                                                              .Execute();
                                                      }};
 
-const mdux::spec::Register semanticHardcodedTextList{
-    "A literal inside a text-key list is reported as hardcoded text at that element",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-semantic-hardcoded-text-list")
-            .Given("a StatusIndicator states list mixing a literal and a governed key", [] {})
-            .When("the list is analyzed element by element", [] {})
-            .Then("the literal reports MEDUI-E017 without hiding valid keys",
-                  [] {
-                      constexpr std::string_view source = R"(Screen States {
+const mdux::spec::Register semanticHardcodedTextList{"A literal inside a text-key list is reported as hardcoded text at that element", "evidence-unit", [] {
+                                                         return speclab::Test("medui-semantic-hardcoded-text-list")
+                                                             .Given("a StatusIndicator states list mixing a literal and a governed key", [] {})
+                                                             .When("the list is analyzed element by element", [] {})
+                                                             .Then("the literal reports MEDUI-E017 without hiding valid keys",
+                                                                   [] {
+                                                                       constexpr std::string_view                   source = R"(Screen States {
     layout: Vertical { spacing: 0px; padding: 0px; }
     StatusIndicator {
         id: state;
@@ -340,14 +334,68 @@ const mdux::spec::Register semanticHardcodedTextList{
         states: ["Ready", t("STR-STOP")];
     }
 })";
-                      const std::array<std::string_view, 0> themes{};
-                      const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};
-                      const md::SemanticResult result = analyze(source, themes, packages);
-                      const cli::Diagnostic* literal = find(result, md::Code::HardcodedString);
+                                                                       const std::array<std::string_view, 0>        themes{};
+                                                                       const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};
+                                                                       const md::SemanticResult                     result = analyze(source, themes, packages);
+                                                                       const cli::Diagnostic* literal = find(result, md::Code::HardcodedString);
+                                                                       mdux::spec::Checks     checks;
+                                                                       checks.expect(result.diagnostics.size() == 1, "only the literal is rejected");
+                                                                       checks.expect(literal != nullptr && literal->line == 9 && literal->column == 18,
+                                                                                     "E017 points at the literal list element");
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};
+
+const mdux::spec::Register theLocalePolicyIsAskedForNotInferred{
+    "Skipping the locale check is a mode a caller selects, not a meaning of an empty set",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-semantic-locale-policy")
+            .Given("a screen with a text key and no approved locale supplied", [] {})
+            .When("it is analyzed under each policy", [] {})
+            .Then("the default reports the key and only the explicit mode skips it",
+                  [] {
+                      const std::string_view                       source = R"(Screen Policy {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 200px, 100px;
+
+    Label {
+        id: title;
+        width: 100px;
+        height: 20px;
+        text: t("STR-TITLE");
+        color: Theme.Colors.Title;
+    }
+})";
+                      const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
+                      const std::array<mdux::text::TextPackage, 0> none{};
+
                       mdux::spec::Checks checks;
-                      checks.expect(result.diagnostics.size() == 1, "only the literal is rejected");
-                      checks.expect(literal != nullptr && literal->line == 9 && literal->column == 18,
-                                    "E017 points at the literal list element");
+
+                      // The default has to be the one that fails closed: an empty package span means
+                      // an approved set containing no locale, so every key is absent from all of
+                      // them. A caller who wanted the check skipped and forgot to say so gets a
+                      // finding rather than a clean result.
+                      // Parsed once and checked, rather than dereferenced twice on faith: a fixture
+                      // that stopped parsing would crash here instead of failing, and the helper at
+                      // the top of this file already guards exactly this.
+                      const md::ParseResult parsed = md::parse(source, "policy.medui");
+                      if (!parsed.screen || !parsed.diagnostics.empty()) {
+                          throw speclab::core::AssertionFailure("the locale-policy source did not parse", std::source_location::current());
+                      }
+
+                      const md::SemanticResult required = md::analyze(*parsed.screen,
+                                                                      "policy.medui",
+                                                                      md::SemanticInputs{.themeTokens = themes, .textPackages = none});
+                      checks.expect(count(required, md::Code::UnknownTextKey) == 1, "the default policy reports a key with no locale to resolve in");
+
+                      const md::SemanticResult skipped = md::analyze(
+                          *parsed.screen,
+                          "policy.medui",
+                          md::SemanticInputs{.themeTokens = themes, .textPackages = none, .locales = md::LocalePolicy::Skipped});
+                      checks.expect(skipped.ok(), "and the explicit mode skips it");
+                      checks.expect(count(skipped, md::Code::UnknownTextKey) == 0, "reporting no key findings at all");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief The pinned `Compliatory/MedUI` conformance cases, run against this parser.
  * @file SharedConformanceTests.cpp
+ * @brief The pinned `Compliatory/MedUI` conformance cases, run against this parser.
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -19,41 +19,43 @@
  *   and must be backed by a case that really executed. Claiming a phase with no adapter fails
  *   here instead of passing quietly.
  *
- * Only the parse phase is observable: `md::parse` answers acceptance, codes and positions.
- * Claiming `semantics`, `layout` or `safety` additionally needs the resolver (#193), the solver
- * (#194) and the golden pass (#196), plus a convention for the `inputs` member the case schema
- * declares and no case yet uses — so a claim to any of them is rejected below rather than
- * silently evaluated by a parser that cannot see those phases.
+ * Syntax and semantics are observable: `md::parse` answers syntax acceptance, and `md::analyze`
+ * checks the portable theme-token and per-locale key views in semantic case inputs. Claiming
+ * `layout` or `safety` still needs the solver (#194) and golden pass (#196), so a claim to either
+ * is rejected below rather than silently evaluated by a stage that cannot see it.
  */
 
 import std;
 import speclab;
 import mdux.core.result;
 import mdux.evidence.json;
+import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.diagnostics;
 import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
 import mdux.tools.toml;
 
 #include "../framework/SpecLabBridge.hpp"
 
 namespace {
 
-namespace md = mdux::tools::medui;
-namespace cli = mdux::tools::cli;
+namespace md   = mdux::tools::medui;
+namespace cli  = mdux::tools::cli;
 namespace json = mdux::evidence::json;
 namespace toml = mdux::tools::toml;
 
 /// Phases this file can genuinely observe. Anything else in `capabilities` is a claim with no
 /// adapter behind it.
-constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
+constexpr std::array<std::string_view, 2> runnableCapabilities{"syntax", "semantics"};
 
-[[noreturn]] void fail(std::string message,
-                       std::source_location where = std::source_location::current()) {
+[[noreturn]] void fail(std::string message, std::source_location where = std::source_location::current()) {
     throw speclab::core::AssertionFailure(std::move(message), where);
 }
 
-[[nodiscard]] const char* env(const char* name) { return std::getenv(name); }
+[[nodiscard]] const char* env(const char* name) {
+    return std::getenv(name);
+}
 
 [[nodiscard]] bool isSet(const char* name) {
     const char* value = env(name);
@@ -62,7 +64,9 @@ constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
 
 [[nodiscard]] std::string readFile(const std::filesystem::path& path) {
     std::ifstream in{path, std::ios::binary};
-    if (!in) { fail(std::format("could not open {}", path.generic_string())); }
+    if (!in) {
+        fail(std::format("could not open {}", path.generic_string()));
+    }
     std::ostringstream buffer;
     buffer << in.rdbuf();
     return buffer.str();
@@ -78,6 +82,21 @@ constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
         return {};
     }
     return std::string{first, last};
+}
+
+void rejectUnknownMembers(const json::Value&                      object,
+                          std::initializer_list<std::string_view> known,
+                          std::string_view                        context,
+                          const std::filesystem::path&            path) {
+    for (const json::Member& entry : object.members()) {
+        if (std::ranges::find(known, entry.key) == known.end()) {
+            fail(std::format("{}: unknown {} member '{}'; shared inputs are rejected unless this "
+                             "adapter consumes them",
+                             path.generic_string(),
+                             context,
+                             entry.key));
+        }
+    }
 }
 
 [[nodiscard]] bool isCommitSha(std::string_view value) {
@@ -175,32 +194,29 @@ constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
 enum class Positions : std::uint8_t { Full, LineOnly, None };
 
 struct Manifest {
-    std::string commit;
+    std::string              commit;
     std::vector<std::string> capabilities;
-    Positions positions{Positions::Full};
+    Positions                positions{Positions::Full};
 };
 
 /// `governance/versioning.md` makes an unknown key an error rather than something to ignore, so a
 /// misspelled `capabilties` fails here instead of silently claiming nothing.
-constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "version", "commit",
-                                                            "capabilities", "positions"};
+constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "version", "commit", "capabilities", "positions"};
 
 [[nodiscard]] Manifest manifest() {
-    const std::filesystem::path path =
-        std::filesystem::path{MDUX_REPO_ROOT} / "medui-conformance.toml";
-    const std::string text = readFile(path);
-    const toml::Document document = toml::parse(text);
-    const toml::Table& root = document.root();
+    const std::filesystem::path path     = std::filesystem::path{MDUX_REPO_ROOT} / "medui-conformance.toml";
+    const std::string           text     = readFile(path);
+    const toml::Document        document = toml::parse(text);
+    const toml::Table&          root     = document.root();
 
-    Manifest result{.commit = root.require("commit").asString(),
-                    .capabilities = root.require("capabilities").asStringArray(),
-                    .positions = Positions::Full};
+    Manifest result{.commit = root.require("commit").asString(), .capabilities = root.require("capabilities").asStringArray(), .positions = Positions::Full};
 
     for (const auto& entry : root.entries()) {
         if (std::ranges::find(knownManifestKeys, entry.first) == knownManifestKeys.end()) {
             fail(std::format("{}: unknown key '{}'; the consumer manifest rejects keys it does "
                              "not define",
-                             path.generic_string(), entry.first));
+                             path.generic_string(),
+                             entry.first));
         }
     }
 
@@ -212,18 +228,15 @@ constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "versi
     } else if (declared == "none") {
         result.positions = Positions::None;
     } else {
-        fail(std::format("{}: positions must be \"full\", \"line-only\" or \"none\", got '{}'",
-                         path.generic_string(), declared));
+        fail(std::format("{}: positions must be \"full\", \"line-only\" or \"none\", got '{}'", path.generic_string(), declared));
     }
 
     if (!isCommitSha(result.commit)) {
-        fail(std::format("{} must pin a 40-character commit SHA, got '{}'", path.generic_string(),
-                         result.commit));
+        fail(std::format("{} must pin a 40-character commit SHA, got '{}'", path.generic_string(), result.commit));
     }
     if (result.capabilities.empty()) {
         // An empty claim would make this whole suite assert nothing while still looking green.
-        fail(std::format("{} claims no capabilities, so nothing would be checked",
-                         path.generic_string()));
+        fail(std::format("{} claims no capabilities, so nothing would be checked", path.generic_string()));
     }
     return result;
 }
@@ -238,16 +251,22 @@ struct ExpectedDiagnostic {
     std::size_t column{0};
 };
 
-struct Case {
-    std::string id;
-    std::string phase;
-    std::filesystem::path source;
-    bool valid{false};
-    std::vector<ExpectedDiagnostic> diagnostics;
+struct TextPackageInput {
+    std::string              locale;
+    std::vector<std::string> keys;
 };
 
-[[nodiscard]] const json::Value& member(const json::Value& object, std::string_view key,
-                                        const std::filesystem::path& path) {
+struct Case {
+    std::string                     id;
+    std::string                     phase;
+    std::filesystem::path           source;
+    bool                            valid{false};
+    std::vector<ExpectedDiagnostic> diagnostics;
+    std::vector<std::string>        themeTokens;
+    std::vector<TextPackageInput>   textPackages;
+};
+
+[[nodiscard]] const json::Value& member(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const json::Value* found = object.find(key);
     if (found == nullptr) {
         fail(std::format("{}: missing required member '{}'", path.generic_string(), key));
@@ -255,15 +274,15 @@ struct Case {
     return *found;
 }
 
-[[nodiscard]] std::string requireString(const json::Value& object, std::string_view key,
-                                        const std::filesystem::path& path) {
+[[nodiscard]] std::string requireString(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const auto text = member(object, key, path).asString();
-    if (!text) { fail(std::format("{}: member '{}' is not a string", path.generic_string(), key)); }
+    if (!text) {
+        fail(std::format("{}: member '{}' is not a string", path.generic_string(), key));
+    }
     return std::string{*text};
 }
 
-[[nodiscard]] std::size_t requirePosition(const json::Value& object, std::string_view key,
-                                          const std::filesystem::path& path) {
+[[nodiscard]] std::size_t requirePosition(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const auto number = member(object, key, path).asInt();
     if (!number) {
         fail(std::format("{}: member '{}' is not an integer", path.generic_string(), key));
@@ -277,9 +296,7 @@ struct Case {
 /// `Value::elements()` yields an empty span for anything that is not an array, so a `diagnostics`
 /// member of the wrong shape would silently read as "no expectations" and the case would assert
 /// almost nothing. Check the kind instead of trusting the span.
-[[nodiscard]] std::span<const json::Value> requireArray(const json::Value& object,
-                                                        std::string_view key,
-                                                        const std::filesystem::path& path) {
+[[nodiscard]] std::span<const json::Value> requireArray(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const json::Value& found = member(object, key, path);
     if (found.kind() != json::Value::Kind::Array) {
         fail(std::format("{}: member '{}' is not an array", path.generic_string(), key));
@@ -287,26 +304,28 @@ struct Case {
     return found.elements();
 }
 
-[[nodiscard]] bool requireBool(const json::Value& object, std::string_view key,
-                               const std::filesystem::path& path) {
+[[nodiscard]] bool requireBool(const json::Value& object, std::string_view key, const std::filesystem::path& path) {
     const auto flag = member(object, key, path).asBool();
-    if (!flag) { fail(std::format("{}: member '{}' is not a boolean", path.generic_string(), key)); }
+    if (!flag) {
+        fail(std::format("{}: member '{}' is not a boolean", path.generic_string(), key));
+    }
     return *flag;
 }
 
 [[nodiscard]] Case readCase(const std::filesystem::path& path) {
-    const std::string text = readFile(path);
-    const auto document = json::parse(text);
-    if (!document) { fail(std::format("{}: is not valid JSON", path.generic_string())); }
+    const std::string text     = readFile(path);
+    const auto        document = json::parse(text);
+    if (!document) {
+        fail(std::format("{}: is not valid JSON", path.generic_string()));
+    }
 
     Case result;
-    result.id = requireString(*document, "id", path);
+    result.id    = requireString(*document, "id", path);
     result.phase = requireString(*document, "phase", path);
 
     const std::string source = requireString(*document, "source", path);
     if (source.contains('/') || source.contains('\\') || !source.ends_with(".medui")) {
-        fail(std::format("{}: source must be a sibling .medui file, got '{}'",
-                         path.generic_string(), source));
+        fail(std::format("{}: source must be a sibling .medui file, got '{}'", path.generic_string(), source));
     }
     result.source = path.parent_path() / source;
 
@@ -314,23 +333,156 @@ struct Case {
     // the wrong phase is a contract error rather than something to route around.
     const std::string directoryPhase = path.parent_path().parent_path().filename().string();
     if (result.phase != directoryPhase) {
-        fail(std::format("{}: declares phase '{}' but sits under '{}'", path.generic_string(),
-                         result.phase, directoryPhase));
+        fail(std::format("{}: declares phase '{}' but sits under '{}'", path.generic_string(), result.phase, directoryPhase));
+    }
+
+    if (const json::Value* inputs = document->find("inputs")) {
+        if (inputs->kind() != json::Value::Kind::Object) {
+            fail(std::format("{}: member 'inputs' is not an object", path.generic_string()));
+        }
+        rejectUnknownMembers(*inputs, {"themeTokens", "textPackages"}, "inputs", path);
+        if (inputs->find("themeTokens") != nullptr) {
+            for (const json::Value& token : requireArray(*inputs, "themeTokens", path)) {
+                const auto value = token.asString();
+                if (!value) {
+                    fail(std::format("{}: themeTokens contains a non-string", path.generic_string()));
+                }
+                result.themeTokens.emplace_back(*value);
+            }
+        }
+        if (inputs->find("textPackages") != nullptr) {
+            for (const json::Value& package : requireArray(*inputs, "textPackages", path)) {
+                if (package.kind() != json::Value::Kind::Object) {
+                    fail(std::format("{}: textPackages contains a non-object", path.generic_string()));
+                }
+                rejectUnknownMembers(package, {"locale", "keys"}, "text package", path);
+                TextPackageInput packageInput{.locale = requireString(package, "locale", path), .keys = {}};
+                for (const json::Value& key : requireArray(package, "keys", path)) {
+                    const auto value = key.asString();
+                    if (!value) {
+                        fail(std::format("{}: text package keys contains a non-string", path.generic_string()));
+                    }
+                    packageInput.keys.emplace_back(*value);
+                }
+                result.textPackages.push_back(std::move(packageInput));
+            }
+        }
     }
 
     const json::Value& expected = member(*document, "expected", path);
-    result.valid = requireBool(expected, "valid", path);
+    result.valid                = requireBool(expected, "valid", path);
     for (const json::Value& entry : requireArray(expected, "diagnostics", path)) {
-        result.diagnostics.push_back({.code = requireString(entry, "code", path),
-                                      .line = requirePosition(entry, "line", path),
-                                      .column = requirePosition(entry, "column", path)});
+        result.diagnostics.push_back(
+            {.code = requireString(entry, "code", path), .line = requirePosition(entry, "line", path), .column = requirePosition(entry, "column", path)});
     }
     return result;
 }
 
+/// @brief Compares the canonical contract dictionary with the executable transcription.
+///
+/// Checking both at the pinned revision prevents a new or renamed field from becoming an
+/// unreviewed local dialect merely because implementation and unit tests copied the old table.
+using DictionaryEntry = std::tuple<std::string, std::string, bool>;
+
+[[nodiscard]] std::vector<std::string> backtickValues(std::string_view cell) {
+    std::vector<std::string> values;
+    std::size_t              cursor = 0;
+    for (;;) {
+        const std::size_t open = cell.find('`', cursor);
+        if (open == std::string_view::npos) {
+            break;
+        }
+        const std::size_t close = cell.find('`', open + 1);
+        if (close == std::string_view::npos) {
+            fail("spec/component-model.md contains an unterminated backtick value");
+        }
+        values.emplace_back(cell.substr(open + 1, close - open - 1));
+        cursor = close + 1;
+    }
+    return values;
+}
+
+[[nodiscard]] std::vector<std::string_view> tableCells(std::string_view line) {
+    std::vector<std::string_view> cells;
+    std::size_t                   start = 1;
+    for (;;) {
+        const std::size_t separator = line.find('|', start);
+        if (separator == std::string_view::npos) {
+            break;
+        }
+        std::string_view cell = line.substr(start, separator - start);
+        while (!cell.empty() && std::isspace(static_cast<unsigned char>(cell.front())) != 0) {
+            cell.remove_prefix(1);
+        }
+        while (!cell.empty() && std::isspace(static_cast<unsigned char>(cell.back())) != 0) {
+            cell.remove_suffix(1);
+        }
+        cells.push_back(cell);
+        start = separator + 1;
+    }
+    return cells;
+}
+
+[[nodiscard]] std::set<DictionaryEntry> contractDictionary(const std::filesystem::path& checkout) {
+    const std::filesystem::path path = checkout / "spec" / "component-model.md";
+    std::istringstream          lines{readFile(path)};
+    std::set<DictionaryEntry>   entries;
+    bool                        inTable = false;
+    for (std::string line; std::getline(lines, line);) {
+        if (line.starts_with("| Construct |")) {
+            inTable = true;
+            continue;
+        }
+        if (!inTable) {
+            continue;
+        }
+        if (!line.starts_with('|')) {
+            break;
+        }
+        if (line.starts_with("|---")) {
+            continue;
+        }
+
+        const std::vector<std::string_view> cells = tableCells(line);
+        if (cells.size() != 3) {
+            fail(std::format("{}: malformed component dictionary row '{}'", path.generic_string(), line));
+        }
+        const std::vector<std::string> component = backtickValues(cells[0]);
+        if (component.size() != 1) {
+            fail(std::format("{}: component dictionary row has no single component name", path.generic_string()));
+        }
+        for (const std::string& field : backtickValues(cells[1])) {
+            entries.emplace(component.front(), field, true);
+        }
+        for (const std::string& field : backtickValues(cells[2])) {
+            entries.emplace(component.front(), field, false);
+        }
+    }
+    if (entries.empty()) {
+        fail(std::format("{}: component dictionary table is empty or missing", path.generic_string()));
+    }
+    return entries;
+}
+
+[[nodiscard]] std::set<DictionaryEntry> implementedDictionary() {
+    std::set<DictionaryEntry> entries;
+    for (const md::ComponentRule& component : md::componentDictionary()) {
+        for (const md::FieldRule& field : component.fields) {
+            entries.emplace(component.name, field.name, field.required);
+        }
+    }
+    return entries;
+}
+
+void checkComponentDictionary(const std::filesystem::path& checkout, mdux::spec::Checks& checks) {
+    checks.expect(implementedDictionary() == contractDictionary(checkout),
+                  "the implemented component/field/requiredness set exactly matches the pinned "
+                  "spec/component-model.md table");
+}
+
 [[nodiscard]] std::vector<Case> loadCases(const std::filesystem::path& root) {
     std::vector<std::filesystem::path> paths;
-    const std::filesystem::path directory = root / "conformance";
+    const std::filesystem::path        directory = root / "conformance";
     if (!std::filesystem::is_directory(directory)) {
         fail(std::format("{} has no conformance/ directory; is MEDUI_CONFORMANCE_DIR pointing at "
                          "a Compliatory/MedUI checkout?",
@@ -345,7 +497,9 @@ struct Case {
 
     std::vector<Case> cases;
     cases.reserve(paths.size());
-    for (const std::filesystem::path& path : paths) { cases.push_back(readCase(path)); }
+    for (const std::filesystem::path& path : paths) {
+        cases.push_back(readCase(path));
+    }
     return cases;
 }
 
@@ -356,17 +510,23 @@ struct Case {
 [[nodiscard]] std::string join(const std::vector<std::string>& parts) {
     std::string joined;
     for (const std::string& part : parts) {
-        if (!joined.empty()) { joined += ", "; }
+        if (!joined.empty()) {
+            joined += ", ";
+        }
         joined += part;
     }
     return joined;
 }
 
 [[nodiscard]] std::string codesOf(const std::vector<cli::Diagnostic>& diagnostics) {
-    if (diagnostics.empty()) { return "no diagnostics"; }
+    if (diagnostics.empty()) {
+        return "no diagnostics";
+    }
     std::string joined;
     for (const cli::Diagnostic& diagnostic : diagnostics) {
-        if (!joined.empty()) { joined += ", "; }
+        if (!joined.empty()) {
+            joined += ", ";
+        }
         joined += std::format("{} at {}:{}", diagnostic.code, diagnostic.line, diagnostic.column);
     }
     return joined;
@@ -376,61 +536,92 @@ struct Case {
 /// the declared precision goes, and reporting more than was declared fails. The declaration is
 /// checked rather than tolerated, so precision cannot move in either direction without a manifest
 /// edit. MduX reports `0` for "unknown", which is how an absent position is spelled.
-void checkPosition(const Case& item, const ExpectedDiagnostic& expected, const cli::Diagnostic& got,
-                   Positions positions, mdux::spec::Checks& checks) {
+void checkPosition(const Case& item, const ExpectedDiagnostic& expected, const cli::Diagnostic& got, Positions positions, mdux::spec::Checks& checks) {
     switch (positions) {
-    case Positions::Full:
-        checks.expect(got.line == expected.line && got.column == expected.column,
-                      std::format("{}: {} at {}:{}, got {}:{}", item.id, expected.code,
-                                  expected.line, expected.column, got.line, got.column));
-        return;
-    case Positions::LineOnly:
-        checks.expect(got.line == expected.line,
-                      std::format("{}: {} at line {}, got {}", item.id, expected.code,
-                                  expected.line, got.line));
-        checks.expect(got.column == 0,
-                      std::format("{}: medui-conformance.toml declares positions = \"line-only\", "
-                                  "but {} reported column {}. Raise the declaration to \"full\" so "
-                                  "the pinned column {} is checked.",
-                                  item.id, expected.code, got.column, expected.column));
-        return;
-    case Positions::None:
-        checks.expect(got.line == 0 && got.column == 0,
-                      std::format("{}: medui-conformance.toml declares positions = \"none\", but "
-                                  "{} reported {}:{}. Raise the declaration so the pinned position "
-                                  "{}:{} is checked.",
-                                  item.id, expected.code, got.line, got.column, expected.line,
-                                  expected.column));
-        return;
+        case Positions::Full:
+            checks.expect(got.line == expected.line && got.column == expected.column,
+                          std::format("{}: {} at {}:{}, got {}:{}", item.id, expected.code, expected.line, expected.column, got.line, got.column));
+            return;
+        case Positions::LineOnly:
+            checks.expect(got.line == expected.line, std::format("{}: {} at line {}, got {}", item.id, expected.code, expected.line, got.line));
+            checks.expect(got.column == 0,
+                          std::format("{}: medui-conformance.toml declares positions = \"line-only\", "
+                                      "but {} reported column {}. Raise the declaration to \"full\" so "
+                                      "the pinned column {} is checked.",
+                                      item.id,
+                                      expected.code,
+                                      got.column,
+                                      expected.column));
+            return;
+        case Positions::None:
+            checks.expect(got.line == 0 && got.column == 0,
+                          std::format("{}: medui-conformance.toml declares positions = \"none\", but "
+                                      "{} reported {}:{}. Raise the declaration so the pinned position "
+                                      "{}:{} is checked.",
+                                      item.id,
+                                      expected.code,
+                                      got.line,
+                                      got.column,
+                                      expected.line,
+                                      expected.column));
+            return;
     }
 }
 
 void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) {
-    const std::string source = readFile(item.source);
-    const md::ParseResult result = md::parse(source, item.source.filename().string());
+    const std::string            source      = readFile(item.source);
+    const std::string            file        = item.source.filename().string();
+    const md::ParseResult        parsed      = md::parse(source, file);
+    std::vector<cli::Diagnostic> diagnostics = parsed.diagnostics;
+
+    if (item.phase == "semantics" && parsed.screen) {
+        std::vector<std::string_view> themeTokens;
+        themeTokens.reserve(item.themeTokens.size());
+        for (const std::string& token : item.themeTokens) {
+            themeTokens.push_back(token);
+        }
+
+        std::vector<mdux::text::TextPackage> packages;
+        packages.reserve(item.textPackages.size());
+        for (const TextPackageInput& input : item.textPackages) {
+            mdux::text::TextPackage package;
+            package.header.id   = std::format("shared-conformance-{}", input.locale);
+            package.atlasId     = "shared-conformance-atlas";
+            package.locale      = input.locale;
+            package.sidecarPath = "runs.bin";
+            for (const std::string& key : input.keys) {
+                package.runs.push_back(mdux::text::TextRun{.id = key, .byteOffset = 0, .byteLength = 0, .sha256 = {}});
+            }
+            packages.push_back(std::move(package));
+        }
+
+        md::SemanticResult semantic = md::analyze(*parsed.screen, file, md::SemanticInputs{.themeTokens = themeTokens, .textPackages = packages});
+        diagnostics.insert(diagnostics.end(), std::make_move_iterator(semantic.diagnostics.begin()), std::make_move_iterator(semantic.diagnostics.end()));
+    }
+
+    const bool accepted = parsed.screen.has_value() && diagnostics.empty();
 
     if (item.valid) {
-        checks.expect(result.ok(), std::format("{}: accepted, got {}", item.id,
-                                               codesOf(result.diagnostics)));
+        checks.expect(accepted, std::format("{}: accepted, got {}", item.id, codesOf(diagnostics)));
         return;
     }
 
-    checks.expect(!result.ok(), std::format("{}: rejected, but the parser accepted it", item.id));
+    checks.expect(!accepted, std::format("{}: rejected, but the claimed phase accepted it", item.id));
 
-    std::vector<bool> consumed(result.diagnostics.size(), false);
+    std::vector<bool> consumed(diagnostics.size(), false);
     for (const ExpectedDiagnostic& expected : item.diagnostics) {
-        std::size_t match = result.diagnostics.size();
-        for (std::size_t index = 0; index < result.diagnostics.size(); ++index) {
-            if (!consumed[index] && result.diagnostics[index].code == expected.code) {
+        std::size_t match = diagnostics.size();
+        for (std::size_t index = 0; index < diagnostics.size(); ++index) {
+            if (!consumed[index] && diagnostics[index].code == expected.code) {
                 match = index;
                 break;
             }
         }
-        const bool reported = match != result.diagnostics.size();
-        checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code, codesOf(result.diagnostics)));
+        const bool reported = match != diagnostics.size();
+        checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code, codesOf(diagnostics)));
         if (reported) {
             consumed[match] = true;
-            checkPosition(item, expected, result.diagnostics[match], positions, checks);
+            checkPosition(item, expected, diagnostics[match], positions, checks);
         }
     }
 
@@ -438,7 +629,7 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
                                       [](bool value) {
                                           return value;
                                       }),
-                  std::format("{}: every emitted diagnostic is expected, got {}", item.id, codesOf(result.diagnostics)));
+                  std::format("{}: every emitted diagnostic is expected, got {}", item.id, codesOf(diagnostics)));
 }
 
 }  // namespace
@@ -447,85 +638,85 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
 // Scenarios
 // ---------------------------------------------------------------------------
 
-const mdux::spec::Register claimsNameAPhaseThisSuiteCanObserve{
-    "Every claimed capability is one this suite can actually check",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-shared-claims-are-observable")
-            .Given("the capabilities named in medui-conformance.toml", [] {})
-            .When("they are compared with what this suite can observe", [] {})
-            .Then("no phase is claimed without an adapter behind it", [] {
-                mdux::spec::Checks checks;
-                for (const std::string& capability : manifest().capabilities) {
-                    checks.expect(std::ranges::find(runnableCapabilities, capability) != runnableCapabilities.end(),
-                                  std::format("'{}' is observable here; add the adapter that "
-                                              "checks that phase before claiming it",
-                                              capability));
-                }
-                checks.raise();
-            })
-            .Execute();
-    }};
+const mdux::spec::Register claimsNameAPhaseThisSuiteCanObserve{"Every claimed capability is one this suite can actually check", "evidence-unit", [] {
+                                                                   return speclab::Test("medui-shared-claims-are-observable")
+                                                                       .Given("the capabilities named in medui-conformance.toml", [] {})
+                                                                       .When("they are compared with what this suite can observe", [] {})
+                                                                       .Then("no phase is claimed without an adapter behind it",
+                                                                             [] {
+                                                                                 mdux::spec::Checks checks;
+                                                                                 for (const std::string& capability : manifest().capabilities) {
+                                                                                     checks.expect(std::ranges::find(runnableCapabilities, capability)
+                                                                                                       != runnableCapabilities.end(),
+                                                                                                   std::format("'{}' is observable here; add the adapter that "
+                                                                                                               "checks that phase before claiming it",
+                                                                                                               capability));
+                                                                                 }
+                                                                                 checks.raise();
+                                                                             })
+                                                                       .Execute();
+                                                               }};
 
-const mdux::spec::Register pinnedCasesPass{
-    "The parser satisfies every pinned case in a claimed phase",
-    "evidence-unit",
-    [] {
-        return speclab::Test("medui-shared-conformance")
-            .Given("the exact checkout named by medui-conformance.toml", [] {})
-            .When("each case in a claimed phase is parsed", [] {})
-            .Then("acceptance, codes and positions match the pinned expectations", [] {
-                mdux::spec::Checks checks;
-                const Manifest pinned = manifest();
+const mdux::spec::Register pinnedCasesPass{"The parser satisfies every pinned case in a claimed phase", "evidence-unit", [] {
+                                               return speclab::Test("medui-shared-conformance")
+                                                   .Given("the exact checkout named by medui-conformance.toml", [] {})
+                                                   .When("each case in a claimed phase is parsed", [] {})
+                                                   .Then("acceptance, codes and positions match the pinned expectations",
+                                                         [] {
+                                                             mdux::spec::Checks checks;
+                                                             const Manifest     pinned = manifest();
 
-                const char* root = env("MEDUI_CONFORMANCE_DIR");
-                if (root == nullptr || *root == '\0') {
-                    // Never a silent skip: in CI this is the failure that keeps the claim honest,
-                    // and offline it says out loud that nothing shared was checked.
-                    checks.expect(!isSet("CI"),
-                                  "MEDUI_CONFORMANCE_DIR is set in CI, so the capabilities "
-                                  "claimed in medui-conformance.toml are actually substantiated");
-                    checks.raise();
-                    std::cerr << "MedUI conformance: SKIPPED - set MEDUI_CONFORMANCE_DIR to a "
-                                 "checkout of the pinned commit to run the shared cases locally.\n";
-                    return;
-                }
+                                                             const char* root = env("MEDUI_CONFORMANCE_DIR");
+                                                             if (root == nullptr || *root == '\0') {
+                                                                 // Never a silent skip: in CI this is the failure that keeps the claim honest,
+                                                                 // and offline it says out loud that nothing shared was checked.
+                                                                 checks.expect(!isSet("CI"),
+                                                                               "MEDUI_CONFORMANCE_DIR is set in CI, so the capabilities "
+                                                                               "claimed in medui-conformance.toml are actually substantiated");
+                                                                 checks.raise();
+                                                                 std::cerr << "MedUI conformance: SKIPPED - set MEDUI_CONFORMANCE_DIR to a "
+                                                                              "checkout of the pinned commit to run the shared cases locally.\n";
+                                                                 return;
+                                                             }
 
-                const std::filesystem::path checkout{root};
-                const std::string           actualCommit = checkoutRevision(checkout);
-                checks.expect(actualCommit == pinned.commit,
-                              std::format("MEDUI_CONFORMANCE_DIR is checked out at {}, but "
-                                          "medui-conformance.toml pins {}",
-                                          actualCommit,
-                                          pinned.commit));
-                checks.raise();
+                                                             const std::filesystem::path checkout{root};
+                                                             const std::string           actualCommit = checkoutRevision(checkout);
+                                                             checks.expect(actualCommit == pinned.commit,
+                                                                           std::format("MEDUI_CONFORMANCE_DIR is checked out at {}, but "
+                                                                                       "medui-conformance.toml pins {}",
+                                                                                       actualCommit,
+                                                                                       pinned.commit));
+                                                             checks.raise();
 
-                const std::vector<Case> cases = loadCases(checkout);
-                checks.expect(!cases.empty(), "the pinned checkout contains conformance cases");
+                                                             checkComponentDictionary(checkout, checks);
+                                                             checks.raise();
 
-                std::set<std::string> executed;
-                std::vector<std::string> unclaimed;
-                for (const Case& item : cases) {
-                    if (std::ranges::find(pinned.capabilities, item.phase) != pinned.capabilities.end()) {
-                        runCase(item, pinned.positions, checks);
-                        executed.insert(item.phase);
-                    } else {
-                        unclaimed.push_back(std::format("{} ({})", item.id, item.phase));
-                    }
-                }
+                                                             const std::vector<Case> cases = loadCases(checkout);
+                                                             checks.expect(!cases.empty(), "the pinned checkout contains conformance cases");
 
-                for (const std::string& capability : pinned.capabilities) {
-                    checks.expect(executed.contains(capability),
-                                  std::format("capability '{}' is backed by a case that ran; "
-                                              "either the pin is wrong or the claim is unsupported",
-                                              capability));
-                }
+                                                             std::set<std::string>    executed;
+                                                             std::vector<std::string> unclaimed;
+                                                             for (const Case& item : cases) {
+                                                                 if (std::ranges::find(pinned.capabilities, item.phase) != pinned.capabilities.end()) {
+                                                                     runCase(item, pinned.positions, checks);
+                                                                     executed.insert(item.phase);
+                                                                 } else {
+                                                                     unclaimed.push_back(std::format("{} ({})", item.id, item.phase));
+                                                                 }
+                                                             }
 
-                std::cerr << std::format(
-                    "MedUI conformance: {} case(s) at {}; unclaimed and not asserted: {}\n",
-                    cases.size(), pinned.commit,
-                    unclaimed.empty() ? std::string{"none"} : join(unclaimed));
-                checks.raise();
-            })
-            .Execute();
-    }};
+                                                             for (const std::string& capability : pinned.capabilities) {
+                                                                 checks.expect(executed.contains(capability),
+                                                                               std::format("capability '{}' is backed by a case that ran; "
+                                                                                           "either the pin is wrong or the claim is unsupported",
+                                                                                           capability));
+                                                             }
+
+                                                             std::cerr << std::format("MedUI conformance: {} case(s) at {}; unclaimed and not asserted: {}\n",
+                                                                                      cases.size(),
+                                                                                      pinned.commit,
+                                                                                      unclaimed.empty() ? std::string{"none"} : join(unclaimed));
+                                                             checks.raise();
+                                                         })
+                                                   .Execute();
+                                           }};

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -1,0 +1,531 @@
+/**
+ * @file SharedConformanceTests.cpp
+ * @brief The pinned `Compliatory/MedUI` conformance cases, run against this parser.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Every expectation is read from the pinned checkout's `case.json`, never from a copy in this
+ * file. A hand-written copy is a second source of truth: the shared contract can change an
+ * expected code or position and a copy keeps passing, which is the one thing pinning a contract
+ * is supposed to prevent.
+ *
+ * `MEDUI-DEC-005` says a consumer "must not silently skip a claimed phase". Two rules follow:
+ *
+ * - CI has the checkout, so a missing one there is a failure rather than a skip. A developer
+ *   without it gets a notice on stderr; `CI` in the environment turns that into a hard failure,
+ *   so the run that produces evidence can never be vacuous.
+ * - A capability named in `medui-conformance.toml` must be one this file can actually observe,
+ *   and must be backed by a case that really executed. Claiming a phase with no adapter fails
+ *   here instead of passing quietly.
+ *
+ * Only the parse phase is observable: `md::parse` answers acceptance, codes and positions.
+ * Claiming `semantics`, `layout` or `safety` additionally needs the resolver (#193), the solver
+ * (#194) and the golden pass (#196), plus a convention for the `inputs` member the case schema
+ * declares and no case yet uses — so a claim to any of them is rejected below rather than
+ * silently evaluated by a parser that cannot see those phases.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.evidence.json;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.parser;
+import mdux.tools.toml;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md = mdux::tools::medui;
+namespace cli = mdux::tools::cli;
+namespace json = mdux::evidence::json;
+namespace toml = mdux::tools::toml;
+
+/// Phases this file can genuinely observe. Anything else in `capabilities` is a claim with no
+/// adapter behind it.
+constexpr std::array<std::string_view, 1> runnableCapabilities{"syntax"};
+
+[[noreturn]] void fail(std::string message,
+                       std::source_location where = std::source_location::current()) {
+    throw speclab::core::AssertionFailure(std::move(message), where);
+}
+
+[[nodiscard]] const char* env(const char* name) { return std::getenv(name); }
+
+[[nodiscard]] bool isSet(const char* name) {
+    const char* value = env(name);
+    return value != nullptr && *value != '\0';
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream in{path, std::ios::binary};
+    if (!in) { fail(std::format("could not open {}", path.generic_string())); }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+[[nodiscard]] std::string trim(std::string value) {
+    const auto isWhitespace = [](unsigned char c) {
+        return std::isspace(c) != 0;
+    };
+    const auto first = std::ranges::find_if_not(value, isWhitespace);
+    const auto last  = std::ranges::find_if_not(value | std::views::reverse, isWhitespace).base();
+    if (first >= last) {
+        return {};
+    }
+    return std::string{first, last};
+}
+
+[[nodiscard]] bool isCommitSha(std::string_view value) {
+    return value.size() == 40 && std::ranges::all_of(value, [](unsigned char c) {
+               return std::isxdigit(c) != 0;
+           });
+}
+
+[[nodiscard]] std::filesystem::path resolveGitDirectory(const std::filesystem::path& root) {
+    const std::filesystem::path dotGit = root / ".git";
+    if (std::filesystem::is_directory(dotGit)) {
+        return dotGit;
+    }
+    if (!std::filesystem::is_regular_file(dotGit)) {
+        fail(std::format("{} has no .git metadata; cannot verify the checked-out MedUI revision", root.generic_string()));
+    }
+
+    constexpr std::string_view prefix{"gitdir: "};
+    const std::string          metadata = trim(readFile(dotGit));
+    if (!metadata.starts_with(prefix)) {
+        fail(std::format("{} has malformed gitdir metadata", dotGit.generic_string()));
+    }
+    std::filesystem::path directory{metadata.substr(prefix.size())};
+    if (directory.is_relative()) {
+        directory = root / directory;
+    }
+    return directory.lexically_normal();
+}
+
+[[nodiscard]] std::filesystem::path resolveCommonGitDirectory(const std::filesystem::path& gitDirectory) {
+    const std::filesystem::path marker = gitDirectory / "commondir";
+    if (!std::filesystem::is_regular_file(marker)) {
+        return gitDirectory;
+    }
+
+    std::filesystem::path common{trim(readFile(marker))};
+    if (common.is_relative()) {
+        common = gitDirectory / common;
+    }
+    return common.lexically_normal();
+}
+
+[[nodiscard]] std::string checkoutRevision(const std::filesystem::path& root) {
+    const std::filesystem::path gitDirectory = resolveGitDirectory(root);
+    const std::string           head         = trim(readFile(gitDirectory / "HEAD"));
+    if (isCommitSha(head)) {
+        return head;
+    }
+
+    constexpr std::string_view prefix{"ref: "};
+    if (!head.starts_with(prefix)) {
+        fail(std::format("{} has malformed HEAD metadata", gitDirectory.generic_string()));
+    }
+    const std::string reference = head.substr(prefix.size());
+    if (!reference.starts_with("refs/") || reference.contains("..") || reference.contains('\\')) {
+        fail(std::format("{} names an unsafe HEAD reference '{}'", gitDirectory.generic_string(), reference));
+    }
+
+    const std::filesystem::path commonDirectory = resolveCommonGitDirectory(gitDirectory);
+    for (const std::filesystem::path& directory : {gitDirectory, commonDirectory}) {
+        const std::filesystem::path looseReference = directory / reference;
+        if (std::filesystem::is_regular_file(looseReference)) {
+            const std::string revision = trim(readFile(looseReference));
+            if (isCommitSha(revision)) {
+                return revision;
+            }
+            fail(std::format("{} does not contain a commit SHA", looseReference.generic_string()));
+        }
+    }
+
+    const std::filesystem::path packedReferences = commonDirectory / "packed-refs";
+    if (std::filesystem::is_regular_file(packedReferences)) {
+        std::istringstream lines{readFile(packedReferences)};
+        for (std::string line; std::getline(lines, line);) {
+            const std::size_t separator = line.find(' ');
+            if (separator != std::string::npos && line.substr(separator + 1) == reference) {
+                const std::string revision = line.substr(0, separator);
+                if (isCommitSha(revision)) {
+                    return revision;
+                }
+                fail(std::format("{} has a malformed entry for '{}'", packedReferences.generic_string(), reference));
+            }
+        }
+    }
+    fail(std::format("could not resolve HEAD reference '{}' under {}", reference, gitDirectory.generic_string()));
+}
+
+// ---------------------------------------------------------------------------
+// medui-conformance.toml
+// ---------------------------------------------------------------------------
+
+/// The declared diagnostic position precision from `spec/diagnostics.md`. MduX's lexer carries
+/// exact columns, so it declares `full`; the other two exist because the manifest may name them
+/// and a declaration this file ignored would be a declaration nothing checks.
+enum class Positions : std::uint8_t { Full, LineOnly, None };
+
+struct Manifest {
+    std::string commit;
+    std::vector<std::string> capabilities;
+    Positions positions{Positions::Full};
+};
+
+/// `governance/versioning.md` makes an unknown key an error rather than something to ignore, so a
+/// misspelled `capabilties` fails here instead of silently claiming nothing.
+constexpr std::array<std::string_view, 5> knownManifestKeys{"repository", "version", "commit",
+                                                            "capabilities", "positions"};
+
+[[nodiscard]] Manifest manifest() {
+    const std::filesystem::path path =
+        std::filesystem::path{MDUX_REPO_ROOT} / "medui-conformance.toml";
+    const std::string text = readFile(path);
+    const toml::Document document = toml::parse(text);
+    const toml::Table& root = document.root();
+
+    Manifest result{.commit = root.require("commit").asString(),
+                    .capabilities = root.require("capabilities").asStringArray(),
+                    .positions = Positions::Full};
+
+    for (const auto& entry : root.entries()) {
+        if (std::ranges::find(knownManifestKeys, entry.first) == knownManifestKeys.end()) {
+            fail(std::format("{}: unknown key '{}'; the consumer manifest rejects keys it does "
+                             "not define",
+                             path.generic_string(), entry.first));
+        }
+    }
+
+    const std::string declared = root.require("positions").asString();
+    if (declared == "full") {
+        result.positions = Positions::Full;
+    } else if (declared == "line-only") {
+        result.positions = Positions::LineOnly;
+    } else if (declared == "none") {
+        result.positions = Positions::None;
+    } else {
+        fail(std::format("{}: positions must be \"full\", \"line-only\" or \"none\", got '{}'",
+                         path.generic_string(), declared));
+    }
+
+    if (!isCommitSha(result.commit)) {
+        fail(std::format("{} must pin a 40-character commit SHA, got '{}'", path.generic_string(),
+                         result.commit));
+    }
+    if (result.capabilities.empty()) {
+        // An empty claim would make this whole suite assert nothing while still looking green.
+        fail(std::format("{} claims no capabilities, so nothing would be checked",
+                         path.generic_string()));
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// conformance/**/case.json
+// ---------------------------------------------------------------------------
+
+struct ExpectedDiagnostic {
+    std::string code;
+    std::size_t line{0};
+    std::size_t column{0};
+};
+
+struct Case {
+    std::string id;
+    std::string phase;
+    std::filesystem::path source;
+    bool valid{false};
+    std::vector<ExpectedDiagnostic> diagnostics;
+};
+
+[[nodiscard]] const json::Value& member(const json::Value& object, std::string_view key,
+                                        const std::filesystem::path& path) {
+    const json::Value* found = object.find(key);
+    if (found == nullptr) {
+        fail(std::format("{}: missing required member '{}'", path.generic_string(), key));
+    }
+    return *found;
+}
+
+[[nodiscard]] std::string requireString(const json::Value& object, std::string_view key,
+                                        const std::filesystem::path& path) {
+    const auto text = member(object, key, path).asString();
+    if (!text) { fail(std::format("{}: member '{}' is not a string", path.generic_string(), key)); }
+    return std::string{*text};
+}
+
+[[nodiscard]] std::size_t requirePosition(const json::Value& object, std::string_view key,
+                                          const std::filesystem::path& path) {
+    const auto number = member(object, key, path).asInt();
+    if (!number) {
+        fail(std::format("{}: member '{}' is not an integer", path.generic_string(), key));
+    }
+    if (*number < 0) {
+        fail(std::format("{}: member '{}' is negative", path.generic_string(), key));
+    }
+    return static_cast<std::size_t>(*number);
+}
+
+/// `Value::elements()` yields an empty span for anything that is not an array, so a `diagnostics`
+/// member of the wrong shape would silently read as "no expectations" and the case would assert
+/// almost nothing. Check the kind instead of trusting the span.
+[[nodiscard]] std::span<const json::Value> requireArray(const json::Value& object,
+                                                        std::string_view key,
+                                                        const std::filesystem::path& path) {
+    const json::Value& found = member(object, key, path);
+    if (found.kind() != json::Value::Kind::Array) {
+        fail(std::format("{}: member '{}' is not an array", path.generic_string(), key));
+    }
+    return found.elements();
+}
+
+[[nodiscard]] bool requireBool(const json::Value& object, std::string_view key,
+                               const std::filesystem::path& path) {
+    const auto flag = member(object, key, path).asBool();
+    if (!flag) { fail(std::format("{}: member '{}' is not a boolean", path.generic_string(), key)); }
+    return *flag;
+}
+
+[[nodiscard]] Case readCase(const std::filesystem::path& path) {
+    const std::string text = readFile(path);
+    const auto document = json::parse(text);
+    if (!document) { fail(std::format("{}: is not valid JSON", path.generic_string())); }
+
+    Case result;
+    result.id = requireString(*document, "id", path);
+    result.phase = requireString(*document, "phase", path);
+
+    const std::string source = requireString(*document, "source", path);
+    if (source.contains('/') || source.contains('\\') || !source.ends_with(".medui")) {
+        fail(std::format("{}: source must be a sibling .medui file, got '{}'",
+                         path.generic_string(), source));
+    }
+    result.source = path.parent_path() / source;
+
+    // `case.schema.json` binds the phase to the directory holding the case, so a case filed under
+    // the wrong phase is a contract error rather than something to route around.
+    const std::string directoryPhase = path.parent_path().parent_path().filename().string();
+    if (result.phase != directoryPhase) {
+        fail(std::format("{}: declares phase '{}' but sits under '{}'", path.generic_string(),
+                         result.phase, directoryPhase));
+    }
+
+    const json::Value& expected = member(*document, "expected", path);
+    result.valid = requireBool(expected, "valid", path);
+    for (const json::Value& entry : requireArray(expected, "diagnostics", path)) {
+        result.diagnostics.push_back({.code = requireString(entry, "code", path),
+                                      .line = requirePosition(entry, "line", path),
+                                      .column = requirePosition(entry, "column", path)});
+    }
+    return result;
+}
+
+[[nodiscard]] std::vector<Case> loadCases(const std::filesystem::path& root) {
+    std::vector<std::filesystem::path> paths;
+    const std::filesystem::path directory = root / "conformance";
+    if (!std::filesystem::is_directory(directory)) {
+        fail(std::format("{} has no conformance/ directory; is MEDUI_CONFORMANCE_DIR pointing at "
+                         "a Compliatory/MedUI checkout?",
+                         root.generic_string()));
+    }
+    for (const auto& entry : std::filesystem::recursive_directory_iterator{directory}) {
+        if (entry.is_regular_file() && entry.path().filename() == "case.json") {
+            paths.push_back(entry.path());
+        }
+    }
+    std::ranges::sort(paths);
+
+    std::vector<Case> cases;
+    cases.reserve(paths.size());
+    for (const std::filesystem::path& path : paths) { cases.push_back(readCase(path)); }
+    return cases;
+}
+
+// ---------------------------------------------------------------------------
+// Running one case
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] std::string join(const std::vector<std::string>& parts) {
+    std::string joined;
+    for (const std::string& part : parts) {
+        if (!joined.empty()) { joined += ", "; }
+        joined += part;
+    }
+    return joined;
+}
+
+[[nodiscard]] std::string codesOf(const std::vector<cli::Diagnostic>& diagnostics) {
+    if (diagnostics.empty()) { return "no diagnostics"; }
+    std::string joined;
+    for (const cli::Diagnostic& diagnostic : diagnostics) {
+        if (!joined.empty()) { joined += ", "; }
+        joined += std::format("{} at {}:{}", diagnostic.code, diagnostic.line, diagnostic.column);
+    }
+    return joined;
+}
+
+/// `spec/diagnostics.md`, "Positions in conformance cases": a pinned position is matched as far as
+/// the declared precision goes, and reporting more than was declared fails. The declaration is
+/// checked rather than tolerated, so precision cannot move in either direction without a manifest
+/// edit. MduX reports `0` for "unknown", which is how an absent position is spelled.
+void checkPosition(const Case& item, const ExpectedDiagnostic& expected, const cli::Diagnostic& got,
+                   Positions positions, mdux::spec::Checks& checks) {
+    switch (positions) {
+    case Positions::Full:
+        checks.expect(got.line == expected.line && got.column == expected.column,
+                      std::format("{}: {} at {}:{}, got {}:{}", item.id, expected.code,
+                                  expected.line, expected.column, got.line, got.column));
+        return;
+    case Positions::LineOnly:
+        checks.expect(got.line == expected.line,
+                      std::format("{}: {} at line {}, got {}", item.id, expected.code,
+                                  expected.line, got.line));
+        checks.expect(got.column == 0,
+                      std::format("{}: medui-conformance.toml declares positions = \"line-only\", "
+                                  "but {} reported column {}. Raise the declaration to \"full\" so "
+                                  "the pinned column {} is checked.",
+                                  item.id, expected.code, got.column, expected.column));
+        return;
+    case Positions::None:
+        checks.expect(got.line == 0 && got.column == 0,
+                      std::format("{}: medui-conformance.toml declares positions = \"none\", but "
+                                  "{} reported {}:{}. Raise the declaration so the pinned position "
+                                  "{}:{} is checked.",
+                                  item.id, expected.code, got.line, got.column, expected.line,
+                                  expected.column));
+        return;
+    }
+}
+
+void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) {
+    const std::string source = readFile(item.source);
+    const md::ParseResult result = md::parse(source, item.source.filename().string());
+
+    if (item.valid) {
+        checks.expect(result.ok(), std::format("{}: accepted, got {}", item.id,
+                                               codesOf(result.diagnostics)));
+        return;
+    }
+
+    checks.expect(!result.ok(), std::format("{}: rejected, but the parser accepted it", item.id));
+
+    std::vector<bool> consumed(result.diagnostics.size(), false);
+    for (const ExpectedDiagnostic& expected : item.diagnostics) {
+        std::size_t match = result.diagnostics.size();
+        for (std::size_t index = 0; index < result.diagnostics.size(); ++index) {
+            if (!consumed[index] && result.diagnostics[index].code == expected.code) {
+                match = index;
+                break;
+            }
+        }
+        const bool reported = match != result.diagnostics.size();
+        checks.expect(reported, std::format("{}: {} reported, got {}", item.id, expected.code, codesOf(result.diagnostics)));
+        if (reported) {
+            consumed[match] = true;
+            checkPosition(item, expected, result.diagnostics[match], positions, checks);
+        }
+    }
+
+    checks.expect(std::ranges::all_of(consumed,
+                                      [](bool value) {
+                                          return value;
+                                      }),
+                  std::format("{}: every emitted diagnostic is expected, got {}", item.id, codesOf(result.diagnostics)));
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register claimsNameAPhaseThisSuiteCanObserve{
+    "Every claimed capability is one this suite can actually check",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-shared-claims-are-observable")
+            .Given("the capabilities named in medui-conformance.toml", [] {})
+            .When("they are compared with what this suite can observe", [] {})
+            .Then("no phase is claimed without an adapter behind it", [] {
+                mdux::spec::Checks checks;
+                for (const std::string& capability : manifest().capabilities) {
+                    checks.expect(std::ranges::find(runnableCapabilities, capability) != runnableCapabilities.end(),
+                                  std::format("'{}' is observable here; add the adapter that "
+                                              "checks that phase before claiming it",
+                                              capability));
+                }
+                checks.raise();
+            })
+            .Execute();
+    }};
+
+const mdux::spec::Register pinnedCasesPass{
+    "The parser satisfies every pinned case in a claimed phase",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-shared-conformance")
+            .Given("the exact checkout named by medui-conformance.toml", [] {})
+            .When("each case in a claimed phase is parsed", [] {})
+            .Then("acceptance, codes and positions match the pinned expectations", [] {
+                mdux::spec::Checks checks;
+                const Manifest pinned = manifest();
+
+                const char* root = env("MEDUI_CONFORMANCE_DIR");
+                if (root == nullptr || *root == '\0') {
+                    // Never a silent skip: in CI this is the failure that keeps the claim honest,
+                    // and offline it says out loud that nothing shared was checked.
+                    checks.expect(!isSet("CI"),
+                                  "MEDUI_CONFORMANCE_DIR is set in CI, so the capabilities "
+                                  "claimed in medui-conformance.toml are actually substantiated");
+                    checks.raise();
+                    std::cerr << "MedUI conformance: SKIPPED - set MEDUI_CONFORMANCE_DIR to a "
+                                 "checkout of the pinned commit to run the shared cases locally.\n";
+                    return;
+                }
+
+                const std::filesystem::path checkout{root};
+                const std::string           actualCommit = checkoutRevision(checkout);
+                checks.expect(actualCommit == pinned.commit,
+                              std::format("MEDUI_CONFORMANCE_DIR is checked out at {}, but "
+                                          "medui-conformance.toml pins {}",
+                                          actualCommit,
+                                          pinned.commit));
+                checks.raise();
+
+                const std::vector<Case> cases = loadCases(checkout);
+                checks.expect(!cases.empty(), "the pinned checkout contains conformance cases");
+
+                std::set<std::string> executed;
+                std::vector<std::string> unclaimed;
+                for (const Case& item : cases) {
+                    if (std::ranges::find(pinned.capabilities, item.phase) != pinned.capabilities.end()) {
+                        runCase(item, pinned.positions, checks);
+                        executed.insert(item.phase);
+                    } else {
+                        unclaimed.push_back(std::format("{} ({})", item.id, item.phase));
+                    }
+                }
+
+                for (const std::string& capability : pinned.capabilities) {
+                    checks.expect(executed.contains(capability),
+                                  std::format("capability '{}' is backed by a case that ran; "
+                                              "either the pin is wrong or the claim is unsupported",
+                                              capability));
+                }
+
+                std::cerr << std::format(
+                    "MedUI conformance: {} case(s) at {}; unclaimed and not asserted: {}\n",
+                    cases.size(), pinned.commit,
+                    unclaimed.empty() ? std::string{"none"} : join(unclaimed));
+                checks.raise();
+            })
+            .Execute();
+    }};

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -19,11 +19,15 @@
  *   and must be backed by a case that really executed. Claiming a phase with no adapter fails
  *   here instead of passing quietly.
  *
- * Syntax, semantics and layout are observable: `md::parse` answers syntax acceptance,
+ * Syntax, semantics, layout and safety are observable: `md::parse` answers syntax acceptance,
  * `md::analyze` checks the portable theme-token and per-locale key views in semantic case inputs,
- * and `md::resolveLayout` runs the integer-only bounded solver. Claiming `safety` still needs the
- * golden pass (#196), so that claim is rejected below rather than silently evaluated by a stage
- * that cannot see it.
+ * `md::resolveLayout` runs the integer-only bounded solver, and `md::validateSafetyAnnotations`
+ * applies the `@safety_critical` rules (#196).
+ *
+ * The safety adapter deliberately does not run semantic analysis first. Those rules are decidable
+ * from source alone, the shared case schema carries no inputs for a safety case, and a screen that
+ * declares no `surface:` - as `MEDUI-CASE-SAFETY-MISSING-REQUIREMENT` does not - cannot reach the
+ * solver at all. Running analyze would add theme and locale findings the case never claimed.
  */
 
 import std;
@@ -34,6 +38,7 @@ import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.ast;
 import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.goldens;
 import mdux.tools.medui.layout;
 import mdux.tools.medui.parser;
 import mdux.tools.medui.semantic;
@@ -50,7 +55,7 @@ namespace toml = mdux::tools::toml;
 
 /// Phases this file can genuinely observe. Anything else in `capabilities` is a claim with no
 /// adapter behind it.
-constexpr std::array<std::string_view, 3> runnableCapabilities{"syntax", "semantics", "layout"};
+constexpr std::array<std::string_view, 4> runnableCapabilities{"syntax", "semantics", "layout", "safety"};
 
 [[noreturn]] void fail(std::string message, std::source_location where = std::source_location::current()) {
     throw speclab::core::AssertionFailure(std::move(message), where);
@@ -666,6 +671,11 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
             md::LayoutResult resolved = md::resolveLayout(*parsed.screen, file, inputs);
             diagnostics.insert(diagnostics.end(), std::make_move_iterator(resolved.diagnostics.begin()), std::make_move_iterator(resolved.diagnostics.end()));
         }
+    }
+
+    if (item.phase == "safety" && parsed.screen) {
+        md::SafetyResult safety = md::validateSafetyAnnotations(*parsed.screen, file);
+        diagnostics.insert(diagnostics.end(), std::make_move_iterator(safety.diagnostics.begin()), std::make_move_iterator(safety.diagnostics.end()));
     }
 
     const bool accepted = parsed.screen.has_value() && diagnostics.empty();

--- a/tests/medui/SharedConformanceTests.cpp
+++ b/tests/medui/SharedConformanceTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @file SharedConformanceTests.cpp
  * @brief The pinned `Compliatory/MedUI` conformance cases, run against this parser.
+ * @file SharedConformanceTests.cpp
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary
@@ -19,10 +19,11 @@
  *   and must be backed by a case that really executed. Claiming a phase with no adapter fails
  *   here instead of passing quietly.
  *
- * Syntax and semantics are observable: `md::parse` answers syntax acceptance, and `md::analyze`
- * checks the portable theme-token and per-locale key views in semantic case inputs. Claiming
- * `layout` or `safety` still needs the solver (#194) and golden pass (#196), so a claim to either
- * is rejected below rather than silently evaluated by a stage that cannot see it.
+ * Syntax, semantics and layout are observable: `md::parse` answers syntax acceptance,
+ * `md::analyze` checks the portable theme-token and per-locale key views in semantic case inputs,
+ * and `md::resolveLayout` runs the integer-only bounded solver. Claiming `safety` still needs the
+ * golden pass (#196), so that claim is rejected below rather than silently evaluated by a stage
+ * that cannot see it.
  */
 
 import std;
@@ -31,7 +32,9 @@ import mdux.core.result;
 import mdux.evidence.json;
 import mdux.text.schema;
 import mdux.tools.cli;
+import mdux.tools.medui.ast;
 import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
 import mdux.tools.medui.parser;
 import mdux.tools.medui.semantic;
 import mdux.tools.toml;
@@ -47,7 +50,7 @@ namespace toml = mdux::tools::toml;
 
 /// Phases this file can genuinely observe. Anything else in `capabilities` is a claim with no
 /// adapter behind it.
-constexpr std::array<std::string_view, 2> runnableCapabilities{"syntax", "semantics"};
+constexpr std::array<std::string_view, 3> runnableCapabilities{"syntax", "semantics", "layout"};
 
 [[noreturn]] void fail(std::string message, std::source_location where = std::source_location::current()) {
     throw speclab::core::AssertionFailure(std::move(message), where);
@@ -532,6 +535,32 @@ void checkComponentDictionary(const std::filesystem::path& checkout, mdux::spec:
     return joined;
 }
 
+/// Collects authored external names so layout cases can pass the semantic shape gate without
+/// inventing theme or locale failures that belong to the semantics phase.
+void collectLayoutSemanticNames(const md::ast::Node& node, std::set<std::string>& themeTokens, std::set<std::string>& textKeys) {
+    const auto collectValue = [&](auto&& self, const md::ast::Value& value) -> void {
+        if (value.kind == md::ast::ValueKind::ColorToken) {
+            themeTokens.insert(value.text);
+        } else if (value.kind == md::ast::ValueKind::TextKey) {
+            textKeys.insert(value.text);
+        }
+        for (const std::shared_ptr<md::ast::Value>& element : value.list) {
+            if (element != nullptr) {
+                self(self, *element);
+            }
+        }
+    };
+
+    for (const md::ast::Field& field : node.fields) {
+        if (field.value != nullptr) {
+            collectValue(collectValue, *field.value);
+        }
+    }
+    for (const md::ast::Node& child : node.children) {
+        collectLayoutSemanticNames(child, themeTokens, textKeys);
+    }
+}
+
 /// `spec/diagnostics.md`, "Positions in conformance cases": a pinned position is matched as far as
 /// the declared precision goes, and reporting more than was declared fails. The declaration is
 /// checked rather than tolerated, so precision cannot move in either direction without a manifest
@@ -597,6 +626,46 @@ void runCase(const Case& item, Positions positions, mdux::spec::Checks& checks) 
 
         md::SemanticResult semantic = md::analyze(*parsed.screen, file, md::SemanticInputs{.themeTokens = themeTokens, .textPackages = packages});
         diagnostics.insert(diagnostics.end(), std::make_move_iterator(semantic.diagnostics.begin()), std::make_move_iterator(semantic.diagnostics.end()));
+    }
+    if (item.phase == "layout" && parsed.screen && diagnostics.empty()) {
+        std::set<std::string> themeTokenStorage;
+        std::set<std::string> textKeyStorage;
+        for (const md::ast::Node& node : parsed.screen->nodes) {
+            collectLayoutSemanticNames(node, themeTokenStorage, textKeyStorage);
+        }
+
+        std::vector<std::string_view> themeTokens;
+        themeTokens.reserve(themeTokenStorage.size());
+        for (const std::string& token : themeTokenStorage) {
+            themeTokens.push_back(token);
+        }
+
+        mdux::text::TextPackage textPackage;
+        textPackage.header.id   = "shared-layout-semantic-gate";
+        textPackage.atlasId     = "shared-layout-atlas";
+        textPackage.locale      = "shared-layout-locale";
+        textPackage.sidecarPath = "runs.bin";
+        for (const std::string& key : textKeyStorage) {
+            textPackage.runs.push_back(mdux::text::TextRun{.id = key, .byteOffset = 0, .byteLength = 0, .sha256 = {}});
+        }
+        const std::array textPackages{textPackage};
+
+        md::SemanticResult semantic = md::analyze(*parsed.screen, file, md::SemanticInputs{.themeTokens = themeTokens, .textPackages = textPackages});
+        diagnostics.insert(diagnostics.end(), std::make_move_iterator(semantic.diagnostics.begin()), std::make_move_iterator(semantic.diagnostics.end()));
+
+        if (diagnostics.empty()) {
+            // The shared schema has no build-surface input. Use a declared surface when present;
+            // otherwise pass the honest "unspecified" sentinel. Preflight findings such as
+            // positioned Fill remain observable, while a case that needs actual resolution must
+            // declare dimensions rather than inherit a local 800x600 invention.
+            md::LayoutInputs inputs{};
+            if (parsed.screen->surface) {
+                inputs.surfaceWidth  = parsed.screen->surface->x;
+                inputs.surfaceHeight = parsed.screen->surface->y;
+            }
+            md::LayoutResult resolved = md::resolveLayout(*parsed.screen, file, inputs);
+            diagnostics.insert(diagnostics.end(), std::make_move_iterator(resolved.diagnostics.begin()), std::make_move_iterator(resolved.diagnostics.end()));
+        }
     }
 
     const bool accepted = parsed.screen.has_value() && diagnostics.empty();

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief BDD scenarios for text-budget and dynamic-charset validation (issue #195).
  * @file TextBudgetTests.cpp
+ * @brief BDD scenarios for text-budget and dynamic-charset validation (issue #195).
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-010 No on-device text shaping

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -1,0 +1,858 @@
+/**
+ * @brief BDD scenarios for text-budget and dynamic-charset validation (issue #195).
+ * @file TextBudgetTests.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-010 No on-device text shaping
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The fixture font and the per-locale text packages are built here rather than read from
+ * `generated/`, and that is a deliberate difference from the evidence suites. A committed package
+ * pins one set of real translations; these scenarios need a *pair* of locales whose widths differ
+ * by a known number of pixels, so that "the widest approved translation is what the budget is
+ * measured against" is checkable by arithmetic rather than by whichever German string happens to be
+ * in the corpus today.
+ *
+ * The font is still a real `mdux::font::FontPackage` and passes `validate()`; the runs are still
+ * real v1 records decoded by the same `mdux::text::draw::decodeRecord()` the device draws with.
+ * What is synthetic is the vocabulary, not the format.
+ *
+ * Every call supplies both locales the fixture font approves, because the stage refuses a subset -
+ * a budget measured over some of the approved locales is not a budget. The scenarios that leave one
+ * out are the ones asserting that refusal.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.font.schema;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.textbudget;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace md   = mdux::tools::medui;
+namespace cli  = mdux::tools::cli;
+namespace font = mdux::font;
+namespace text = mdux::text;
+
+/// Every glyph in the fixture font is this size, so an extent is countable by hand.
+constexpr std::uint32_t glyphWidth  = 8;
+constexpr std::uint32_t glyphHeight = 10;
+
+/// The pen step the fixture runs are baked at. Not the font's advance: a baker chooses positions,
+/// and this suite chooses a round number so that a run of n glyphs is `(n - 1) * 10 + 8` wide.
+constexpr std::int16_t penStep = 10;
+
+/// The baseline every fixture run sits on. With `bitmapOriginY == glyphHeight`, ink runs from y 0.
+constexpr std::int16_t baseline = 10;
+
+/// Package indices into the fixture font's glyph table, which is sorted by code point.
+constexpr std::uint16_t spaceIndex  = 0;   ///< U+0020, blank: an advance and no coverage
+constexpr std::uint16_t letterIndex = 12;  ///< U+0041 'A'
+
+/// The id the fixture font publishes, and the id every fixture text package references.
+constexpr std::string_view fontId = "fixture-ui";
+
+/**
+ * @brief The fixture font: a blank space, the ten digits, `:`, and A-C, all 8x10.
+ *
+ * The digits share one advance width because `validate()` requires it - the tabular-figure rule
+ * from #161 - and this font is built to pass that check rather than around it. It approves two
+ * locales, which is what makes "the complete approved set" a testable idea below.
+ */
+[[nodiscard]] font::FontPackage fixtureFont() {
+    font::FontPackage package;
+    package.id         = std::string{fontId};
+    package.unitsPerEm = 1000;
+    package.pixelSize  = 10;
+    package.locales    = {"en-US", "de-DE"};
+    package.atlas =
+        font::AtlasMetrics{.path = "atlas.bin", .width = 64, .height = 64, .byteLength = 64 * 64, .sha256 = std::string(64, 'a'), .occupancyPercent = 50};
+
+    const auto append = [&package](char32_t codePoint, bool blank) {
+        const auto slot = static_cast<std::uint32_t>(package.glyphs.size());
+        package.glyphs.push_back(font::GlyphRecord{.codePoint       = codePoint,
+                                                   .glyphIndex      = static_cast<std::uint16_t>(slot + 1),
+                                                   .advanceWidth    = 500,
+                                                   .leftSideBearing = 0,
+                                                   .x               = (slot % 8) * glyphWidth,
+                                                   .y               = (slot / 8) * glyphHeight,
+                                                   .width           = blank ? 0 : glyphWidth,
+                                                   .height          = blank ? 0 : glyphHeight,
+                                                   .bitmapOriginX   = 0,
+                                                   .bitmapOriginY   = blank ? 0 : static_cast<std::int32_t>(glyphHeight)});
+    };
+
+    append(U' ', true);
+    for (char32_t digit = U'0'; digit <= U'9'; ++digit) {
+        append(digit, false);
+    }
+    append(U':', false);
+    for (char32_t letter = U'A'; letter <= U'C'; ++letter) {
+        append(letter, false);
+    }
+
+    package.restrictedCharset = {
+        font::CharsetRange{.first = U' ', .last = U' '},
+        font::CharsetRange{.first = U'0', .last = U':'},
+        font::CharsetRange{.first = U'A', .last = U'C'}
+    };
+    return package;
+}
+
+/// Appends one little-endian v1 run record: package glyph index, pen x, baseline y.
+void appendRecord(std::vector<std::byte>& bytes, std::uint16_t packageIndex, std::int16_t x, std::int16_t y) {
+    const auto emit16 = [&bytes](std::uint16_t value) {
+        bytes.push_back(static_cast<std::byte>(value & 0xFFu));
+        bytes.push_back(static_cast<std::byte>((value >> 8) & 0xFFu));
+    };
+    emit16(packageIndex);
+    emit16(static_cast<std::uint16_t>(x));
+    emit16(static_cast<std::uint16_t>(y));
+}
+
+/// Bakes one run: the given glyphs, one `penStep` apart, on the fixture baseline.
+[[nodiscard]] std::vector<std::byte> bakeRun(std::span<const std::uint16_t> glyphs) {
+    std::vector<std::byte> bytes;
+    for (std::size_t index = 0; index < glyphs.size(); ++index) {
+        appendRecord(bytes, glyphs[index], static_cast<std::int16_t>(static_cast<std::int64_t>(index) * penStep), baseline);
+    }
+    return bytes;
+}
+
+/// One approved locale's package and the sidecar its runs address, kept together so a test can
+/// hand `checkTextBudgets()` a `LocaleText` without managing two lifetimes.
+struct Locale {
+    text::TextPackage      package;
+    std::vector<std::byte> sidecar;
+
+    [[nodiscard]] md::LocaleText view() const noexcept {
+        return md::LocaleText{.package = &package, .sidecar = sidecar};
+    }
+};
+
+/// Builds one locale's text package from `key -> run bytes`, concatenating the sidecar in order.
+///
+/// Only the header's id is set: `TextPackage` already defaults its `kind` and `schemaVersion`, and
+/// restating them here would be a second opinion about a format this suite does not own.
+[[nodiscard]] Locale bakeLocale(std::string locale, std::span<const std::pair<std::string, std::vector<std::byte>>> runs) {
+    Locale built;
+    built.package.header.id   = std::format("fixture-{}", locale);
+    built.package.atlasId     = std::string{fontId};
+    built.package.locale      = std::move(locale);
+    built.package.sidecarPath = "runs.bin";
+
+    for (const auto& [key, bytes] : runs) {
+        built.package.runs.push_back(text::TextRun{.id = key, .byteOffset = built.sidecar.size(), .byteLength = bytes.size(), .sha256 = {}});
+        built.sidecar.insert(built.sidecar.end(), bytes.begin(), bytes.end());
+    }
+    built.package.sidecarByteLength = built.sidecar.size();
+    return built;
+}
+
+/// One locale whose keys are each the given number of copies of 'A'.
+[[nodiscard]] Locale lettersLocale(std::string locale, std::span<const std::pair<std::string, std::size_t>> keys) {
+    std::vector<std::pair<std::string, std::vector<std::byte>>> runs;
+    for (const auto& [key, count] : keys) {
+        const std::vector<std::uint16_t> glyphs(count, letterIndex);
+        runs.emplace_back(key, bakeRun(glyphs));
+    }
+    return bakeLocale(std::move(locale), runs);
+}
+
+/// One locale whose single key is `count` copies of 'A'.
+[[nodiscard]] Locale letterLocale(std::string locale, std::string key, std::size_t count) {
+    const std::array<std::pair<std::string, std::size_t>, 1> keys{
+        std::pair{std::move(key), count}
+    };
+    return lettersLocale(std::move(locale), keys);
+}
+
+/**
+ * @brief The complete approved locale set: one package per tag the fixture font declares.
+ *
+ * The stage refuses anything else, so a scenario that is not *about* that refusal builds its
+ * locales through this type and hands over `views()`.
+ */
+struct ApprovedText {
+    Locale english;
+    Locale german;
+
+    [[nodiscard]] std::array<md::LocaleText, 2> views() const noexcept {
+        return {english.view(), german.view()};
+    }
+};
+
+/// One key in both approved locales, at the requested glyph counts.
+[[nodiscard]] ApprovedText approvedText(std::string_view key, std::size_t englishGlyphs, std::size_t germanGlyphs) {
+    return ApprovedText{.english = letterLocale("en-US", std::string{key}, englishGlyphs), .german = letterLocale("de-DE", std::string{key}, germanGlyphs)};
+}
+
+/// Wraps a component body in a screen whose declared surface matches the build surface.
+[[nodiscard]] std::string screenWith(std::string_view body) {
+    return std::format("Screen Test {{\n"
+                       "    layout: Vertical {{ spacing: 0px; padding: 0px; }}\n"
+                       "    surface: 200px, 100px;\n"
+                       "{}"
+                       "}}\n",
+                       body);
+}
+
+/// One `Label` of the given box, carrying one text key.
+[[nodiscard]] std::string labelScreen(std::int64_t width, std::int64_t height, std::string_view key) {
+    return screenWith(std::format("    Label {{ id: title; width: {}px; height: {}px; text: t(\"{}\"); "
+                                  "color: Theme.Colors.Title; }}\n",
+                                  width,
+                                  height,
+                                  key));
+}
+
+/// Parses and resolves a screen against the 200x100 build surface these scenarios declare.
+[[nodiscard]] md::LayoutResult layoutOf(std::string_view source) {
+    md::ParseResult parsed = md::parse(source, "budget.medui");
+    if (!parsed.screen || !parsed.diagnostics.empty()) {
+        throw speclab::core::AssertionFailure("text budget test source did not parse", std::source_location::current());
+    }
+    md::LayoutResult resolved = md::resolveLayout(*parsed.screen, "budget.medui", {.surfaceWidth = 200, .surfaceHeight = 100});
+    if (!resolved.ok()) {
+        throw speclab::core::AssertionFailure("text budget test source did not resolve", std::source_location::current());
+    }
+    return resolved;
+}
+
+/// Finds one registered diagnostic in a budget result.
+[[nodiscard]] const cli::Diagnostic* find(const md::TextBudgetResult& result, md::Code code) {
+    const std::string_view wanted = md::id(code);
+    const auto             found  = std::ranges::find_if(result.diagnostics, [wanted](const cli::Diagnostic& diagnostic) {
+        return diagnostic.code == wanted;
+    });
+    return found == result.diagnostics.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool mentions(const cli::Diagnostic* diagnostic, std::string_view fragment) {
+    return diagnostic != nullptr && diagnostic->message.find(fragment) != std::string::npos;
+}
+
+[[nodiscard]] bool mentions(const cli::Diagnostic& diagnostic, std::string_view fragment) {
+    return diagnostic.message.find(fragment) != std::string::npos;
+}
+
+/// Runs `call` and answers whether it threw the wiring error every gate below is documented to use.
+[[nodiscard]] bool throwsWiringError(const std::function<void()>& call) {
+    try {
+        call();
+    } catch (const std::logic_error&) {
+        return true;
+    }
+    return false;
+}
+
+// The governed dynamic-text table these scenarios resolve `format:` and `charset:` against. The
+// ranges are namespace-scope so the spans in a `DynamicTextRule` outlive the call that reads them.
+constexpr std::array digitsAndColon{
+    font::CharsetRange{.first = U'0', .last = U':'}
+};
+constexpr std::array digitsAndZone{
+    font::CharsetRange{.first = U'0', .last = U':'},
+    font::CharsetRange{.first = U'Z', .last = U'Z'}
+};
+
+/// U+0030..U+0041: the digits and the colon, then the gap the fixture font does not hold, then 'A'.
+constexpr std::array digitsThroughLetter{
+    font::CharsetRange{.first = U'0', .last = U'A'}
+};
+
+/// A single code point one past the last Unicode scalar value, which is not a character at all.
+constexpr std::array beyondUnicode{
+    font::CharsetRange{.first = static_cast<char32_t>(0x110000), .last = static_cast<char32_t>(0x110000)}
+};
+
+/// U+D7FF..U+E000: a range whose ends are real characters but which spans the surrogate block.
+constexpr std::array acrossSurrogates{
+    font::CharsetRange{.first = static_cast<char32_t>(0xD7FF), .last = static_cast<char32_t>(0xE000)}
+};
+
+}  // namespace
+
+const mdux::spec::Register widestTranslationDrivesTheBudget{
+    "The budget is measured against the widest approved translation, not the authoring one",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-widest-locale")
+            .Given("a 40px Label whose en-US run is 28px and whose de-DE run is 58px", [] {})
+            .When("the resolved screen is checked against both approved locales", [] {})
+            .Then("MEDUI-E050 names de-DE, the key, the required width and the available one",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
+                      const auto              locales     = approved.views();
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(40, 20, "STR-TITLE")),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::TextBudgetExceeded);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(result.diagnostics.size() == 1, std::format("only the failing locale is reported, got {}", result.diagnostics.size()));
+                      checks.expect(mentions(reported, "de-DE"), "the diagnostic names the locale");
+                      checks.expect(mentions(reported, "STR-TITLE"), "the diagnostic names the text key");
+                      checks.expect(mentions(reported, "58px"), "the diagnostic names the required width");
+                      checks.expect(mentions(reported, "40px"), "the diagnostic names the available width");
+                      checks.expect(result.measurements.empty(), "no measurement survives a failed budget");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register fittingScreenReportsItsWorstCase{
+    "A screen that fits every locale reports the worst case for the emitter to budget",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-worst-case-measurement")
+            .Given("a 100px Label whose widest approved translation is 58px", [] {})
+            .When("the resolved screen is checked", [] {})
+            .Then("it compiles and the measurement names de-DE with the per-axis maximum",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
+                      const auto              locales     = approved.views();
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(100, 20, "STR-TITLE")),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      checks.expect(result.ok(), "the screen compiles");
+                      checks.expect(result.measurements.size() == 1, std::format("one text field is measured, got {}", result.measurements.size()));
+                      if (result.measurements.size() == 1) {
+                          const md::TextMeasurement& measured = result.measurements.front();
+                          checks.expect(measured.nodeId == "title", "the measurement names the node");
+                          checks.expect(measured.field == "text", "the measurement names the field");
+                          checks.expect(measured.textKey == "STR-TITLE", "the measurement names the key");
+                          checks.expect(measured.locale == "de-DE", "the widest locale is recorded");
+                          checks.expect(measured.extent == md::TextExtent{58, 10},
+                                        std::format("the extent is 58x10, got {}x{}", measured.extent.width, measured.extent.height));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register widestLocaleWinsRegardlessOfOrder{
+    "The widest translation is recorded whichever position it holds in the input",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-worst-case-not-overwritten")
+            .Given("the 58px de-DE package first and the 28px en-US package second", [] {})
+            .When("both are measured for the same key", [] {})
+            .Then("the recorded worst case is still 58px from de-DE",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
+
+                      // Reversed on purpose: the maximum has to come from a comparison, not from
+                      // whichever package the caller happened to list last.
+                      const std::array<md::LocaleText, 2> locales{approved.german.view(), approved.english.view()};
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(100, 20, "STR-TITLE")),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      checks.expect(result.ok(), "the screen compiles");
+                      checks.expect(result.measurements.size() == 1, "the field is measured");
+                      if (result.measurements.size() == 1) {
+                          checks.expect(result.measurements.front().locale == "de-DE", "the widest locale is recorded");
+                          checks.expect(result.measurements.front().extent.width == 58,
+                                        std::format("the worst case is 58px, got {}px", result.measurements.front().extent.width));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register blankGlyphsAreNotInk{
+    "A leading blank glyph does not widen the measured extent",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-blank-glyphs-skipped")
+            .Given("a run that opens with a space at the pen origin and three letters after it", [] {})
+            .When("a 30px Label carrying that run is measured", [] {})
+            .Then("the ink measures 28px and the box is accepted",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+
+                      // Records at x = 0, 10, 20, 30: a blank space, then three letters. Counting
+                      // the space as ink would measure from x 0 and make this 38px, which a 30px
+                      // box would reject - so the acceptance below is the assertion.
+                      const std::array<std::uint16_t, 4>                                  glyphs{spaceIndex, letterIndex, letterIndex, letterIndex};
+                      const std::array<std::pair<std::string, std::vector<std::byte>>, 1> englishRuns{
+                          std::pair{std::string{"STR-TITLE"}, bakeRun(glyphs)}
+                      };
+                      const ApprovedText approved{.english = bakeLocale("en-US", englishRuns), .german = letterLocale("de-DE", "STR-TITLE", 1)};
+                      const auto         locales = approved.views();
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(labelScreen(30, 20, "STR-TITLE")),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      checks.expect(result.ok(), "the screen compiles");
+                      checks.expect(result.measurements.size() == 1, "the field is measured");
+                      if (result.measurements.size() == 1) {
+                          checks.expect(
+                              result.measurements.front().extent == md::TextExtent{28, 10},
+                              std::format("the ink is 28x10, got {}x{}", result.measurements.front().extent.width, result.measurements.front().extent.height));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register heightIsBudgetedToo{"A box shorter than its translation is rejected on the vertical axis", "evidence-unit", [] {
+                                                   return speclab::Test("medui-textbudget-height-exceeded")
+                                                       .Given("a Label 8px tall carrying a run whose ink is 10px tall", [] {})
+                                                       .When("the resolved screen is checked", [] {})
+                                                       .Then("MEDUI-E050 names the height it needs and the height it has",
+                                                             [] {
+                                                                 mdux::spec::Checks      checks;
+                                                                 const font::FontPackage fontPackage = fixtureFont();
+                                                                 const ApprovedText      approved    = approvedText("STR-TITLE", 2, 2);
+                                                                 const auto              locales     = approved.views();
+
+                                                                 const md::TextBudgetResult result = md::checkTextBudgets(
+                                                                     layoutOf(labelScreen(100, 8, "STR-TITLE")),
+                                                                     "budget.medui",
+                                                                     {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                                                                 const cli::Diagnostic* reported = find(result, md::Code::TextBudgetExceeded);
+                                                                 checks.expect(!result.ok(), "the screen is rejected");
+                                                                 checks.expect(mentions(reported, "height"), "the diagnostic names the axis that failed");
+                                                                 checks.expect(mentions(reported, "10px"), "the diagnostic names the required height");
+                                                                 checks.expect(mentions(reported, "8px"), "the diagnostic names the available height");
+                                                                 checks.raise();
+                                                             })
+                                                       .Execute();
+                                               }};
+
+const mdux::spec::Register listValuedTextIsMeasuredPerElement{
+    "Every element of a list-valued text field is measured, not only the first",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-text-key-list")
+            .Given("a StatusIndicator whose states are a 28px key and a 58px key", [] {})
+            .When("a box that fits both, and then one that fits only the first, are checked", [] {})
+            .Then("both keys are measured, and the second is what the narrow box rejects",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+
+                      const std::array<std::pair<std::string, std::size_t>, 2> keys{
+                          std::pair{   std::string{"STR-OK"}, std::size_t{3}},
+                          std::pair{std::string{"STR-ALARM"}, std::size_t{6}}
+                      };
+                      const ApprovedText approved{.english = lettersLocale("en-US", keys), .german = lettersLocale("de-DE", keys)};
+                      const auto         locales = approved.views();
+
+                      const auto states = [](std::int64_t width) {
+                          return screenWith(std::format("    StatusIndicator {{ id: status; width: {}px; height: 20px; "
+                                                        "requirement: \"REQ-1\"; source: \"STATE\"; "
+                                                        "states: [t(\"STR-OK\"), t(\"STR-ALARM\")]; }}\n",
+                                                        width));
+                      };
+
+                      const md::TextBudgetResult fits = md::checkTextBudgets(layoutOf(states(100)),
+                                                                             "budget.medui",
+                                                                             {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                      checks.expect(fits.ok(), std::format("the wide box compiles, got {} diagnostics", fits.diagnostics.size()));
+                      checks.expect(fits.measurements.size() == 2, std::format("both list elements are measured, got {}", fits.measurements.size()));
+                      if (fits.measurements.size() == 2) {
+                          checks.expect(fits.measurements[0].textKey == "STR-OK" && fits.measurements[1].textKey == "STR-ALARM",
+                                        "the measurements follow the authored list order");
+                          checks.expect(fits.measurements[1].field == "states", "a list element is attributed to its field");
+                      }
+
+                      const md::TextBudgetResult narrow = md::checkTextBudgets(layoutOf(states(40)),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                      checks.expect(!narrow.ok(), "the narrow box is rejected");
+                      checks.expect(mentions(find(narrow, md::Code::TextBudgetExceeded), "STR-ALARM"), "the second element is the one that does not fit");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register diagnosticsFollowNodeAndLocaleOrder{
+    "Diagnostics accumulate in node order, then in the input order of the locales",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-diagnostic-order")
+            .Given("two 10px Labels, each too narrow for both approved translations", [] {})
+            .When("the resolved screen is checked", [] {})
+            .Then("the four diagnostics arrive title/en-US, title/de-DE, subtitle/en-US, subtitle/de-DE",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+
+                      const std::array<std::pair<std::string, std::size_t>, 2> keys{
+                          std::pair{   std::string{"STR-TITLE"}, std::size_t{3}},
+                          std::pair{std::string{"STR-SUBTITLE"}, std::size_t{3}}
+                      };
+                      const ApprovedText approved{.english = lettersLocale("en-US", keys), .german = lettersLocale("de-DE", keys)};
+                      const auto         locales = approved.views();
+
+                      const std::string source = screenWith(
+                          "    Label { id: title; width: 10px; height: 20px; text: t(\"STR-TITLE\"); color: Theme.Colors.Title; }\n"
+                          "    Label { id: subtitle; width: 10px; height: 20px; text: t(\"STR-SUBTITLE\"); color: Theme.Colors.Title; }\n");
+
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      checks.expect(result.diagnostics.size() == 4, std::format("every failing pair is reported, got {}", result.diagnostics.size()));
+                      if (result.diagnostics.size() == 4) {
+                          checks.expect(mentions(result.diagnostics[0], "STR-TITLE") && mentions(result.diagnostics[0], "en-US"),
+                                        "the first node's first locale comes first");
+                          checks.expect(mentions(result.diagnostics[1], "STR-TITLE") && mentions(result.diagnostics[1], "de-DE"),
+                                        "locales follow their input order within a field");
+                          checks.expect(mentions(result.diagnostics[2], "STR-SUBTITLE") && mentions(result.diagnostics[2], "en-US"),
+                                        "the second node follows the first");
+                          checks.expect(mentions(result.diagnostics[3], "STR-SUBTITLE") && mentions(result.diagnostics[3], "de-DE"),
+                                        "and its locales follow the same order");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register dynamicTextCannotEscapeTheCharset{
+    "A format that can produce an unbaked character is MEDUI-E053",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-escape")
+            .Given("a Clock whose format can emit U+005A, which the font package does not hold", [] {})
+            .When("the format is resolved against the governed dynamic-text table", [] {})
+            .Then("MEDUI-E053 names the escaping code point",
+                  [] {
+                      mdux::spec::Checks                       checks;
+                      const font::FontPackage                  fontPackage = fixtureFont();
+                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales     = approved.views();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "HH_MM_TZ", .produces = digitsAndZone}
+                      };
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM_TZ; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(mentions(reported, "HH_MM_TZ"), "the diagnostic names the dynamic-text source");
+                      checks.expect(mentions(reported, "U+005A"), "the diagnostic names the code point that escapes");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register charsetWalkCrossesRangeBoundaries{
+    "A produced range spanning a gap in the charset is caught at the gap",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-gap")
+            .Given("a source producing U+0030..U+0041, which the font holds either side of a gap", [] {})
+            .When("the produced range is walked against the restricted charset", [] {})
+            .Then("MEDUI-E053 names U+003B, the first code point in the gap",
+                  [] {
+                      mdux::spec::Checks                       checks;
+                      const font::FontPackage                  fontPackage = fixtureFont();
+                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales     = approved.views();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "DIGITS_TO_A", .produces = digitsThroughLetter}
+                      };
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: DIGITS_TO_A; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(mentions(reported, "U+003B"), "the walk stops at the first code point the charset omits");
+                      checks.expect(result.diagnostics.size() == 1, std::format("one diagnostic per field, got {}", result.diagnostics.size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register nonScalarRangesAreReported{
+    "A produced range naming something that is not a character is reported, never asked about",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-beyond-unicode")
+            .Given("governed entries declaring U+110000, and one spanning the surrogate block", [] {})
+            .When("each entry is checked", [] {})
+            .Then("MEDUI-E053 names the first non-character in each, rather than measuring around it",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto              locales     = approved.views();
+
+                      const auto reportFor = [&](std::string_view name, std::span<const font::CharsetRange> produces) {
+                          const std::array<md::DynamicTextRule, 1> table{
+                              md::DynamicTextRule{.name = name, .produces = produces}
+                          };
+                          const std::string source = screenWith(std::format("    Clock {{ id: now; width: 100px; height: 20px; format: {}; }}\n", name));
+                          return md::checkTextBudgets(layoutOf(source), "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = table});
+                      };
+
+                      const md::TextBudgetResult beyond = reportFor("OUT_OF_RANGE", beyondUnicode);
+                      checks.expect(!beyond.ok(), "the out-of-range entry is rejected");
+                      checks.expect(mentions(find(beyond, md::Code::CharsetEscape), "U+110000"), "the diagnostic names the offending code point");
+                      checks.expect(mentions(find(beyond, md::Code::CharsetEscape), "not a Unicode scalar value"), "and says what is wrong with it");
+
+                      // U+D7FF and U+E000 are real characters, so a check that compared only the
+                      // ends would pass this range - and the font package is never consulted, since
+                      // a surrogate is not something any package can draw whatever its table says.
+                      const md::TextBudgetResult surrogates = reportFor("SURROGATE_SPAN", acrossSurrogates);
+                      checks.expect(!surrogates.ok(), "the surrogate-spanning entry is rejected");
+                      checks.expect(mentions(find(surrogates, md::Code::CharsetEscape), "U+D800"), "the diagnostic names the first surrogate");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unresolvedDynamicTextFailsClosed{
+    "A dynamic-text source with no governed entry fails closed",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-unbounded-dynamic-source")
+            .Given("a Clock naming a format the governed table does not define", [] {})
+            .When("the format is resolved", [] {})
+            .Then("MEDUI-E053 says what it produces is not bounded, rather than passing it over",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto              locales     = approved.views();
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::CharsetEscape);
+                      checks.expect(!result.ok(), "the screen is rejected");
+                      checks.expect(mentions(reported, "HH_MM"), "the diagnostic names the unresolved source");
+                      checks.expect(mentions(reported, "not bounded"), "the diagnostic says why it cannot pass");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register boundedDynamicTextIsAccepted{
+    "A format inside the restricted charset compiles, and an unnamed charset is not an error",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-charset-accepted")
+            .Given("a Clock producing digits and a colon, and a TextInput with no charset field", [] {})
+            .When("the screen is checked against the font package's restricted charset", [] {})
+            .Then("neither component is reported",
+                  [] {
+                      mdux::spec::Checks                       checks;
+                      const font::FontPackage                  fontPackage = fixtureFont();
+                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales     = approved.views();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
+                      };
+
+                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n"
+                                                                     "    TextInput { id: entry; width: 100px; height: 20px; source: \"OPERATOR_NOTE\"; "
+                                                                     "max_length: 16; color: Theme.Colors.Title; }\n");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
+
+                      checks.expect(result.ok(), std::format("the screen compiles, got {} diagnostics", result.diagnostics.size()));
+                      checks.expect(result.measurements.empty(), "a screen with no text key measures nothing");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register incompleteApprovedSetIsRefused{
+    "A budget measured over some of the approved locales is refused as a wiring error",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-approved-set")
+            .Given("a font package approving en-US and de-DE", [] {})
+            .When("a caller supplies a subset, a duplicate, or a locale the font does not approve", [] {})
+            .Then("each is std::logic_error rather than a screen certified against a set nobody approved",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
+                      const md::LayoutResult  resolved    = layoutOf(labelScreen(100, 20, "STR-TITLE"));
+
+                      const auto check = [&](std::span<const md::LocaleText> locales) {
+                          return throwsWiringError([&] {
+                              [[maybe_unused]] const md::TextBudgetResult ignored =
+                                  md::checkTextBudgets(resolved, "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                          });
+                      };
+
+                      // The omission this check exists for: the 58px German translation is the one
+                      // that overflows, and leaving it out is how a screen passes without it.
+                      const std::array<md::LocaleText, 1> englishOnly{approved.english.view()};
+                      checks.expect(check(englishOnly), "an approved locale that was not supplied is refused");
+
+                      const std::array<md::LocaleText, 2> duplicated{approved.english.view(), approved.english.view()};
+                      checks.expect(check(duplicated), "the same locale supplied twice is refused");
+
+                      const Locale                        unapproved = letterLocale("fr-FR", "STR-TITLE", 3);
+                      const std::array<md::LocaleText, 3> extra{approved.english.view(), approved.german.view(), unapproved.view()};
+                      checks.expect(check(extra), "a locale the font package does not approve is refused");
+
+                      const auto complete = approved.views();
+                      checks.expect(!check(complete), "the complete approved set is accepted");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unwalkableFontCharsetIsRefused{
+    "A font package whose charset table cannot be walked is refused rather than walked",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-font-charset-walkable")
+            .Given("a font package with a charset range ending at the type maximum, and one that descends", [] {})
+            .When("a screen naming a dynamic-text source is checked against each", [] {})
+            .Then("both are std::logic_error, and the walk cannot loop",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // Without the up-front check this scenario would hang rather than fail: the
+                      // walk advances to `covering->last + 1`, which wraps to zero for a range
+                      // ending at the type maximum and selects the same range forever. A hang is
+                      // the one failure a test cannot report, which is why the check is up front
+                      // rather than a guard inside the loop.
+                      font::FontPackage wrapping = fixtureFont();
+                      wrapping.restrictedCharset.push_back(font::CharsetRange{.first = U'X', .last = static_cast<char32_t>(0xFFFFFFFF)});
+
+                      font::FontPackage descending = fixtureFont();
+                      descending.restrictedCharset.push_back(font::CharsetRange{.first = U'Y', .last = U'X'});
+
+                      const ApprovedText                       approved = approvedText("STR-UNUSED", 1, 1);
+                      const auto                               locales  = approved.views();
+                      const std::array<md::DynamicTextRule, 1> table{
+                          md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
+                      };
+                      const md::LayoutResult resolved = layoutOf(screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n"));
+
+                      const auto check = [&](const font::FontPackage& fontPackage) {
+                          return throwsWiringError([&] {
+                              [[maybe_unused]] const md::TextBudgetResult ignored =
+                                  md::checkTextBudgets(resolved, "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = table});
+                          });
+                      };
+
+                      checks.expect(check(wrapping), "a charset range past the last Unicode scalar value is refused");
+                      checks.expect(check(descending), "a descending charset range is refused");
+                      checks.expect(!wrapping.validate().has_value() && !descending.validate().has_value(),
+                                    "FontPackage::validate() rejects both too - this stage guards the packages it is handed unvalidated");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register malformedPackagesAreWiringErrors{
+    "A miswired stage throws rather than emitting a diagnostic an author cannot act on",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-gates-throw")
+            .Given("a null font, a truncated sidecar, a foreign atlas, a partial record and a missing key", [] {})
+            .When("the budget check runs on each", [] {})
+            .Then("every one is std::logic_error",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const md::LayoutResult  resolved    = layoutOf(labelScreen(100, 20, "STR-TITLE"));
+
+                      const auto check = [&](std::span<const md::LocaleText> locales) {
+                          return throwsWiringError([&] {
+                              [[maybe_unused]] const md::TextBudgetResult ignored =
+                                  md::checkTextBudgets(resolved, "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                          });
+                      };
+
+                      checks.expect(throwsWiringError([&] {
+                                        [[maybe_unused]] const md::TextBudgetResult ignored =
+                                            md::checkTextBudgets(resolved, "budget.medui", {.font = nullptr, .locales = {}, .dynamicText = {}});
+                                    }),
+                                    "a null font package is a wiring error, not a diagnostic");
+
+                      // A sidecar one byte short of what its package declares. The selected run
+                      // still fits inside what was handed over, which is exactly why the check is
+                      // against the declared length rather than against this run's end.
+                      ApprovedText truncated = approvedText("STR-TITLE", 3, 6);
+                      truncated.english.sidecar.pop_back();
+                      const auto truncatedViews = truncated.views();
+                      checks.expect(check(truncatedViews), "a sidecar shorter than the package declares is refused");
+
+                      ApprovedText foreign            = approvedText("STR-TITLE", 3, 6);
+                      foreign.english.package.atlasId = "another-font";
+                      const auto foreignViews         = foreign.views();
+                      checks.expect(check(foreignViews), "a package baked against a different font is refused");
+
+                      // 17 bytes is not a whole number of 6-byte records, so the run cannot be
+                      // enumerated - the failure `mdux.text.schema` documents as the one byte
+                      // identity cannot detect once it reaches a device.
+                      ApprovedText partial                             = approvedText("STR-TITLE", 3, 6);
+                      partial.english.package.runs.front().byteLength -= 1;
+                      partial.english.package.sidecarByteLength       -= 1;
+                      partial.english.sidecar.pop_back();
+                      const auto partialViews = partial.views();
+                      checks.expect(check(partialViews), "a run whose byte length is not a whole number of records is refused");
+
+                      const ApprovedText missing      = approvedText("STR-OTHER", 3, 6);
+                      const auto         missingViews = missing.views();
+                      checks.expect(check(missingViews), "an unmeasurable key means analyze() was bypassed");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register fixturePackagesAreRealArtifacts{
+    "The fixture font and text packages satisfy their own schemas",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-fixtures-validate")
+            .Given("the synthetic font package and both approved locales", [] {})
+            .When("each is validated by the module that owns its format", [] {})
+            .Then("all three pass, so the measurements above are taken from legal artifacts",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-TITLE", 3, 6);
+
+                      checks.expect(fontPackage.validate().has_value(), "the fixture font is a valid font package");
+                      checks.expect(approved.english.package.validate().has_value(), "the fixture en-US package is valid");
+                      checks.expect(approved.german.package.validate().has_value(), "the fixture de-DE package is valid");
+                      checks.expect(fontPackage.permits(U'A') && !fontPackage.permits(U'Z'),
+                                    "the restricted charset holds the letters the runs use and not the one they must not");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/medui/fixtures/accepted-every-component.medui
+++ b/tests/medui/fixtures/accepted-every-component.medui
@@ -1,0 +1,108 @@
+// One screen carrying all eleven compiled payloads, for the package round trip (#197).
+//
+// Every component in the dictionary appears once, and the Row declares a background so the solver
+// synthesises the eleventh payload - a Panel, which an author cannot write. A round trip over this
+// screen therefore executes every branch of the writer and every branch of the reader, which is
+// what keeps the two halves of the file format in step: an assertion on either alone could not.
+//
+// Optional fields are declared where they change the emitted shape: `requirement:` on the Button
+// and the TextInput, `charset:` on the TextInput, and `colors:` on the StatusIndicator, so the
+// round trip covers a spec whose optional names are present as well as one where they are absent.
+Screen EveryComponent {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 800px, 700px;
+
+    Row {
+        id: topbar;
+        height: 64px;
+        background: Theme.Colors.TopbarBackground;
+
+        Label {
+            id: title;
+            width: Fill;
+            height: 64px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+    }
+
+    Clock {
+        id: wall-clock;
+        width: 200px;
+        height: 40px;
+        format: TimeSeconds;
+    }
+
+    Image {
+        id: logo;
+        width: 120px;
+        height: 60px;
+        source: img("IMG-LOGO");
+    }
+
+    VulkanViewport {
+        id: endoscope;
+        width: 640px;
+        height: 200px;
+        stream_source: "ENDOSCOPE";
+    }
+
+    SignalTrace {
+        id: ecg;
+        width: 640px;
+        height: 100px;
+        stream_source: "ECG_LEAD_II";
+        color: Theme.Colors.Nominal;
+    }
+
+    Button {
+        id: freeze;
+        width: 160px;
+        height: 40px;
+        label: t("STR-FREEZE");
+        color: Theme.Colors.PrimaryAction;
+        source: "FREEZE";
+        requirement: "REQ-EC-001";
+    }
+
+    CriticalButton {
+        id: halt;
+        requirement: "REQ-EC-002";
+        width: 160px;
+        height: 40px;
+        label: t("STR-HALT");
+        color: Theme.Colors.Fault;
+        on_press: TriggerHalt;
+    }
+
+    NumericDisplay {
+        id: sedation-index;
+        width: 200px;
+        height: 60px;
+        requirement: "REQ-EC-003";
+        template: "TPL-SEDATION-INDEX-160";
+        source: "SEDATION_INDEX";
+        color: Theme.Colors.ScoreDigits;
+    }
+
+    StatusIndicator {
+        id: state;
+        width: 200px;
+        height: 40px;
+        requirement: "REQ-EC-004";
+        source: "STATE";
+        states: [t("STR-OK"), t("STR-ALARM")];
+        colors: [Theme.Colors.Nominal, Theme.Colors.Alert];
+    }
+
+    TextInput {
+        id: patient-id;
+        width: 240px;
+        height: 40px;
+        source: "PATIENT_ID";
+        max_length: 16;
+        color: Theme.Colors.Neutral;
+        charset: Ascii;
+        requirement: "REQ-EC-005";
+    }
+}

--- a/tests/medui/fixtures/accepted-goldens.medui
+++ b/tests/medui/fixtures/accepted-goldens.medui
@@ -1,0 +1,66 @@
+// Every rule ADR-011 fixes for golden references, in one screen a reviewer can read.
+//
+//   action  @safety_critical only          -> one entry, the checks the annotation names
+//   pinned  position: only                 -> one entry, an automatic Bounds
+//   score   annotated *and* positioned     -> exactly one entry, checks merged and deduplicated
+//   state   dynamic content                -> bounds and nothing that varies: no text, no tint
+//   plain   neither                        -> no entry at all
+//
+// Deliberately not a Label for `action`: the dictionary gives Label no `requirement:` field, and a
+// @safety_critical node must carry one. Button, NumericDisplay and StatusIndicator are the
+// components where an annotation and a requirement can coexist.
+Screen Goldens {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 400px, 300px;
+
+    @safety_critical(cv_check: [ColorHash])
+    Button {
+        id: action;
+        width: 200px;
+        height: 40px;
+        label: t("STR-ACTION");
+        color: Theme.Colors.PrimaryAction;
+        source: "ACTION";
+        requirement: "REQ-G-001";
+    }
+
+    Label {
+        id: pinned;
+        width: 100px;
+        height: 40px;
+        position: 250px, 0px;
+        text: t("STR-PINNED");
+        color: Theme.Colors.Title;
+    }
+
+    @safety_critical(cv_check: [Bounds, ColorHash])
+    NumericDisplay {
+        id: score;
+        width: 120px;
+        height: 60px;
+        position: 250px, 60px;
+        requirement: "REQ-G-002";
+        template: "TPL-SCORE";
+        source: "SCORE";
+        color: Theme.Colors.ScoreDigits;
+    }
+
+    StatusIndicator {
+        id: state;
+        width: 120px;
+        height: 40px;
+        position: 250px, 140px;
+        requirement: "REQ-G-003";
+        source: "STATE";
+        states: [t("STR-OK"), t("STR-ALARM")];
+        colors: [Theme.Colors.Title, Theme.Colors.ScoreDigits];
+    }
+
+    Label {
+        id: plain;
+        width: 100px;
+        height: 40px;
+        text: t("STR-PLAIN");
+        color: Theme.Colors.Title;
+    }
+}

--- a/tests/medui/fixtures/accepted-layout.medui
+++ b/tests/medui/fixtures/accepted-layout.medui
@@ -1,0 +1,53 @@
+// Hand-derived layout fixture for issue #194.
+// Surface content is 1248x688 after 16px padding. The Row consumes 48px, the NumericDisplay
+// 120px, and two 8px gaps; the final Fill viewport therefore receives 504px.
+Screen MonitorLayout {
+    layout: Vertical { spacing: 8px; padding: 16px; }
+    surface: 1280px, 720px;
+
+    Row {
+        id: topbar;
+        height: 48px;
+        spacing: 16px;
+        background: Theme.Colors.TopbarBackground;
+
+        Label {
+            id: title;
+            width: 340px;
+            height: 48px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+        Clock {
+            id: clock;
+            width: Fill;
+            height: Fill;
+            format: DateTimeSeconds;
+        }
+        StatusIndicator {
+            id: status;
+            width: 200px;
+            height: 48px;
+            requirement: "REQ-STATUS-001";
+            source: "MONITOR_STATUS";
+            states: [t("STR-NOMINAL")];
+        }
+    }
+
+    NumericDisplay {
+        id: score;
+        width: Fill;
+        height: 120px;
+        requirement: "REQ-SCORE-001";
+        template: "TPL-SCORE";
+        source: "SCORE";
+        color: Theme.Colors.ScoreDigits;
+    }
+
+    VulkanViewport {
+        id: viewport;
+        width: Fill;
+        height: Fill;
+        stream_source: "MONITOR_VIEW";
+    }
+}

--- a/tests/medui/fixtures/accepted-neurosense.medui
+++ b/tests/medui/fixtures/accepted-neurosense.medui
@@ -1,0 +1,35 @@
+// The skill's worked example, extended to exercise every construct the parser accepts.
+// One property per line, matching TrustSC's own neurosense.medui: its parser splits a component
+// body line by line, so two properties on one line are rejected there even though MduX's
+// token-based parser would accept them. Written the portable way on purpose - a fixture that
+// only compiles under one of the two implementations is not evidence the grammar is shared.
+Screen NeuroSense500 {
+    layout: Vertical { spacing: 8px; padding: 0px; }
+    surface: 1920px, 1080px;
+
+    @safety_critical(cv_check: [Bounds, ColorHash])
+    NumericDisplay {
+        id: sedation-index;
+        width: 512px;
+        height: 512px;
+        position: 1392px, 80px;
+        requirement: "REQ-NS-001";
+        template: "TPL-SEDATION-INDEX-160";
+        source: "SEDATION_INDEX";
+        color: Theme.Colors.ScoreDigits;
+    }
+
+    Row {
+        id: topbar;
+        height: 64px;
+        background: Theme.Colors.TopbarBackground;
+
+        Label {
+            id: title;
+            width: Fill;
+            height: 64px;
+            text: t("STR-TITLE");
+            color: Theme.Colors.Title;
+        }
+    }
+}

--- a/tests/medui/fixtures/accepted-textless.medui
+++ b/tests/medui/fixtures/accepted-textless.medui
@@ -1,0 +1,43 @@
+// A screen that draws no text, for the compiler driver's happy path (#198).
+//
+// Every node here is a component that paints pixels rather than characters: a Row background, an
+// Image, a VulkanViewport and a SignalTrace. That is what makes it compilable without a font
+// package and without an approved locale - `needsTextBudget()` answers false for it, so the recipe
+// needs no [text] table and the budget stage has nothing to measure.
+//
+// The SignalTrace is positioned, which is the other half of what this fixture is for: an explicitly
+// positioned node is pinned by a golden reference, so `goldens.json` carries one entry rather than
+// being empty and proving nothing.
+Screen TextlessScreen {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 400px, 300px;
+
+    Row {
+        id: topbar;
+        height: 40px;
+        background: Theme.Colors.TopbarBackground;
+
+        Image {
+            id: logo;
+            width: 120px;
+            height: 40px;
+            source: img("IMG-LOGO");
+        }
+    }
+
+    VulkanViewport {
+        id: scope;
+        width: 400px;
+        height: 160px;
+        stream_source: "ENDOSCOPE";
+    }
+
+    SignalTrace {
+        id: ecg;
+        width: 400px;
+        height: 100px;
+        position: 0px, 200px;
+        stream_source: "ECG_LEAD_II";
+        color: Theme.Colors.Nominal;
+    }
+}

--- a/tests/medui/fixtures/empty-screen-package.json
+++ b/tests/medui/fixtures/empty-screen-package.json
@@ -1,0 +1,13 @@
+{
+  "budget": {
+    "maxCommands": 0,
+    "maxIndices": 0,
+    "maxVertices": 0
+  },
+  "id": "empty-screen",
+  "kind": "screen",
+  "nodes": [],
+  "schemaVersion": 1,
+  "surfaceHeight": 100,
+  "surfaceWidth": 200
+}

--- a/tests/medui/fixtures/every-component-package.json
+++ b/tests/medui/fixtures/every-component-package.json
@@ -1,0 +1,181 @@
+{
+  "budget": {
+    "maxCommands": 256,
+    "maxIndices": 6144,
+    "maxVertices": 4096
+  },
+  "id": "every-component",
+  "kind": "screen",
+  "nodes": [
+    {
+      "bounds": {
+        "height": 64,
+        "width": 800,
+        "x": 0,
+        "y": 0
+      },
+      "id": "topbar-background",
+      "kind": "Panel",
+      "spec": {
+        "colorToken": "Theme.Colors.TopbarBackground"
+      }
+    },
+    {
+      "bounds": {
+        "height": 64,
+        "width": 800,
+        "x": 0,
+        "y": 0
+      },
+      "id": "title",
+      "kind": "Label",
+      "spec": {
+        "colorToken": "Theme.Colors.Title",
+        "textKey": "STR-TITLE"
+      }
+    },
+    {
+      "bounds": {
+        "height": 40,
+        "width": 200,
+        "x": 0,
+        "y": 64
+      },
+      "id": "wall-clock",
+      "kind": "Clock",
+      "spec": {
+        "format": "TimeSeconds"
+      }
+    },
+    {
+      "bounds": {
+        "height": 60,
+        "width": 120,
+        "x": 0,
+        "y": 104
+      },
+      "id": "logo",
+      "kind": "Image",
+      "spec": {
+        "source": "IMG-LOGO"
+      }
+    },
+    {
+      "bounds": {
+        "height": 200,
+        "width": 640,
+        "x": 0,
+        "y": 164
+      },
+      "id": "endoscope",
+      "kind": "VulkanViewport",
+      "spec": {
+        "streamSource": "ENDOSCOPE"
+      }
+    },
+    {
+      "bounds": {
+        "height": 100,
+        "width": 640,
+        "x": 0,
+        "y": 364
+      },
+      "id": "ecg",
+      "kind": "SignalTrace",
+      "spec": {
+        "colorToken": "Theme.Colors.Nominal",
+        "streamSource": "ECG_LEAD_II"
+      }
+    },
+    {
+      "bounds": {
+        "height": 40,
+        "width": 160,
+        "x": 0,
+        "y": 464
+      },
+      "id": "freeze",
+      "kind": "Button",
+      "spec": {
+        "colorToken": "Theme.Colors.PrimaryAction",
+        "labelKey": "STR-FREEZE",
+        "requirement": "REQ-EC-001",
+        "source": "FREEZE"
+      }
+    },
+    {
+      "bounds": {
+        "height": 40,
+        "width": 160,
+        "x": 0,
+        "y": 504
+      },
+      "id": "halt",
+      "kind": "CriticalButton",
+      "spec": {
+        "colorToken": "Theme.Colors.Fault",
+        "labelKey": "STR-HALT",
+        "onPress": "TriggerHalt",
+        "requirement": "REQ-EC-002"
+      }
+    },
+    {
+      "bounds": {
+        "height": 60,
+        "width": 200,
+        "x": 0,
+        "y": 544
+      },
+      "id": "sedation-index",
+      "kind": "NumericDisplay",
+      "spec": {
+        "colorToken": "Theme.Colors.ScoreDigits",
+        "requirement": "REQ-EC-003",
+        "source": "SEDATION_INDEX",
+        "templateId": "TPL-SEDATION-INDEX-160"
+      }
+    },
+    {
+      "bounds": {
+        "height": 40,
+        "width": 200,
+        "x": 0,
+        "y": 604
+      },
+      "id": "state",
+      "kind": "StatusIndicator",
+      "spec": {
+        "colorTokens": [
+          "Theme.Colors.Nominal",
+          "Theme.Colors.Alert"
+        ],
+        "requirement": "REQ-EC-004",
+        "source": "STATE",
+        "stateKeys": [
+          "STR-OK",
+          "STR-ALARM"
+        ]
+      }
+    },
+    {
+      "bounds": {
+        "height": 40,
+        "width": 240,
+        "x": 0,
+        "y": 644
+      },
+      "id": "patient-id",
+      "kind": "TextInput",
+      "spec": {
+        "charset": "Ascii",
+        "colorToken": "Theme.Colors.Neutral",
+        "maxLength": 16,
+        "requirement": "REQ-EC-005",
+        "source": "PATIENT_ID"
+      }
+    }
+  ],
+  "schemaVersion": 1,
+  "surfaceHeight": 700,
+  "surfaceWidth": 800
+}

--- a/tests/medui/fixtures/rejected-bad-unit.medui
+++ b/tests/medui/fixtures/rejected-bad-unit.medui
@@ -1,0 +1,8 @@
+Screen BadUnit {
+    surface: 800px, 600px;
+    Label {
+        id: label;
+        width: 10rem;
+        height: 10px;
+    }
+}

--- a/tests/medui/fixtures/rejected-duplicate-id.medui
+++ b/tests/medui/fixtures/rejected-duplicate-id.medui
@@ -1,0 +1,11 @@
+Screen Duplicated {
+    surface: 800px, 600px;
+    Label {
+        id: same;
+        width: 10px; height: 10px;
+    }
+    Label {
+        id: same;
+        width: 10px; height: 10px;
+    }
+}

--- a/tests/medui/fixtures/rejected-forbidden-construct.medui
+++ b/tests/medui/fixtures/rejected-forbidden-construct.medui
@@ -1,0 +1,6 @@
+Screen WithControlFlow {
+    surface: 800px, 600px;
+    if {
+        id: nope;
+    }
+}

--- a/tests/medui/fixtures/rejected-nested-row.medui
+++ b/tests/medui/fixtures/rejected-nested-row.medui
@@ -1,0 +1,11 @@
+Screen Nested {
+    surface: 800px, 600px;
+    Row {
+        id: outer;
+        height: 64px;
+        Row {
+            id: inner;
+            height: 32px;
+        }
+    }
+}

--- a/tests/medui/fixtures/rejected-safety-without-requirement.medui
+++ b/tests/medui/fixtures/rejected-safety-without-requirement.medui
@@ -1,0 +1,20 @@
+// A @safety_critical node with nothing to trace it to. MEDUI-E070, reported at the annotation
+// rather than at the node: the annotation is the claim that needs a requirement behind it.
+//
+// `requirement:` is optional on Button, so nothing earlier in the compiler objects - which is the
+// point. Without this rule a safety-critical node could ship with no requirement at all, and the
+// annotation would be decoration.
+Screen Unsafe {
+    layout: Vertical { spacing: 0px; padding: 0px; }
+    surface: 200px, 100px;
+
+    @safety_critical(cv_check: [Bounds])
+    Button {
+        id: action;
+        width: 100px;
+        height: 40px;
+        label: t("STR-ACTION");
+        color: Theme.Colors.PrimaryAction;
+        source: "ACTION";
+    }
+}

--- a/tests/medui/fixtures/rejected-unterminated-string.medui
+++ b/tests/medui/fixtures/rejected-unterminated-string.medui
@@ -1,0 +1,7 @@
+Screen Unterminated {
+    surface: 800px, 600px;
+    Label {
+        id: label;
+        requirement: "REQ-OPEN;
+    }
+}

--- a/tests/medui/fixtures/textless-screen.toml
+++ b/tests/medui/fixtures/textless-screen.toml
@@ -1,0 +1,29 @@
+# The recipe the compiler-driver scenarios compile (#198).
+#
+# A fixture rather than a registered artifact: `mdux_compile_screen()` and the first committed screen
+# under generated/screen/ are the second half of #198. What this file is for is the driver's own
+# contract - every knob required, no defaults - so a scenario can point `run()` at something an
+# author could actually have written.
+#
+# There is no [text] table, and that is the interesting part: the screen it names draws no text, so
+# `needsTextBudget()` answers false and the compile does not need a font package or an approved
+# locale. A screen that did draw text and left this table out is refused rather than compiled
+# without the check.
+
+[package]
+# The slug and the screen name are the same word: `Screen TextlessScreen` compiles as
+# `textless-screen`. The compiler checks that pairing, because a slug naming one screen while the
+# package inside names another would leave every later consumer following one of the two.
+id            = "textless-screen"
+source        = "tests/medui/fixtures/accepted-textless.medui"
+# The panel this screen is drawn for. Declared here rather than taken from the source, so a screen
+# drawn for another panel is a diagnostic rather than a silently rescaled frame.
+surfaceWidth  = 400
+surfaceHeight = 300
+
+# What the runtime may draw for this screen. Declared by the product rather than computed: the cost
+# model belongs to the runtime (#199), and DrawList fails closed against these numbers at run time.
+[budget]
+maxVertices = 4096
+maxIndices  = 6144
+maxCommands = 256

--- a/tests/ml/NoHeapTests.cpp
+++ b/tests/ml/NoHeapTests.cpp
@@ -38,150 +38,10 @@ import mdux.ml.runtime;
 // The interposition
 // ---------------------------------------------------------------------------
 
-namespace {
-
-/// Bumped by every allocating operator below. Not atomic-by-necessity - the scenarios are
-/// single-threaded - but atomic anyway, so that a future threaded case cannot make this quietly
-/// unreliable.
-std::atomic<std::size_t> allocationCount{0};
-
-[[nodiscard]] std::size_t allocations() noexcept {
-    return allocationCount.load(std::memory_order_relaxed);
-}
-
-/**
- * @brief Over-aligned allocation built on plain malloc, with no platform branch.
- *
- * Neither standard route works here. `std::aligned_alloc` does not exist on MSVC at all, and
- * `_aligned_malloc` is declared in `<malloc.h>` - a header this translation unit cannot include,
- * because it reaches the standard library through `import std;` and mixing the two is what the
- * C5050 diagnostics elsewhere in this epic were about.
- *
- * So the alignment is done by hand: over-allocate, step the pointer up to the boundary, and stash
- * the original just below it for the matching free. Portable, needs nothing but `std::malloc`, and
- * keeps the counter covering over-aligned allocations - which matters, because leaving the aligned
- * operators unreplaced would leave a path through which predict() could allocate uncounted.
- */
-[[nodiscard]] void* allocateAligned(std::size_t size, std::size_t alignment) {
-    // The stash slot has to be addressable, so never align more loosely than a pointer.
-    const std::size_t effective = alignment < alignof(void*) ? alignof(void*) : alignment;
-    const std::size_t slack = effective - 1 + sizeof(void*);
-
-    void* raw = std::malloc(size + slack);
-    if (raw == nullptr) {
-        return nullptr;
-    }
-
-    auto address = reinterpret_cast<std::uintptr_t>(raw) + sizeof(void*);
-    address = (address + effective - 1) & ~static_cast<std::uintptr_t>(effective - 1);
-    auto* aligned = reinterpret_cast<void*>(address);
-
-    // `aligned` is a multiple of effective >= alignof(void*), so the slot below it is aligned too.
-    *(reinterpret_cast<void**>(aligned) - 1) = raw;
-    return aligned;
-}
-
-void freeAligned(void* pointer) noexcept {
-    if (pointer == nullptr) {
-        return;
-    }
-    std::free(*(reinterpret_cast<void**>(pointer) - 1));
-}
-
-}  // namespace
-
-// Every allocating form is replaced, not just the common one. A partial replacement would leave a
-// path through which predict() could allocate uncounted, which is the failure this file exists to
-// make impossible.
-
-void* operator new(std::size_t size) {
-    allocationCount.fetch_add(1, std::memory_order_relaxed);
-    void* pointer = std::malloc(size == 0 ? 1 : size);
-    if (pointer == nullptr) {
-        throw std::bad_alloc{};
-    }
-    return pointer;
-}
-
-void* operator new[](std::size_t size) {
-    return ::operator new(size);
-}
-
-void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
-    allocationCount.fetch_add(1, std::memory_order_relaxed);
-    return std::malloc(size == 0 ? 1 : size);
-}
-
-void* operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
-    return ::operator new(size, tag);
-}
-
-void* operator new(std::size_t size, std::align_val_t alignment) {
-    allocationCount.fetch_add(1, std::memory_order_relaxed);
-    void* pointer = allocateAligned(size == 0 ? 1 : size, static_cast<std::size_t>(alignment));
-    if (pointer == nullptr) {
-        throw std::bad_alloc{};
-    }
-    return pointer;
-}
-
-void* operator new[](std::size_t size, std::align_val_t alignment) {
-    return ::operator new(size, alignment);
-}
-
-// GCC's -Wmismatched-new-delete sees std::free() applied to a pointer that came from
-// `operator new` and reports a mismatch. It is right about the shape and wrong about the facts:
-// the operator new above *is* std::malloc, so free is the correct counterpart. The warning cannot
-// see that pairing because these are separate replaceable functions. Scoped to exactly the delete
-// family below, so the diagnostic keeps working everywhere else in this file.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-
-void operator delete(void* pointer) noexcept {
-    std::free(pointer);
-}
-
-void operator delete[](void* pointer) noexcept {
-    std::free(pointer);
-}
-
-void operator delete(void* pointer, std::size_t) noexcept {
-    std::free(pointer);
-}
-
-void operator delete[](void* pointer, std::size_t) noexcept {
-    std::free(pointer);
-}
-
-void operator delete(void* pointer, const std::nothrow_t&) noexcept {
-    std::free(pointer);
-}
-
-void operator delete[](void* pointer, const std::nothrow_t&) noexcept {
-    std::free(pointer);
-}
-
-void operator delete(void* pointer, std::align_val_t) noexcept {
-    freeAligned(pointer);
-}
-
-void operator delete[](void* pointer, std::align_val_t) noexcept {
-    freeAligned(pointer);
-}
-
-void operator delete(void* pointer, std::size_t, std::align_val_t) noexcept {
-    freeAligned(pointer);
-}
-
-void operator delete[](void* pointer, std::size_t, std::align_val_t) noexcept {
-    freeAligned(pointer);
-}
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+// The interposition itself lives in the shared header: replacing a global operator is a
+// whole-program property, and a second copy of that code would be a second thing to keep right.
+// `allocations()` and the deliberate-allocation scenario below come with it.
+#include "../framework/CountingAllocations.hpp"
 
 // ---------------------------------------------------------------------------
 // The model under test - the same shape the runtime suite uses
@@ -192,53 +52,53 @@ namespace {
 using namespace mdux::ml;
 namespace evidence = mdux::evidence;
 
-constexpr std::uint32_t modelInputLength = 8;
-constexpr std::uint32_t modelOutputLength = 2;
+constexpr std::uint32_t modelInputLength   = 8;
+constexpr std::uint32_t modelOutputLength  = 2;
 constexpr std::uint32_t modelScratchFloats = 24;
-constexpr std::size_t weightFloatCount = 22;
+constexpr std::size_t   weightFloatCount   = 22;
 
 [[nodiscard]] std::vector<LayerDesc> modelLayers() {
     return {
-        LayerDesc{.kind = LayerKind::Conv1d,
-                  .activation = Activation::Relu,
-                  .inLength = 8,
-                  .inChannels = 1,
-                  .outLength = 6,
+        LayerDesc{   .kind        = LayerKind::Conv1d,
+                  .activation  = Activation::Relu,
+                  .inLength    = 8,
+                  .inChannels  = 1,
+                  .outLength   = 6,
                   .outChannels = 2,
-                  .kernelSize = 3,
-                  .stride = 1,
-                  .weights = TensorRef{.byteOffset = 0, .shape = {2, 1, 3}, .rank = 3},
-                  .bias = TensorRef{.byteOffset = 24, .shape = {2, 0, 0}, .rank = 1}},
-        LayerDesc{.kind = LayerKind::MaxPool1d,
-                  .activation = Activation::None,
-                  .inLength = 6,
-                  .inChannels = 2,
-                  .outLength = 3,
+                  .kernelSize  = 3,
+                  .stride      = 1,
+                  .weights     = TensorRef{.byteOffset = 0, .shape = {2, 1, 3}, .rank = 3},
+                  .bias        = TensorRef{.byteOffset = 24, .shape = {2, 0, 0}, .rank = 1}},
+        LayerDesc{.kind        = LayerKind::MaxPool1d,
+                  .activation  = Activation::None,
+                  .inLength    = 6,
+                  .inChannels  = 2,
+                  .outLength   = 3,
                   .outChannels = 2,
-                  .kernelSize = 2,
-                  .stride = 2,
-                  .weights = TensorRef{},
-                  .bias = TensorRef{}},
-        LayerDesc{.kind = LayerKind::Flatten,
-                  .activation = Activation::None,
-                  .inLength = 3,
-                  .inChannels = 2,
-                  .outLength = 6,
+                  .kernelSize  = 2,
+                  .stride      = 2,
+                  .weights     = TensorRef{},
+                  .bias        = TensorRef{}                                               },
+        LayerDesc{  .kind        = LayerKind::Flatten,
+                  .activation  = Activation::None,
+                  .inLength    = 3,
+                  .inChannels  = 2,
+                  .outLength   = 6,
                   .outChannels = 1,
-                  .kernelSize = 0,
-                  .stride = 0,
-                  .weights = TensorRef{},
-                  .bias = TensorRef{}},
-        LayerDesc{.kind = LayerKind::Dense,
-                  .activation = Activation::Softmax,
-                  .inLength = 6,
-                  .inChannels = 1,
-                  .outLength = 2,
+                  .kernelSize  = 0,
+                  .stride      = 0,
+                  .weights     = TensorRef{},
+                  .bias        = TensorRef{}                                               },
+        LayerDesc{    .kind        = LayerKind::Dense,
+                  .activation  = Activation::Softmax,
+                  .inLength    = 6,
+                  .inChannels  = 1,
+                  .outLength   = 2,
                   .outChannels = 1,
-                  .kernelSize = 0,
-                  .stride = 0,
-                  .weights = TensorRef{.byteOffset = 32, .shape = {2, 6, 0}, .rank = 2},
-                  .bias = TensorRef{.byteOffset = 80, .shape = {2, 0, 0}, .rank = 1}},
+                  .kernelSize  = 0,
+                  .stride      = 0,
+                  .weights     = TensorRef{.byteOffset = 32, .shape = {2, 6, 0}, .rank = 2},
+                  .bias        = TensorRef{.byteOffset = 80, .shape = {2, 0, 0}, .rank = 1}},
     };
 }
 
@@ -247,11 +107,11 @@ constexpr std::size_t weightFloatCount = 22;
 
 /// Everything a classifier needs, kept alive for the duration of a scenario.
 struct Harness {
-    std::vector<float> weightStorage;
-    std::vector<LayerDesc> layers = modelLayers();
-    std::vector<float> scratch = std::vector<float>(modelScratchFloats, 0.0f);
-    std::string id{"noheap-fixture"};
-    evidence::Digest digest{};
+    std::vector<float>     weightStorage;
+    std::vector<LayerDesc> layers  = modelLayers();
+    std::vector<float>     scratch = std::vector<float>(modelScratchFloats, 0.0f);
+    std::string            id{"noheap-fixture"};
+    evidence::Digest       digest{};
 
     Harness() : weightStorage(weightFloatCount, 0.0f) {
         std::uint32_t state = 99001u;
@@ -272,34 +132,28 @@ struct Harness {
      * here is what create() will later reproduce.
      */
     void bakeGoldens() {
-        const auto input = sampleInput();
-        const std::span<const float> weightFloats{weightStorage};
-        const std::size_t width = modelScratchFloats / 2;
+        const auto                            input = sampleInput();
+        const std::span<const float>          weightFloats{weightStorage};
+        const std::size_t                     width = modelScratchFloats / 2;
         std::array<float, modelScratchFloats> work{};
-        std::span<float> bufferA{work.data(), width};
-        std::span<float> bufferB{work.data() + width, width};
+        std::span<float>                      bufferA{work.data(), width};
+        std::span<float>                      bufferB{work.data() + width, width};
 
         for (std::size_t i = 0; i < input.size(); ++i) {
             bufferA[i] = input[i];
         }
-        std::span<const float> current =
-            bufferA.first(static_cast<std::size_t>(layers[0].inputFloats()));
+        std::span<const float> current = bufferA.first(static_cast<std::size_t>(layers[0].inputFloats()));
         for (std::size_t i = 0; i < layers.size(); ++i) {
-            const LayerDesc& layer = layers[i];
+            const LayerDesc&       layer = layers[i];
             std::span<const float> weights;
             std::span<const float> bias;
             if (layer.weights.present()) {
-                weights = weightFloats.subspan(
-                    layer.weights.byteOffset / sizeof(float),
-                    static_cast<std::size_t>(layer.weights.elementCount()));
+                weights = weightFloats.subspan(layer.weights.byteOffset / sizeof(float), static_cast<std::size_t>(layer.weights.elementCount()));
             }
             if (layer.bias.present()) {
-                bias = weightFloats.subspan(layer.bias.byteOffset / sizeof(float),
-                                            static_cast<std::size_t>(layer.bias.elementCount()));
+                bias = weightFloats.subspan(layer.bias.byteOffset / sizeof(float), static_cast<std::size_t>(layer.bias.elementCount()));
             }
-            std::span<float> destination =
-                ((i % 2) == 0 ? bufferB : bufferA)
-                    .first(static_cast<std::size_t>(layer.outputFloats()));
+            std::span<float> destination = ((i % 2) == 0 ? bufferB : bufferA).first(static_cast<std::size_t>(layer.outputFloats()));
             if (!applyLayer(layer, current, weights, bias, destination)) {
                 return;
             }
@@ -312,25 +166,24 @@ struct Harness {
         for (std::size_t i = 0; i < modelOutputLength; ++i) {
             goldenOutputBits.push_back(std::bit_cast<std::uint32_t>(current[i]));
         }
-        goldenViews.push_back(GoldenVector{.inputBits = goldenInputBits,
-                                           .expectedOutputBits = goldenOutputBits});
+        goldenViews.push_back(GoldenVector{.inputBits = goldenInputBits, .expectedOutputBits = goldenOutputBits});
     }
 
     /// Golden storage, filled by bakeGoldens() before any classifier is built.
     std::vector<std::uint32_t> goldenInputBits;
     std::vector<std::uint32_t> goldenOutputBits;
-    std::vector<GoldenVector> goldenViews;
+    std::vector<GoldenVector>  goldenViews;
 
     [[nodiscard]] ModelPackage package() const noexcept {
-        return ModelPackage{.id = id,
-                            .schemaVersion = evidence::kSchemaVersion,
-                            .weightsDigest = digest,
+        return ModelPackage{.id                = id,
+                            .schemaVersion     = evidence::kSchemaVersion,
+                            .weightsDigest     = digest,
                             .weightsByteLength = weightStorage.size() * sizeof(float),
-                            .layers = layers,
-                            .goldens = goldenViews,
-                            .inputLength = modelInputLength,
-                            .outputLength = modelOutputLength,
-                            .maxScratchFloats = modelScratchFloats};
+                            .layers            = layers,
+                            .goldens           = goldenViews,
+                            .inputLength       = modelInputLength,
+                            .outputLength      = modelOutputLength,
+                            .maxScratchFloats  = modelScratchFloats};
     }
 };
 
@@ -342,108 +195,101 @@ struct Harness {
 // Scenarios
 // ---------------------------------------------------------------------------
 
-const mdux::spec::Register counterIsLive{
-    "The allocation counter actually observes allocations", "noheap", [] {
-        return speclab::Test("ml-noheap-counter-is-live")
-            .Given("the replaced global operator new", [] {})
-            .When("an allocation is deliberately performed", [] {})
-            .Then("the counter moves, so a zero delta elsewhere means something",
-                  [] {
-                      // Without this scenario the whole file could pass while the interposition
-                      // was not in effect at all - the counter would simply never move. This is
-                      // the control that makes every other assertion here meaningful.
-                      mdux::spec::Checks checks;
+const mdux::spec::Register counterIsLive{"The allocation counter actually observes allocations", "noheap", [] {
+                                             return speclab::Test("ml-noheap-counter-is-live")
+                                                 .Given("the replaced global operator new", [] {})
+                                                 .When("an allocation is deliberately performed", [] {})
+                                                 .Then("the counter moves, so a zero delta elsewhere means something",
+                                                       [] {
+                                                           // Without this scenario the whole file could pass while the interposition
+                                                           // was not in effect at all - the counter would simply never move. This is
+                                                           // the control that makes every other assertion here meaningful.
+                                                           mdux::spec::Checks checks;
 
-                      const std::size_t before = allocations();
-                      // volatile so the allocation cannot be optimised away entirely.
-                      auto* volatile probe = new int(7);
-                      const std::size_t afterNew = allocations();
-                      delete probe;
+                                                           const std::size_t before = allocations();
+                                                           // volatile so the allocation cannot be optimised away entirely.
+                                                           auto* volatile probe       = new int(7);
+                                                           const std::size_t afterNew = allocations();
+                                                           delete probe;
 
-                      checks.expect(afterNew > before,
-                                    std::format("operator new is interposed: {} -> {}", before,
-                                                afterNew));
+                                                           checks.expect(afterNew > before,
+                                                                         std::format("operator new is interposed: {} -> {}", before, afterNew));
 
-                      const std::size_t beforeVector = allocations();
-                      std::vector<double> values(64, 1.0);
-                      // Defeat any chance of the vector being elided.
-                      values[0] += static_cast<double>(values.size());
-                      const std::size_t afterVector = allocations();
-                      checks.expect(afterVector > beforeVector,
-                                    "container allocation is counted too");
+                                                           const std::size_t   beforeVector = allocations();
+                                                           std::vector<double> values(64, 1.0);
+                                                           // Defeat any chance of the vector being elided.
+                                                           values[0]                    += static_cast<double>(values.size());
+                                                           const std::size_t afterVector = allocations();
+                                                           checks.expect(afterVector > beforeVector, "container allocation is counted too");
 
-                      // The over-aligned path is hand-written pointer arithmetic, so it is
-                      // exercised here rather than left to chance. Without this the aligned
-                      // operators could be quietly broken and every scenario would still pass,
-                      // because nothing else in this binary allocates an over-aligned type.
-                      struct alignas(64) Overaligned {
-                          double values[8];
-                      };
-                      const std::size_t beforeAligned = allocations();
-                      auto* volatile wide = new Overaligned{};
-                      const auto address = reinterpret_cast<std::uintptr_t>(wide);
-                      const std::size_t afterAligned = allocations();
+                                                           // The over-aligned path is hand-written pointer arithmetic, so it is
+                                                           // exercised here rather than left to chance. Without this the aligned
+                                                           // operators could be quietly broken and every scenario would still pass,
+                                                           // because nothing else in this binary allocates an over-aligned type.
+                                                           struct alignas(64) Overaligned {
+                                                               double values[8];
+                                                           };
+                                                           const std::size_t beforeAligned = allocations();
+                                                           auto* volatile wide             = new Overaligned{};
+                                                           const auto        address       = reinterpret_cast<std::uintptr_t>(wide);
+                                                           const std::size_t afterAligned  = allocations();
 
-                      checks.expect(afterAligned > beforeAligned,
-                                    "over-aligned operator new is counted");
-                      checks.expect(address % 64 == 0,
-                                    std::format("over-aligned allocation is 64-aligned (got {})",
-                                                address % 64));
-                      // Freeing through the replaced aligned delete has to recover the original
-                      // malloc pointer; if the stash were wrong this would corrupt the heap.
-                      delete wide;
-                      checks.raise();
-                  })
-            .Execute();
-    }};
+                                                           checks.expect(afterAligned > beforeAligned, "over-aligned operator new is counted");
+                                                           checks.expect(address % 64 == 0,
+                                                                         std::format("over-aligned allocation is 64-aligned (got {})", address % 64));
+                                                           // Freeing through the replaced aligned delete has to recover the original
+                                                           // malloc pointer; if the stash were wrong this would corrupt the heap.
+                                                           delete wide;
+                                                           checks.raise();
+                                                       })
+                                                 .Execute();
+                                         }};
 
 const mdux::spec::Register predictAllocatesNothing{
-    "predict() allocates nothing across a thousand calls", "noheap", [] {
+    "predict() allocates nothing across a thousand calls",
+    "noheap",
+    [] {
         return speclab::Test("ml-noheap-predict")
             .Given("a constructed classifier and a warmed-up first call", [] {})
             .When("predict() runs a thousand times", [] {})
             .Then("the allocation counter has not moved at all",
                   [] {
                       mdux::spec::Checks checks;
-                      Harness harness;
+                      Harness            harness;
 
-                      auto classifier = Classifier1D::create(
-                          harness.package(), std::as_bytes(std::span{harness.weightStorage}),
-                          harness.scratch);
+                      auto classifier = Classifier1D::create(harness.package(), std::as_bytes(std::span{harness.weightStorage}), harness.scratch);
                       checks.expect(classifier.has_value(), "classifier created");
                       if (!classifier.has_value()) {
                           checks.raise();
                           return;
                       }
 
-                      const auto input = sampleInput();
+                      const auto                           input = sampleInput();
                       std::array<float, modelOutputLength> output{};
 
                       // One call outside the measurement, so anything one-time - a lazily
                       // initialised locale, a first-touch page - cannot be mistaken for a
                       // per-prediction allocation.
-                      checks.expect(classifier->predict(input, output).has_value(),
-                                    "warm-up prediction succeeded");
+                      checks.expect(classifier->predict(input, output).has_value(), "warm-up prediction succeeded");
 
-                      const std::size_t before = allocations();
-                      bool everyCallSucceeded = true;
+                      const std::size_t before             = allocations();
+                      bool              everyCallSucceeded = true;
                       for (int i = 0; i < 1000; ++i) {
-                          everyCallSucceeded =
-                              everyCallSucceeded && classifier->predict(input, output).has_value();
+                          everyCallSucceeded = everyCallSucceeded && classifier->predict(input, output).has_value();
                       }
                       const std::size_t after = allocations();
 
                       checks.expect(everyCallSucceeded, "all 1000 predictions succeeded");
-                      checks.expect(after == before,
-                                    std::format("{} allocation(s) during 1000 predictions",
-                                                after - before));
+                      checks.expect(after == before, std::format("{} allocation(s) during 1000 predictions", after - before));
                       checks.raise();
                   })
             .Execute();
     }};
 
 const mdux::spec::Register failingPredictAllocatesNothing{
-    "A refused prediction allocates nothing either", "noheap", [] {
+    "A refused prediction allocates nothing either",
+    "noheap",
+    [] {
         return speclab::Test("ml-noheap-predict-error-path")
             .Given("a classifier and inputs of the wrong shape", [] {})
             .When("predict() refuses them repeatedly", [] {})
@@ -453,67 +299,61 @@ const mdux::spec::Register failingPredictAllocatesNothing{
                       // most plausibly creep in, so it is measured separately rather than assumed
                       // to be covered by the success case.
                       mdux::spec::Checks checks;
-                      Harness harness;
+                      Harness            harness;
 
-                      auto classifier = Classifier1D::create(
-                          harness.package(), std::as_bytes(std::span{harness.weightStorage}),
-                          harness.scratch);
+                      auto classifier = Classifier1D::create(harness.package(), std::as_bytes(std::span{harness.weightStorage}), harness.scratch);
                       checks.expect(classifier.has_value(), "classifier created");
                       if (!classifier.has_value()) {
                           checks.raise();
                           return;
                       }
 
-                      const std::array<float, 3> wrongInput{};
+                      const std::array<float, 3>           wrongInput{};
                       std::array<float, modelOutputLength> output{};
                       (void)classifier->predict(wrongInput, output);  // warm-up
 
-                      const std::size_t before = allocations();
-                      bool everyCallRefused = true;
+                      const std::size_t before           = allocations();
+                      bool              everyCallRefused = true;
                       for (int i = 0; i < 1000; ++i) {
-                          everyCallRefused = everyCallRefused &&
-                                             !classifier->predict(wrongInput, output).has_value();
+                          everyCallRefused = everyCallRefused && !classifier->predict(wrongInput, output).has_value();
                       }
                       const std::size_t after = allocations();
 
                       checks.expect(everyCallRefused, "all 1000 predictions were refused");
-                      checks.expect(after == before,
-                                    std::format("{} allocation(s) on the error path",
-                                                after - before));
+                      checks.expect(after == before, std::format("{} allocation(s) on the error path", after - before));
                       checks.raise();
                   })
             .Execute();
     }};
 
-const mdux::spec::Register selfTestAllocatesNothing{
-    "create()'s golden self-test allocates nothing", "noheap", [] {
-        return speclab::Test("ml-noheap-create")
-            .Given("a package carrying golden vectors", [] {})
-            .When("create() runs its digest check and self-test", [] {})
-            .Then("no allocation occurs, so create() is usable before any heap exists",
-                  [] {
-                      // create() runs once at startup, so an allocation there would be far less
-                      // serious than one in predict(). It is still asserted: on a device that
-                      // brings the classifier up before its allocator, "bounded startup work"
-                      // needs to mean no heap at all.
-                      mdux::spec::Checks checks;
-                      Harness harness;
+const mdux::spec::Register selfTestAllocatesNothing{"create()'s golden self-test allocates nothing", "noheap", [] {
+                                                        return speclab::Test("ml-noheap-create")
+                                                            .Given("a package carrying golden vectors", [] {})
+                                                            .When("create() runs its digest check and self-test", [] {})
+                                                            .Then("no allocation occurs, so create() is usable before any heap exists",
+                                                                  [] {
+                                                                      // create() runs once at startup, so an allocation there would be far less
+                                                                      // serious than one in predict(). It is still asserted: on a device that
+                                                                      // brings the classifier up before its allocator, "bounded startup work"
+                                                                      // needs to mean no heap at all.
+                                                                      mdux::spec::Checks checks;
+                                                                      Harness            harness;
 
-                      // The harness baked its goldens at construction, so the package handed
-                      // to create() below already carries a real self-test to run.
-                      const ModelPackage package = harness.package();
-                      const auto weights = std::as_bytes(std::span{harness.weightStorage});
+                                                                      // The harness baked its goldens at construction, so the package handed
+                                                                      // to create() below already carries a real self-test to run.
+                                                                      const ModelPackage package = harness.package();
+                                                                      const auto         weights = std::as_bytes(std::span{harness.weightStorage});
 
-                      const std::size_t before = allocations();
-                      auto verified = Classifier1D::create(package, weights, harness.scratch);
-                      const std::size_t after = allocations();
+                                                                      const std::size_t before   = allocations();
+                                                                      auto              verified = Classifier1D::create(package, weights, harness.scratch);
+                                                                      const std::size_t after    = allocations();
 
-                      checks.expect(verified.has_value(), "self-tested classifier created");
-                      checks.expect(after == before,
-                                    std::format("{} allocation(s) during create()", after - before));
-                      checks.raise();
-                  })
-            .Execute();
-    }};
+                                                                      checks.expect(verified.has_value(), "self-tested classifier created");
+                                                                      checks.expect(after == before,
+                                                                                    std::format("{} allocation(s) during create()", after - before));
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
 
 }  // namespace

--- a/tests/render/ScreenPixelTests.cpp
+++ b/tests/render/ScreenPixelTests.cpp
@@ -1,0 +1,307 @@
+/**
+ * @file ScreenPixelTests.cpp
+ * @brief The first pixel drawn from an authored screen (issue #201).
+ *
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Every link in the chain this epic set out to build, exercised end to end in one test: an authored
+ * `.medui` file becomes a committed, byte-compared artifact (#198), the artifact becomes `constexpr`
+ * C++ this translation unit links (#197), the governed runtime turns that into draw commands without
+ * allocating (#199), and the Vulkan renderer draws them into an offscreen target that is read back
+ * and compared pixel by pixel (#125, #126).
+ *
+ * ## What is on screen, and why it is one rectangle
+ *
+ * The runtime draws a `Panel`. `EndoscopeMonitor`'s Row declares a background, so the solver
+ * synthesised one, and that is what appears: a 1280x72 bar in `Theme.Colors.TopbarBackground`. Its
+ * image, its video surface, its numeric readout and its waveform are visited, counted as deferred,
+ * and left undrawn - because a compiled screen carries a `textKey` rather than glyphs and no text
+ * package is baked in this tree, and because live-data components have no geometry until a sample
+ * exists.
+ *
+ * That makes this test thin in content and complete in path, and the distinction is the point. What
+ * it proves is not that MduX can draw a clinical screen; it is that a rectangle on this display came
+ * from a file an author wrote, through every stage, with nothing hand-carried between them. The
+ * content grows when the text package lands and the remaining components learn their geometry; the
+ * path does not have to be built again.
+ *
+ * ## What the golden sidecar has here, and what it does not
+ *
+ * `goldens.json` gets its first consumer in this file, and it is a **static** one: the last scenario
+ * reads the committed sidecar and cross-checks every entry against the compiled screen. That is a
+ * real check - it fails if the `@safety_critical` annotation is removed, or if a golden's bounds stop
+ * matching the node it names - and it is not the consumer ADR-012 describes.
+ *
+ * The rendered one cannot exist yet, and the reason is structural rather than an omission here.
+ * Both golden nodes on this screen are deferred - a `NumericDisplay` and a `SignalTrace` - so there
+ * are no pixels to check `Bounds` or `ColorHash` against, and the only node that *is* drawn is the
+ * Row's synthetic `Panel`, which no golden can ever name: `collectGoldens()` skips synthetic nodes,
+ * and a `Row` carries neither `requirement:` nor `position:`. So no screen in this repository can
+ * have a rendered golden consumer until a golden-eligible component learns to draw, which is #17,
+ * and the verifier that would consume it is #16.
+ *
+ * The scenario below therefore asserts the one rendered fact that is true: the region the golden
+ * names is empty today. That is a tripwire rather than a goal - the day the `NumericDisplay` draws,
+ * it fails and has to be replaced by the check ADR-012 actually wants.
+ *
+ * ## Compared against the compiled screen, not against a copy of it
+ *
+ * The expectation is painted from the package's own node bounds and the governed colour table -
+ * `screen.find("topbar-background")->bounds` - rather than from four numbers written here. A test
+ * carrying its own copy of the rectangle would pass while the compiler moved it, which is the one
+ * regression this test exists to catch.
+ */
+#include <cstddef>
+#include <cstdint>
+
+#include <vulkan/vulkan.h>
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.evidence.json;
+import mdux.draw;
+import mdux.medui.generated.screen_endoscope_monitor;
+import mdux.medui.schema;
+import mdux.medui.screen;
+import mdux.render.offscreen;
+import mdux.render.vulkan;
+import mdux.shader.schema;
+import mdux.shader.generated.mdux_ui;
+import mdux.test;
+
+#include "../framework/MduXTest.hpp"
+#include "HeadlessDevice.hpp"
+#include "PixelExpectation.hpp"
+
+namespace {
+
+using namespace mdux::render;
+namespace core  = mdux::core;
+namespace draw  = mdux::draw;
+namespace medui = mdux::medui;
+using mdux::test::compare;
+using mdux::test::ExpectedImage;
+using mdux::test::sharedDevice;
+
+/// The screen as generated code holds it: read-only data, validated at compile time by the
+/// `static_assert` the emitter wrote beside it.
+[[nodiscard]] medui::ScreenPackage screen() noexcept {
+    return medui::generated::screen_endoscope_monitor::package();
+}
+
+/// The offscreen surface is the screen's own, so a node lands where the compiler said it would.
+/// Taken from the package rather than written out: a test that fixed its own extent would keep
+/// passing while the screen was drawn for a different panel.
+[[nodiscard]] core::Extent2D surfaceOf(const medui::ScreenPackage& package) noexcept {
+    return core::Extent2D{.width = package.surfaceWidth, .height = package.surfaceHeight};
+}
+
+constexpr core::ColorRgba8 background{.r = 0, .g = 0, .b = 0, .a = 255};
+
+/// The screen as a constant expression, so the storage below can be sized from the budget the
+/// artifact bakes rather than from three numbers copied out of it.
+constexpr medui::ScreenPackage compiled = medui::generated::screen_endoscope_monitor::package();
+
+/// Storage sized once from the screen's own budget, as a device would size it - and sized *by* it,
+/// so the two cannot drift. Hard-coding the three numbers would have left this test claiming a
+/// contract it did not exercise the moment a recipe changed one.
+struct Frame {
+    std::array<draw::UiVertex, compiled.budget.maxVertices>    vertices{};
+    std::array<draw::Index, compiled.budget.maxIndices>        indices{};
+    std::array<draw::DrawCommand, compiled.budget.maxCommands> commands{};
+};
+
+struct RecordContext {
+    UiRenderer*           renderer;
+    const draw::DrawList* list;
+};
+
+void recordFrame(VkCommandBuffer commandBuffer, void* context) {
+    auto* recording = static_cast<RecordContext*>(context);
+    static_cast<void>(recording->renderer->record(commandBuffer, *recording->list));
+}
+
+}  // namespace
+
+TEST_CASE("The compiled screen is the one the compiler produced", "pixel") {
+    // Checked before any GPU is involved, so a mismatch here reports the compiler rather than the
+    // renderer. This is also the assertion that would fail if the committed artifact and the
+    // generated source ever stopped agreeing.
+    const medui::ScreenPackage package = screen();
+
+    CHECK(package.id == "endoscope-monitor");
+    CHECK(package.validate().has_value());
+    CHECK(package.surfaceWidth == 1280);
+    CHECK(package.surfaceHeight == 720);
+    CHECK(package.nodes.size() == 5);
+
+    // The safety-critical node #201 asks for, reached through the function a traceability export
+    // walks rather than by index.
+    const medui::CompiledNode* traced = package.find("insufflation-pressure");
+    REQUIRE(traced != nullptr);
+    CHECK(medui::requirementOf(*traced) == "REQ-EM-001");
+}
+
+TEST_CASE("An authored screen draws its panel where the compiler put it", "pixel") {
+    const medui::ScreenPackage package = screen();
+    const core::Extent2D       surface = surfaceOf(package);
+
+    const auto& gpu    = sharedDevice();
+    auto        target = OffscreenTarget::create(gpu.device(), gpu.physicalDevice(), surface, gpu.queueFamilyIndex());
+    REQUIRE(target.has_value());
+
+    VulkanRenderContext context;
+    context.device           = gpu.device();
+    context.physicalDevice   = gpu.physicalDevice();
+    context.renderPass       = target->renderPass();
+    context.queue            = gpu.queue();
+    context.queueFamilyIndex = gpu.queueFamilyIndex();
+    context.viewport         = surface;
+
+    auto renderer = UiRenderer::create(context, mdux::shader::generated::mdux_ui::package(), package.budget);
+    REQUIRE(renderer.has_value());
+
+    Frame frame;
+    auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, package.budget);
+    REQUIRE(list.has_value());
+
+    // The governed runtime, doing the only work between a compiled screen and a frame.
+    const auto recorded = medui::render(package, *list);
+    REQUIRE(recorded.has_value());
+    CHECK(recorded->rects == 1);
+    // Four of five nodes are visited and left undrawn, and the frame says so rather than looking
+    // complete. See this file's header for which, and why each.
+    CHECK(recorded->deferred == 4);
+
+    RecordContext recording{.renderer = &*renderer, .list = &*list};
+    auto          pixels = target->renderAndRead(gpu.queue(), background, recordFrame, &recording);
+    REQUIRE(pixels.has_value());
+
+    // Painted from the package and the governed table, so the expectation moves when the screen
+    // does. The colour is the quantisation the runtime applies - {0.82, 0.84, 0.86, 1.0} linear
+    // becoming {209, 214, 219, 255} - which makes this a check on the whole conversion rather than
+    // on the geometry alone.
+    const medui::CompiledNode* panel = package.find("topbar-background");
+    REQUIRE(panel != nullptr);
+
+    ExpectedImage expected{surface, background};
+    expected.paint(core::Rect{.x = panel->bounds.x, .y = panel->bounds.y, .width = panel->bounds.width, .height = panel->bounds.height},
+                   core::ColorRgba8{.r = 209, .g = 214, .b = 219, .a = 255});
+
+    const auto diff = compare(expected, *pixels);
+    CHECK_MESSAGE(diff.matched(), diff.message);
+}
+
+TEST_CASE("The golden sidecar names this screen's safety-critical content", "pixel") {
+    // The sidecar's first consumer in this tree, and a static one: it reads the committed file and
+    // checks it against the compiled screen. See this file's header for why the rendered consumer
+    // ADR-012 describes cannot exist yet, and what would have to change for it to.
+    const medui::ScreenPackage package = screen();
+
+    const std::filesystem::path sidecar = std::filesystem::path{MDUX_REPO_ROOT} / "generated" / "screen" / "endoscope-monitor" / "goldens.json";
+    std::ifstream               file{sidecar, std::ios::binary};
+    REQUIRE(file.is_open());
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+
+    const auto parsed = mdux::evidence::json::parse(buffer.str());
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->kind() == mdux::evidence::json::Value::Kind::Array);
+
+    // Two entries, one per rule ADR-011 fixes: the annotated node, and the positioned one.
+    const std::span<const mdux::evidence::json::Value> entries = parsed->elements();
+    CHECK(entries.size() == 2);
+
+    bool sawAnnotated = false;
+    for (const mdux::evidence::json::Value& entry : entries) {
+        const auto nodeId = entry.require("nodeId");
+        REQUIRE(nodeId.has_value());
+        const auto name = (*nodeId)->asString();
+        REQUIRE(name.has_value());
+
+        // Every golden names a node this screen actually has, and pins the rectangle that node
+        // actually occupies. A sidecar that drifted from the package would address content the
+        // verifier could never find.
+        const medui::CompiledNode* node = package.find(*name);
+        REQUIRE(node != nullptr);
+
+        const auto bounds = entry.require("bounds");
+        REQUIRE(bounds.has_value());
+        const auto x      = (*bounds)->require("x");
+        const auto y      = (*bounds)->require("y");
+        const auto width  = (*bounds)->require("width");
+        const auto height = (*bounds)->require("height");
+        REQUIRE(x.has_value());
+        REQUIRE(y.has_value());
+        REQUIRE(width.has_value());
+        REQUIRE(height.has_value());
+        CHECK((*x)->asInt().value_or(-1) == node->bounds.x);
+        CHECK((*y)->asInt().value_or(-1) == node->bounds.y);
+        CHECK((*width)->asInt().value_or(-1) == node->bounds.width);
+        CHECK((*height)->asInt().value_or(-1) == node->bounds.height);
+
+        if (*name == "insufflation-pressure") {
+            sawAnnotated = true;
+            // The two checks the annotation asked for, and the tint the ColorHash one would compare
+            // against. Removing `@safety_critical` from the screen drops this entry entirely, which
+            // is what makes this scenario a check on the authored safety marking rather than on the
+            // serialiser.
+            const auto checks = entry.require("cvChecks");
+            REQUIRE(checks.has_value());
+            const std::span<const mdux::evidence::json::Value> named = (*checks)->elements();
+            REQUIRE(named.size() == 2);
+            CHECK(named[0].asString().value_or("") == "Bounds");
+            CHECK(named[1].asString().value_or("") == "ColorHash");
+
+            const auto tint = entry.require("colorToken");
+            REQUIRE(tint.has_value());
+            CHECK((*tint)->asString().value_or("") == "Theme.Colors.ScoreDigits");
+        }
+    }
+    CHECK(sawAnnotated);
+}
+
+TEST_CASE("The safety-critical region is empty, which is what the golden cannot yet check", "pixel") {
+    // A tripwire, not a goal. `insufflation-pressure` is deferred, so its golden's Bounds and
+    // ColorHash have nothing to compare against - and saying that out loud, in a test that fails the
+    // day the component draws, is more honest than a comment nobody re-reads. When #17 gives a
+    // NumericDisplay its geometry, this scenario must be replaced by the check ADR-012 wants.
+    const medui::ScreenPackage package = screen();
+    const core::Extent2D       surface = surfaceOf(package);
+
+    const auto& gpu    = sharedDevice();
+    auto        target = OffscreenTarget::create(gpu.device(), gpu.physicalDevice(), surface, gpu.queueFamilyIndex());
+    REQUIRE(target.has_value());
+
+    VulkanRenderContext context;
+    context.device           = gpu.device();
+    context.physicalDevice   = gpu.physicalDevice();
+    context.renderPass       = target->renderPass();
+    context.queue            = gpu.queue();
+    context.queueFamilyIndex = gpu.queueFamilyIndex();
+    context.viewport         = surface;
+
+    auto renderer = UiRenderer::create(context, mdux::shader::generated::mdux_ui::package(), package.budget);
+    REQUIRE(renderer.has_value());
+
+    Frame frame;
+    auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, package.budget);
+    REQUIRE(list.has_value());
+    REQUIRE(medui::render(package, *list).has_value());
+
+    RecordContext recording{.renderer = &*renderer, .list = &*list};
+    auto          pixels = target->renderAndRead(gpu.queue(), background, recordFrame, &recording);
+    REQUIRE(pixels.has_value());
+
+    const medui::CompiledNode* traced = package.find("insufflation-pressure");
+    REQUIRE(traced != nullptr);
+
+    // Sampled at the centre of the region the golden pins, which is where content would appear.
+    const auto        centreX = static_cast<std::size_t>(traced->bounds.x + traced->bounds.width / 2);
+    const auto        centreY = static_cast<std::size_t>(traced->bounds.y + traced->bounds.height / 2);
+    const std::size_t index   = centreY * static_cast<std::size_t>(surface.width) + centreX;
+    REQUIRE(index < pixels->size());
+    CHECK((*pixels)[index] == background);
+}

--- a/tests/text/RasterTests.cpp
+++ b/tests/text/RasterTests.cpp
@@ -1,11 +1,14 @@
 /**
  * @file RasterTests.cpp
- * @brief BDD scenarios for the governed-zone glyph rasteriser (issue #159).
+ * @brief BDD scenarios for the host-tools glyph rasteriser (issue #159).
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
  * @compliance ADR-010 No on-device text shaping
+ *
+ * Part of text_tools_spec rather than text_spec since #116, because `mdux.text.raster` moved to
+ * the host-tools zone. The scenarios themselves are unchanged: the rasteriser is still
+ * integer-only, and the frozen-digest scenario at the bottom still holds it to the byte.
  *
  * The outlines here are built in code rather than loaded from a font, for the reason
  * `TruetypeTests.cpp` gives: a fixture whose intended defect a reviewer has to take on trust is

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -275,9 +275,8 @@ endif()
 # integer-only bounded layout solver, the text-budget check that measures a resolved box against the
 # widest approved translation (#195), the golden references that say where safety-critical content
 # must appear (#196), and the compiled-screen document with the canonical JSON it is committed as.
-# The C++ emitters are the second half of #197, and the mdux-meduic executable with its
-# mdux_compile_screen() registration is #198 - so there is still no add_executable() here and no
-# bake call site. Every later stage adds sources to this target rather than inventing another.
+# The mdux-meduic executable with its mdux_compile_screen() registration is #198, so there is still
+# no bake call site. Every later stage adds sources to this target rather than inventing another.
 #
 # The package stage reaches mdux.evidence.json and mdux.medui.schema through MduX::ToolsCommon's
 # link to MduX::Core, which is what the acceptance criterion on #197 asks for: the host compiler and
@@ -303,6 +302,7 @@ target_sources(MduXMeduiLib
             medui/TextBudget.cppm
             medui/Goldens.cppm
             medui/Package.cppm
+            medui/Emit.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -312,6 +312,7 @@ target_sources(MduXMeduiLib
         medui/TextBudget.cpp
         medui/Goldens.cpp
         medui/Package.cpp
+        medui/Emit.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)
@@ -331,6 +332,27 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(MduXMeduiLib PRIVATE /experimental:module /std:c++latest)
+endif()
+
+# The screen emitter (issue #197). Its own executable rather than a mode of the compiler, for the
+# reason mdux-shaderemit is its own: compiling a source and rendering a committed package are
+# different jobs, and the second must stay runnable on an artifact whose source is not present.
+add_executable(mdux-screenemit medui/ScreenEmitMain.cpp)
+target_link_libraries(mdux-screenemit PRIVATE MduX::MeduiLib MduX_warnings)
+
+set_target_properties(mdux-screenemit
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(mdux-screenemit PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(mdux-screenemit PRIVATE /experimental:module /std:c++latest)
 endif()
 
 add_executable(mdux-textbake text/TextBakeMain.cpp)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,10 +271,10 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S3 (#192) this is the diagnostic registry (#191) plus the lexer, AST and parser. The
-# emitters are #197, and the mdux-meduic executable with its mdux_compile_screen() registration
-# is #198 - so there is still no add_executable() here and no bake call site. Every later stage
-# adds sources to this target rather than inventing another.
+# At S4 (#193) this is the diagnostic registry (#191), lexer, AST, parser and semantic analyzer.
+# The emitters are #197, and the mdux-meduic executable with its mdux_compile_screen()
+# registration is #198 - so there is still no add_executable() here and no bake call site. Every
+# later stage adds sources to this target rather than inventing another.
 add_library(MduXMeduiLib)
 add_library(MduX::MeduiLib ALIAS MduXMeduiLib)
 
@@ -287,10 +287,12 @@ target_sources(MduXMeduiLib
             medui/Lexer.cppm
             medui/Ast.cppm
             medui/Parser.cppm
+            medui/Semantic.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
         medui/Parser.cpp
+        medui/Semantic.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,11 +271,10 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S2 (#191) this is the diagnostic code registry and nothing else. The lexer, parser and AST
-# are #192, the emitters #197, and the mdux-meduic executable and its mdux_compile_screen()
-# registration are #198 - so there is no add_executable() here yet, and no bake call site. The
-# library exists now because the registry has to live somewhere the tests can link, and because
-# every later stage adds sources to this target rather than inventing another.
+# At S3 (#192) this is the diagnostic registry (#191) plus the lexer, AST and parser. The
+# emitters are #197, and the mdux-meduic executable with its mdux_compile_screen() registration
+# is #198 - so there is still no add_executable() here and no bake call site. Every later stage
+# adds sources to this target rather than inventing another.
 add_library(MduXMeduiLib)
 add_library(MduX::MeduiLib ALIAS MduXMeduiLib)
 
@@ -285,8 +284,13 @@ target_sources(MduXMeduiLib
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         FILES
             medui/Diagnostics.cppm
+            medui/Lexer.cppm
+            medui/Ast.cppm
+            medui/Parser.cppm
     PRIVATE
         medui/Diagnostics.cpp
+        medui/Lexer.cpp
+        medui/Parser.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,8 +271,8 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S4 (#193) this is the diagnostic registry (#191), lexer, AST, parser and semantic analyzer.
-# The emitters are #197, and the mdux-meduic executable with its mdux_compile_screen()
+# At S5 (#194) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer and
+# integer-only bounded layout solver. The emitters are #197, and the mdux-meduic executable with its mdux_compile_screen()
 # registration is #198 - so there is still no add_executable() here and no bake call site. Every
 # later stage adds sources to this target rather than inventing another.
 add_library(MduXMeduiLib)
@@ -288,11 +288,13 @@ target_sources(MduXMeduiLib
             medui/Ast.cppm
             medui/Parser.cppm
             medui/Semantic.cppm
+            medui/Layout.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
         medui/Parser.cpp
         medui/Semantic.cpp
+        medui/Layout.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -305,6 +305,7 @@ target_sources(MduXMeduiLib
             medui/Package.cppm
             medui/Emit.cppm
             medui/Compile.cppm
+            medui/Check.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -316,6 +317,7 @@ target_sources(MduXMeduiLib
         medui/Package.cpp
         medui/Emit.cpp
         medui/Compile.cpp
+        medui/Check.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)
@@ -355,6 +357,26 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(mdux-meduic PRIVATE /experimental:module /std:c++latest)
+endif()
+
+# The single-file checker (issue #200). The surface an author and an agent reach for first: it takes
+# a file, runs every stage that file admits, and writes nothing.
+add_executable(mdux-medui-check medui/MeduiCheckMain.cpp)
+target_link_libraries(mdux-medui-check PRIVATE MduX::MeduiLib MduX_warnings)
+
+set_target_properties(mdux-medui-check
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(mdux-medui-check PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(mdux-medui-check PRIVATE /experimental:module /std:c++latest)
 endif()
 
 # The screen emitter (issue #197). Its own executable rather than a mode of the compiler, for the

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,9 +271,10 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S6 (#195) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
-# integer-only bounded layout solver, and the text-budget check that measures a resolved box against
-# the widest approved translation. The emitters are #197, and the mdux-meduic executable with its
+# At S7 (#196) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
+# integer-only bounded layout solver, the text-budget check that measures a resolved box against the
+# widest approved translation (#195), and the golden references that say where safety-critical
+# content must appear. The emitters are #197, and the mdux-meduic executable with its
 # mdux_compile_screen() registration is #198 - so there is still no add_executable() here and no
 # bake call site. Every later stage adds sources to this target rather than inventing another.
 #
@@ -295,6 +296,7 @@ target_sources(MduXMeduiLib
             medui/Semantic.cppm
             medui/Layout.cppm
             medui/TextBudget.cppm
+            medui/Goldens.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -302,6 +304,7 @@ target_sources(MduXMeduiLib
         medui/Semantic.cpp
         medui/Layout.cpp
         medui/TextBudget.cpp
+        medui/Goldens.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,10 +271,15 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S5 (#194) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer and
-# integer-only bounded layout solver. The emitters are #197, and the mdux-meduic executable with its mdux_compile_screen()
-# registration is #198 - so there is still no add_executable() here and no bake call site. Every
-# later stage adds sources to this target rather than inventing another.
+# At S6 (#195) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
+# integer-only bounded layout solver, and the text-budget check that measures a resolved box against
+# the widest approved translation. The emitters are #197, and the mdux-meduic executable with its
+# mdux_compile_screen() registration is #198 - so there is still no add_executable() here and no
+# bake call site. Every later stage adds sources to this target rather than inventing another.
+#
+# The budget stage reaches mdux.text.draw and mdux.font.schema through MduX::ToolsCommon's link to
+# MduX::Core: it decodes committed run records with the same decoder the device draws them with, so
+# the byte-order and baseline contracts have one implementation rather than a host copy of one.
 add_library(MduXMeduiLib)
 add_library(MduX::MeduiLib ALIAS MduXMeduiLib)
 
@@ -289,12 +294,14 @@ target_sources(MduXMeduiLib
             medui/Parser.cppm
             medui/Semantic.cppm
             medui/Layout.cppm
+            medui/TextBudget.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
         medui/Parser.cpp
         medui/Semantic.cpp
         medui/Layout.cpp
+        medui/TextBudget.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -275,8 +275,9 @@ endif()
 # integer-only bounded layout solver, the text-budget check that measures a resolved box against the
 # widest approved translation (#195), the golden references that say where safety-critical content
 # must appear (#196), and the compiled-screen document with the canonical JSON it is committed as.
-# The mdux-meduic executable with its mdux_compile_screen() registration is #198, so there is still
-# no bake call site. Every later stage adds sources to this target rather than inventing another.
+# At S9 (#198) the compiler driver joins them: one file fixing the order the stages run in, the
+# recipe model, and the bake report. mdux_compile_screen() and the first committed screen artifact
+# are the second half of #198, so there is still no bake call site.
 #
 # The package stage reaches mdux.evidence.json and mdux.medui.schema through MduX::ToolsCommon's
 # link to MduX::Core, which is what the acceptance criterion on #197 asks for: the host compiler and
@@ -303,6 +304,7 @@ target_sources(MduXMeduiLib
             medui/Goldens.cppm
             medui/Package.cppm
             medui/Emit.cppm
+            medui/Compile.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -313,6 +315,7 @@ target_sources(MduXMeduiLib
         medui/Goldens.cpp
         medui/Package.cpp
         medui/Emit.cpp
+        medui/Compile.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)
@@ -332,6 +335,26 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(MduXMeduiLib PRIVATE /experimental:module /std:c++latest)
+endif()
+
+# The compiler (issue #198). Split library-and-executable like every other baker, so tests drive
+# run()/write()/verify() as calls rather than spawning a process and asserting an exit status.
+add_executable(mdux-meduic medui/MeduicMain.cpp)
+target_link_libraries(mdux-meduic PRIVATE MduX::MeduiLib MduX_warnings)
+
+set_target_properties(mdux-meduic
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(mdux-meduic PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(mdux-meduic PRIVATE /experimental:module /std:c++latest)
 endif()
 
 # The screen emitter (issue #197). Its own executable rather than a mode of the compiler, for the

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -271,12 +271,17 @@ endif()
 # governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
 # reports that at configure time.
 #
-# At S7 (#196) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
+# At S8 (#197) this is the diagnostic registry (#191), lexer, AST, parser, semantic analyzer,
 # integer-only bounded layout solver, the text-budget check that measures a resolved box against the
-# widest approved translation (#195), and the golden references that say where safety-critical
-# content must appear. The emitters are #197, and the mdux-meduic executable with its
+# widest approved translation (#195), the golden references that say where safety-critical content
+# must appear (#196), and the compiled-screen document with the canonical JSON it is committed as.
+# The C++ emitters are the second half of #197, and the mdux-meduic executable with its
 # mdux_compile_screen() registration is #198 - so there is still no add_executable() here and no
 # bake call site. Every later stage adds sources to this target rather than inventing another.
+#
+# The package stage reaches mdux.evidence.json and mdux.medui.schema through MduX::ToolsCommon's
+# link to MduX::Core, which is what the acceptance criterion on #197 asks for: the host compiler and
+# the device runtime import one definition of a compiled screen rather than two that can drift.
 #
 # The budget stage reaches mdux.text.draw and mdux.font.schema through MduX::ToolsCommon's link to
 # MduX::Core: it decodes committed run records with the same decoder the device draws them with, so
@@ -297,6 +302,7 @@ target_sources(MduXMeduiLib
             medui/Layout.cppm
             medui/TextBudget.cppm
             medui/Goldens.cppm
+            medui/Package.cppm
     PRIVATE
         medui/Diagnostics.cpp
         medui/Lexer.cpp
@@ -305,6 +311,7 @@ target_sources(MduXMeduiLib
         medui/Layout.cpp
         medui/TextBudget.cpp
         medui/Goldens.cpp
+        medui/Package.cpp
 )
 
 target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -262,6 +262,52 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(MduXTextBakeLib PRIVATE /experimental:module /std:c++latest)
 endif()
 
+# ---------------------------------------------------------------------------
+# The .medui compiler (epic #15, ADR-011, ADR-012)
+# ---------------------------------------------------------------------------
+#
+# Host-tools zone, like every other baker: the compiler parses untrusted input and may throw and
+# allocate freely, because nothing it contains reaches a device. Deliberately not declared
+# governed, which is also what stops a governed target linking it - mdux_verify_trust_zones()
+# reports that at configure time.
+#
+# At S2 (#191) this is the diagnostic code registry and nothing else. The lexer, parser and AST
+# are #192, the emitters #197, and the mdux-meduic executable and its mdux_compile_screen()
+# registration are #198 - so there is no add_executable() here yet, and no bake call site. The
+# library exists now because the registry has to live somewhere the tests can link, and because
+# every later stage adds sources to this target rather than inventing another.
+add_library(MduXMeduiLib)
+add_library(MduX::MeduiLib ALIAS MduXMeduiLib)
+
+target_sources(MduXMeduiLib
+    PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES
+            medui/Diagnostics.cppm
+    PRIVATE
+        medui/Diagnostics.cpp
+)
+
+target_compile_features(MduXMeduiLib PUBLIC cxx_std_23)
+target_link_libraries(MduXMeduiLib PUBLIC MduX::ToolsCommon)
+target_link_libraries(MduXMeduiLib PRIVATE MduX_warnings)
+
+set_target_properties(MduXMeduiLib
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(MduXMeduiLib PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(MduXMeduiLib PRIVATE /experimental:module /std:c++latest)
+endif()
+
 add_executable(mdux-textbake text/TextBakeMain.cpp)
 target_link_libraries(mdux-textbake PRIVATE MduX::TextBakeLib MduX_warnings)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -218,6 +218,12 @@ endif()
 # that hosts the recipe model. S4 extends the recipe with the font pipeline inputs and S5
 # (#161) adds the restricted-charset validation; no mdux_bake_artifact() call site is
 # registered until S4 commits a real artifact.
+#
+# `mdux.text.raster` moved here from MduXCore in #116. It allocates, and `std::vector` reports
+# failure by throwing, so its noexcept entry point has to catch - which ADR-005 forbids in the
+# governed zone.
+# Nothing else about it changed - it is integer-only and its output is still byte-compared in CI.
+# See tools/text/Raster.cppm for the full argument.
 add_library(MduXTextBakeLib)
 add_library(MduX::TextBakeLib ALIAS MduXTextBakeLib)
 
@@ -229,10 +235,12 @@ target_sources(MduXTextBakeLib
             text/TextBake.cppm
             text/Truetype.cppm
             text/AtlasPacker.cppm
+            text/Raster.cppm
     PRIVATE
         text/TextBake.cpp
         text/Truetype.cpp
         text/AtlasPacker.cpp
+        text/Raster.cpp
 )
 
 target_compile_features(MduXTextBakeLib PUBLIC cxx_std_23)

--- a/tools/docs-lint/check_file_headers.py
+++ b/tools/docs-lint/check_file_headers.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Fails when a C++ file's opening Doxygen block does not follow CONTRIBUTING.md.
+
+Host-only tool (ADR-004): standard library only, no third-party dependencies.
+
+`CONTRIBUTING.md` fixes one shape for a file-level block - `@file <name.ext>`, then `@brief`, no
+`@author` - and records why with a measurement rather than a preference: `@file` is what attaches
+the block to the *file*. Without it the block is not ignored, it silently becomes the documentation
+of whatever declaration follows. On `tests/framework/RunRecords.hpp` with Doxygen 1.15, dropping the
+tag moved the file's brief onto `namespace mdux::spec` - wrong documentation, and no warning.
+
+## Why a lint and not another sweep
+
+The rule has been settled twice. #180 changed it to match what the tree did, and issue #223 found ten
+files still in the retired order - all in one epic, spread by copying the neighbour. A sweep fixes
+the ten; it does nothing about the eleventh. Worse, the drift has a second cost that a sweep cannot
+touch: review bots cite `CONTRIBUTING.md`, find the tree contradicting it, and raise the same finding
+on unrelated pull requests, which trains everyone to wave it through.
+
+So this runs in `Documentation Lint`, on a job that needs no C++ toolchain, and answers the question
+a reviewer would otherwise have to ask by hand.
+
+## What it checks, and what it deliberately does not
+
+- the first `/** ... */` block in the file opens with `@file`;
+- its argument is the file's own name **with extension and no path**, since `Draw.cppm` and
+  `Draw.cpp` are different files with one stem and this tree has several such pairs;
+- `@brief` follows it, and is present at all;
+- no `@author` anywhere in the block.
+
+It does not check the prose, the `@compliance` lines, or whether the brief is any good. It reads the
+first block only: a file whose first block is a licence banner rather than documentation would be a
+different convention, and the tree has none.
+
+Usage:
+    python3 tools/docs-lint/check_file_headers.py [--repo-root PATH] [paths...]
+
+Exit status 0 when every scanned file conforms, 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# The extensions CONTRIBUTING.md declares this project uses: `.hpp` for headers, `.cpp` for sources,
+# `.cppm` for module interfaces. `.h` is deliberately not here - a `.h` in this tree would be a
+# naming violation, and listing it would quietly bless it as a project extension while asking a
+# vendored C header for a Doxygen block it has no reason to carry.
+SOURCE_SUFFIXES = (".cpp", ".cppm", ".hpp")
+
+# Where MduX's own C++ lives. `_deps` holds fetched dependencies and `build*` holds build trees;
+# neither is this project's to format.
+SCAN_ROOTS = ("include", "src", "tools", "tests", "examples")
+SKIP_DIRECTORY_NAMES = {"_deps", "__pycache__", "fixtures"}
+
+BLOCK_PATTERN = re.compile(r"/\*\*(.*?)\*/", re.DOTALL)
+
+# A Doxygen tag is a line whose content starts with `@name`, after the leading ` * `. Matching the
+# bare word anywhere would read prose as markup: a block that discusses `@author` in a sentence -
+# this file's own tests do - is not a block that carries the tag.
+TAG_LINE_PATTERN = re.compile(r"^\s*\*?\s*@(\w+)(?:[ \t]+(.*))?$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    message: str
+
+
+@dataclass(frozen=True)
+class Tag:
+    name: str
+    argument: str
+
+
+def first_block(text: str) -> str | None:
+    """The body of the first `/** ... */` comment, or None when the file has none."""
+    match = BLOCK_PATTERN.search(text)
+    return match.group(1) if match else None
+
+
+def tags_of(block: str) -> list[Tag]:
+    """Every Doxygen tag the block carries, in order."""
+    found: list[Tag] = []
+    for line in block.splitlines():
+        match = TAG_LINE_PATTERN.match(line)
+        if match is not None:
+            found.append(Tag(match.group(1), (match.group(2) or "").strip()))
+    return found
+
+
+def check_text(path: Path, text: str) -> list[Finding]:
+    """Every way `text`'s opening block departs from the documented shape."""
+    block = first_block(text)
+    if block is None:
+        return [Finding(path, "has no file-level Doxygen block; open one with @file then @brief")]
+
+    tags = tags_of(block)
+    names = [tag.name for tag in tags]
+    findings: list[Finding] = []
+
+    if "author" in names:
+        findings.append(Finding(path, "carries an @author tag, which this project does not use"))
+
+    if "file" not in names:
+        findings.append(
+            Finding(
+                path,
+                "opens a block without @file. Doxygen then attaches the block to whatever "
+                "declaration follows instead of to the file",
+            )
+        )
+    else:
+        named = tags[names.index("file")].argument
+        if named != path.name:
+            findings.append(
+                Finding(
+                    path,
+                    f"@file names '{named}'; it must name '{path.name}', with the extension and no path",
+                )
+            )
+
+    if "brief" not in names:
+        findings.append(Finding(path, "has a file-level block with no @brief"))
+    elif "file" in names and names.index("brief") < names.index("file"):
+        findings.append(Finding(path, "puts @brief before @file; CONTRIBUTING.md fixes the order the other way"))
+    elif "file" in names and names.index("file") != 0:
+        findings.append(Finding(path, f"opens with @{names[0]} rather than @file"))
+
+    return findings
+
+
+def collect_sources(root: Path, paths: list[str]) -> list[Path]:
+    """The files to scan: the ones named, or every C++ source under the scan roots."""
+    if paths:
+        return [Path(entry) if Path(entry).is_absolute() else root / entry for entry in paths]
+
+    found: list[Path] = []
+    for scan_root in SCAN_ROOTS:
+        base = root / scan_root
+        if not base.is_dir():
+            continue
+        for candidate in sorted(base.rglob("*")):
+            if candidate.suffix not in SOURCE_SUFFIXES or not candidate.is_file():
+                continue
+            if SKIP_DIRECTORY_NAMES.intersection(part for part in candidate.parts):
+                continue
+            found.append(candidate)
+    return found
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (default: inferred from this script's location)",
+    )
+    parser.add_argument("paths", nargs="*", help="files to check (default: every C++ source in the tree)")
+    args = parser.parse_args(argv)
+    root: Path = args.repo_root
+
+    sources = collect_sources(root, args.paths)
+    findings: list[Finding] = []
+    for source in sources:
+        findings.extend(check_text(source, source.read_text(encoding="utf-8", errors="replace")))
+
+    if findings:
+        for finding in findings:
+            relative = finding.path.relative_to(root) if finding.path.is_relative_to(root) else finding.path
+            print(f"mdux-file-headers: {relative}: {finding.message}", file=sys.stderr)
+        print(f"mdux-file-headers: {len(findings)} finding(s)", file=sys.stderr)
+        print("mdux-file-headers: the rule and the reason are in CONTRIBUTING.md, 'Documentation'", file=sys.stderr)
+        return 1
+
+    print(f"mdux-file-headers: OK ({len(sources)} sources checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/docs-lint/test_check_file_headers.py
+++ b/tools/docs-lint/test_check_file_headers.py
@@ -1,0 +1,130 @@
+"""Tests for check_file_headers.
+
+The tests that matter are the ones proving the check *fails*. A header lint that only ever passes is
+indistinguishable from no lint, and it is the failure paths a reviewer trusts when they read
+"file headers OK" in a CI log - so every departure CONTRIBUTING.md names has a test that it is
+caught, and the shape the tree actually uses has one that it is not.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_file_headers as headers
+
+CONFORMING = """\
+/**
+ * @file Widget.cppm
+ * @brief One sentence on what this file is.
+ *
+ * @compliance ADR-004 Trust zones in C++
+ *
+ * Prose that mentions @author and @brief in passing, well after the tags.
+ */
+module;
+export module mdux.widget;
+"""
+
+
+def check(name: str, text: str) -> list[str]:
+    return [finding.message for finding in headers.check_text(Path(name), text)]
+
+
+class CheckFileHeadersTests(unittest.TestCase):
+    def test_accepts_the_documented_shape(self) -> None:
+        self.assertEqual(check("Widget.cppm", CONFORMING), [])
+
+    def test_rejects_brief_before_file(self) -> None:
+        swapped = CONFORMING.replace(
+            " * @file Widget.cppm\n * @brief One sentence on what this file is.\n",
+            " * @brief One sentence on what this file is.\n * @file Widget.cppm\n",
+        )
+        findings = check("Widget.cppm", swapped)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("@brief before @file", findings[0])
+
+    def test_rejects_a_block_opening_with_another_tag(self) -> None:
+        # A block whose first tag is not @file but which still has both, in the right order relative
+        # to each other. CONTRIBUTING says to *open* with @file, so this is its own finding rather
+        # than a variant of the ordering one - and without this case that branch was never executed.
+        moved = CONFORMING.replace(
+            " * @file Widget.cppm\n",
+            " * @compliance ADR-004 Trust zones in C++\n * @file Widget.cppm\n",
+        )
+        findings = check("Widget.cppm", moved)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("opens with @compliance", findings[0])
+
+    def test_rejects_a_missing_file_tag(self) -> None:
+        # The case with teeth: without @file the block documents whatever declaration follows it,
+        # silently and with no Doxygen warning.
+        findings = check("Widget.cppm", CONFORMING.replace(" * @file Widget.cppm\n", ""))
+        self.assertEqual(len(findings), 1)
+        self.assertIn("without @file", findings[0])
+
+    def test_rejects_a_file_tag_naming_another_file(self) -> None:
+        findings = check("Widget.cppm", CONFORMING.replace("@file Widget.cppm", "@file Widget.cpp"))
+        self.assertEqual(len(findings), 1)
+        self.assertIn("must name 'Widget.cppm'", findings[0])
+
+    def test_rejects_a_file_tag_carrying_a_path(self) -> None:
+        # `Draw.cppm` and `Draw.cpp` are different files with one stem, and this tree has several
+        # such pairs, so the extension is load-bearing - and so is the absence of a path.
+        findings = check("Widget.cppm", CONFORMING.replace("@file Widget.cppm", "@file include/mdux/Widget.cppm"))
+        self.assertEqual(len(findings), 1)
+        self.assertIn("no path", findings[0])
+
+    def test_rejects_an_author_tag(self) -> None:
+        findings = check("Widget.cppm", CONFORMING.replace(" * @brief", " * @author A. Person\n * @brief"))
+        self.assertEqual(len(findings), 1)
+        self.assertIn("@author", findings[0])
+
+    def test_rejects_a_file_with_no_block_at_all(self) -> None:
+        findings = check("Widget.cppm", "module;\nexport module mdux.widget;\n")
+        self.assertEqual(len(findings), 1)
+        self.assertIn("no file-level Doxygen block", findings[0])
+
+    def test_rejects_a_block_with_no_brief(self) -> None:
+        findings = check("Widget.cppm", "/**\n * @file Widget.cppm\n */\nmodule;\n")
+        self.assertEqual(len(findings), 1)
+        self.assertIn("no @brief", findings[0])
+
+    def test_reads_only_the_first_block(self) -> None:
+        # A later block documenting a function must not be mistaken for the file's own.
+        text = CONFORMING + "\n/**\n * @brief A function, documented after the file block.\n */\nvoid f();\n"
+        self.assertEqual(check("Widget.cppm", text), [])
+
+    def test_collects_sources_and_skips_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "src").mkdir()
+            (root / "src" / "Widget.cpp").write_text(CONFORMING, encoding="utf-8")
+            (root / "src" / "notes.md").write_text("not a source", encoding="utf-8")
+            (root / "tests" / "_deps" / "vendor").mkdir(parents=True)
+            (root / "tests" / "_deps" / "vendor" / "Vendor.cpp").write_text("no block here", encoding="utf-8")
+            (root / "tests" / "fixtures").mkdir(parents=True)
+            (root / "tests" / "fixtures" / "Fixture.cpp").write_text("no block here either", encoding="utf-8")
+
+            # `.h` is deliberately absent from the suffix list: CONTRIBUTING fixes this project's
+            # extensions as .hpp, .cpp and .cppm, so a `.h` in the tree is a naming violation rather
+            # than a file this lint should be asking for Doxygen blocks in - and treating it as a
+            # source would quietly bless it.
+            (root / "src" / "legacy.h").write_text("no block here", encoding="utf-8")
+
+            collected = [path.name for path in headers.collect_sources(root, [])]
+            self.assertEqual(collected, ["Widget.cpp"])
+
+    def test_the_tree_itself_conforms(self) -> None:
+        # The sweep in #223 is what makes this pass; it is here so that a file added later cannot
+        # reintroduce the deviation without a test saying so.
+        root = Path(__file__).resolve().parents[2]
+        offenders = [
+            f"{path.relative_to(root)}: {message}"
+            for path in headers.collect_sources(root, [])
+            for message in check(path.name, path.read_text(encoding="utf-8", errors="replace"))
+        ]
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/governed-lint/mdux_governed_lint.py
+++ b/tools/governed-lint/mdux_governed_lint.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""mdux-governed-lint: enforces ADR-005's governed-zone source rules.
+
+Host-only tool (see ADR-004's trust-zone model) - never built into MduXCore or MduX, no
+third-party dependencies, standard library only, so it runs anywhere Python 3.9+ runs without
+a build.
+
+## Why this exists
+
+ADR-005 states that governed code does not throw, and ADR-004 that it reaches no platform,
+filesystem, time or randomness facility. Until issue #116 nothing checked either claim. The ADR
+described a lint "the governed-zone source lint also rejects `throw`, `try`, and `catch`" that had
+never been written, which is the worst shape a compliance claim can take: asserted in the present
+tense, believed by readers, enforced by nothing.
+
+The intended mechanism was compiling MduXCore with `-fno-exceptions -fno-rtti`. That is not
+available while the governed zone uses `import std`: GCC records the language dialect in every
+module BMI, and CMake synthesises one shared `std` target for the whole build, so a governed module
+built with those flags cannot read the same `std` BMI the adapter and host-tools targets read. See
+ADR-005's constraint section.
+
+So the rule is enforced at two levels instead, and this is the source-level one:
+
+- **this lint** reads the source and rejects the construct;
+- **`governed.noThrow.symbolScan`** (cmake/MduXNoHeapScan.cmake) reads the emitted objects and
+  rejects the symbol, catching a throw that arrives through a std facility the source never
+  spells out.
+
+Neither subsumes the other. The scan is blind to a `std::filesystem` call that never throws; this
+is blind to a throw inside a header it does not read.
+
+GOV009 additionally closes the gap ADR-004 item 1 names explicitly: denying `MduXCore` Vulkan's
+include *directories* does not make a system-installed `<vulkan/vulkan.h>` unreachable, because the
+compiler still finds it in a default search path. Only a source-level check does.
+
+## What it scans
+
+**Exactly the sources `CMakeLists.txt` lists for `MduXCore`**, parsed out of the
+`target_sources(MduXCore ...)` block rather than globbed. Three reasons, all of them things a glob
+gets wrong:
+
+1. `include/mdux/**` also holds the *adapter* modules (`render/`, `vulkansc/`), which are permitted
+   exceptions and would be reported as violations.
+2. Generated shader C arrays land in `<binary>/mdux_generated/`, outside the source tree - a
+   requirement in #116 is that they are not scanned as hand-authored governed source. Deriving from
+   the source list excludes them by construction rather than by an exclusion pattern someone has to
+   remember to maintain.
+3. A module added to MduXCore is covered the moment it is registered, with no second edit here.
+   That matters most for #15, which adds several.
+
+If the block cannot be parsed, this exits non-zero rather than scanning nothing. A lint that
+silently checks an empty list reports success identically to one that is working.
+
+## How it matches
+
+On the source **with comments and string literals removed**, not on raw lines. The governed tree is
+heavily commented and those comments discuss the very constructs banned here - `Kernels.cppm` says
+"Never `std::fma`", `Draw.cpp` says "a new command is needed", `Runtime.cppm` says "throw away
+exactly the information the incident report needs". Every one of those is prose, and a line-based
+matcher reports all of them. Stripping first is what makes the rule enforceable without forcing
+authors to reword documentation to appease a regex.
+
+Removal preserves line numbers, so a finding still points at the right line.
+
+## Escape hatch
+
+A line ending with `mdux-governed-lint:allow` is exempt. Intended for the genuinely unavoidable
+case - `src/ml/Runtime.cpp` reinterprets a caller-supplied byte span as floats, which is the entire
+mechanism ADR-008 chose for weights - and reviewed rather than routine. It is deliberately per-line
+and visible in the diff.
+
+Usage:
+    python3 tools/governed-lint/mdux_governed_lint.py [--format text|json] [paths...]
+
+Exit status 0 if no findings, 1 otherwise. With no paths, scans MduXCore's declared sources.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SUPPRESS_MARKER = "mdux-governed-lint:allow"
+
+# The block in CMakeLists.txt that declares what the governed target is made of.
+GOVERNED_TARGET = "MduXCore"
+
+SOURCE_LINE_RE = re.compile(r"^\s*((?:include|src|tools|tests)/[^\s()]+\.(?:cppm|cpp))\s*$")
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One banned construct.
+
+    `code` is stable once published: an agent keys off it, and a reworded `message` must not break
+    that. See docs/governance/schemas/diagnostic.schema.json.
+    """
+
+    code: str
+    pattern: re.Pattern
+    message: str
+    fix_hint: str
+
+
+RULES = (
+    Rule(
+        code="GOV001",
+        pattern=re.compile(r"\bthrow\b"),
+        message="`throw` in governed code",
+        fix_hint=(
+            "Return a mdux::core::Result error instead (ADR-005). If the throwing construct is "
+            "unavoidable, the module belongs in the host-tools zone - that is where "
+            "mdux.text.raster went in #116."
+        ),
+    ),
+    Rule(
+        code="GOV002",
+        pattern=re.compile(r"\b(?:try|catch)\b"),
+        message="`try`/`catch` in governed code",
+        fix_hint=(
+            "Governed code has nothing to catch, because governed code does not throw (ADR-005). "
+            "A module that needs to catch belongs in the host-tools zone."
+        ),
+    ),
+    Rule(
+        code="GOV003",
+        pattern=re.compile(r"\.value\(\)"),
+        message="`.value()` on a Result/expected, which throws when the value is absent",
+        fix_hint=(
+            "Branch on has_value() or operator bool, then use operator* or operator->, which do "
+            "not throw. ADR-005's risk register names this construct specifically."
+        ),
+    ),
+    Rule(
+        code="GOV004",
+        # `delete` needs the `[` alternative: `\bdelete\s` requires trailing whitespace, so the
+        # very common `delete[] p` spelling slipped through while `delete [] p` was caught.
+        pattern=re.compile(
+            r"\bnew\s+[A-Za-z_:(]|\bdelete\s*(?:\[\s*\]|\s)"
+            r"|\b(?:m|c|re)alloc\s*\(|\bfree\s*\("
+        ),
+        message="raw owning allocation in governed code",
+        fix_hint=(
+            "Governed code uses caller-supplied storage or std containers, never a raw new/delete "
+            "or the C allocator family. See ADR-004; mdux.ml.runtime's no-heap predict() is the "
+            "pattern to follow for a hot path."
+        ),
+    ),
+    Rule(
+        code="GOV005",
+        # The printf family is matched with an optional `std::`, because the C spellings are
+        # equally reachable through `import std` and a bare `system("...")` is the one that
+        # matters most. `snprintf`/`vsnprintf` are included: they write to a buffer rather than a
+        # stream, but they are still the C formatting machinery this zone has no use for, and
+        # ADR-007 has its own reasons to keep float formatting out of anything evidence-adjacent.
+        pattern=re.compile(
+            r"std::filesystem|\bstd::(?:i|o)fstream\b|\bstd::(?:cout|cerr|cin|clog)\b"
+            r"|\b(?:std::)?getenv\s*\(|\b(?:std::)?system\s*\("
+            r"|\b(?:std::)?v?(?:f|s|sn)?printf\s*\("
+        ),
+        message="platform, filesystem or console facility in governed code",
+        fix_hint=(
+            "Governed code performs no I/O: it is meant to run on a device with no filesystem and "
+            "no console (ADR-004, ADR-008 decision 2). Move the I/O to a host tool and pass the "
+            "bytes in."
+        ),
+    ),
+    Rule(
+        code="GOV006",
+        pattern=re.compile(
+            r"std::chrono::(?:system_clock|steady_clock|high_resolution_clock)"
+            r"|std::random_device|std::mt19937|\bstd::s?rand\s*\(|\bstd::time\s*\("
+        ),
+        message="clock or randomness in governed code, which makes output non-reproducible",
+        fix_hint=(
+            "A governed result must be a pure function of its inputs, or the evidence pipeline's "
+            "byte-identity guarantee (ADR-007) does not hold. Pass a timestamp or seed in as data."
+        ),
+    ),
+    Rule(
+        code="GOV007",
+        pattern=re.compile(r"\b(?:reinterpret_cast|const_cast)\b"),
+        message="unsafe cast in governed code",
+        fix_hint=(
+            "Prefer std::bit_cast, std::as_bytes or a span conversion. Where the cast is genuinely "
+            f"the mechanism - reading a caller-supplied blob - end the line with {SUPPRESS_MARKER} "
+            "so the exception is reviewed rather than silent."
+        ),
+    ),
+    Rule(
+        code="GOV009",
+        # A blocklist, and therefore not exhaustive - stated plainly here because the alternative
+        # is a reader assuming otherwise. An allowlist of std headers would be the airtight shape,
+        # but governed code reaches std through `import std` and carries almost no #include at all
+        # (one, `<cstddef>`, at the time of writing), so an allowlist would be a large mechanism
+        # guarding a nearly empty surface. The names below are the ones actually reachable on the
+        # platforms this project builds on; add to them when a new one becomes reachable.
+        #
+        # The real backstop is not this rule: it is ADR-004 item 3's link-graph assertion, which
+        # fails at configure time if a governed target ever acquires a dependency that would make
+        # such a header resolvable through target usage requirements.
+        pattern=re.compile(
+            r"#\s*include\s*<\s*(?:vulkan/|GLFW/|windows\.h|winsock|unistd\.h|sys/|fcntl\.h"
+            r"|pthread\.h|dlfcn\.h|X11/|wayland-|linux/|termios\.h|io\.h|direct\.h|process\.h"
+            r"|signal\.h|poll\.h|netinet/|arpa/|sched\.h|mmintrin\.h|immintrin\.h)",
+            re.IGNORECASE,
+        ),
+        message="platform, graphics or OS header in governed code",
+        fix_hint=(
+            "ADR-004 item 1 keeps these off the include path that MduXCore is *given*, but a "
+            "system-installed header is still findable in the compiler's default search paths - "
+            "which is the gap this rule closes. Governed code takes handles and bytes from its "
+            "caller; the adapter zone is where a platform header belongs. This list is a "
+            "blocklist: if you have reached a platform header it does not name, add it."
+        ),
+    ),
+    Rule(
+        code="GOV008",
+        pattern=re.compile(r"\bstd::fmaf?\b"),
+        message="std::fma in governed code",
+        fix_hint=(
+            "std::fma rounds once where the scalar multiply-then-add sequence rounds twice, so it "
+            "changes results against the golden vectors. Write the multiply and the add "
+            "separately. See mdux.ml.kernels' header and ADR-008."
+        ),
+    ),
+)
+
+
+@dataclass
+class Finding:
+    """One finding in the shared envelope - docs/governance/schemas/diagnostic.schema.json.
+
+    Deliberately the same field names and severity vocabulary as `mdux::tools::cli::Diagnostic`
+    (tools/common/Cli.cppm), mdux-docs-lint and mdux-evidence-lint, so an agent parses one schema
+    for the whole repository. `line` and `column` are both 1-based, with 0 meaning "no precise
+    position on this axis". This lint reports both: stripping preserves offsets, so the column a
+    match lands on is the column in the original file.
+    """
+
+    path: str
+    line: int
+    code: str
+    severity: str
+    message: str
+    fix_hint: str = ""
+    column: int = 0
+
+    def to_json(self) -> dict:
+        return {
+            "file": self.path,
+            "line": self.line,
+            "column": self.column,
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "fixHint": self.fix_hint,
+        }
+
+
+def strip_comments_and_literals(text: str) -> str:
+    """Blanks out comments and string/character literals, preserving length and line breaks.
+
+    Every removed character becomes a space, and newlines inside a removed run are kept, so an
+    offset into the result is an offset into the original: line and column numbers survive.
+
+    This is the inverse of mdux-evidence-lint's `extract_string_literals`, which keeps the literals
+    and discards the code. Both exist because the two lints ask opposite questions - a format
+    specifier can only be in a literal, and a `throw` can only be outside one.
+    """
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        two = text[i : i + 2]
+
+        if two == "//":
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+
+        if two == "/*":
+            end = text.find("*/", i + 2)
+            end = n if end == -1 else end + 2
+            for c in text[i:end]:
+                out.append("\n" if c == "\n" else " ")
+            i = end
+            continue
+
+        # Raw string literal: R"delim(body)delim", no escape processing inside.
+        if text[i] == "R" and text[i + 1 : i + 2] == '"':
+            open_paren = text.find("(", i + 2)
+            if open_paren != -1:
+                terminator = ")" + text[i + 2 : open_paren] + '"'
+                end = text.find(terminator, open_paren + 1)
+                if end != -1:
+                    end += len(terminator)
+                    for c in text[i:end]:
+                        out.append("\n" if c == "\n" else " ")
+                    i = end
+                    continue
+
+        if text[i] in ('"', "'"):
+            quote = text[i]
+            start = i
+            i += 1
+            while i < n:
+                if text[i] == "\\" and i + 1 < n:
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    i += 1
+                    break
+                if text[i] == "\n":  # unterminated; let the compiler complain about it
+                    break
+                i += 1
+            for c in text[start:i]:
+                out.append("\n" if c == "\n" else " ")
+            continue
+
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+
+def governed_sources(root: Path) -> list[Path]:
+    """The files CMakeLists.txt lists for MduXCore, in declaration order.
+
+    Raises ValueError if the block cannot be found or yields nothing - see the module docstring on
+    why this fails rather than returning an empty list.
+    """
+    cmakelists = root / "CMakeLists.txt"
+    try:
+        text = cmakelists.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"could not read {cmakelists}: {exc}") from exc
+
+    marker = f"target_sources({GOVERNED_TARGET}"
+    start = text.find(marker)
+    if start == -1:
+        raise ValueError(
+            f"no `{marker}` block in CMakeLists.txt. The governed source list is derived from "
+            "that block; if the target was renamed, update GOVERNED_TARGET in this file."
+        )
+
+    # Scan from the opening paren itself, not from the end of the marker: starting past it leaves
+    # depth at 0, so the block's own closing paren takes it to -1, the `depth == 0` test never
+    # fires, and the "block" runs to end of file - swallowing the *adapter* target's source list
+    # and reporting its permitted exceptions as governed violations. Observed while writing this.
+    open_paren = text.index("(", start)
+    depth = 0
+    end = start
+    for index in range(open_paren, len(text)):
+        if text[index] == "(":
+            depth += 1
+        elif text[index] == ")":
+            depth -= 1
+            if depth == 0:
+                end = index
+                break
+    else:
+        raise ValueError(f"unterminated `{marker}` block in CMakeLists.txt")
+
+    block = strip_cmake_comments(text[start:end])
+    paths = []
+    for line in block.splitlines():
+        match = SOURCE_LINE_RE.match(line)
+        if match:
+            paths.append(root / match.group(1))
+
+    if not paths:
+        raise ValueError(
+            f"the `{marker}` block parsed to zero sources. Refusing to report success on an "
+            "empty scan."
+        )
+    return paths
+
+
+def strip_cmake_comments(text: str) -> str:
+    """Drops `#` comments from a CMake fragment. No literals to worry about in a source list."""
+    return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+
+
+def display_path(path: Path, root: Path) -> str:
+    """The path as a finding should name it: repository-relative where possible.
+
+    `Path.relative_to` raises for anything outside `root`, which made the documented `[paths...]`
+    interface traceback on any file elsewhere on the filesystem - reported in review, reproduced
+    with a file under /tmp. A lint that crashes instead of reporting is not usable in the editor
+    integrations that interface exists for, so `os.path.relpath` handles the outside case and falls
+    back to the absolute path when even that is not expressible (a different drive on Windows).
+    """
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        try:
+            return os.path.relpath(path, root)
+        except ValueError:
+            return str(path)
+
+
+def check_file(path: Path, root: Path, findings: list[Finding]) -> None:
+    relative = display_path(path, root)
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        findings.append(
+            Finding(
+                path=relative,
+                line=0,
+                code="GOV000",
+                severity="error",
+                message=f"could not read file: {exc}",
+            )
+        )
+        return
+    code_only = strip_comments_and_literals(text)
+    original_lines = text.splitlines()
+
+    # Offset of the first character of each 1-based line, for turning a match position into a
+    # line and column without scanning the whole prefix per match.
+    line_starts = [0]
+    for index, character in enumerate(code_only):
+        if character == "\n":
+            line_starts.append(index + 1)
+
+    def position_of(offset: int) -> tuple[int, int]:
+        low, high = 0, len(line_starts) - 1
+        while low < high:
+            mid = (low + high + 1) // 2
+            if line_starts[mid] <= offset:
+                low = mid
+            else:
+                high = mid - 1
+        return low + 1, offset - line_starts[low] + 1
+
+    for rule in RULES:
+        for match in rule.pattern.finditer(code_only):
+            line, column = position_of(match.start())
+            original = original_lines[line - 1] if line <= len(original_lines) else ""
+            if original.rstrip().endswith(SUPPRESS_MARKER):
+                continue
+            findings.append(
+                Finding(
+                    path=relative,
+                    line=line,
+                    column=column,
+                    code=rule.code,
+                    severity="error",
+                    message=f"{rule.message}: {match.group(0)!r}",
+                    fix_hint=rule.fix_hint,
+                )
+            )
+
+    findings.sort(key=lambda f: (f.path, f.line, f.column, f.code))
+
+
+def find_repository_root() -> Path:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / ".git").exists():
+            return candidate
+    return here.parents[2]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Enforce ADR-005's governed-zone source rules over MduXCore's sources."
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Files to scan. Defaults to MduXCore's declared sources.",
+    )
+    args = parser.parse_args(argv)
+
+    root = find_repository_root()
+    if args.paths:
+        # Relative arguments resolve against the working directory, not the repository root.
+        # That is what every other command-line tool does, and what mdux-evidence-lint already
+        # does, so `mdux_governed_lint.py Draw.cpp` from inside src/draw/ means the file the shell
+        # would have completed. Findings are still *reported* repository-relative - see
+        # display_path(), which also keeps a path outside the repository from crashing the run.
+        sources = [p if p.is_absolute() else (Path.cwd() / p) for p in args.paths]
+    else:
+        try:
+            sources = governed_sources(root)
+        except ValueError as exc:
+            print(f"mdux-governed-lint: {exc}", file=sys.stderr)
+            return 1
+
+    missing = [s for s in sources if not s.is_file()]
+    if missing:
+        for path in missing:
+            print(f"mdux-governed-lint: declared source not found: {path}", file=sys.stderr)
+        return 1
+
+    findings: list[Finding] = []
+    for source in sources:
+        check_file(source, root, findings)
+
+    if args.format == "json":
+        # The shared envelope: docs/governance/schemas/diagnostic.schema.json.
+        print(
+            json.dumps(
+                {
+                    "tool": "mdux-governed-lint",
+                    "filesChecked": len(sources),
+                    "findings": [f.to_json() for f in findings],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for finding in findings:
+            print(
+                f"{finding.path}:{finding.line}:{finding.column}: {finding.severity}: "
+                f"[{finding.code}] {finding.message}"
+            )
+            if finding.fix_hint:
+                print(f"    fix: {finding.fix_hint}")
+        if findings:
+            print(f"mdux-governed-lint: {len(findings)} finding(s) in {len(sources)} file(s)")
+        else:
+            print(f"mdux-governed-lint: OK ({len(sources)} files checked, 0 findings)")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/governed-lint/test_mdux_governed_lint.py
+++ b/tools/governed-lint/test_mdux_governed_lint.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Unit tests for mdux-governed-lint.
+
+Run with `python3 -m unittest discover -s tools/governed-lint -p "test_*.py"`, the same way
+tools/docs-lint and tools/evidence-lint are run in CI.
+
+The tests that matter most here are the *negative* ones - the cases where the lint must not fire.
+A source lint over a heavily-commented tree earns its keep by being quiet about prose, and the
+governed tree discusses every construct this file bans. A lint that reports those is a lint an
+author learns to route around by rewording documentation, which is worse than no lint at all.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import mdux_governed_lint as lint
+
+
+def findings_for(source: str) -> list[lint.Finding]:
+    """Runs the rules over a source string, without touching the filesystem."""
+    findings: list[lint.Finding] = []
+    code_only = lint.strip_comments_and_literals(source)
+    original_lines = source.splitlines()
+
+    line_starts = [0]
+    for index, character in enumerate(code_only):
+        if character == "\n":
+            line_starts.append(index + 1)
+
+    for rule in lint.RULES:
+        for match in rule.pattern.finditer(code_only):
+            line = sum(1 for start in line_starts if start <= match.start())
+            original = original_lines[line - 1] if line <= len(original_lines) else ""
+            if original.rstrip().endswith(lint.SUPPRESS_MARKER):
+                continue
+            findings.append(
+                lint.Finding(
+                    path="<test>",
+                    line=line,
+                    code=rule.code,
+                    severity="error",
+                    message=rule.message,
+                )
+            )
+    return findings
+
+
+def codes_for(source: str) -> list[str]:
+    return sorted(f.code for f in findings_for(source))
+
+
+class StripCommentsAndLiterals(unittest.TestCase):
+    def test_preserves_line_numbers(self):
+        source = 'int a;\n// throw\nint b;\n"throw"\nint c;\n'
+        stripped = lint.strip_comments_and_literals(source)
+        self.assertEqual(source.count("\n"), stripped.count("\n"))
+
+    def test_preserves_offsets(self):
+        source = 'x = "abc"; y = 1;\n'
+        stripped = lint.strip_comments_and_literals(source)
+        self.assertEqual(len(source), len(stripped))
+        self.assertEqual(stripped.index("y"), source.index("y"))
+
+    def test_blanks_line_comment(self):
+        self.assertNotIn("throw", lint.strip_comments_and_literals("int a; // throw here\n"))
+
+    def test_blanks_block_comment_spanning_lines(self):
+        source = "/*\n * throw\n */\nint a;\n"
+        stripped = lint.strip_comments_and_literals(source)
+        self.assertNotIn("throw", stripped)
+        self.assertIn("int a;", stripped)
+
+    def test_blanks_string_literal(self):
+        self.assertNotIn("throw", lint.strip_comments_and_literals('auto s = "throw";\n'))
+
+    def test_blanks_raw_string_literal(self):
+        source = 'auto s = R"json({"throw": 1})json";\n'
+        self.assertNotIn("throw", lint.strip_comments_and_literals(source))
+
+    def test_keeps_code_outside_literals(self):
+        self.assertIn("throw", lint.strip_comments_and_literals('throw Err{"msg"};\n'))
+
+    def test_escaped_quote_does_not_end_the_literal(self):
+        # The literal runs to the *second* unescaped quote; `throw` is inside it throughout.
+        source = 'auto s = "a\\" throw b";\nint after;\n'
+        stripped = lint.strip_comments_and_literals(source)
+        self.assertNotIn("throw", stripped)
+        self.assertIn("int after;", stripped)
+
+
+class Rules(unittest.TestCase):
+    def test_throw(self):
+        self.assertEqual(codes_for("throw Error{};\n"), ["GOV001"])
+
+    def test_try_and_catch(self):
+        self.assertEqual(codes_for("try { f(); } catch (...) {}\n"), ["GOV002", "GOV002"])
+
+    def test_value_accessor(self):
+        self.assertEqual(codes_for("auto x = result.value();\n"), ["GOV003"])
+
+    def test_raw_allocation(self):
+        self.assertEqual(codes_for("auto* p = new Widget{};\n"), ["GOV004"])
+        self.assertEqual(codes_for("delete p;\n"), ["GOV004"])
+        self.assertEqual(codes_for("void* p = malloc(4);\n"), ["GOV004"])
+
+    def test_array_delete_spellings(self):
+        """`delete[] p` slipped through until review: `\\bdelete\\s` needs trailing whitespace."""
+        self.assertEqual(codes_for("delete[] p;\n"), ["GOV004"])
+        self.assertEqual(codes_for("delete [] p;\n"), ["GOV004"])
+        self.assertEqual(codes_for("auto* p = new int[4];\n"), ["GOV004"])
+
+    def test_c_formatting_and_system(self):
+        self.assertEqual(codes_for('std::snprintf(b, n, "x");\n'), ["GOV005"])
+        self.assertEqual(codes_for('snprintf(b, n, "x");\n'), ["GOV005"])
+        self.assertEqual(codes_for('system("rm -rf /");\n'), ["GOV005"])
+        self.assertEqual(codes_for("getenv(\"HOME\");\n"), ["GOV005"])
+
+    def test_filesystem_and_console(self):
+        self.assertEqual(codes_for("std::filesystem::path p;\n"), ["GOV005"])
+        self.assertEqual(codes_for("std::cout << x;\n"), ["GOV005"])
+
+    def test_clock_and_randomness(self):
+        self.assertEqual(codes_for("auto t = std::chrono::system_clock::now();\n"), ["GOV006"])
+        self.assertEqual(codes_for("std::random_device rd;\n"), ["GOV006"])
+
+    def test_unsafe_casts(self):
+        self.assertEqual(codes_for("auto* p = reinterpret_cast<int*>(q);\n"), ["GOV007"])
+        self.assertEqual(codes_for("auto* p = const_cast<int*>(q);\n"), ["GOV007"])
+
+    def test_fma(self):
+        self.assertEqual(codes_for("acc = std::fma(a, b, acc);\n"), ["GOV008"])
+
+    def test_banned_platform_headers(self):
+        self.assertEqual(codes_for("#include <vulkan/vulkan.h>\n"), ["GOV009"])
+        self.assertEqual(codes_for("#include <GLFW/glfw3.h>\n"), ["GOV009"])
+        self.assertEqual(codes_for("#include <windows.h>\n"), ["GOV009"])
+        self.assertEqual(codes_for("#include <sys/mman.h>\n"), ["GOV009"])
+        # Spacing variants a real file might use.
+        self.assertEqual(codes_for("#  include  < vulkan/vulkan.h >\n"), ["GOV009"])
+
+    def test_permitted_std_headers(self):
+        # src/draw/Draw.cppm:39 does exactly this, in a global module fragment.
+        self.assertEqual(codes_for("#include <cstddef>\n"), [])
+        self.assertEqual(codes_for("#include <stdexcept>\n"), [])
+
+    def test_suppression_marker(self):
+        source = "auto* p = reinterpret_cast<int*>(q);  // mdux-governed-lint:allow\n"
+        self.assertEqual(codes_for(source), [])
+
+
+class NotFindings(unittest.TestCase):
+    """Constructs that must stay quiet. Each quotes a real line from the governed tree.
+
+    The `/**` and `*/` around the block-comment cases are not decoration. A comment *interior*
+    passed on its own is, correctly, code - which is what these fixtures asserted on the first
+    attempt, and they failed for exactly that reason. The delimiters are what makes the fixture
+    the thing it claims to quote.
+    """
+
+    def test_prose_about_throwing(self):
+        # include/mdux/ml/Runtime.cppm:46
+        source = "/**\n * throw away exactly the information the incident report needs\n */\n"
+        self.assertEqual(codes_for(source), [])
+
+    def test_prose_about_fma(self):
+        # include/mdux/ml/Kernels.cppm:28
+        source = (
+            "/**\n"
+            " * - **Never `std::fma`.** It rounds once where the scalar sequence rounds twice.\n"
+            " */\n"
+        )
+        self.assertEqual(codes_for(source), [])
+
+    def test_prose_about_a_new_command(self):
+        # src/draw/Draw.cpp:168
+        source = "    // A new command is needed when nothing has been recorded yet\n"
+        self.assertEqual(codes_for(source), [])
+
+    def test_prose_about_catching(self):
+        # include/mdux/text/Draw.cppm:54
+        source = "/**\n * is not an error the type system can catch, but\n */\n"
+        self.assertEqual(codes_for(source), [])
+
+    def test_has_value_is_not_value(self):
+        self.assertEqual(codes_for("if (result.has_value()) { }\n"), [])
+
+    def test_identifier_containing_new(self):
+        self.assertEqual(codes_for("auto renewed = compute();\n"), [])
+
+    def test_string_mentioning_a_banned_construct(self):
+        self.assertEqual(codes_for('report("cannot throw here");\n'), [])
+
+
+class GovernedSourceList(unittest.TestCase):
+    def test_parses_the_real_cmakelists(self):
+        root = lint.find_repository_root()
+        sources = lint.governed_sources(root)
+        self.assertTrue(sources)
+        for path in sources:
+            self.assertTrue(path.is_file(), f"{path} does not exist")
+
+    def test_excludes_the_adapter_target(self):
+        """The block scan must stop at MduXCore's closing paren.
+
+        It did not, in the first version of this file: the scan started one character past the
+        opening paren, so depth never returned to zero and the "block" ran to end of file,
+        swallowing MduX's source list. The adapter is permitted to throw, so the lint reported
+        every one of DeviceObjectManager.cpp's throws as a governed violation.
+        """
+        root = lint.find_repository_root()
+        names = {str(p.relative_to(root)) for p in lint.governed_sources(root)}
+        self.assertNotIn("src/vulkansc/DeviceObjectManager.cpp", names)
+        self.assertNotIn("src/render/Offscreen.cpp", names)
+        self.assertIn("src/ml/Runtime.cpp", names)
+
+    def test_excludes_generated_sources(self):
+        """#116 requires that generated shader C arrays are not scanned as governed source.
+
+        They are emitted into the build tree, so nothing under the repository's source list can
+        name one - this asserts that property rather than trusting it.
+        """
+        root = lint.find_repository_root()
+        for path in lint.governed_sources(root):
+            self.assertNotIn("mdux_generated", str(path))
+
+    def test_display_path_handles_a_file_outside_the_repository(self):
+        """The documented [paths...] interface must not traceback.
+
+        `Path.relative_to` raises for anything outside the root, which crashed the tool for any
+        file elsewhere on the filesystem - reported in review and reproduced with a file under
+        /tmp. Editor integrations are the reason that interface exists, and they pass absolute
+        paths.
+        """
+        root = lint.find_repository_root()
+        outside = Path("/tmp/definitely-not-in-the-repo.cpp")
+        self.assertIsInstance(lint.display_path(outside, root), str)
+
+    def test_check_file_reports_rather_than_crashes_outside_the_repository(self):
+        import tempfile
+
+        root = lint.find_repository_root()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Outside.cpp"
+            path.write_text("void f() { throw 1; }\n", encoding="utf-8")
+            findings: list[lint.Finding] = []
+            lint.check_file(path, root, findings)
+            self.assertEqual(["GOV001"], [f.code for f in findings])
+
+    def test_rejects_a_cmakelists_without_the_block(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "CMakeLists.txt").write_text("project(Nothing)\n", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                lint.governed_sources(Path(tmp))
+
+
+class TreeIsClean(unittest.TestCase):
+    def test_no_findings_on_the_governed_tree(self):
+        """The lint passes on `develop`. Kept as a test so a violation fails here too, not only
+        in the CI job - a contributor running the unit tests locally should see it."""
+        root = lint.find_repository_root()
+        findings: list[lint.Finding] = []
+        for source in lint.governed_sources(root):
+            lint.check_file(source, root, findings)
+        self.assertEqual(
+            [],
+            [f"{f.path}:{f.line}: [{f.code}] {f.message}" for f in findings],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/medui/Ast.cppm
+++ b/tools/medui/Ast.cppm
@@ -59,9 +59,10 @@ enum class ValueKind : std::uint8_t {
     Point,       ///< `1392px, 80px`
     String,      ///< `"REQ-NS-001"` - a literal, which most fields must not accept (#193)
     TextKey,     ///< `t("STR-KEY")`
+    ImageRef,    ///< `img("IMAGE-ID")`
     ColorToken,  ///< `Theme.Colors.ScoreDigits`, carried unresolved
     Identifier,  ///< `Vertical`, `sedation-index`
-    Number,      ///< a bare integer, e.g. `spacing: 8` without a unit
+    Number,      ///< a bare integer, e.g. `max_length: 16`
     List,        ///< `[Bounds, ColorHash]`
 };
 
@@ -80,7 +81,7 @@ struct Value {
 
     Size size{};                       ///< kind == Size
     Point point{};                     ///< kind == Point
-    std::string text;                  ///< String, TextKey, ColorToken (the token name), Identifier
+    std::string text;                  ///< String, TextKey, ImageRef, ColorToken, Identifier
     std::int64_t number{0};            ///< Number
     std::vector<std::shared_ptr<Value>> list;  ///< List
 };

--- a/tools/medui/Ast.cppm
+++ b/tools/medui/Ast.cppm
@@ -1,0 +1,122 @@
+/**
+ * @file Ast.cppm
+ * @brief The `.medui` abstract syntax tree.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Host-only, and deliberately *unresolved*. Component names, field names and theme tokens are all
+ * carried as the strings the author wrote, with their positions. Nothing here is checked against
+ * the component dictionary or the theme table.
+ *
+ * That is the boundary between this stage (#192) and the next (#193), and it is worth stating
+ * because the opposite arrangement is the tempting one. A parser that knew the dictionary could
+ * reject an unknown component at the point it reads the name, which reads like an improvement -
+ * until adding a component means touching the parser, and until a field's meaning depends on which
+ * component encloses it, at which point the parser is doing semantic analysis with a worse error
+ * vocabulary. Keeping names as names means #193 can be replaced without this file changing.
+ *
+ * What the parser *does* enforce is structure that no dictionary can express: nesting depth, the
+ * absence of control flow, and id uniqueness. Those are properties of the grammar rather than of
+ * any particular component, so they belong here (ADR-011 decision 5).
+ *
+ * Every node carries the line and column of the token that introduced it, so a diagnostic raised
+ * three stages later can still point at the source. Positions are cheap here and impossible to
+ * reconstruct later.
+ */
+module;
+
+export module mdux.tools.medui.ast;
+
+import std;
+
+export namespace mdux::tools::medui::ast {
+
+/// Where something was written. 1-based, matching the shared diagnostic envelope.
+struct Position {
+    std::size_t line{0};
+    std::size_t column{0};
+};
+
+/// A `Npx` length, or `Fill`.
+struct Size {
+    bool fill{false};
+    std::int64_t pixels{0};
+    Position position{};
+};
+
+/// `position: Xpx, Ypx` - out-of-flow placement at exact coordinates.
+struct Point {
+    std::int64_t x{0};
+    std::int64_t y{0};
+    Position position{};
+};
+
+/// What a field's value is. `Identifier` covers bare words such as `Vertical` or `Fill`; the
+/// parser does not know which are meaningful, only which are syntactically possible.
+enum class ValueKind : std::uint8_t {
+    Size,        ///< `512px` or `Fill`
+    Point,       ///< `1392px, 80px`
+    String,      ///< `"REQ-NS-001"` - a literal, which most fields must not accept (#193)
+    TextKey,     ///< `t("STR-KEY")`
+    ColorToken,  ///< `Theme.Colors.ScoreDigits`, carried unresolved
+    Identifier,  ///< `Vertical`, `sedation-index`
+    Number,      ///< a bare integer, e.g. `spacing: 8` without a unit
+    List,        ///< `[Bounds, ColorHash]`
+};
+
+struct Value;
+
+/// One `name: value;` inside a node or a layout block.
+struct Field {
+    std::string name;
+    Position namePosition{};
+    std::shared_ptr<Value> value;  ///< shared_ptr because Value is incomplete here and lists nest
+};
+
+struct Value {
+    ValueKind kind{ValueKind::Identifier};
+    Position position{};
+
+    Size size{};                       ///< kind == Size
+    Point point{};                     ///< kind == Point
+    std::string text;                  ///< String, TextKey, ColorToken (the token name), Identifier
+    std::int64_t number{0};            ///< Number
+    std::vector<std::shared_ptr<Value>> list;  ///< List
+};
+
+/// `@safety_critical(cv_check: [Bounds, ColorHash])`, carried unresolved.
+struct Annotation {
+    std::string name;
+    Position position{};
+    std::vector<Field> arguments;
+};
+
+/**
+ * @brief A component instance, or a `Row`.
+ *
+ * `children` is non-empty only for `Row`. The parser rejects a `Row` inside a `Row` (`MDX-E015`),
+ * so this is one level deep by construction rather than by convention - #194's solver relies on
+ * that, and ADR-011 decision 5 records why the restriction is a solver argument rather than a
+ * budget one.
+ */
+struct Node {
+    std::string component;   ///< as written; not checked against the dictionary here
+    Position position{};
+    std::vector<Annotation> annotations;
+    std::vector<Field> fields;
+    std::vector<Node> children;
+};
+
+/// One `Screen <Name> { ... }`. A source declares exactly one.
+struct Screen {
+    std::string name;
+    Position position{};
+    std::vector<Field> layout;   ///< the `layout:` block's fields, e.g. spacing and padding
+    std::string layoutKind;      ///< `Vertical`; empty when no `layout:` was declared
+    Position layoutPosition{};
+    std::optional<Point> surface;
+    std::vector<Node> nodes;
+};
+
+}  // namespace mdux::tools::medui::ast

--- a/tools/medui/Ast.cppm
+++ b/tools/medui/Ast.cppm
@@ -95,7 +95,7 @@ struct Annotation {
 /**
  * @brief A component instance, or a `Row`.
  *
- * `children` is non-empty only for `Row`. The parser rejects a `Row` inside a `Row` (`MDX-E015`),
+ * `children` is non-empty only for `Row`. The parser rejects a `Row` inside a `Row` (`MEDUI-E015`),
  * so this is one level deep by construction rather than by convention - #194's solver relies on
  * that, and ADR-011 decision 5 records why the restriction is a solver argument rather than a
  * budget one.

--- a/tools/medui/Check.cpp
+++ b/tools/medui/Check.cpp
@@ -1,0 +1,121 @@
+/**
+ * @file Check.cpp
+ * @brief Implementation of the single-file checker.
+ */
+
+module;
+
+module mdux.tools.medui.check;
+
+import std;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+namespace ms = mdux::medui;
+
+/// Codes for what a run could not cover. Local to this tool, in the sense `SHE0NN` and `SCP0NN` are:
+/// the `MEDUI-E0NN` registry is the shared contract for what a screen may *say*, and "this run did
+/// not check X" is a statement about the run rather than about the screen.
+constexpr std::string_view textNotChecked   = "MDC001";
+constexpr std::string_view layoutNotChecked = "MDC002";
+
+void note(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::string_view code, std::string message, std::string fixHint) {
+    cli::Diagnostic entry;
+    entry.file     = std::move(file);
+    entry.code     = std::string{code};
+    entry.severity = cli::Severity::Note;
+    entry.message  = std::move(message);
+    entry.fixHint  = std::move(fixHint);
+    diagnostics.push_back(std::move(entry));
+}
+
+}  // namespace
+
+CheckResult checkScreen(std::string_view source, std::string file) {
+    CheckResult result;
+
+    // 1. Parse. Everything after this reads an AST, so a file that does not parse stops here rather
+    //    than producing a second opinion about a screen nobody could read.
+    ParseResult parsed = parse(source, file);
+    if (!parsed.diagnostics.empty() || !parsed.screen.has_value()) {
+        result.diagnostics = std::move(parsed.diagnostics);
+        if (result.diagnostics.empty()) {
+            result.diagnostics.push_back(diagnose(Code::SourceUnreadable, file, 0, 0, "the source produced no screen and no diagnostic"));
+        }
+        return result;
+    }
+    const ast::Screen& screen = *parsed.screen;
+
+    // 2. Semantic analysis, against the governed theme table and no approved locale. `analyze()`
+    //    runs the key checks unless a caller asks for `LocalePolicy::Skipped`, which is what the
+    //    call below does - an empty package list on its own still means every key is absent. See the
+    //    note recorded further down for what asking for that leaves uncovered.
+    std::vector<std::string_view> themeTokens;
+    themeTokens.reserve(ms::themeColors.size());
+    for (const ms::ThemeColor& colour : ms::themeColors) {
+        themeTokens.push_back(colour.token);
+    }
+
+    // The one caller that asks for the partial mode, and the reason the mode is a request rather
+    // than something inferred from an empty package list: this file may belong to no recipe at all.
+    const SemanticResult semantic = analyze(screen, file, {.themeTokens = themeTokens, .textPackages = {}, .locales = LocalePolicy::Skipped});
+    if (!semantic.ok()) {
+        result.diagnostics = semantic.diagnostics;
+        return result;
+    }
+
+    // 3. Annotations. Before layout, as the compiler runs them: the shared conformance suite pins
+    //    MEDUI-E070 on a screen with no `surface:`, which the solver cannot resolve at all.
+    const SafetyResult safety = validateSafetyAnnotations(screen, file);
+    if (!safety.ok()) {
+        result.diagnostics = safety.diagnostics;
+        return result;
+    }
+
+    // 4. Layout and goldens, when the file says what surface it is drawn for. A screen without one
+    //    is not malformed - the compiler takes the surface from the recipe - so this is a gap in
+    //    what can be checked here rather than a finding about the file.
+    if (screen.surface.has_value()) {
+        const LayoutResult layout = resolveLayout(screen, file, {.surfaceWidth = screen.surface->x, .surfaceHeight = screen.surface->y});
+        if (!layout.ok()) {
+            result.diagnostics = layout.diagnostics;
+            return result;
+        }
+        result.layoutChecked = true;
+
+        // Called for its own sake: it throws if the annotation gate was bypassed, and running it
+        // here is what makes a golden that cannot be derived show up in a check rather than in a
+        // compile three commits later.
+        static_cast<void>(collectGoldens(layout));
+    } else {
+        note(result.diagnostics,
+             file,
+             layoutNotChecked,
+             "this screen declares no `surface:`, so layout, overflow and golden bounds were not checked",
+             "add `surface: <width>px, <height>px;` to check it here, or compile it through a recipe that declares one");
+    }
+
+    // 5. What a file on its own cannot answer. Reported every time, including on a screen that draws
+    //    no text: "there was nothing to check" and "the check did not run" are different statements,
+    //    and only the second one is true here.
+    note(result.diagnostics,
+         file,
+         textNotChecked,
+         "text keys and text budgets were not checked: a single file names no approved locale",
+         "compile through a recipe with a [text] table to check keys against every approved locale and "
+         "boxes against the widest translation");
+
+    return result;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Check.cppm
+++ b/tools/medui/Check.cppm
@@ -1,0 +1,84 @@
+/**
+ * @file Check.cppm
+ * @brief Validating one `.medui` file on its own, and saying what that cannot cover.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The surface an author and an agent both reach for first: point it at a file, read the
+ * diagnostics, fix them. `mdux-meduic` compiles a screen from a recipe and writes artifacts; this
+ * runs the same stages over a file that may not belong to a recipe at all, and writes nothing.
+ *
+ * ## What a single file cannot answer, and why that is said out loud
+ *
+ * Two stages need inputs a file does not carry.
+ *
+ * **Text keys** are checked against the approved locales a recipe names. With no recipe there are no
+ * approved locales, and a checker that ran the check anyway would report every `t("STR-KEY")` as
+ * absent from every locale - which is a vacuous truth dressed as a finding, and the fastest way to
+ * teach an author that this tool's output is noise. So the check does not run, and the run says so.
+ *
+ * **Text budgets** need the font package those locales were baked into. Same reasoning, same
+ * treatment.
+ *
+ * A third case is the file's own doing rather than the recipe's: a screen with no `surface:` cannot
+ * be resolved to rectangles at all, so layout, overflow and golden bounds go unchecked. That is
+ * reported the same way.
+ *
+ * Each of these is a `Severity::Note` carrying an `MDC0NN` code, travelling in the same envelope as
+ * the findings. Two consequences worth having: a clean run is visibly *partial* rather than
+ * silently so, and an agent can key off the code to decide whether to re-run through the compiler
+ * with a recipe.
+ *
+ * ## What it does check
+ *
+ * Everything decidable from the file plus the governed tables: the grammar (#192), the component
+ * dictionary, field value domains, hardcoded strings and theme tokens (#193), the `@safety_critical`
+ * annotation rules (#196), and - when the file declares a surface - bounded layout with its overflow
+ * and containment rules (#194) and the golden set that follows from it (#196).
+ */
+module;
+
+export module mdux.tools.medui.check;
+
+import std;
+import mdux.tools.cli;
+
+export namespace mdux::tools::medui {
+
+/// The tool name that appears in every diagnostic envelope this produces.
+inline constexpr std::string_view checkToolName = "mdux-medui-check";
+
+/**
+ * @brief One file's findings, and which checks were able to run.
+ *
+ * The booleans are not a substitute for the notes - both are produced, because a human reads the
+ * notes and a caller reads the flags. They exist so a test can assert that a check was *skipped*
+ * rather than merely that it reported nothing, which is the distinction that would otherwise be
+ * invisible.
+ */
+struct CheckResult {
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+    bool                                      layoutChecked{false};  ///< the file declared a surface
+    bool                                      textChecked{false};    ///< approved locales were available
+
+    /// Whether anything of error severity was reported. Notes and warnings do not fail a check.
+    [[nodiscard]] bool ok() const noexcept {
+        return std::ranges::none_of(diagnostics, [](const mdux::tools::cli::Diagnostic& diagnostic) {
+            return diagnostic.severity == mdux::tools::cli::Severity::Error;
+        });
+    }
+};
+
+/**
+ * @brief Runs every stage a single file admits, in the order the compiler runs them.
+ *
+ * @param source the file's text
+ * @param file   the path to name in diagnostics
+ *
+ * Stops at the first stage that reports an error, for the reason the compiler driver stops: a later
+ * stage reading a screen an earlier one rejected reports consequences rather than causes.
+ */
+[[nodiscard]] CheckResult checkScreen(std::string_view source, std::string file);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -171,6 +171,10 @@ evidence::json::Value Recipe::toOptions() const {
     Value options = Value::emptyObject();
     put(options, "budget", std::move(budgetValue));
     put(options, "dynamicText", Value::array(std::move(dynamic)));
+    // The id belongs in the report for the reason every other resolved knob does: it names the
+    // directory the artifact lives in, and a report that did not record it would describe a compile
+    // without saying which screen it produced.
+    put(options, "id", Value::string(id));
     put(options, "fontPackage", Value::string(fontPackage));
     put(options, "source", Value::string(source));
     put(options, "surfaceHeight", Value::integer(surfaceHeight));

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -1,0 +1,792 @@
+/**
+ * @file Compile.cpp
+ * @brief Implementation of the `.medui` compiler driver.
+ */
+
+module;
+
+module mdux.tools.medui.compile;
+
+import std;
+import mdux.draw;
+import mdux.evidence.digest;
+import mdux.evidence.json;
+import mdux.evidence.report;
+import mdux.font.schema;
+import mdux.medui.schema;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.package;
+import mdux.tools.medui.parser;
+import mdux.tools.medui.semantic;
+import mdux.tools.medui.textbudget;
+import mdux.tools.toml;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+namespace ms = mdux::medui;
+
+void report(std::vector<cli::Diagnostic>& diagnostics, Code code, std::string file, std::size_t line, std::string message, std::string fixHint = {}) {
+    diagnostics.push_back(diagnose(code, std::move(file), line, 0, std::move(message), std::move(fixHint)));
+}
+
+/// Whether `id` is the lowercase slug an artifact directory, an evidence test name and a generated
+/// C++ identifier are all derived from. `mdux_bake_artifact()` enforces the same shape at configure
+/// time; this is the half that also holds when the compiler is run directly.
+[[nodiscard]] bool isArtifactSlug(std::string_view id) noexcept {
+    const auto lower = [](char c) {
+        return c >= 'a' && c <= 'z';
+    };
+    const auto digit = [](char c) {
+        return c >= '0' && c <= '9';
+    };
+    if (id.empty() || (!lower(id.front()) && !digit(id.front()))) {
+        return false;
+    }
+    return std::ranges::all_of(id, [&](char c) {
+        return lower(c) || digit(c) || c == '-';
+    });
+}
+
+/// A screen name and an artifact slug reduced to the one word they must both spell: lowercase, with
+/// every separator removed.
+///
+/// A weaker check than deriving one from the other, and deliberately so. A slug cannot be derived
+/// injectively from a screen name - a name may carry `-` and `_`, and lowercasing is not injective
+/// across case - which is why ADR-012 has the recipe *record* the mapping rather than compute it.
+/// What must not happen is the two drifting apart: `generated/screen/foo/` holding a package that
+/// calls itself `bar`. Comparing the reduced forms catches exactly that, and leaves an author free
+/// to hyphenate a slug as they like.
+[[nodiscard]] std::string reduced(std::string_view text) {
+    std::string out;
+    out.reserve(text.size());
+    for (const char c : text) {
+        if (c == '-' || c == '_') {
+            continue;
+        }
+        out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    }
+    return out;
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string& text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] evidence::FileRecord fileRecord(std::string path, std::span<const std::byte> bytes) {
+    return evidence::FileRecord{.path = std::move(path), .sha256 = evidence::sha256(bytes)};
+}
+
+/// A path as a report and a diagnostic spell it: forward slashes on every platform, because
+/// `BakeReport::validate()` rejects a backslash and would be right to.
+///
+/// Named for the spelling rather than for the file, because `verify()` takes a `reportPath`
+/// parameter and a helper sharing that name would be shadowed at exactly one call site.
+[[nodiscard]] std::string displayPath(const std::filesystem::path& path) {
+    return path.generic_string();
+}
+
+[[nodiscard]] std::string_view textOf(std::span<const std::byte> bytes) noexcept {
+    return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+/// Reads a committed package beside the recipe, as text, reporting the path that failed.
+[[nodiscard]] std::optional<std::vector<std::byte>>
+readInput(const std::filesystem::path& root, const std::string& relative, std::vector<cli::Diagnostic>& diagnostics) {
+    std::optional<std::vector<std::byte>> bytes = readFile(root / relative);
+    if (!bytes.has_value()) {
+        report(diagnostics, Code::SourceUnreadable, relative, 0, "the file named by the recipe could not be read");
+    }
+    return bytes;
+}
+
+}  // namespace
+
+std::optional<std::vector<std::byte>> readFile(const std::filesystem::path& path) {
+    std::ifstream file{path, std::ios::binary | std::ios::ate};
+    if (!file) {
+        return std::nullopt;
+    }
+    // tellg() answers -1 on a stream error rather than throwing, and sizing the vector before the
+    // check would turn that into a request for 2^64-1 bytes.
+    const std::streamoff size = file.tellg();
+    if (size < 0 || !file.seekg(0)) {
+        return std::nullopt;
+    }
+    std::vector<std::byte> bytes(static_cast<std::size_t>(size));
+    if (size > 0) {
+        file.read(reinterpret_cast<char*>(bytes.data()), size);
+        if (!file) {
+            return std::nullopt;
+        }
+    }
+    return bytes;
+}
+
+evidence::json::Value Recipe::toOptions() const {
+    using evidence::json::Value;
+
+    const auto put = [](Value& object, std::string key, Value value) {
+        if (const auto inserted = object.set(std::move(key), std::move(value)); !inserted.has_value()) {
+            throw std::logic_error("canonical JSON refused a recipe option");
+        }
+    };
+
+    Value budgetValue = Value::emptyObject();
+    put(budgetValue, "maxCommands", Value::unsignedInteger(budget.maxCommands));
+    put(budgetValue, "maxIndices", Value::unsignedInteger(budget.maxIndices));
+    put(budgetValue, "maxVertices", Value::unsignedInteger(budget.maxVertices));
+
+    std::vector<Value> packages;
+    packages.reserve(textPackages.size());
+    for (const std::string& package : textPackages) {
+        packages.push_back(Value::string(package));
+    }
+
+    // The table as resolved, so a report shows what a compile was actually checked against rather
+    // than the name of a table whose contents nobody can see.
+    std::vector<Value> dynamic;
+    dynamic.reserve(dynamicText.size());
+    for (const DynamicText& rule : dynamicText) {
+        std::vector<Value> ranges;
+        ranges.reserve(rule.produces.size());
+        for (const mdux::font::CharsetRange& range : rule.produces) {
+            Value entry = Value::emptyObject();
+            put(entry, "first", Value::unsignedInteger(static_cast<std::uint64_t>(range.first)));
+            put(entry, "last", Value::unsignedInteger(static_cast<std::uint64_t>(range.last)));
+            ranges.push_back(std::move(entry));
+        }
+        Value named = Value::emptyObject();
+        put(named, "name", Value::string(rule.name));
+        put(named, "produces", Value::array(std::move(ranges)));
+        dynamic.push_back(std::move(named));
+    }
+
+    Value options = Value::emptyObject();
+    put(options, "budget", std::move(budgetValue));
+    put(options, "dynamicText", Value::array(std::move(dynamic)));
+    put(options, "fontPackage", Value::string(fontPackage));
+    put(options, "source", Value::string(source));
+    put(options, "surfaceHeight", Value::integer(surfaceHeight));
+    put(options, "surfaceWidth", Value::integer(surfaceWidth));
+    put(options, "textPackages", Value::array(std::move(packages)));
+    return options;
+}
+
+std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipePath, std::vector<cli::Diagnostic>& diagnostics) {
+    toml::Document document{};
+    try {
+        document = toml::parse(text);
+    } catch (const toml::TomlError& error) {
+        report(diagnostics,
+               Code::RecipeUnparsed,
+               std::string{recipePath},
+               error.line(),
+               error.what(),
+               "see recipes/screen/ for the accepted shape; there is no [[table]] support");
+        return std::nullopt;
+    }
+
+    Recipe recipe;
+
+    const toml::Table* package = document.table("package");
+    if (package == nullptr) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "recipe has no [package] table",
+               "add a [package] table with 'id' and 'source' keys");
+        return std::nullopt;
+    }
+
+    // Every knob is required, defaults included - which is to say there are none. MEDUI-E002 states
+    // the reason: a defaulted knob does not appear in report.json, so changing the default later
+    // would leave every report looking unchanged, which ADR-007 forbids.
+    try {
+        recipe.id            = package->require("id").asString();
+        recipe.source        = package->require("source").asString();
+        recipe.surfaceWidth  = package->require("surfaceWidth").asInteger();
+        recipe.surfaceHeight = package->require("surfaceHeight").asInteger();
+    } catch (const toml::TomlError& error) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               error.line(),
+               error.what(),
+               "[package] needs 'id', 'source', 'surfaceWidth' and 'surfaceHeight'");
+        return std::nullopt;
+    }
+
+    // The slug shape ADR-012 fixes, checked here rather than left to `mdux_bake_artifact()`'s
+    // FATAL_ERROR: the id names the directory, the evidence test and the emitted C++ identifier, and
+    // a compile run outside CMake would otherwise write `generated/screen/NeuroSense500/`, which no
+    // registration could ever match.
+    if (!isArtifactSlug(recipe.id)) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               std::format("the id '{}' is not a lowercase slug", recipe.id),
+               "an artifact id matches ^[a-z0-9][a-z0-9-]*$ - it names a directory, a test and a C++ identifier");
+        return std::nullopt;
+    }
+
+    const toml::Table* budget = document.table("budget");
+    if (budget == nullptr) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "recipe has no [budget] table",
+               "add a [budget] table with 'maxVertices', 'maxIndices' and 'maxCommands'. The runtime "
+               "fails closed against these, so a product declares them rather than inheriting them");
+        return std::nullopt;
+    }
+
+    try {
+        const std::int64_t vertices   = budget->require("maxVertices").asInteger();
+        const std::int64_t indices    = budget->require("maxIndices").asInteger();
+        const std::int64_t commands   = budget->require("maxCommands").asInteger();
+        const std::size_t  budgetLine = budget->require("maxVertices").line();
+        for (const std::int64_t value : {vertices, indices, commands}) {
+            if (value < 0 || value > std::numeric_limits<std::uint32_t>::max()) {
+                report(diagnostics,
+                       Code::RecipeMissingMember,
+                       std::string{recipePath},
+                       budget->require("maxVertices").line(),
+                       std::format("a draw budget entry is {}, which is outside the range a budget holds", value));
+                return std::nullopt;
+            }
+        }
+        // The 16-bit index bound, refused while the recipe can still be told about it. Left to
+        // `ScreenPackage::validate()` it becomes `BudgetExceedsIndexWidth` reported to a caller that
+        // treats a schema failure as a compiler bug and throws - so an author's extra digit would
+        // terminate the tool instead of producing a diagnostic.
+        if (vertices > mdux::draw::maxIndexableVertices) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   budgetLine,
+                   std::format("maxVertices is {}, and a 16-bit index cannot address more than {}", vertices, mdux::draw::maxIndexableVertices));
+            return std::nullopt;
+        }
+        recipe.budget = mdux::draw::DrawBudget{.maxVertices = static_cast<std::uint32_t>(vertices),
+                                               .maxIndices  = static_cast<std::uint32_t>(indices),
+                                               .maxCommands = static_cast<std::uint32_t>(commands)};
+    } catch (const toml::TomlError& error) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               error.line(),
+               error.what(),
+               "[budget] needs 'maxVertices', 'maxIndices' and 'maxCommands'");
+        return std::nullopt;
+    }
+
+    // The text half is optional as a *table*, and the compile refuses later if the screen turns out
+    // to need it - see run(). A screen that draws no text has no font to name, and requiring one
+    // would mean inventing an approved locale set for a screen that has no text to approve.
+    if (const toml::Table* textTable = document.table("text"); textTable != nullptr) {
+        try {
+            recipe.fontPackage  = textTable->require("fontPackage").asString();
+            recipe.textPackages = textTable->require("packages").asStringArray();
+        } catch (const toml::TomlError& error) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   error.line(),
+                   error.what(),
+                   "[text] needs 'fontPackage' and a 'packages' array, one committed text package per approved locale");
+            return std::nullopt;
+        }
+    }
+
+    // The governed dynamic-text table. Optional as a table for the same reason [text] is: a screen
+    // with no `format:` and no `charset:` has no name to resolve, and the budget stage refuses an
+    // unknown name rather than accepting one, so an absent table is fail-closed.
+    if (const toml::Table* dynamicTable = document.table("dynamicText"); dynamicTable != nullptr) {
+        std::vector<std::string>  names;
+        std::vector<std::int64_t> firstPoints;
+        std::vector<std::int64_t> lastPoints;
+        std::size_t               namesLine = 0;
+        try {
+            const toml::Value& namesValue = dynamicTable->require("names");
+            namesLine                     = namesValue.line();
+            names                         = namesValue.asStringArray();
+            firstPoints                   = dynamicTable->require("firstCodePoints").asIntegerArray();
+            lastPoints                    = dynamicTable->require("lastCodePoints").asIntegerArray();
+        } catch (const toml::TomlError& error) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   error.line(),
+                   error.what(),
+                   "[dynamicText] needs parallel 'names', 'firstCodePoints' and 'lastCodePoints' arrays");
+            return std::nullopt;
+        }
+
+        if (names.size() != firstPoints.size() || names.size() != lastPoints.size()) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   namesLine,
+                   std::format("[dynamicText] names has {} entries, firstCodePoints {} and lastCodePoints {}",
+                               names.size(),
+                               firstPoints.size(),
+                               lastPoints.size()),
+                   "the arrays are positional: entry N of each describes rule N");
+            return std::nullopt;
+        }
+
+        for (std::size_t index = 0; index < names.size(); ++index) {
+            const std::int64_t first = firstPoints[index];
+            const std::int64_t last  = lastPoints[index];
+            // Bounded here rather than left to the walk: the budget stage refuses a range outside
+            // Unicode, but a recipe naming one should be told which entry it was rather than which
+            // glyph the walk stopped at.
+            if (first < 0 || last < 0 || first > 0x10FFFF || last > 0x10FFFF) {
+                report(diagnostics,
+                       Code::RecipeMissingMember,
+                       std::string{recipePath},
+                       namesLine,
+                       std::format("[dynamicText] entry '{}' names the range {}..{}, which is outside Unicode", names[index], first, last));
+                return std::nullopt;
+            }
+            // A descending range is refused rather than read as empty, and it is the one entry here
+            // that would be fail-open if it were wrong. The budget stage deliberately skips a range
+            // with `last < first` - what an author wrote is a name, and the shape of the table behind
+            // it is not theirs to fix - so an inverted range produces *no* charset check at all for a
+            // Clock or a TextInput using that rule, while this table is the governed upper bound on
+            // what the runtime can put on screen.
+            if (first > last) {
+                report(diagnostics,
+                       Code::RecipeMissingMember,
+                       std::string{recipePath},
+                       namesLine,
+                       std::format("[dynamicText] entry '{}' names the descending range {}..{}", names[index], first, last),
+                       "an inverted range checks nothing, so it is refused rather than read as empty");
+                return std::nullopt;
+            }
+            DynamicText rule;
+            rule.name = names[index];
+            rule.produces.push_back(mdux::font::CharsetRange{.first = static_cast<char32_t>(first), .last = static_cast<char32_t>(last)});
+            recipe.dynamicText.push_back(std::move(rule));
+        }
+    }
+
+    return recipe;
+}
+
+
+// ---------------------------------------------------------------------------
+// run(): every stage, in the one order this file fixes
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// One approved locale's committed package and the sidecar its runs address.
+struct LoadedLocale {
+    mdux::text::TextPackage package;
+    std::vector<std::byte>  sidecar;
+};
+
+/// Reads the font package the recipe names, or reports why it could not.
+[[nodiscard]] std::optional<mdux::font::FontPackage>
+loadFont(const Recipe& recipe, const std::filesystem::path& root, std::vector<evidence::FileRecord>& inputs, std::vector<cli::Diagnostic>& diagnostics) {
+    const std::optional<std::vector<std::byte>> bytes = readInput(root, recipe.fontPackage, diagnostics);
+    if (!bytes.has_value()) {
+        return std::nullopt;
+    }
+    inputs.push_back(fileRecord(recipe.fontPackage, *bytes));
+
+    auto package = mdux::font::FontPackage::parse(textOf(*bytes));
+    if (!package.has_value()) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               recipe.fontPackage,
+               0,
+               std::format("the font package is not valid: {}", mdux::font::describe(package.error())));
+        return std::nullopt;
+    }
+    return std::move(*package);
+}
+
+/// Reads every text package the recipe names, with the sidecar each one records.
+[[nodiscard]] std::optional<std::vector<LoadedLocale>>
+loadLocales(const Recipe& recipe, const std::filesystem::path& root, std::vector<evidence::FileRecord>& inputs, std::vector<cli::Diagnostic>& diagnostics) {
+    std::vector<LoadedLocale> locales;
+    locales.reserve(recipe.textPackages.size());
+
+    for (const std::string& relative : recipe.textPackages) {
+        const std::optional<std::vector<std::byte>> bytes = readInput(root, relative, diagnostics);
+        if (!bytes.has_value()) {
+            return std::nullopt;
+        }
+        inputs.push_back(fileRecord(relative, *bytes));
+
+        auto package = mdux::text::TextPackage::parse(textOf(*bytes));
+        if (!package.has_value()) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   relative,
+                   0,
+                   std::format("the text package is not valid: {}", mdux::text::describe(package.error())));
+            return std::nullopt;
+        }
+
+        // The sidecar sits beside the package, under the name the package itself records - the same
+        // arrangement every other artifact kind uses, so a caller never guesses a filename.
+        const std::filesystem::path                 sidecarRelative = std::filesystem::path{relative}.parent_path() / package->sidecarPath;
+        const std::optional<std::vector<std::byte>> sidecar         = readInput(root, sidecarRelative.generic_string(), diagnostics);
+        if (!sidecar.has_value()) {
+            return std::nullopt;
+        }
+        inputs.push_back(fileRecord(sidecarRelative.generic_string(), *sidecar));
+
+        locales.push_back(LoadedLocale{.package = std::move(*package), .sidecar = *sidecar});
+    }
+    return locales;
+}
+
+/**
+ * @brief The cross-package invariants `checkTextBudgets()` would otherwise throw over.
+ *
+ * Its contract is that `locales` is *exactly* the set the font approves - one entry per tag, none
+ * missing, none repeated, none outside it - and that every package addresses that font's atlas. Each
+ * of those is decided by paths an author typed into a recipe, so each is a diagnostic here rather
+ * than a `std::logic_error` from a library whose caller is supposed to be code.
+ *
+ * The omission is the dangerous one and the reason the library refuses it: a budget is a claim about
+ * the worst approved translation, so a compile checked against only the locale someone happened to
+ * list would certify a screen against a set nobody approved - and the missing German or Finnish
+ * string is exactly the one that overflows the box.
+ */
+[[nodiscard]] bool checkLocaleWiring(const mdux::font::FontPackage& font,
+                                     std::span<const LoadedLocale>  locales,
+                                     std::string_view               recipePath,
+                                     std::vector<cli::Diagnostic>&  diagnostics) {
+    if (locales.empty()) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "this screen draws text and the recipe lists no text package",
+               "[text] needs one committed package per locale the font approves");
+        return false;
+    }
+
+    std::vector<std::string_view> seen;
+    seen.reserve(locales.size());
+    for (const LoadedLocale& locale : locales) {
+        if (locale.package.atlasId != font.id) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   0,
+                   std::format("the text package for '{}' was baked against the font '{}', and the recipe names '{}'",
+                               locale.package.locale,
+                               locale.package.atlasId,
+                               font.id),
+                   "a package measured against one atlas cannot be checked against another");
+            return false;
+        }
+        if (std::ranges::find(seen, std::string_view{locale.package.locale}) != seen.end()) {
+            report(diagnostics, Code::RecipeMissingMember, std::string{recipePath}, 0, std::format("the locale '{}' is listed twice", locale.package.locale));
+            return false;
+        }
+        if (std::ranges::find(font.locales, locale.package.locale) == font.locales.end()) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   0,
+                   std::format("the locale '{}' is not one the font package approves", locale.package.locale));
+            return false;
+        }
+        seen.push_back(locale.package.locale);
+    }
+
+    for (const std::string& approved : font.locales) {
+        if (std::ranges::find(seen, std::string_view{approved}) == seen.end()) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   std::string{recipePath},
+                   0,
+                   std::format("the font approves '{}' and the recipe lists no text package for it", approved),
+                   "a budget checked against fewer locales than were approved is a claim nobody made");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+}  // namespace
+
+std::optional<CompileOutputs> run(const Recipe&                 recipe,
+                                  std::string_view              recipePath,
+                                  std::span<const std::byte>    recipeBytes,
+                                  const std::filesystem::path&  root,
+                                  std::vector<cli::Diagnostic>& diagnostics) {
+    std::vector<evidence::FileRecord> inputs;
+
+    const std::optional<std::vector<std::byte>> sourceBytes = readFile(root / recipe.source);
+    if (!sourceBytes.has_value()) {
+        report(diagnostics, Code::SourceUnreadable, recipe.source, 0, "the .medui source could not be read");
+        return std::nullopt;
+    }
+    inputs.push_back(fileRecord(recipe.source, *sourceBytes));
+
+    // 1. Parse. The lexer decides UTF-8 validity, so MEDUI-E004 comes from there rather than from a
+    //    second check here that could disagree with it.
+    ParseResult parsed = parse(textOf(*sourceBytes), recipe.source);
+    if (!parsed.diagnostics.empty() || !parsed.screen.has_value()) {
+        diagnostics.insert(diagnostics.end(), parsed.diagnostics.begin(), parsed.diagnostics.end());
+        // Guarded on the parser's own diagnostics, not on the caller's vector: `diagnostics` is an
+        // out-parameter a caller may hand over already populated, and then a parse that produced
+        // neither a screen nor a reason would have returned nullopt with nothing of its own to say.
+        if (parsed.diagnostics.empty()) {
+            report(diagnostics, Code::SourceUnreadable, recipe.source, 0, "the source produced no screen and no diagnostic");
+        }
+        return std::nullopt;
+    }
+    const ast::Screen& screen = *parsed.screen;
+
+    // The slug and the screen name have to be the same screen. Without this the registration can
+    // put outputs in `generated/screen/foo/` while the package inside calls itself `bar`, and every
+    // later consumer - the evidence test, the emitted identifier, a requirement trace - follows one
+    // of the two names with nothing to say the other exists.
+    if (reduced(recipe.id) != reduced(screen.name)) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               std::format("the recipe compiles 'Screen {}' as the artifact '{}', which is a different name", screen.name, recipe.id),
+               "the slug is the screen's name in lowercase; hyphenation is free, the word is not");
+        return std::nullopt;
+    }
+
+    // The recipe has to be complete for *this* screen. Asked of the budget stage's own module rather
+    // than answered here, so the two cannot disagree about what counts as text.
+    const bool measurable = needsTextBudget(screen);
+    if (measurable && recipe.fontPackage.empty()) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "this screen draws text, so the recipe needs a [text] table naming the font package and one text package per "
+               "approved locale",
+               "a screen that draws text and declares no approved locale would be certified against a set nobody approved");
+        return std::nullopt;
+    }
+
+    std::optional<mdux::font::FontPackage> font;
+    std::vector<LoadedLocale>              locales;
+    if (measurable) {
+        font = loadFont(recipe, root, inputs, diagnostics);
+        if (!font.has_value()) {
+            return std::nullopt;
+        }
+        std::optional<std::vector<LoadedLocale>> loaded = loadLocales(recipe, root, inputs, diagnostics);
+        if (!loaded.has_value()) {
+            return std::nullopt;
+        }
+        locales = std::move(*loaded);
+
+        // `checkTextBudgets()` classifies every one of these as a *caller wiring* error and throws
+        // `std::logic_error`, which is right for a library whose caller is code. Here the caller is
+        // a recipe an author wrote, so each one is diagnosed instead: a mistyped path or a forgotten
+        // locale must produce a report, not terminate the compiler.
+        if (!checkLocaleWiring(*font, locales, recipePath, diagnostics)) {
+            return std::nullopt;
+        }
+    }
+
+    std::vector<mdux::text::TextPackage> textPackages;
+    textPackages.reserve(locales.size());
+    for (const LoadedLocale& locale : locales) {
+        textPackages.push_back(locale.package);
+    }
+
+    // 2. Semantic analysis. The theme tokens are the governed table the schema publishes, not a
+    //    second list: `resolveColorToken()` on a device and this check on the host then agree by
+    //    construction rather than by review.
+    std::vector<std::string_view> themeTokens;
+    themeTokens.reserve(ms::themeColors.size());
+    for (const ms::ThemeColor& colour : ms::themeColors) {
+        themeTokens.push_back(colour.token);
+    }
+
+    const SemanticResult semantic = analyze(screen, recipe.source, {.themeTokens = themeTokens, .textPackages = textPackages});
+    if (!semantic.ok()) {
+        diagnostics.insert(diagnostics.end(), semantic.diagnostics.begin(), semantic.diagnostics.end());
+        return std::nullopt;
+    }
+
+    // 3. Annotations, before layout: the shared conformance suite pins MEDUI-E070 on a screen with
+    //    no `surface:`, which the solver cannot resolve at all.
+    const SafetyResult safety = validateSafetyAnnotations(screen, recipe.source);
+    if (!safety.ok()) {
+        diagnostics.insert(diagnostics.end(), safety.diagnostics.begin(), safety.diagnostics.end());
+        return std::nullopt;
+    }
+
+    // 4. Layout, against the surface the recipe declares. The solver checks the source's own
+    //    `surface:` against it, so a screen drawn for another panel is a diagnostic rather than a
+    //    silently rescaled frame.
+    const LayoutResult layout = resolveLayout(screen, recipe.source, {.surfaceWidth = recipe.surfaceWidth, .surfaceHeight = recipe.surfaceHeight});
+    if (!layout.ok()) {
+        diagnostics.insert(diagnostics.end(), layout.diagnostics.begin(), layout.diagnostics.end());
+        return std::nullopt;
+    }
+
+    // 5. Text budgets, when there is anything to measure.
+    if (measurable) {
+        std::vector<LocaleText> localeTexts;
+        localeTexts.reserve(locales.size());
+        for (const LoadedLocale& locale : locales) {
+            localeTexts.push_back(LocaleText{.package = &locale.package, .sidecar = locale.sidecar});
+        }
+
+        std::vector<DynamicTextRule> dynamicRules;
+        dynamicRules.reserve(recipe.dynamicText.size());
+        for (const DynamicText& rule : recipe.dynamicText) {
+            dynamicRules.push_back(DynamicTextRule{.name = rule.name, .produces = rule.produces});
+        }
+
+        const TextBudgetResult budgets = checkTextBudgets(layout, recipe.source, {.font = &*font, .locales = localeTexts, .dynamicText = dynamicRules});
+        if (!budgets.diagnostics.empty()) {
+            diagnostics.insert(diagnostics.end(), budgets.diagnostics.begin(), budgets.diagnostics.end());
+            return std::nullopt;
+        }
+    }
+
+    // The budget the recipe declared has to be usable for the screen that came out of the solver.
+    // `ScreenPackage::validate()` refuses an empty budget on a screen with nodes - the first
+    // rectangle would be turned away and the frame would silently be blank - and `buildPackage()`
+    // treats a schema failure as a compiler bug and throws. So the recipe is told here, where it can
+    // still be corrected.
+    if (!layout.nodes.empty() && (recipe.budget.maxVertices == 0 || recipe.budget.maxIndices == 0 || recipe.budget.maxCommands == 0)) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               std::format("the budget is empty and this screen resolves to {} nodes", layout.nodes.size()),
+               "a screen with nodes needs room for at least one rectangle, or every draw call it makes is refused");
+        return std::nullopt;
+    }
+
+    // 6. Goldens, from the resolved screen. Called rather than re-derived: ADR-012 decision 4 makes
+    //    one implementation of the predicate, applied once, the thing that guarantees completeness.
+    const std::vector<GoldenReference> goldens = collectGoldens(layout);
+
+    // 7. The compiled screen and its bytes.
+    const ScreenDocument    document = buildPackage(layout, {.id = recipe.id, .budget = recipe.budget});
+    const ms::ScreenPackage package  = document.package();
+
+    CompileOutputs outputs;
+    outputs.packageJson = writePackage(package);
+    outputs.goldensJson = writeGoldens(goldens);
+    outputs.screenId    = recipe.id;
+    outputs.nodeCount   = package.nodes.size();
+    outputs.goldenCount = goldens.size();
+
+    evidence::BakeReport bakeReport;
+    bakeReport.tool        = std::string{compilerToolName};
+    bakeReport.toolVersion = MDUX_TOOL_VERSION;
+    bakeReport.recipe      = fileRecord(std::string{recipePath}, recipeBytes);
+    bakeReport.inputs      = std::move(inputs);
+    bakeReport.options     = recipe.toOptions();
+    // report.json is deliberately absent from its own outputs: a file cannot carry its own digest,
+    // for the same reason ADR-007 gives for there being no commit SHA in one.
+    bakeReport.outputs = {fileRecord("goldens.json", asBytes(outputs.goldensJson)), fileRecord("package.json", asBytes(outputs.packageJson))};
+
+    auto reportText = bakeReport.write();
+    if (!reportText.has_value()) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               std::format("the bake report is not valid: {}", evidence::describe(reportText.error())));
+        return std::nullopt;
+    }
+    outputs.reportJson = std::move(*reportText);
+
+    return outputs;
+}
+
+// ---------------------------------------------------------------------------
+// write() / verify()
+// ---------------------------------------------------------------------------
+
+namespace {
+
+[[nodiscard]] bool writeText(const std::filesystem::path& path, const std::string& text, std::vector<cli::Diagnostic>& diagnostics) {
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    if (!file) {
+        report(diagnostics, Code::SourceUnreadable, displayPath(path), 0, "cannot open for writing");
+        return false;
+    }
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+    if (!file) {
+        report(diagnostics, Code::SourceUnreadable, displayPath(path), 0, "write failed");
+        return false;
+    }
+    return true;
+}
+
+[[nodiscard]] bool matches(const std::filesystem::path& path, const std::string& expected, std::vector<cli::Diagnostic>& diagnostics) {
+    const std::optional<std::vector<std::byte>> committed = readFile(path);
+    if (!committed.has_value()) {
+        report(diagnostics, Code::SourceUnreadable, displayPath(path), 0, "the committed artifact could not be read");
+        return false;
+    }
+    if (textOf(*committed) != expected) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               displayPath(path),
+               0,
+               "the committed artifact differs from what this compiler produces",
+               "run `cmake --build <dir> --target mdux-bake-update` and review the diff; do not hand-edit generated/");
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+bool write(const CompileOutputs& outputs, const std::filesystem::path& outputDir, std::vector<cli::Diagnostic>& diagnostics) {
+    std::error_code code;
+    std::filesystem::create_directories(outputDir, code);
+    if (code) {
+        report(diagnostics, Code::SourceUnreadable, displayPath(outputDir), 0, std::format("cannot create the output directory: {}", code.message()));
+        return false;
+    }
+
+    // All three, unconditionally. ADR-012 declares each an add_custom_command OUTPUT, so a compiler
+    // that skipped `goldens.json` for a screen with nothing to pin would break the build rather than
+    // produce a smaller artifact.
+    bool ok = writeText(outputDir / "package.json", outputs.packageJson, diagnostics);
+    ok      = writeText(outputDir / "goldens.json", outputs.goldensJson, diagnostics) && ok;
+    ok      = writeText(outputDir / "report.json", outputs.reportJson, diagnostics) && ok;
+    return ok;
+}
+
+bool verify(const CompileOutputs&         outputs,
+            const std::filesystem::path&  packagePath,
+            const std::filesystem::path&  goldensPath,
+            const std::filesystem::path&  reportPath,
+            std::vector<cli::Diagnostic>& diagnostics) {
+    bool ok = matches(packagePath, outputs.packageJson, diagnostics);
+    ok      = matches(goldensPath, outputs.goldensJson, diagnostics) && ok;
+    ok      = matches(reportPath, outputs.reportJson, diagnostics) && ok;
+    return ok;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Compile.cppm
+++ b/tools/medui/Compile.cppm
@@ -1,0 +1,162 @@
+/**
+ * @file Compile.cppm
+ * @brief The `.medui` compiler driver: a recipe in, three committed artifacts out.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-005 Error handling and exceptions policy (host tools may throw)
+ * @compliance ADR-007 Evidence pipeline doctrine (canonical form, byte-identity, bake reports)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Every stage this epic built exists as a call. This is the file that says in what order they run,
+ * and it is the only place that answer is written down - a driver that let each caller choose would
+ * make the order a convention rather than a contract.
+ *
+ * ## The order, and why it is this one
+ *
+ * 1. **parse** - structure the grammar fixes, nothing the dictionary does (#192).
+ * 2. **analyze** - components, field domains, theme tokens, and keys against *every* approved
+ *    locale (#193).
+ * 3. **validate annotations** - `@safety_critical` needs a requirement, and a `cv_check` must name a
+ *    verification that exists (#196). Before layout, deliberately: the shared conformance suite pins
+ *    `MEDUI-E070` on a screen with no `surface:`, which the solver cannot resolve at all, so a
+ *    design that could only report it after layout could not satisfy the contract it implements.
+ * 4. **resolve layout** - integer-only, bounded, one absolute rectangle per node (#194).
+ * 5. **check text budgets** - every resolved box against the widest approved translation (#195).
+ * 6. **collect goldens** - where safety-critical content must appear (#196).
+ * 7. **build and write** - the compiled screen, its sidecar and the bake report (#197).
+ *
+ * A stage that reports anything stops the compile. Diagnostics are not accumulated across stages,
+ * because a later stage reading a screen an earlier one rejected reports consequences rather than
+ * causes - the layout solver on an unresolvable surface being the clearest case.
+ *
+ * ## The budget stage runs when there is anything to measure
+ *
+ * `checkTextBudgets()` requires a font package and *exactly* the locales that font approves, so a
+ * recipe that declares neither cannot run it. That is not a hole: a screen carrying any `t("KEY")`
+ * with no approved locale to check it against is already refused by stage 2, which validates every
+ * key against every declared locale and finds none. So the stage is skipped only for a screen that
+ * draws no text at all, and a screen that draws text cannot reach stage 5 without the inputs.
+ *
+ * ## What the recipe carries, and why nothing defaults
+ *
+ * Every knob is required. `MEDUI-E002` says why in the registry: a defaulted knob does not appear in
+ * `report.json`, so a silently changed default would leave every report looking unchanged - which
+ * ADR-007 forbids. The surface is declared by the recipe rather than taken from the source, and the
+ * solver checks the source's own `surface:` against it, so the panel a product ships and the screen
+ * an author drew for it disagree loudly rather than silently.
+ */
+module;
+
+export module mdux.tools.medui.compile;
+
+import std;
+import mdux.draw;
+import mdux.evidence.json;
+import mdux.font.schema;
+import mdux.tools.cli;
+
+export namespace mdux::tools::medui {
+
+/// The tool name that appears in every diagnostic and in `report.json`.
+inline constexpr std::string_view compilerToolName = "mdux-meduic";
+
+/**
+ * @brief One named dynamic-text source from the recipe, and every code point it can produce.
+ *
+ * The governed table an author's `format: TimeSeconds` or `charset: Ascii` resolves against. It is a
+ * recipe input rather than a compiler constant for the reason `DynamicTextRule` gives: the names
+ * belong to a product's governed tables, and a compiler shipping its own list would be authoritative
+ * about a set it does not own.
+ *
+ * Spelled as parallel arrays because `mdux.tools.toml` implements a subset with no array-of-tables
+ * support - the same shape `recipes/font/dejavu-ui.toml` uses for its charset, and the same
+ * length-mismatch check.
+ *
+ * Owning its ranges rather than viewing them: a `DynamicTextRule` is a view, and the storage it
+ * views has to outlive the compile that uses it.
+ */
+struct DynamicText {
+    std::string                           name;
+    std::vector<mdux::font::CharsetRange> produces;
+};
+
+/**
+ * @brief A parsed and resolved screen recipe.
+ *
+ * Paths are repository-relative, because the compiler runs with the repository root as its working
+ * directory and `BakeReport::validate()` rejects an absolute path - a report naming a path that
+ * exists on one machine is not evidence.
+ *
+ * `textPackages` is one committed text package per approved locale, and `fontPackage` the font they
+ * were baked into. Both are empty for a screen that draws no text; see the module comment for why
+ * that is safe rather than a way around the check.
+ */
+struct Recipe {
+    std::string              id;      ///< the artifact slug: `generated/screen/<id>/`
+    std::string              source;  ///< the `.medui` file
+    std::int64_t             surfaceWidth{0};
+    std::int64_t             surfaceHeight{0};
+    mdux::draw::DrawBudget   budget{};
+    std::string              fontPackage;   ///< committed font package.json, or empty
+    std::vector<std::string> textPackages;  ///< committed text package.json, one per approved locale
+    std::vector<DynamicText> dynamicText;   ///< the product's governed dynamic-text table
+
+    /// The fully resolved options, as `report.json` records them.
+    [[nodiscard]] evidence::json::Value toOptions() const;
+};
+
+/**
+ * @brief Everything a compile produces, held in memory so bake and verify share one code path.
+ *
+ * Bytes and two counts, not the structured screen: a caller wanting the package parses the JSON,
+ * which exercises the reader on the writer's own output rather than inspecting a value that never
+ * made the round trip. `mdux.tools.shaderbake` gives the same reasoning at greater length, plus the
+ * GCC 15 `std::optional` constraint that makes carrying a module type here a hazard.
+ */
+struct CompileOutputs {
+    std::string packageJson;  ///< canonical `package.json` text
+    std::string goldensJson;  ///< canonical `goldens.json` text, `[]` when nothing is pinned
+    std::string reportJson;   ///< canonical `report.json` text
+    std::string screenId;     ///< for the summary line
+    std::size_t nodeCount{0};
+    std::size_t goldenCount{0};
+};
+
+/// Reads a file as bytes. Returns nullopt when it cannot be opened or read.
+[[nodiscard]] std::optional<std::vector<std::byte>> readFile(const std::filesystem::path& path);
+
+/// Parses recipe text. Diagnostics are appended; nullopt means it did not parse.
+[[nodiscard]] std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipePath, std::vector<cli::Diagnostic>& diagnostics);
+
+/**
+ * @brief Runs every compiler stage over the screen the recipe names.
+ *
+ * @param recipe      the resolved recipe
+ * @param recipePath  repository-relative, for `report.json`'s recipe record and for diagnostics
+ * @param recipeBytes the recipe's own bytes, for its digest
+ * @param root        the directory the recipe's paths resolve against - the repository root
+ * @param diagnostics appended to; a stage that reports anything stops the compile
+ *
+ * Returns nullopt when any stage rejects the screen, when an input cannot be read, or when the
+ * compiled screen fails its own schema.
+ */
+[[nodiscard]] std::optional<CompileOutputs> run(const Recipe&                 recipe,
+                                                std::string_view              recipePath,
+                                                std::span<const std::byte>    recipeBytes,
+                                                const std::filesystem::path&  root,
+                                                std::vector<cli::Diagnostic>& diagnostics);
+
+/// Writes `outputs` into `outputDir`, creating it if needed. All three files, always: ADR-012 makes
+/// them unconditional outputs, so "this screen pins nothing" is an empty array rather than a missing
+/// file.
+[[nodiscard]] bool write(const CompileOutputs& outputs, const std::filesystem::path& outputDir, std::vector<cli::Diagnostic>& diagnostics);
+
+/// Compares `outputs` against the committed files, appending a diagnostic per mismatch.
+[[nodiscard]] bool verify(const CompileOutputs&         outputs,
+                          const std::filesystem::path&  packagePath,
+                          const std::filesystem::path&  goldensPath,
+                          const std::filesystem::path&  reportPath,
+                          std::vector<cli::Diagnostic>& diagnostics);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Diagnostics.cpp
+++ b/tools/medui/Diagnostics.cpp
@@ -1,0 +1,165 @@
+/**
+ * @file Diagnostics.cpp
+ * @brief The `.medui` diagnostic registry table.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * The table is the interesting part of this file; everything else is lookup. Each row's `summary`
+ * says what the code means rather than what one call site happened to print, because the summary is
+ * what a reader consults when deciding whether an existing code already covers a new situation -
+ * and reusing a code whose meaning nearly fits is how a stable identifier stops being stable.
+ */
+module;
+
+module mdux.tools.medui.diagnostics;
+
+import std;
+import mdux.tools.cli;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+using cli::Severity;
+
+// Numbers are assigned in blocks, with gaps left inside each block on purpose: a new grammar rule
+// should land next to the grammar rules rather than at the end of the table, and it can only do
+// that if its block has room. The blocks are documented on the enum in Diagnostics.cppm.
+constexpr std::array<CodeInfo, 22> table{{
+    {Code::RecipeUnreadable, "MDX-E000", Severity::Error,
+     "the recipe file could not be opened",
+     "check the path passed on the command line, and that the file is readable"},
+    {Code::RecipeUnparsed, "MDX-E001", Severity::Error,
+     "the recipe is not valid TOML in the subset mdux.tools.toml accepts",
+     "see recipes/font/dejavu-ui.toml for the accepted shape; there is no [[table]] support"},
+    {Code::RecipeMissingMember, "MDX-E002", Severity::Error,
+     "the recipe is missing a member the compiler requires",
+     "add the named key; every recipe knob is required because a defaulted one would not appear "
+     "in report.json (ADR-007)"},
+    {Code::SourceUnreadable, "MDX-E003", Severity::Error,
+     "the .medui source named by the recipe could not be opened", "check the path in the recipe"},
+    {Code::SourceNotUtf8, "MDX-E004", Severity::Error,
+     "the .medui source is not valid UTF-8", "re-save the file as UTF-8 without a byte-order mark"},
+
+    {Code::UnexpectedToken, "MDX-E010", Severity::Error,
+     "the parser found a token that cannot appear here", ""},
+    {Code::UnknownComponent, "MDX-E011", Severity::Error,
+     "the component name is not in the dictionary",
+     "see the component table in the medui-authoring skill; the dictionary is closed"},
+    {Code::MissingRequiredField, "MDX-E012", Severity::Error,
+     "a component is missing a field its dictionary entry requires", ""},
+    {Code::UnknownField, "MDX-E013", Severity::Error,
+     "a component carries a field its dictionary entry does not define",
+     "check the spelling; unknown fields are rejected rather than ignored, so a typo cannot "
+     "silently do nothing"},
+    {Code::DuplicateNodeId, "MDX-E014", Severity::Error,
+     "two nodes in one screen share an id",
+     "ids address nodes in golden references and requirement traces, so they must be unique "
+     "within a screen"},
+    {Code::NestedRow, "MDX-E015", Severity::Error,
+     "a Row contains another Row",
+     "flatten the inner Row into its parent. Row is a single level so that layout stays one "
+     "flattening pass (ADR-011 decision 5)"},
+    {Code::ForbiddenConstruct, "MDX-E016", Severity::Error,
+     "the source uses a loop, conditional, recursion or scripting construct",
+     "express the screen at its maximum extent and hide what is unused. These make the primitive "
+     "count depend on data the compiler cannot see, so DrawBudget could not be computed exactly "
+     "(ADR-011 decision 5)"},
+    {Code::HardcodedString, "MDX-E017", Severity::Error,
+     "a literal string appears where a text key is required",
+     "use t(\"STR-KEY\") against an approved text package. A hardcoded string cannot be validated "
+     "against every approved locale, which is what the budget check needs"},
+
+    {Code::UnknownColorToken, "MDX-E030", Severity::Error,
+     "a Theme.Colors token is not in the governed table",
+     "check the spelling against the theme token table. Unknown tokens are a compile error rather "
+     "than a fallback colour, because a fallback would render something nobody approved"},
+    {Code::UnknownTextKey, "MDX-E031", Severity::Error,
+     "a text key is not in the approved text package at all", ""},
+    {Code::TextKeyMissingForLocale, "MDX-E032", Severity::Error,
+     "a text key exists but is missing from at least one approved locale",
+     "add the translation, or remove the locale from the recipe's approved list. A key present in "
+     "one locale and absent in another is a screen that renders blank on a shipped device"},
+
+    {Code::TextBudgetExceeded, "MDX-E050", Severity::Error,
+     "a component's bounds cannot contain the widest approved translation",
+     "widen the component or shorten the translation. The check is against the widest approved "
+     "locale, not the authoring one"},
+    {Code::LayoutOverflow, "MDX-E051", Severity::Error,
+     "a node does not fit the space its parent allows",
+     "the solver reports overflow rather than clamping, because a clamped layout renders "
+     "something the author did not describe"},
+    {Code::SurfaceExceeded, "MDX-E052", Severity::Error,
+     "a node falls outside the declared surface", ""},
+    {Code::CharsetEscape, "MDX-E053", Severity::Error,
+     "dynamic text could produce a character outside the restricted charset",
+     "restrict the format, or extend the charset in the font recipe and re-bake. The charset is "
+     "what makes \"no shaping on device\" checkable rather than conventional (ADR-010)"},
+
+    {Code::SafetyCriticalWithoutRequirement, "MDX-E070", Severity::Error,
+     "a @safety_critical node carries no requirement:",
+     "add requirement:, or remove the annotation. A safety-critical node with no requirement "
+     "cannot be traced, and tracing is what the annotation is for"},
+    {Code::UnknownCvCheck, "MDX-E071", Severity::Error,
+     "a cv_check names a verification this compiler does not emit", ""},
+}};
+
+}  // namespace
+
+std::span<const CodeInfo> registry() noexcept { return table; }
+
+const CodeInfo* tryInfo(Code code) noexcept {
+    for (const CodeInfo& row : table) {
+        if (row.code == code) {
+            return &row;
+        }
+    }
+    return nullptr;
+}
+
+const CodeInfo& info(Code code) {
+    if (const CodeInfo* row = tryInfo(code)) {
+        return *row;
+    }
+    // Fails loudly rather than returning the first row.
+    //
+    // An earlier revision returned `table.front()` on the argument that the completeness test makes
+    // this unreachable. Two reviewers objected independently, and they were right: the completeness
+    // test covers every *enumerator*, and `Code` has a fixed underlying type, so
+    // `static_cast<Code>(200)` is a well-formed value of the type that no enumerator names. A cast,
+    // a value read from data, or an uninitialised member would all have mapped silently to
+    // MDX-E000 - "the recipe file could not be opened" - with that code's severity and fix hint
+    // attached to an unrelated failure. A registry whose purpose is that a code means one thing
+    // cannot have a path that quietly assigns the wrong one.
+    //
+    // Throwing is available here because this is the host-tools zone (ADR-004, ADR-005): the
+    // compiler never reaches a device, and `tools/CMakeLists.txt` says as much. Callers that need
+    // the non-throwing form have `tryInfo()`.
+    throw std::logic_error{
+        std::format("mdux::tools::medui::info: no registry row for Code value {}. Every enumerator "
+                    "must have a row in Diagnostics.cpp's table; a value outside the enumerators "
+                    "means a cast or an uninitialised Code reached this call.",
+                    static_cast<unsigned>(code))};
+}
+
+std::string_view id(Code code) { return info(code).id; }
+
+std::span<const std::string_view> retired() noexcept {
+    static constexpr std::array<std::string_view, 0> none{};
+    return none;
+}
+
+cli::Diagnostic diagnose(Code code, std::string file, std::size_t line, std::size_t column,
+                         std::string message, std::string fixHint) {
+    const CodeInfo& row = info(code);
+    return cli::Diagnostic{.file = std::move(file),
+                           .line = line,
+                           .column = column,
+                           .code = std::string{row.id},
+                           .severity = row.severity,
+                           .message = std::move(message),
+                           .fixHint = fixHint.empty() ? std::string{row.fixHint} : std::move(fixHint)};
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Diagnostics.cpp
+++ b/tools/medui/Diagnostics.cpp
@@ -27,81 +27,81 @@ using cli::Severity;
 // should land next to the grammar rules rather than at the end of the table, and it can only do
 // that if its block has room. The blocks are documented on the enum in Diagnostics.cppm.
 constexpr std::array<CodeInfo, 22> table{{
-    {Code::RecipeUnreadable, "MDX-E000", Severity::Error,
+    {Code::RecipeUnreadable, "MEDUI-E000", Severity::Error,
      "the recipe file could not be opened",
      "check the path passed on the command line, and that the file is readable"},
-    {Code::RecipeUnparsed, "MDX-E001", Severity::Error,
+    {Code::RecipeUnparsed, "MEDUI-E001", Severity::Error,
      "the recipe is not valid TOML in the subset mdux.tools.toml accepts",
      "see recipes/font/dejavu-ui.toml for the accepted shape; there is no [[table]] support"},
-    {Code::RecipeMissingMember, "MDX-E002", Severity::Error,
+    {Code::RecipeMissingMember, "MEDUI-E002", Severity::Error,
      "the recipe is missing a member the compiler requires",
      "add the named key; every recipe knob is required because a defaulted one would not appear "
      "in report.json (ADR-007)"},
-    {Code::SourceUnreadable, "MDX-E003", Severity::Error,
+    {Code::SourceUnreadable, "MEDUI-E003", Severity::Error,
      "the .medui source named by the recipe could not be opened", "check the path in the recipe"},
-    {Code::SourceNotUtf8, "MDX-E004", Severity::Error,
+    {Code::SourceNotUtf8, "MEDUI-E004", Severity::Error,
      "the .medui source is not valid UTF-8", "re-save the file as UTF-8 without a byte-order mark"},
 
-    {Code::UnexpectedToken, "MDX-E010", Severity::Error,
+    {Code::UnexpectedToken, "MEDUI-E010", Severity::Error,
      "the parser found a token that cannot appear here", ""},
-    {Code::UnknownComponent, "MDX-E011", Severity::Error,
+    {Code::UnknownComponent, "MEDUI-E011", Severity::Error,
      "the component name is not in the dictionary",
      "see the component table in the medui-authoring skill; the dictionary is closed"},
-    {Code::MissingRequiredField, "MDX-E012", Severity::Error,
+    {Code::MissingRequiredField, "MEDUI-E012", Severity::Error,
      "a component is missing a field its dictionary entry requires", ""},
-    {Code::UnknownField, "MDX-E013", Severity::Error,
+    {Code::UnknownField, "MEDUI-E013", Severity::Error,
      "a component carries a field its dictionary entry does not define",
      "check the spelling; unknown fields are rejected rather than ignored, so a typo cannot "
      "silently do nothing"},
-    {Code::DuplicateNodeId, "MDX-E014", Severity::Error,
+    {Code::DuplicateNodeId, "MEDUI-E014", Severity::Error,
      "two nodes in one screen share an id",
      "ids address nodes in golden references and requirement traces, so they must be unique "
      "within a screen"},
-    {Code::NestedRow, "MDX-E015", Severity::Error,
+    {Code::NestedRow, "MEDUI-E015", Severity::Error,
      "a Row contains another Row",
      "flatten the inner Row into its parent. Row is a single level so that layout stays one "
      "flattening pass (ADR-011 decision 5)"},
-    {Code::ForbiddenConstruct, "MDX-E016", Severity::Error,
+    {Code::ForbiddenConstruct, "MEDUI-E016", Severity::Error,
      "the source uses a loop, conditional, recursion or scripting construct",
      "express the screen at its maximum extent and hide what is unused. These make the primitive "
      "count depend on data the compiler cannot see, so DrawBudget could not be computed exactly "
      "(ADR-011 decision 5)"},
-    {Code::HardcodedString, "MDX-E017", Severity::Error,
+    {Code::HardcodedString, "MEDUI-E017", Severity::Error,
      "a literal string appears where a text key is required",
      "use t(\"STR-KEY\") against an approved text package. A hardcoded string cannot be validated "
      "against every approved locale, which is what the budget check needs"},
 
-    {Code::UnknownColorToken, "MDX-E030", Severity::Error,
+    {Code::UnknownColorToken, "MEDUI-E030", Severity::Error,
      "a Theme.Colors token is not in the governed table",
      "check the spelling against the theme token table. Unknown tokens are a compile error rather "
      "than a fallback colour, because a fallback would render something nobody approved"},
-    {Code::UnknownTextKey, "MDX-E031", Severity::Error,
+    {Code::UnknownTextKey, "MEDUI-E031", Severity::Error,
      "a text key is not in the approved text package at all", ""},
-    {Code::TextKeyMissingForLocale, "MDX-E032", Severity::Error,
+    {Code::TextKeyMissingForLocale, "MEDUI-E032", Severity::Error,
      "a text key exists but is missing from at least one approved locale",
      "add the translation, or remove the locale from the recipe's approved list. A key present in "
      "one locale and absent in another is a screen that renders blank on a shipped device"},
 
-    {Code::TextBudgetExceeded, "MDX-E050", Severity::Error,
+    {Code::TextBudgetExceeded, "MEDUI-E050", Severity::Error,
      "a component's bounds cannot contain the widest approved translation",
      "widen the component or shorten the translation. The check is against the widest approved "
      "locale, not the authoring one"},
-    {Code::LayoutOverflow, "MDX-E051", Severity::Error,
+    {Code::LayoutOverflow, "MEDUI-E051", Severity::Error,
      "a node does not fit the space its parent allows",
      "the solver reports overflow rather than clamping, because a clamped layout renders "
      "something the author did not describe"},
-    {Code::SurfaceExceeded, "MDX-E052", Severity::Error,
+    {Code::SurfaceExceeded, "MEDUI-E052", Severity::Error,
      "a node falls outside the declared surface", ""},
-    {Code::CharsetEscape, "MDX-E053", Severity::Error,
+    {Code::CharsetEscape, "MEDUI-E053", Severity::Error,
      "dynamic text could produce a character outside the restricted charset",
      "restrict the format, or extend the charset in the font recipe and re-bake. The charset is "
      "what makes \"no shaping on device\" checkable rather than conventional (ADR-010)"},
 
-    {Code::SafetyCriticalWithoutRequirement, "MDX-E070", Severity::Error,
+    {Code::SafetyCriticalWithoutRequirement, "MEDUI-E070", Severity::Error,
      "a @safety_critical node carries no requirement:",
      "add requirement:, or remove the annotation. A safety-critical node with no requirement "
      "cannot be traced, and tracing is what the annotation is for"},
-    {Code::UnknownCvCheck, "MDX-E071", Severity::Error,
+    {Code::UnknownCvCheck, "MEDUI-E071", Severity::Error,
      "a cv_check names a verification this compiler does not emit", ""},
 }};
 
@@ -129,7 +129,7 @@ const CodeInfo& info(Code code) {
     // test covers every *enumerator*, and `Code` has a fixed underlying type, so
     // `static_cast<Code>(200)` is a well-formed value of the type that no enumerator names. A cast,
     // a value read from data, or an uninitialised member would all have mapped silently to
-    // MDX-E000 - "the recipe file could not be opened" - with that code's severity and fix hint
+    // MEDUI-E000 - "the recipe file could not be opened" - with that code's severity and fix hint
     // attached to an unrelated failure. A registry whose purpose is that a code means one thing
     // cannot have a path that quietly assigns the wrong one.
     //
@@ -144,6 +144,11 @@ const CodeInfo& info(Code code) {
 }
 
 std::string_view id(Code code) { return info(code).id; }
+
+std::string legacyId(Code code) {
+    const std::string_view canonical = id(code);
+    return std::string{"MDX"} + std::string{canonical.substr(5)};
+}
 
 std::span<const std::string_view> retired() noexcept {
     static constexpr std::array<std::string_view, 0> none{};

--- a/tools/medui/Diagnostics.cpp
+++ b/tools/medui/Diagnostics.cpp
@@ -26,7 +26,7 @@ using cli::Severity;
 // Numbers are assigned in blocks, with gaps left inside each block on purpose: a new grammar rule
 // should land next to the grammar rules rather than at the end of the table, and it can only do
 // that if its block has room. The blocks are documented on the enum in Diagnostics.cppm.
-constexpr std::array<CodeInfo, 22> table{{
+constexpr std::array<CodeInfo, 23> table{{
     {Code::RecipeUnreadable, "MEDUI-E000", Severity::Error,
      "the recipe file could not be opened",
      "check the path passed on the command line, and that the file is readable"},
@@ -81,6 +81,9 @@ constexpr std::array<CodeInfo, 22> table{{
      "a text key exists but is missing from at least one approved locale",
      "add the translation, or remove the locale from the recipe's approved list. A key present in "
      "one locale and absent in another is a screen that renders blank on a shipped device"},
+    {Code::FieldValueKind, "MEDUI-E033", Severity::Error,
+     "a field value has the wrong semantic kind",
+     "use the value form assigned to this field in the shared component model"},
 
     {Code::TextBudgetExceeded, "MEDUI-E050", Severity::Error,
      "a component's bounds cannot contain the widest approved translation",

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -20,23 +20,22 @@
  * is answerable by grep with any confidence, and all three are answerable by construction here.
  *
  * The shape is a `constexpr` table keyed by an enum. Call sites name `Code::UnknownColorToken`,
- * never `"MDX-E030"`, so:
+ * never `"MEDUI-E030"`, so:
  *
  * - **An unregistered code cannot be emitted.** There is no overload taking a string.
  * - **A registered-but-unused code is detectable**, because the enum is exhaustive and a test can
  *   walk it. `DiagnosticsTests.cpp` does.
  * - **A typo is a compile error** rather than a diagnostic nobody can grep for.
  *
- * ## The `MDX-E` prefix
+ * ## The shared `MEDUI-E` prefix
  *
- * `mdux-docs-lint` publishes `MDX-D###`, and the diagnostic schema names `MDX-D011` in its own
- * description, so `MDX-` + one letter + three digits is an established family and this joins it as
- * `MDX-E###`. The bakers' three-letter codes (`SHB`, `SHE`, `TXT`, `MLB`, `EVL`, `GOV`) are a
- * second, older convention; they are not changed here, and nothing needs them to be - the schema's
- * `code` pattern admits both, and `code` is opaque to a consumer that keys off it.
+ * MedUI diagnostics are owned by the pinned `Compliatory/MedUI` contract rather than by either
+ * implementation. MduX's previously published `MDX-E###` identifiers map one-to-one to the same
+ * numbered `MEDUI-E###` identifiers for one release; the upstream alias manifest records that
+ * transition. Non-MedUI tools retain their existing local code families.
  *
- * **`E` is for the language, not for "error".** Severity is a separate field, and an `MDX-E` code
- * may be a warning. Reading the letter as a severity would make `MDX-E###` at severity `warning`
+ * **`E` is for the language, not for "error".** Severity is a separate field, and a `MEDUI-E` code
+ * may be a warning. Reading the letter as a severity would make `MEDUI-E###` at severity `warning`
  * look like a mistake, so it is worth saying which reading is intended.
  *
  * ## Stability
@@ -103,7 +102,7 @@ enum class Code : std::uint8_t {
 /// One row of the registry. `constexpr`-friendly throughout: the table is built at compile time.
 struct CodeInfo {
     Code code{};
-    std::string_view id;       ///< the published `MDX-E###` string; stable once shipped
+    std::string_view id;       ///< the published `MEDUI-E###` string; stable once shipped
     cli::Severity severity{};  ///< the severity this code is emitted at, unless a call site lowers it
     std::string_view summary;  ///< what the code means, one clause, for documentation and tests
     std::string_view fixHint;  ///< what an author should do; empty when there is no single fix
@@ -138,15 +137,26 @@ struct CodeInfo {
  */
 [[nodiscard]] const CodeInfo& info(Code code);
 
-/// The published identifier, e.g. `"MDX-E030"`. Throws for an unregistered value, as `info()` does.
+/**
+ * @brief Gets the published identifier, for example `"MEDUI-E030"`.
+ *
+ * Throws for an unregistered value, as `info()` does.
+ */
 [[nodiscard]] std::string_view id(Code code);
+
+/**
+ * @brief Gets the one-release compatibility alias, for example `"MDX-E030"`.
+ *
+ * Canonical output always uses `id()`.
+ */
+[[nodiscard]] std::string legacyId(Code code);
 
 /**
  * @brief Numbers that were published and then retired.
  *
  * Empty today, and present from the start so that the first retirement has somewhere to go rather
  * than prompting a decision under time pressure. A retired number is never reused: a consumer that
- * pinned behaviour to `MDX-E017` must not silently start matching a different rule.
+ * pinned behaviour to `MEDUI-E017` must not silently start matching a different rule.
  */
 [[nodiscard]] std::span<const std::string_view> retired() noexcept;
 

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -1,0 +1,168 @@
+/**
+ * @file Diagnostics.cppm
+ * @brief The `.medui` compiler's diagnostic code registry: one table, enumerated by tests.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Host-only. The compiler never reaches a device, so this module may allocate and throw freely -
+ * and the codes it publishes are the compiler's contract with an agent, which is the reason the
+ * registry exists at all.
+ *
+ * ## Why a registry rather than string literals
+ *
+ * Every other tool in this repository spells its codes as string literals at the call site:
+ * `constexpr std::string_view recipeUnparsed = "TXT001";` in `tools/text/TextBake.cpp`, and in
+ * `mdux-docs-lint` not even that - its nineteen `MDX-D###` call sites spell the code inline, with
+ * no table anywhere. That works until someone needs to answer a question about the *set*: is this
+ * code already taken, is this code still emitted, does every code have a fix hint. None of those
+ * is answerable by grep with any confidence, and all three are answerable by construction here.
+ *
+ * The shape is a `constexpr` table keyed by an enum. Call sites name `Code::UnknownColorToken`,
+ * never `"MDX-E030"`, so:
+ *
+ * - **An unregistered code cannot be emitted.** There is no overload taking a string.
+ * - **A registered-but-unused code is detectable**, because the enum is exhaustive and a test can
+ *   walk it. `DiagnosticsTests.cpp` does.
+ * - **A typo is a compile error** rather than a diagnostic nobody can grep for.
+ *
+ * ## The `MDX-E` prefix
+ *
+ * `mdux-docs-lint` publishes `MDX-D###`, and the diagnostic schema names `MDX-D011` in its own
+ * description, so `MDX-` + one letter + three digits is an established family and this joins it as
+ * `MDX-E###`. The bakers' three-letter codes (`SHB`, `SHE`, `TXT`, `MLB`, `EVL`, `GOV`) are a
+ * second, older convention; they are not changed here, and nothing needs them to be - the schema's
+ * `code` pattern admits both, and `code` is opaque to a consumer that keys off it.
+ *
+ * **`E` is for the language, not for "error".** Severity is a separate field, and an `MDX-E` code
+ * may be a warning. Reading the letter as a severity would make `MDX-E###` at severity `warning`
+ * look like a mistake, so it is worth saying which reading is intended.
+ *
+ * ## Stability
+ *
+ * A code's meaning is fixed once published. Rewording `message` or `fixHint` is always allowed and
+ * never a breaking change; changing what a code *means* is not, and the replacement takes a new
+ * number rather than reusing a retired one. Numbers are therefore not reused even when a check is
+ * deleted - `retired` records that, so the gap is visible rather than looking like an oversight.
+ */
+module;
+
+export module mdux.tools.medui.diagnostics;
+
+import std;
+import mdux.tools.cli;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief Every diagnostic the `.medui` compiler can emit.
+ *
+ * Each enumerator has exactly one row in `registry()`, and a test asserts that. The order here is
+ * the order of the table and has no other meaning; codes are assigned by number, not by position.
+ *
+ * Only codes whose meaning is already fixed by an accepted document appear. ADR-011, ADR-012 and
+ * the `medui-authoring` skill between them mandate every one below; nothing here anticipates a
+ * check that has not yet been argued for, because a code invented ahead of its rule is a code
+ * whose meaning is decided by whoever implements it first.
+ */
+enum class Code : std::uint8_t {
+    // 000-009: the recipe and the file, before any `.medui` text is read.
+    RecipeUnreadable,
+    RecipeUnparsed,
+    RecipeMissingMember,
+    SourceUnreadable,
+    SourceNotUtf8,
+
+    // 010-029: the grammar. See the `medui-authoring` skill for the shape being enforced.
+    UnexpectedToken,
+    UnknownComponent,
+    MissingRequiredField,
+    UnknownField,
+    DuplicateNodeId,
+    NestedRow,
+    ForbiddenConstruct,
+    HardcodedString,
+
+    // 030-049: names that must resolve. ADR-011: validated at build time, substituted on device.
+    UnknownColorToken,
+    UnknownTextKey,
+    TextKeyMissingForLocale,
+
+    // 050-069: the bounds and budgets that make the runtime's job finite.
+    TextBudgetExceeded,
+    LayoutOverflow,
+    SurfaceExceeded,
+    CharsetEscape,
+
+    // 070-089: safety-critical annotation rules, per the skill and ADR-012 decision 1.
+    SafetyCriticalWithoutRequirement,
+    UnknownCvCheck,
+};
+
+/// One row of the registry. `constexpr`-friendly throughout: the table is built at compile time.
+struct CodeInfo {
+    Code code{};
+    std::string_view id;       ///< the published `MDX-E###` string; stable once shipped
+    cli::Severity severity{};  ///< the severity this code is emitted at, unless a call site lowers it
+    std::string_view summary;  ///< what the code means, one clause, for documentation and tests
+    std::string_view fixHint;  ///< what an author should do; empty when there is no single fix
+};
+
+/**
+ * @brief The registry, in code order.
+ *
+ * `std::span` over a namespace-scope `constexpr` array in the module's implementation unit
+ * rather than an inline variable, so there is exactly one table however many translation units
+ * import this module.
+ */
+[[nodiscard]] std::span<const CodeInfo> registry() noexcept;
+
+/// The row for `code`, or `nullptr` when no row names it. Non-throwing; `info()` is the form
+/// most callers want.
+[[nodiscard]] const CodeInfo* tryInfo(Code code) noexcept;
+
+/**
+ * @brief The row for `code`. Every enumerator has one, which `DiagnosticsTests` asserts.
+ *
+ * @throws std::logic_error if no row names `code`.
+ *
+ * Not `noexcept`, and it does not fall back to a default row. The completeness test covers every
+ * *enumerator*, but `Code` has a fixed underlying type, so `static_cast<Code>(200)` is a well-formed
+ * value the test cannot reach - and returning some row for it would attach one code's severity and
+ * fix hint to an unrelated failure. A registry exists so that a code means one thing; a silent
+ * wrong answer is the one outcome it must not have.
+ *
+ * Throwing is available because this is the host-tools zone (ADR-004, ADR-005). Use `tryInfo()`
+ * where a miss is an expected outcome rather than a programming error.
+ */
+[[nodiscard]] const CodeInfo& info(Code code);
+
+/// The published identifier, e.g. `"MDX-E030"`. Throws for an unregistered value, as `info()` does.
+[[nodiscard]] std::string_view id(Code code);
+
+/**
+ * @brief Numbers that were published and then retired.
+ *
+ * Empty today, and present from the start so that the first retirement has somewhere to go rather
+ * than prompting a decision under time pressure. A retired number is never reused: a consumer that
+ * pinned behaviour to `MDX-E017` must not silently start matching a different rule.
+ */
+[[nodiscard]] std::span<const std::string_view> retired() noexcept;
+
+/**
+ * @brief Builds a `cli::Diagnostic` carrying `code`'s registered identity.
+ *
+ * The only way to produce a diagnostic from this compiler, and deliberately so - there is no
+ * overload taking a code string, so an unregistered code cannot be emitted. `message` is the
+ * caller's, because only the caller knows the offending value; `fixHint` comes from the registry
+ * unless the caller has something more specific to say.
+ *
+ * `line` and `column` are 1-based, 0 meaning "no precise position on this axis", exactly as the
+ * shared envelope defines them.
+ */
+[[nodiscard]] cli::Diagnostic diagnose(Code code, std::string file, std::size_t line,
+                                       std::size_t column, std::string message,
+                                       std::string fixHint = {});
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -87,6 +87,7 @@ enum class Code : std::uint8_t {
     UnknownColorToken,
     UnknownTextKey,
     TextKeyMissingForLocale,
+    FieldValueKind,
 
     // 050-069: the bounds and budgets that make the runtime's job finite.
     TextBudgetExceeded,

--- a/tools/medui/Emit.cpp
+++ b/tools/medui/Emit.cpp
@@ -1,0 +1,437 @@
+/**
+ * @file Emit.cpp
+ * @brief Implementation of the screen package's two C++ renderings.
+ */
+
+module;
+
+module mdux.tools.medui.emit;
+
+import std;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.package;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+namespace ms = mdux::medui;
+
+/// Stable diagnostic codes for this tool. A malformed package reports the reader's `SCP0NN` codes
+/// instead, since the reader is the thing that found the problem and names it more precisely.
+constexpr std::string_view packageUnreadable  = "SCE001";
+constexpr std::string_view outputUnwritable   = "SCE002";
+constexpr std::string_view identifierReserved = "SCE003";
+
+void report(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::string_view code, std::string message, std::string fixHint = {}) {
+    cli::Diagnostic diagnostic;
+    diagnostic.file     = std::move(file);
+    diagnostic.code     = std::string{code};
+    diagnostic.severity = cli::Severity::Error;
+    diagnostic.message  = std::move(message);
+    diagnostic.fixHint  = std::move(fixHint);
+    diagnostics.push_back(std::move(diagnostic));
+}
+
+[[nodiscard]] std::optional<std::string> readFile(const std::filesystem::path& path) {
+    std::ifstream file{path, std::ios::binary | std::ios::ate};
+    if (!file) {
+        return std::nullopt;
+    }
+    // tellg() answers -1 on a stream error rather than throwing, and sizing the string before the
+    // check would turn that into a request for 2^64-1 bytes.
+    const std::streamoff size = file.tellg();
+    if (size < 0 || !file.seekg(0)) {
+        return std::nullopt;
+    }
+    std::string bytes(static_cast<std::size_t>(size), '\0');
+    if (size > 0) {
+        file.read(bytes.data(), size);
+        if (!file) {
+            return std::nullopt;
+        }
+    }
+    return bytes;
+}
+
+/**
+ * @brief A validated name as the body of a C++ string literal.
+ *
+ * Escapes every byte that could end the literal early or change what follows it, rather than only
+ * the two that obviously could. That is not defensiveness for its own sake: the `.medui` lexer
+ * decodes `\\n` and `\\t` inside a source string, semantic analysis accepts an unrestricted `String`
+ * for `requirement`, `source`, `stream_source` and `template`, and the schema then asks only whether
+ * a required name is non-empty. A `requirement: "REQ\\nHALT"` is therefore a legal screen whose
+ * compiled package is valid, and emitting its decoded newline raw would not merely produce an
+ * unhelpful compiler error - it would end the literal and let the rest of the value be read as C++
+ * tokens. A code generator must not have that property.
+ *
+ * Control bytes become three-digit octal escapes rather than `\\xNN`, because a hex escape is greedy:
+ * `"\\x0aBC"` is one enormous escape, while `"\\012BC"` is a newline followed by two letters. Bytes at
+ * or above 0x80 are left alone - they are continuation bytes of a name that is already valid UTF-8,
+ * and the generated file is UTF-8.
+ */
+[[nodiscard]] std::string escape(std::string_view text) {
+    std::string out;
+    out.reserve(text.size());
+    for (const char character : text) {
+        const auto byte = static_cast<unsigned char>(character);
+        switch (character) {
+            case '"':
+                out += "\\\"";
+                continue;
+            case '\\':
+                out += "\\\\";
+                continue;
+            case '\n':
+                out += "\\n";
+                continue;
+            case '\r':
+                out += "\\r";
+                continue;
+            case '\t':
+                out += "\\t";
+                continue;
+            default:
+                break;
+        }
+        if (byte < 0x20 || byte == 0x7F) {
+            out += std::format("\\{:03o}", byte);
+            continue;
+        }
+        out.push_back(character);
+    }
+    return out;
+}
+
+[[nodiscard]] std::string quoted(std::string_view text) {
+    return std::format("\"{}\"", escape(text));
+}
+
+/// Appends `.member = "value"` when the name is present. An absent optional name is omitted, which
+/// is legal because every spec member carries a default initialiser - #218 made that a property of
+/// the type precisely so generated code would not have to spell out what a component did not say.
+void appendName(std::string& out, bool& first, std::string_view member, std::string_view value) {
+    if (value.empty()) {
+        return;
+    }
+    out  += std::format("{}.{} = {}", first ? "" : ", ", member, quoted(value));
+    first = false;
+}
+
+void appendSpan(std::string& out, bool& first, std::string_view member, std::string_view arrayName) {
+    out  += std::format("{}.{} = {}", first ? "" : ", ", member, arrayName);
+    first = false;
+}
+
+/// The name of the array holding one node's state keys or per-state tints.
+///
+/// Indexed by node position rather than by node id: an id may contain `-` and `_`, so sanitising two
+/// different ids could produce one array name, and the collision would be a compile error in
+/// generated code that names no cause. The node's id goes in a comment beside the array instead.
+[[nodiscard]] std::string arrayName(std::string_view what, std::size_t index) {
+    return std::format("{}OfNode{}", what, index);
+}
+
+/// The `StatusIndicator` arrays a screen needs, declared before the node table that views them.
+[[nodiscard]] std::string renderStateArrays(const ms::ScreenPackage& package) {
+    std::string out;
+    for (std::size_t index = 0; index < package.nodes.size(); ++index) {
+        const auto* status = std::get_if<ms::StatusIndicatorSpec>(&package.nodes[index].payload);
+        if (status == nullptr) {
+            continue;
+        }
+        out += std::format("/// The states node '{}' shows, and the tint each one carries.\n", escape(package.nodes[index].id));
+        out += std::format("inline constexpr std::string_view {}[] = {{", arrayName("stateKeys", index));
+        for (std::size_t key = 0; key < status->stateKeys.size(); ++key) {
+            out += std::format("{}{}", key == 0 ? "" : ", ", quoted(status->stateKeys[key]));
+        }
+        out += "};\n";
+        if (!status->colorTokens.empty()) {
+            out += std::format("inline constexpr std::string_view {}[] = {{", arrayName("colorTokens", index));
+            for (std::size_t token = 0; token < status->colorTokens.size(); ++token) {
+                out += std::format("{}{}", token == 0 ? "" : ", ", quoted(status->colorTokens[token]));
+            }
+            out += "};\n";
+        }
+        out += "\n";
+    }
+    return out;
+}
+
+/**
+ * @brief One node's payload as a spec initialiser.
+ *
+ * Members are written in declaration order, because a designated initialiser out of order is
+ * ill-formed - so this function and `mdux.medui.schema` are coupled, and the `static_assert` in the
+ * generated source is what reports a divergence at the point it happens.
+ */
+[[nodiscard]] std::string renderPayload(const ms::CompiledNode& node, std::size_t index) {
+    std::string out;
+    bool        first = true;
+
+    if (const auto* panel = std::get_if<ms::PanelSpec>(&node.payload)) {
+        out = "mdux::medui::PanelSpec{";
+        appendName(out, first, "colorToken", panel->colorToken);
+    } else if (const auto* label = std::get_if<ms::LabelSpec>(&node.payload)) {
+        out = "mdux::medui::LabelSpec{";
+        appendName(out, first, "textKey", label->textKey);
+        appendName(out, first, "colorToken", label->colorToken);
+    } else if (const auto* clock = std::get_if<ms::ClockSpec>(&node.payload)) {
+        out = "mdux::medui::ClockSpec{";
+        appendName(out, first, "format", clock->format);
+    } else if (const auto* image = std::get_if<ms::ImageSpec>(&node.payload)) {
+        out = "mdux::medui::ImageSpec{";
+        appendName(out, first, "source", image->source);
+    } else if (const auto* viewport = std::get_if<ms::VulkanViewportSpec>(&node.payload)) {
+        out = "mdux::medui::VulkanViewportSpec{";
+        appendName(out, first, "streamSource", viewport->streamSource);
+    } else if (const auto* trace = std::get_if<ms::SignalTraceSpec>(&node.payload)) {
+        out = "mdux::medui::SignalTraceSpec{";
+        appendName(out, first, "streamSource", trace->streamSource);
+        appendName(out, first, "colorToken", trace->colorToken);
+    } else if (const auto* button = std::get_if<ms::ButtonSpec>(&node.payload)) {
+        out = "mdux::medui::ButtonSpec{";
+        appendName(out, first, "labelKey", button->labelKey);
+        appendName(out, first, "colorToken", button->colorToken);
+        appendName(out, first, "source", button->source);
+        appendName(out, first, "requirement", button->requirement);
+    } else if (const auto* critical = std::get_if<ms::CriticalButtonSpec>(&node.payload)) {
+        out = "mdux::medui::CriticalButtonSpec{";
+        appendName(out, first, "requirement", critical->requirement);
+        appendName(out, first, "labelKey", critical->labelKey);
+        appendName(out, first, "colorToken", critical->colorToken);
+        appendName(out, first, "onPress", critical->onPress);
+    } else if (const auto* numeric = std::get_if<ms::NumericDisplaySpec>(&node.payload)) {
+        out = "mdux::medui::NumericDisplaySpec{";
+        appendName(out, first, "requirement", numeric->requirement);
+        appendName(out, first, "templateId", numeric->templateId);
+        appendName(out, first, "source", numeric->source);
+        appendName(out, first, "colorToken", numeric->colorToken);
+    } else if (const auto* status = std::get_if<ms::StatusIndicatorSpec>(&node.payload)) {
+        out = "mdux::medui::StatusIndicatorSpec{";
+        appendName(out, first, "requirement", status->requirement);
+        appendName(out, first, "source", status->source);
+        appendSpan(out, first, "stateKeys", arrayName("stateKeys", index));
+        if (!status->colorTokens.empty()) {
+            appendSpan(out, first, "colorTokens", arrayName("colorTokens", index));
+        }
+    } else if (const auto* input = std::get_if<ms::TextInputSpec>(&node.payload)) {
+        out = "mdux::medui::TextInputSpec{";
+        appendName(out, first, "source", input->source);
+        appendName(out, first, "colorToken", input->colorToken);
+        out  += std::format("{}.maxLength = {}", first ? "" : ", ", input->maxLength);
+        first = false;
+        appendName(out, first, "charset", input->charset);
+        appendName(out, first, "requirement", input->requirement);
+    } else {
+        // Unreachable for a package that validated, which is the only kind that reaches here.
+        throw std::logic_error("a node carries a payload this emitter does not know");
+    }
+    out += "}";
+    return out;
+}
+
+/// The screen value, its compile-time check and its accessor: everything after the node table, which
+/// the empty and non-empty branches of `renderBody()` share.
+[[nodiscard]] std::string renderTail(const ms::ScreenPackage& package, std::string_view identifier) {
+    std::string out;
+
+    out += "/// The screen itself, in read-only memory. A device holds this and parses nothing.\n";
+    out += "inline constexpr mdux::medui::ScreenPackage screen{\n";
+    out += "    .id = id,\n";
+    out += std::format("    .schemaVersion = {},\n", package.schemaVersion);
+    out += std::format("    .surfaceWidth = {},\n", package.surfaceWidth);
+    out += std::format("    .surfaceHeight = {},\n", package.surfaceHeight);
+    out += "    .nodes = nodes,\n";
+    out += std::format("    .budget = {{.maxVertices = {}, .maxIndices = {}, .maxCommands = {}}},\n",
+                       package.budget.maxVertices,
+                       package.budget.maxIndices,
+                       package.budget.maxCommands);
+    out += "};\n\n";
+
+    out += "// The screen is checked where it is defined, so a malformed one is a build failure in\n";
+    out += "// whatever links it rather than a startup failure on a device.\n";
+    out += "static_assert(screen.validate().has_value(), \"this compiled screen does not satisfy mdux.medui.schema\");\n\n";
+
+    out += "/// The screen, as one value a runtime can take by copy.\n";
+    out += "[[nodiscard]] constexpr mdux::medui::ScreenPackage package() noexcept {\n";
+    out += "    return screen;\n";
+    out += "}\n\n";
+
+    out += std::format("}}  // namespace mdux::medui::generated::{}\n", identifier);
+    return out;
+}
+
+/// Everything between the module or header preamble and its closing brace. One function, so the two
+/// outputs cannot describe different screens or a different contract.
+[[nodiscard]] std::string renderBody(const ms::ScreenPackage& package, std::string_view identifier) {
+    std::string out;
+
+    out += std::format("namespace mdux::medui::generated::{} {{\n\n", identifier);
+
+    out += "/// The package id this screen was generated from.\n";
+    out += std::format("inline constexpr std::string_view id = {};\n\n", quoted(package.id));
+
+    out += renderStateArrays(package);
+
+    // A screen with nothing to draw is valid - `ScreenPackage::validate()` permits it, with an empty
+    // budget, and `medui-schema-budget` pins that. An empty C array is not valid C++, so the empty
+    // case is spelled as an empty span, exactly as the shader emitter spells an empty descriptor
+    // set. Both branches leave `nodes` convertible to the span `ScreenPackage` holds.
+    if (package.nodes.empty()) {
+        out += "/// This screen resolves to no nodes.\n";
+        out += "inline constexpr std::span<const mdux::medui::CompiledNode> nodes{};\n\n";
+        return out + renderTail(package, identifier);
+    }
+
+    out += "/// Every node the compiler resolved, in the order the package lists them.\n";
+    out += "inline constexpr mdux::medui::CompiledNode nodes[] = {\n";
+    for (std::size_t index = 0; index < package.nodes.size(); ++index) {
+        const ms::CompiledNode& node = package.nodes[index];
+        out                         += std::format("    {{.id = {},\n", quoted(node.id));
+        out                         += std::format("     .bounds = {{.x = {}, .y = {}, .width = {}, .height = {}}},\n",
+                           node.bounds.x,
+                           node.bounds.y,
+                           node.bounds.width,
+                           node.bounds.height);
+        out                         += std::format("     .payload = {}}},\n", renderPayload(node, index));
+    }
+    out += "};\n\n";
+
+    return out + renderTail(package, identifier);
+}
+
+/**
+ * @brief The provenance comment both outputs open with.
+ *
+ * The id and the path go through the same escaper the string literals use, which is not
+ * belt-and-braces: a `//` comment ends at a newline, and a package id is a non-empty string the
+ * schema does not otherwise restrict, so an id carrying a control character would end the comment
+ * and leave what followed it as generated C++ source. A trailing backslash would do the opposite -
+ * splice the *next* line into the comment - and the same escaper removes that too. Escaping a
+ * comment is unusual enough to say why here: this is a code generator, so every value it writes out
+ * has to be unable to change the structure of what it writes.
+ */
+[[nodiscard]] std::string preamble(std::string_view packageId, std::string_view packagePath) {
+    std::string out;
+    out += std::format("// Generated by {} from {}.\n", emitToolName, escape(packagePath));
+    out += "//\n";
+    out += "// Do not edit, and do not commit: this file is a mechanical rendering of a committed\n";
+    out += "// artifact, regenerated on every build. The reviewed source of truth is the JSON beside\n";
+    out += "// the digests, not these initialisers. See tools/medui/Emit.cppm.\n";
+    out += "//\n";
+    out += std::format("// Screen: {}\n", escape(packageId));
+    return out;
+}
+
+}  // namespace
+
+std::string identifierForScreen(std::string_view packageId) {
+    // Unconditionally prefixed, which is what makes the result an identifier rather than merely
+    // identifier-shaped. A package id is a slug, and `class`, `namespace`, `module` and `import` are
+    // all legal slugs; mapping them to themselves produced a namespace and a module name no compiler
+    // accepts, while both implementations of the rule agreed on that invalid answer, so the parity
+    // test could not see it. The prefix also removes the leading-digit case an earlier revision
+    // handled with a second rule.
+    std::string out{"screen_"};
+    out.reserve(out.size() + packageId.size());
+    for (const char character : packageId) {
+        const bool alnum = (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9');
+        out.push_back(alnum ? character : '_');
+    }
+    return out;
+}
+
+std::optional<EmitOutputs> renderScreen(const std::filesystem::path& packagePath, std::vector<cli::Diagnostic>& diagnostics) {
+    const std::string packageDisplay = packagePath.generic_string();
+
+    const std::optional<std::string> bytes = readFile(packagePath);
+    if (!bytes.has_value()) {
+        report(diagnostics,
+               packageDisplay,
+               packageUnreadable,
+               "cannot read package.json",
+               "Compile the screen first; a screen's artifacts are produced by mdux-meduic.");
+        return std::nullopt;
+    }
+
+    // The reader validates what it read, so everything below this point works on a screen that has
+    // already satisfied the schema once. The static_assert the rendering carries is the second gate,
+    // over the emitted form rather than the parsed one.
+    PackageReadResult read = readPackage(*bytes, packageDisplay);
+    if (!read.ok()) {
+        diagnostics.insert(diagnostics.end(), read.diagnostics.begin(), read.diagnostics.end());
+        return std::nullopt;
+    }
+
+    const ms::ScreenPackage package = read.document.package();
+
+    EmitOutputs outputs;
+    outputs.stem = identifierForScreen(package.id);
+
+    // Two adjacent separators in an id map to `__`, which is reserved to the implementation
+    // everywhere in a program. One `_` per separator keeps the mapping injective - collapsing a run
+    // would let two screens claim one filename - so the reserved case is refused rather than
+    // rewritten, and `mdux_emit_screen_package()` refuses it at configure time for the same reason.
+    if (outputs.stem.contains("__")) {
+        report(diagnostics,
+               packageDisplay,
+               identifierReserved,
+               std::format("the id '{}' maps to '{}', which is a reserved identifier", package.id, outputs.stem),
+               "avoid two adjacent separators in a screen id");
+        return std::nullopt;
+    }
+
+    outputs.moduleName = "mdux.medui.generated." + outputs.stem;
+
+    const std::string body = renderBody(package, outputs.stem);
+    const std::string head = preamble(package.id, packageDisplay);
+
+    outputs.moduleSource = head + "\nmodule;\n\nexport module " + outputs.moduleName + ";\n\nimport std;\nimport mdux.medui.schema;\n\nexport " + body;
+
+    outputs.headerSource = head
+                           + "\n#pragma once\n\n"
+                             "// The header form assumes <span>, <string_view> and mdux.medui.schema are already\n"
+                             "// available to the including translation unit, exactly as the shader emitter's header\n"
+                             "// does. A header cannot import a named module, and including <span> here would\n"
+                             "// reintroduce the include-before-import ordering this repository keeps avoiding.\n\n"
+                           + body;
+
+    return outputs;
+}
+
+bool writeScreen(const EmitOutputs& outputs, const std::filesystem::path& outputDir, std::vector<cli::Diagnostic>& diagnostics) {
+    std::error_code code;
+    std::filesystem::create_directories(outputDir, code);
+    if (code) {
+        report(diagnostics, outputDir.generic_string(), outputUnwritable, "cannot create output directory: " + code.message());
+        return false;
+    }
+
+    const auto writeIfChanged = [&](const std::filesystem::path& path, const std::string& content) {
+        // Rewriting an unchanged file would restamp it and force every consumer to recompile on
+        // every build, which for a module interface is not free.
+        if (const std::optional<std::string> existing = readFile(path); existing.has_value() && *existing == content) {
+            return true;
+        }
+        std::ofstream file{path, std::ios::binary | std::ios::trunc};
+        if (!file) {
+            report(diagnostics, path.generic_string(), outputUnwritable, "cannot open for writing");
+            return false;
+        }
+        file.write(content.data(), static_cast<std::streamsize>(content.size()));
+        if (!file) {
+            report(diagnostics, path.generic_string(), outputUnwritable, "write failed");
+            return false;
+        }
+        return true;
+    };
+
+    bool ok = writeIfChanged(outputDir / (outputs.stem + ".cppm"), outputs.moduleSource);
+    ok      = writeIfChanged(outputDir / (outputs.stem + ".hpp"), outputs.headerSource) && ok;
+    return ok;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Emit.cppm
+++ b/tools/medui/Emit.cppm
@@ -1,0 +1,99 @@
+/**
+ * @file Emit.cppm
+ * @brief Turns a committed screen package into C++ a device can hold as `constexpr` data.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-005 Error handling and exceptions policy (host tools may throw)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * This is what lets a device build link no host-tools module and run no parser at startup. The
+ * screen it draws is namespace-scope `constexpr` data in read-only memory, reached by name.
+ *
+ * ## Generated code lives in the build tree, never in git
+ *
+ * The canonical artifact is `generated/screen/<id>/{package.json, goldens.json, report.json}` -
+ * reviewed as JSON, byte-compared in CI. The C++ here is a mechanical rendering of exactly those
+ * bytes, regenerated on every build, and is not committed. `mdux_emit_shader_package()` established
+ * both the arrangement and the argument for it: committing the rendering would put two
+ * representations of one artifact under review, and the second is the one nobody reads.
+ *
+ * ## The static_assert is the point, not a decoration
+ *
+ * The generated source carries `static_assert(screen.validate().has_value())`. A screen that does
+ * not satisfy its schema is therefore a **build failure in the consumer**, not a startup failure on
+ * a device - and not a diagnostic from a tool somebody might not have run. That is only possible
+ * because `mdux.medui.schema` is header-only and fully `constexpr`, which is the property #197
+ * delivered rather than one that already existed.
+ *
+ * It is also a genuine second gate rather than a restatement of the first: `readPackage()` validates
+ * what it read, so this is the *compiler* re-checking the *emitted* form. If the rendering below
+ * ever dropped a required name or mis-spelled a colour token, the emitted screen would stop
+ * validating and the build would say so at the file that carries the mistake.
+ *
+ * ## C arrays, not std::array
+ *
+ * Generated data is emitted as namespace-scope C arrays, exactly as the shader emitter does: a
+ * `std::array` of any size in a module interface has twice triggered the GCC 15/16 modules ICE this
+ * repository works around elsewhere. `std::span` conversion from a C array is what `ScreenPackage`
+ * takes anyway, so nothing is lost.
+ *
+ * ## Two outputs describing one screen
+ *
+ * A module interface for consumers that `import`, and a header for consumers that cannot - the
+ * examples include Vulkan and GLFW headers before importing anything, precisely because mixing the
+ * two orders has been a source of GCC ICEs. Both come from one in-memory rendering, so they cannot
+ * disagree; `renderBody()` is shared for that reason rather than each output formatting itself.
+ */
+module;
+
+export module mdux.tools.medui.emit;
+
+import std;
+import mdux.tools.cli;
+
+export namespace mdux::tools::medui {
+
+inline constexpr std::string_view emitToolName = "mdux-screenemit";
+
+/// The generated sources, held in memory so both outputs derive from one rendering.
+struct EmitOutputs {
+    std::string moduleName;    ///< e.g. `mdux.medui.generated.neurosense_500`
+    std::string moduleSource;  ///< the .cppm text
+    std::string headerSource;  ///< the .hpp text
+    std::string stem;          ///< filename stem for both, e.g. `neurosense_500`
+};
+
+/**
+ * @brief Reads a committed screen package and renders both outputs.
+ *
+ * @param packagePath repository-relative path to `package.json`
+ * @param diagnostics appended to on any problem, including the reader's own `SCP0NN` codes
+ *
+ * Returns nullopt when the package cannot be read or does not describe a valid screen. The goldens
+ * sidecar is deliberately not read: the runtime never sees a golden reference, so nothing about it
+ * belongs in generated device code (ADR-012, decision 4).
+ */
+[[nodiscard]] std::optional<EmitOutputs> renderScreen(const std::filesystem::path& packagePath, std::vector<cli::Diagnostic>& diagnostics);
+
+/// Writes `outputs` into `outputDir` as `<stem>.cppm` and `<stem>.hpp`, creating it if needed.
+///
+/// Writes only when the content differs from what is already there, so a rebuild that changes
+/// nothing does not restamp the files and force every consumer to recompile.
+[[nodiscard]] bool writeScreen(const EmitOutputs& outputs, const std::filesystem::path& outputDir, std::vector<cli::Diagnostic>& diagnostics);
+
+/**
+ * @brief The C++ identifier a package id maps to: `neurosense-500` becomes `screen_neurosense_500`.
+ *
+ * Prefixed unconditionally, because a package slug may be a keyword - `class` and `module` are both
+ * legal ids - and an identifier-shaped answer that no compiler accepts is worse than a longer one.
+ *
+ * Exported because the tests and the CMake integration both have to predict the generated
+ * filenames. `mdux_screen_identifier()` in `cmake/MduXScreenEmit.cmake` implements the same rule,
+ * and `medui-screen-identifier-parity` runs both over the same ids and compares - an assertion on
+ * this half alone cannot observe a CMake regex, which is exactly how the shader pair drifted.
+ */
+[[nodiscard]] std::string identifierForScreen(std::string_view packageId);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Goldens.cpp
+++ b/tools/medui/Goldens.cpp
@@ -251,7 +251,7 @@ private:
     /**
      * @brief Refuses a `ColorHash` check on a node whose expected tint cannot be derived.
      *
-     * `cv_checks` and `color_token` are two halves of one claim: a verifier asked for `ColorHash`
+     * `cvChecks` and `colorToken` are two halves of one claim: a verifier asked for `ColorHash`
      * reads the token to know what tint to expect. A `StatusIndicator` declares `colors:` as a list,
      * one per state, and a `Clock`, `Image` or `VulkanViewport` declares none at all - so a golden
      * over either would ask for a check with nothing to check it against.

--- a/tools/medui/Goldens.cpp
+++ b/tools/medui/Goldens.cpp
@@ -1,0 +1,399 @@
+/**
+ * @file Goldens.cpp
+ * @brief The `@safety_critical` annotation rules, and the golden set they select.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ */
+module;
+
+module mdux.tools.medui.goldens;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.semantic;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// The one annotation that participates in the predicate. Others are carried by the AST and ignored
+/// here; naming a rule for them would need a diagnostic code no accepted document has argued for.
+constexpr std::string_view safetyCritical = "safety_critical";
+
+/// The argument that lists the verifications a golden asks for.
+constexpr std::string_view cvCheckArgument = "cv_check";
+
+[[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
+    const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
+    return found == node.fields.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const ast::Field* argumentFor(const ast::Annotation& annotation, std::string_view name) noexcept {
+    const auto found = std::ranges::find(annotation.arguments, name, &ast::Field::name);
+    return found == annotation.arguments.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool isSafetyCritical(const ast::Annotation& annotation) noexcept {
+    return annotation.name == safetyCritical;
+}
+
+/// Finds a component's field of one value domain, from the dictionary semantic analysis publishes.
+///
+/// The dictionary rather than a list of field names: `text` on a `Label` and `label` on a `Button`
+/// are the same kind of thing, and a second list here would be one more place to forget a component.
+[[nodiscard]] const ast::Field* fieldOfDomain(const ast::Node& node, FieldDomain domain) noexcept {
+    const std::span<const ComponentRule> dictionary = componentDictionary();
+    const auto                           component  = std::ranges::find(dictionary, node.component, &ComponentRule::name);
+    if (component == dictionary.end()) {
+        return nullptr;
+    }
+    for (const FieldRule& rule : component->fields) {
+        if (rule.domain != domain) {
+            continue;
+        }
+        if (const ast::Field* field = fieldFor(node, rule.name)) {
+            return field;
+        }
+    }
+    return nullptr;
+}
+
+/// Whether the component dictionary gives this component a `requirement:` field at all.
+///
+/// `Row` does not have one, and the dictionary is the pinned shared contract rather than something
+/// this compiler may extend - so a container cannot carry `@safety_critical`, and the diagnostic
+/// should say that rather than asking an author to add a field the language will then reject.
+[[nodiscard]] bool admitsRequirement(const ast::Node& node) noexcept {
+    const std::span<const ComponentRule> dictionary = componentDictionary();
+    const auto                           component  = std::ranges::find(dictionary, node.component, &ComponentRule::name);
+    if (component == dictionary.end()) {
+        return false;
+    }
+    return std::ranges::any_of(component->fields, [](const FieldRule& rule) {
+        return rule.name == "requirement";
+    });
+}
+
+/// Whether `text` carries anything a requirement identifier could be. Blank is not traceable.
+[[nodiscard]] bool isBlank(std::string_view text) noexcept {
+    return std::ranges::all_of(text, [](unsigned char character) {
+        return std::isspace(character) != 0;
+    });
+}
+
+/// The text a golden pins, or empty when the node draws none - or draws one that varies.
+///
+/// Only a single static key qualifies. A list-valued field such as `StatusIndicator`'s `states:` is
+/// deliberately not read: the state on screen is the varying part, and a golden that pinned one
+/// would fail whenever the device showed another.
+[[nodiscard]] std::string textKeyOf(const ast::Node& node) {
+    const ast::Field* field = fieldOfDomain(node, FieldDomain::TextKey);
+    if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::TextKey) {
+        return {};
+    }
+    return field->value->text;
+}
+
+/// The colour token a golden pins, or empty when the node declares none - or declares several.
+///
+/// `StatusIndicator`'s `colors:` is a list, one per state, and which one is on screen is the
+/// varying part. It is left unread for the same reason `states:` is: a golden pins the tint a
+/// verifier can rely on, and a component that legitimately changes tint has none.
+[[nodiscard]] std::string colorTokenOf(const ast::Node& node) {
+    const ast::Field* field = fieldOfDomain(node, FieldDomain::ColorToken);
+    if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::ColorToken) {
+        return {};
+    }
+    return field->value->text;
+}
+
+/// Adds `check` unless it is already present. The list is short - two values exist - so a scan
+/// costs less than the set that would replace it, and it keeps insertion order out of the result.
+void addCheck(std::vector<CvCheck>& checks, CvCheck check) {
+    if (std::ranges::find(checks, check) == checks.end()) {
+        checks.push_back(check);
+    }
+}
+
+/// Collects the checks one annotation asks for, failing loudly if validation was bypassed.
+///
+/// Accepts both `cv_check: [Bounds, ColorHash]` and the single-value `cv_check: Bounds`. The shared
+/// language writes the list form and so does every example here; the single form is accepted because
+/// it means one unambiguous thing, and rejecting it would need a diagnostic for a shape no author
+/// could misread.
+void collectAnnotationChecks(const ast::Annotation& annotation, std::vector<CvCheck>& into) {
+    const ast::Field* argument = argumentFor(annotation, cvCheckArgument);
+    if (argument == nullptr || argument->value == nullptr) {
+        return;
+    }
+
+    const auto take = [&into](const ast::Value& value) {
+        if (value.kind != ast::ValueKind::Identifier) {
+            throw std::logic_error(std::format("goldens received a cv_check value that is not a name at line {}, column {}; "
+                                               "validateSafetyAnnotations() is a required gate",
+                                               value.position.line,
+                                               value.position.column));
+        }
+        const std::optional<CvCheck> check = parseCvCheck(value.text);
+        if (!check.has_value()) {
+            throw std::logic_error(std::format("goldens received unknown cv_check '{}' at line {}, column {}; "
+                                               "validateSafetyAnnotations() is a required gate",
+                                               value.text,
+                                               value.position.line,
+                                               value.position.column));
+        }
+        addCheck(into, *check);
+    };
+
+    if (argument->value->kind == ast::ValueKind::List) {
+        for (const std::shared_ptr<ast::Value>& element : argument->value->list) {
+            if (element == nullptr) {
+                throw std::logic_error("goldens received an empty cv_check element; validateSafetyAnnotations() is a required gate");
+            }
+            take(*element);
+        }
+        return;
+    }
+    take(*argument->value);
+}
+
+/// One pass over a parsed screen, applying the annotation rules.
+class Validator {
+public:
+    explicit Validator(std::string file) : file_{std::move(file)} {}
+
+    [[nodiscard]] SafetyResult run(const ast::Screen& screen) {
+        for (const ast::Node& node : screen.nodes) {
+            validateNode(node);
+        }
+        return SafetyResult{.diagnostics = std::move(diagnostics_)};
+    }
+
+private:
+    void report(Code code, ast::Position position, std::string message) {
+        diagnostics_.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
+    }
+
+    void validateNode(const ast::Node& node) {
+        for (const ast::Annotation& annotation : node.annotations) {
+            if (isSafetyCritical(annotation)) {
+                validateAnnotation(node, annotation);
+            }
+        }
+        for (const ast::Node& child : node.children) {
+            validateNode(child);
+        }
+    }
+
+    void validateAnnotation(const ast::Node& node, const ast::Annotation& annotation) {
+        // Reported at the annotation rather than at the node: the annotation is the claim that
+        // needs a requirement behind it, and the shared case pins that position.
+        validateRequirement(node, annotation);
+        validateColorHashIsDerivable(node, annotation);
+
+        const ast::Field* argument = argumentFor(annotation, cvCheckArgument);
+        if (argument == nullptr || argument->value == nullptr) {
+            return;
+        }
+        if (argument->value->kind == ast::ValueKind::List) {
+            for (const std::shared_ptr<ast::Value>& element : argument->value->list) {
+                if (element != nullptr) {
+                    validateCheckValue(*element);
+                }
+            }
+            return;
+        }
+        validateCheckValue(*argument->value);
+    }
+
+    /**
+     * @brief Requires something to trace the annotation to, not merely a field that exists.
+     *
+     * Presence alone was the first revision's rule and it was too weak: `requirement:` is a
+     * `String` field, `Semantic.cpp`'s domain check accepts every quoted string including `""`, and
+     * a safety-critical node whose requirement is the empty string is exactly the untraceable node
+     * this rule exists to prevent. A blank value therefore reports `MEDUI-E070` as an absent one
+     * does - the code means "carries no requirement", and an empty string carries none.
+     *
+     * The rule is enforced here rather than by tightening `FieldDomain::String`, because the
+     * traceability requirement belongs to the annotation. `template:` and `source:` are the same
+     * domain and are not the same claim.
+     */
+    void validateRequirement(const ast::Node& node, const ast::Annotation& annotation) {
+        const ast::Field* requirement = fieldFor(node, "requirement");
+        if (requirement != nullptr && requirement->value != nullptr && requirement->value->kind == ast::ValueKind::String
+            && !isBlank(requirement->value->text)) {
+            return;
+        }
+
+        // A container cannot satisfy this rule at all: the pinned dictionary gives `Row` no
+        // `requirement:`, so saying "add requirement:" would send an author to a field the language
+        // then rejects as unknown. Say what is actually wrong instead.
+        if (!admitsRequirement(node)) {
+            report(Code::SafetyCriticalWithoutRequirement,
+                   annotation.position,
+                   std::format("component '{}' takes no requirement in the shared component model, so it cannot be "
+                               "@safety_critical; annotate the content it contains instead",
+                               node.component));
+            return;
+        }
+        report(Code::SafetyCriticalWithoutRequirement,
+               annotation.position,
+               requirement == nullptr ? std::format("component '{}' is annotated @safety_critical but declares no requirement", node.component)
+                                      : std::format("component '{}' is annotated @safety_critical but its requirement is empty", node.component));
+    }
+
+    /**
+     * @brief Refuses a `ColorHash` check on a node whose expected tint cannot be derived.
+     *
+     * `cv_checks` and `color_token` are two halves of one claim: a verifier asked for `ColorHash`
+     * reads the token to know what tint to expect. A `StatusIndicator` declares `colors:` as a list,
+     * one per state, and a `Clock`, `Image` or `VulkanViewport` declares none at all - so a golden
+     * over either would ask for a check with nothing to check it against.
+     *
+     * Rejecting is the fail-closed reading, and it is a decision this issue has to take rather than
+     * defer, because the reference shape is frozen here for #16 and #197. The alternative - carrying
+     * a per-state list of expected tints - is a genuine extension of the shape, and one both
+     * consumers would have to agree to; it belongs with the components that would need it (#17),
+     * not with a stage inventing a field ahead of them.
+     */
+    void validateColorHashIsDerivable(const ast::Node& node, const ast::Annotation& annotation) {
+        const ast::Field* argument = argumentFor(annotation, cvCheckArgument);
+        if (argument == nullptr || argument->value == nullptr || !colorTokenOf(node).empty()) {
+            return;
+        }
+
+        const auto namesColorHash = [](const ast::Value& value) {
+            return value.kind == ast::ValueKind::Identifier && parseCvCheck(value.text) == CvCheck::ColorHash;
+        };
+
+        const ast::Value* offending = nullptr;
+        if (argument->value->kind == ast::ValueKind::List) {
+            for (const std::shared_ptr<ast::Value>& element : argument->value->list) {
+                if (element != nullptr && namesColorHash(*element)) {
+                    offending = element.get();
+                    break;
+                }
+            }
+        } else if (namesColorHash(*argument->value)) {
+            offending = argument->value.get();
+        }
+
+        if (offending != nullptr) {
+            report(Code::UnknownCvCheck,
+                   offending->position,
+                   std::format("{} needs one declared colour token to compare against, and component '{}' declares "
+                               "none that a golden could pin",
+                               spell(CvCheck::ColorHash),
+                               node.component));
+        }
+    }
+
+    void validateCheckValue(const ast::Value& value) {
+        if (value.kind != ast::ValueKind::Identifier) {
+            // MEDUI-E033 rather than a new code: an annotation argument is an `ast::Field`, and
+            // "a field value has the wrong semantic kind" is exactly what a quoted or numeric
+            // cv_check is. A code invented for the annotation case would mean the same thing twice.
+            report(Code::FieldValueKind, value.position, "cv_check takes a name, or a list of names, from the closed set");
+            return;
+        }
+        if (!parseCvCheck(value.text).has_value()) {
+            report(Code::UnknownCvCheck,
+                   value.position,
+                   std::format("'{}' is not a verification this compiler emits; the set is {} and {}",
+                               value.text,
+                               spell(CvCheck::Bounds),
+                               spell(CvCheck::ColorHash)));
+        }
+    }
+
+    std::string                  file_;
+    std::vector<cli::Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+std::string_view spell(CvCheck check) noexcept {
+    switch (check) {
+        case CvCheck::Bounds:
+            return "Bounds";
+        case CvCheck::ColorHash:
+            return "ColorHash";
+    }
+    return "";
+}
+
+std::optional<CvCheck> parseCvCheck(std::string_view name) noexcept {
+    if (name == spell(CvCheck::Bounds)) {
+        return CvCheck::Bounds;
+    }
+    if (name == spell(CvCheck::ColorHash)) {
+        return CvCheck::ColorHash;
+    }
+    return std::nullopt;
+}
+
+SafetyResult validateSafetyAnnotations(const ast::Screen& screen, std::string file) {
+    return Validator{std::move(file)}.run(screen);
+}
+
+std::vector<GoldenReference> collectGoldens(const LayoutResult& layout) {
+    std::vector<GoldenReference> references;
+
+    for (const ResolvedNode& node : layout.nodes) {
+        // Goldens describe authored nodes. The only synthetic node the solver produces is a Row's
+        // background, and a Row cannot be annotated - the pinned dictionary gives it no
+        // `requirement:`, so `validateSafetyAnnotations()` rejects the annotation before layout runs
+        // - nor positioned, since `position:` is not one of its fields either. Skipping it states
+        // that rather than leaving a reader to derive it from two other files.
+        if (node.synthetic) {
+            continue;
+        }
+
+        std::vector<CvCheck> checks;
+
+        const bool annotated = std::ranges::any_of(node.source.annotations, isSafetyCritical);
+        for (const ast::Annotation& annotation : node.source.annotations) {
+            if (isSafetyCritical(annotation)) {
+                collectAnnotationChecks(annotation, checks);
+            }
+        }
+
+        // ADR-011: a declared position is a safety-relevant claim by itself, so it adds `Bounds`
+        // whether or not the node is annotated. A node matching both rules is here exactly once,
+        // because this loop walks resolved nodes rather than the two rules in turn - which is what
+        // makes "one merged entry, never two" a property of the shape rather than of a later dedupe.
+        if (node.positioned) {
+            addCheck(checks, CvCheck::Bounds);
+        }
+
+        if (!annotated && !node.positioned) {
+            continue;
+        }
+
+        // An annotation naming no check still selects the node, and pins its bounds. That is read
+        // from ADR-011's positioned rule rather than invented: if a declared position alone is
+        // enough to make a rectangle worth verifying, an explicit safety-critical claim cannot be
+        // worth less. The alternative - an entry with no checks - would be a golden a verifier
+        // reads and does nothing with.
+        if (checks.empty()) {
+            addCheck(checks, CvCheck::Bounds);
+        }
+        std::ranges::sort(checks);
+
+        references.push_back(GoldenReference{.nodeId     = node.id,
+                                             .bounds     = node.bounds,
+                                             .textKey    = textKeyOf(node.source),
+                                             .colorToken = colorTokenOf(node.source),
+                                             .cvChecks   = std::move(checks)});
+    }
+
+    return references;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Goldens.cppm
+++ b/tools/medui/Goldens.cppm
@@ -64,20 +64,33 @@
  * one-to-one onto the canonical JSON:
  *
  * ```json
- * { "node_id": "sedation-index",
- *   "bounds": { "x": 1392, "y": 80, "width": 512, "height": 512 },
- *   "text_key": "STR-SEDATION-LABEL",
- *   "color_token": "Theme.Colors.ScoreDigits",
- *   "cv_checks": ["Bounds", "ColorHash"] }
+ * { "bounds": { "height": 512, "width": 512, "x": 1392, "y": 80 },
+ *   "colorToken": "Theme.Colors.ScoreDigits",
+ *   "cvChecks": ["Bounds", "ColorHash"],
+ *   "nodeId": "sedation-index",
+ *   "textKey": "STR-SEDATION-LABEL" }
  * ```
  *
- * `text_key` and `color_token` are omitted when the node has none. `cv_checks` is sorted and
+ * The C++ members and the JSON members are now the same words, which is worth one line because they
+ * were not: an earlier revision spelled the file `node_id`, `text_key`, `color_token`, `cv_checks`,
+ * transcribed from TrustSC's Rust identifiers. TrustSC emits no screen JSON at all - its compiled
+ * screen is generated Rust - so nothing was being matched, while every package this repository has
+ * committed is camelCase. ADR-011 records the amendment; the effect here is that a reader has one
+ * vocabulary for the struct, the file and the verifier that reads it.
+ *
+ * The example is in the byte order the file actually has. `mdux.evidence.json` sorts every object's
+ * members lexicographically by UTF-8 code unit, nested objects included, so `bounds` reads
+ * `height, width, x, y` rather than the order a reader would write by hand. Object order is
+ * semantically irrelevant in JSON and deliberately relevant here: `goldens.json` is byte-compared
+ * across toolchains, so an example in a different order would be describing a file that cannot exist.
+ *
+ * `textKey` and `colorToken` are omitted when the node has none. `cvChecks` is sorted and
  * deduplicated so that one screen has one serialisation - `goldens.json` is byte-compared across
  * toolchains like every other committed artifact, and a set whose order depended on which rule
  * selected the node first would not survive that.
  *
  * The two members are halves of one claim, which is why a `ColorHash` check is *refused* for a node
- * with no single declared colour token rather than emitted beside an absent `color_token`. A
+ * with no single declared colour token rather than emitted beside an absent `colorToken`. A
  * verifier asked to compare a tint has to be told which tint; a reference that asked without saying
  * would be one #16 could only skip.
  *
@@ -86,7 +99,7 @@
  * A `NumericDisplay`, `Clock`, `SignalTrace` or `StatusIndicator` shows a value that changes. The
  * golden pins **where** that content appears and **in what tint**, never what the value is: pinning
  * a live number would make the verifier fail whenever the demonstrator changed, which trains a team
- * to ignore it. So `text_key` is filled only from a field whose value is a single static key, and a
+ * to ignore it. So `textKey` is filled only from a field whose value is a single static key, and a
  * list-valued field such as `StatusIndicator`'s `states:` leaves it empty - the state shown is
  * exactly the varying part.
  */
@@ -104,7 +117,7 @@ export namespace mdux::tools::medui {
 /**
  * @brief A verification #16's driver performs against a rendered frame.
  *
- * The closed set the shared language defines. Order is the serialisation order: `cv_checks` is
+ * The closed set the shared language defines. Order is the serialisation order: `cvChecks` is
  * sorted by this enumeration so that a screen has one canonical form.
  */
 enum class CvCheck : std::uint8_t {

--- a/tools/medui/Goldens.cppm
+++ b/tools/medui/Goldens.cppm
@@ -1,0 +1,184 @@
+/**
+ * @file Goldens.cppm
+ * @brief Golden references for safety-critical nodes: which nodes a verifier must check, where they
+ *        must appear, and in what tint.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Host-only. A golden reference is the compiler's statement of what a rendered frame must show for
+ * the content that matters clinically, written down at build time so that #16's verifier checks a
+ * frame against a reviewed expectation rather than against the source that produced it. ADR-012
+ * decision 1 commits them to `generated/screen/<id>/goldens.json`, beside the screen package and
+ * outside it - a reviewer approving a moved safety-critical rectangle should see that hunk on its
+ * own, and a goldens-only change should have its own digest.
+ *
+ * ## The predicate is fixed, not chosen here
+ *
+ * ADR-011 settles which nodes are selected, and #16 must use the same rule, so it is restated
+ * rather than re-decided:
+ *
+ * - a node carrying `@safety_critical` emits an entry;
+ * - **any** node with an explicit `position:` emits an entry with a `Bounds` check, annotated or
+ *   not, because a declared position is a safety-relevant claim by itself;
+ * - a node matching both emits exactly **one** entry, with the two check lists merged and
+ *   deduplicated - never two entries for one node;
+ * - a `@safety_critical` node with no `requirement:` is an error (`MEDUI-E070`), because a
+ *   safety-critical node that cannot be traced is the thing the annotation exists to prevent. An
+ *   *empty* requirement is the same error: `requirement:` is a `String` field and the semantic
+ *   domain accepts `""`, so presence alone would let an untraceable node through the rule written
+ *   to stop it.
+ *
+ * One consequence of the pinned component model, stated because it is easy to read the predicate as
+ * promising otherwise: **only a component the dictionary gives a `requirement:` can be
+ * safety-critical.** That is `CriticalButton`, `Button`, `NumericDisplay`, `StatusIndicator` and
+ * `TextInput`. `Row` takes only `id`, `height`, `spacing` and `background`; `Label`, `Clock`,
+ * `Image`, `SignalTrace` and `VulkanViewport` take no requirement either - so an annotation on any
+ * of them always fails the rule above. That is the shared contract's answer rather than this
+ * compiler's, and the diagnostic says so instead of asking an author to add a field the language
+ * would then reject.
+ *
+ * The consequence worth stating: the file's content is *exactly determined* by the screen. That is
+ * what lets #197's consistency test compare sets rather than resolve references - it applies this
+ * predicate to the compiled nodes, derives the id set the goldens must contain, and asserts
+ * equality. A test that only checked that listed ids resolve would accept the dangerous direction
+ * silently, because a safety-critical node whose golden was dropped looks exactly like a screen
+ * with fewer safety-critical nodes (ADR-012, consequences).
+ *
+ * ## Why validation and emission are separate calls
+ *
+ * `validateSafetyAnnotations()` reads the parsed screen; `collectGoldens()` reads the resolved one.
+ * The split is not tidiness: the annotation rules are decidable from source alone, and the shared
+ * conformance suite requires that. `MEDUI-CASE-SAFETY-MISSING-REQUIREMENT` pins `MEDUI-E070` on a
+ * screen that declares no `surface:`, which the layout solver cannot resolve at all - so a design
+ * that could only report `MEDUI-E070` after layout could not satisfy the contract it implements.
+ *
+ * The order for a compiler driver is therefore: parse, analyze, validate annotations, resolve
+ * layout, collect goldens.
+ *
+ * ## The emitted shape, agreed here
+ *
+ * #196 is where the shape is settled, because #197 serialises it and #16 consumes it, and agreeing
+ * it after either of those exists means changing a committed artifact. `GoldenReference` maps
+ * one-to-one onto the canonical JSON:
+ *
+ * ```json
+ * { "node_id": "sedation-index",
+ *   "bounds": { "x": 1392, "y": 80, "width": 512, "height": 512 },
+ *   "text_key": "STR-SEDATION-LABEL",
+ *   "color_token": "Theme.Colors.ScoreDigits",
+ *   "cv_checks": ["Bounds", "ColorHash"] }
+ * ```
+ *
+ * `text_key` and `color_token` are omitted when the node has none. `cv_checks` is sorted and
+ * deduplicated so that one screen has one serialisation - `goldens.json` is byte-compared across
+ * toolchains like every other committed artifact, and a set whose order depended on which rule
+ * selected the node first would not survive that.
+ *
+ * The two members are halves of one claim, which is why a `ColorHash` check is *refused* for a node
+ * with no single declared colour token rather than emitted beside an absent `color_token`. A
+ * verifier asked to compare a tint has to be told which tint; a reference that asked without saying
+ * would be one #16 could only skip.
+ *
+ * ## What a golden pins for dynamic content, and what it must not
+ *
+ * A `NumericDisplay`, `Clock`, `SignalTrace` or `StatusIndicator` shows a value that changes. The
+ * golden pins **where** that content appears and **in what tint**, never what the value is: pinning
+ * a live number would make the verifier fail whenever the demonstrator changed, which trains a team
+ * to ignore it. So `text_key` is filled only from a field whose value is a single static key, and a
+ * list-valued field such as `StatusIndicator`'s `states:` leaves it empty - the state shown is
+ * exactly the varying part.
+ */
+module;
+
+export module mdux.tools.medui.goldens;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.layout;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief A verification #16's driver performs against a rendered frame.
+ *
+ * The closed set the shared language defines. Order is the serialisation order: `cv_checks` is
+ * sorted by this enumeration so that a screen has one canonical form.
+ */
+enum class CvCheck : std::uint8_t {
+    Bounds,    ///< the node's content occupies the rectangle the compiler resolved
+    ColorHash  ///< the node's content carries the tint its colour token resolves to
+};
+
+/// The spelling an author writes and the serialiser emits, e.g. `Bounds`.
+[[nodiscard]] std::string_view spell(CvCheck check) noexcept;
+
+/// The check `name` spells, or nothing when the name is not one of the closed set.
+[[nodiscard]] std::optional<CvCheck> parseCvCheck(std::string_view name) noexcept;
+
+/**
+ * @brief One golden reference: what a verifier must find, and where.
+ *
+ * Field names mirror the canonical JSON members one-to-one; see the module comment for the mapping.
+ * `textKey` and `colorToken` are empty when the node draws neither.
+ */
+struct GoldenReference {
+    std::string          nodeId;
+    LayoutRect           bounds{};
+    std::string          textKey;
+    std::string          colorToken;
+    std::vector<CvCheck> cvChecks;  ///< sorted, deduplicated, never empty
+
+    [[nodiscard]] bool operator==(const GoldenReference&) const = default;
+};
+
+/// Accumulated annotation diagnostics; an empty result admits the screen to layout and emission.
+struct SafetyResult {
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Checks the `@safety_critical` annotation rules on a parsed screen.
+ *
+ * Reports, all at the position of the offending token and in source order:
+ *
+ * - `MEDUI-E070` for an annotated node whose `requirement:` is absent, blank, or unavailable to the
+ *   component at all, at the annotation;
+ * - `MEDUI-E071` for a `cv_check` naming a verification outside the closed set, and for a
+ *   `ColorHash` on a node whose expected tint cannot be derived, at the offending name;
+ * - `MEDUI-E033` for a `cv_check` value that is not a name.
+ *
+ * Deliberately AST-level: see the module comment for why the shared contract requires these two
+ * codes to be reportable without a resolved layout.
+ */
+[[nodiscard]] SafetyResult validateSafetyAnnotations(const ast::Screen& screen, std::string file);
+
+/**
+ * @brief Derives the golden set from a resolved screen.
+ *
+ * Entries follow resolved-node order, which is the order the compiled package lists its nodes in,
+ * so a set comparison and a diff both read top to bottom.
+ *
+ * Returns references rather than a result type with a diagnostic list: every rule that can fail was
+ * decided by `validateSafetyAnnotations()`, and a permanently empty diagnostic vector would suggest
+ * this stage can reject a screen when it cannot.
+ *
+ * That validation is a required gate. A malformed annotation reaching here - a `cv_check` value
+ * that is not a name, or a name outside the closed set - means it was bypassed, and throws
+ * `std::logic_error` rather than emitting a golden nobody can verify.
+ *
+ * Only authored nodes are described. The solver's one synthetic node is a Row's background, and a
+ * Row can be neither annotated nor positioned, so it is never selected - see the interface comment
+ * above for why a container cannot be safety-critical at all.
+ *
+ * @throws std::logic_error if the annotation gate was bypassed.
+ */
+[[nodiscard]] std::vector<GoldenReference> collectGoldens(const LayoutResult& layout);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Layout.cpp
+++ b/tools/medui/Layout.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief Integer-only Vertical/Row layout resolution.
  * @file Layout.cpp
+ * @brief Integer-only Vertical/Row layout resolution.
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tools/medui/Layout.cpp
+++ b/tools/medui/Layout.cpp
@@ -1,0 +1,461 @@
+/**
+ * @brief Integer-only Vertical/Row layout resolution.
+ * @file Layout.cpp
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+module;
+
+module mdux.tools.medui.layout;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// Finds a named field on one component.
+[[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
+    const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
+    return found == node.fields.end() ? nullptr : &*found;
+}
+
+/// Finds a named field in an arbitrary field list.
+[[nodiscard]] const ast::Field* fieldFor(std::span<const ast::Field> fields, std::string_view name) noexcept {
+    const auto found = std::ranges::find(fields, name, &ast::Field::name);
+    return found == fields.end() ? nullptr : &*found;
+}
+
+/// Returns a field value, failing loudly if semantic validation was bypassed.
+[[nodiscard]] const ast::Value& valueOf(const ast::Field& field) {
+    if (field.value == nullptr) {
+        throw std::logic_error(std::format("layout received null value for field '{}'", field.name));
+    }
+    return *field.value;
+}
+
+/// Returns a validated component identifier.
+[[nodiscard]] std::string idOf(const ast::Node& node) {
+    const ast::Field* field = fieldFor(node, "id");
+    if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::Identifier || field->value->text.empty()) {
+        throw std::logic_error(std::format("layout received component '{}' without a validated id", node.component));
+    }
+    return field->value->text;
+}
+
+/// Returns the authored `id` field position, falling back for malformed directly-built ASTs.
+[[nodiscard]] ast::Position idFieldPosition(const ast::Node& node) noexcept {
+    if (const ast::Field* field = fieldFor(node, "id")) {
+        return field->namePosition;
+    }
+    return node.position;
+}
+
+/// Returns a validated size field.
+[[nodiscard]] const ast::Size& sizeOf(const ast::Node& node, std::string_view name) {
+    const ast::Field* field = fieldFor(node, name);
+    if (field == nullptr || field->value == nullptr || field->value->kind != ast::ValueKind::Size) {
+        throw std::logic_error(std::format("layout received component '{}' without validated field '{}'", node.component, name));
+    }
+    return field->value->size;
+}
+
+/// Returns an optional validated position field.
+[[nodiscard]] const ast::Point* positionOf(const ast::Node& node) {
+    const ast::Field* field = fieldFor(node, "position");
+    if (field == nullptr) {
+        return nullptr;
+    }
+    if (field->value == nullptr || field->value->kind != ast::ValueKind::Point) {
+        throw std::logic_error(std::format("layout received component '{}' with an unvalidated position", node.component));
+    }
+    return &field->value->point;
+}
+
+/// Returns the source position used for a positioned-node diagnostic.
+[[nodiscard]] ast::Position positionFieldPosition(const ast::Node& node) noexcept {
+    if (const ast::Field* field = fieldFor(node, "position")) {
+        return field->namePosition;
+    }
+    return node.position;
+}
+
+/// Tests complete rectangle containment without overflow-prone edge addition.
+[[nodiscard]] bool contains(LayoutRect outer, LayoutRect inner) noexcept {
+    if (inner.x < outer.x || inner.y < outer.y || inner.width < 0 || inner.height < 0) {
+        return false;
+    }
+    const std::int64_t relativeX = inner.x - outer.x;
+    const std::int64_t relativeY = inner.y - outer.y;
+    return relativeX <= outer.width && relativeY <= outer.height && inner.width <= outer.width - relativeX && inner.height <= outer.height - relativeY;
+}
+
+/// Tests strict AABB overlap; touching edges are legal adjacency.
+[[nodiscard]] bool overlaps(LayoutRect first, LayoutRect second) noexcept {
+    // All accepted rectangles are non-negative and surface-contained, so these additions cannot
+    // overflow. Shared edges are adjacency, not overlap.
+    return first.x < second.x + second.width && second.x < first.x + first.width && first.y < second.y + second.height && second.y < first.y + first.height;
+}
+
+/// One fail-closed, integer-only layout pass.
+class Solver {
+public:
+    /// Captures the diagnostic path and build-selected surface.
+    Solver(std::string file, LayoutInputs inputs)
+        : file_{std::move(file)},
+          inputs_{inputs},
+          result_{.surfaceWidth = inputs.surfaceWidth, .surfaceHeight = inputs.surfaceHeight, .nodes = {}, .diagnostics = {}} {}
+
+    /// Resolves one semantically valid screen, returning no nodes on any diagnostic.
+    [[nodiscard]] LayoutResult run(const ast::Screen& screen) {
+        assertSingleRowLevel(screen);
+        if (!preflightPositionedFill(screen.nodes)) {
+            return std::move(result_);
+        }
+        if (!preflightPositiveDimensions(screen.nodes)) {
+            return std::move(result_);
+        }
+        if (!readSurface(screen) || !readLayout(screen)) {
+            return std::move(result_);
+        }
+
+        const LayoutRect content{.x = padding_, .y = padding_, .width = inputs_.surfaceWidth - 2 * padding_, .height = inputs_.surfaceHeight - 2 * padding_};
+
+        std::vector<const ast::Node*> flow;
+        for (const ast::Node& node : screen.nodes) {
+            if (node.component == "Row" || positionOf(node) == nullptr) {
+                flow.push_back(&node);
+            }
+        }
+
+        std::vector<ast::Size> heights;
+        heights.reserve(flow.size());
+        for (const ast::Node* node : flow) {
+            heights.push_back(sizeOf(*node, "height"));
+        }
+        const auto resolvedHeights = resolveAxis(heights, content.height, spacing_, screen.layoutPosition, "vertical layout");
+        if (!resolvedHeights) {
+            return std::move(result_);
+        }
+
+        std::int64_t cursorY   = content.y;
+        std::size_t  flowIndex = 0;
+        for (const ast::Node& node : screen.nodes) {
+            if (node.component == "Row") {
+                const LayoutRect rowBounds{.x = content.x, .y = cursorY, .width = content.width, .height = (*resolvedHeights)[flowIndex]};
+                if (!resolveRow(node, rowBounds)) {
+                    return std::move(result_);
+                }
+                cursorY += rowBounds.height + spacing_;
+                ++flowIndex;
+                continue;
+            }
+
+            if (const ast::Point* position = positionOf(node)) {
+                const LayoutRect bounds{.x = position->x, .y = position->y, .width = fixedSize(node, "width"), .height = fixedSize(node, "height")};
+                if (!contains(content, bounds)) {
+                    report(Code::SurfaceExceeded, positionFieldPosition(node), std::format("component '{}' exceeds the padded surface", idOf(node)));
+                    return std::move(result_);
+                }
+                appendLeaf(node, bounds, true);
+                continue;
+            }
+
+            const ast::Size&   width         = sizeOf(node, "width");
+            const std::int64_t resolvedWidth = width.fill ? content.width : width.pixels;
+            if (resolvedWidth <= 0 || resolvedWidth > content.width) {
+                report(Code::LayoutOverflow, width.position, std::format("component '{}' is wider than the vertical layout", idOf(node)));
+                return std::move(result_);
+            }
+            const LayoutRect bounds{.x = content.x, .y = cursorY, .width = resolvedWidth, .height = (*resolvedHeights)[flowIndex]};
+            appendLeaf(node, bounds, false);
+            cursorY += bounds.height + spacing_;
+            ++flowIndex;
+        }
+
+        if (!validateUniqueIds() || !validatePositionedOverlap()) {
+            return std::move(result_);
+        }
+        return std::move(result_);
+    }
+
+private:
+    /// Enforces the parser's one-level Row invariant for directly-built ASTs too.
+    void assertSingleRowLevel(const ast::Screen& screen) const {
+        for (const ast::Node& node : screen.nodes) {
+            if (node.component != "Row" && !node.children.empty()) {
+                throw std::logic_error(std::format("layout received children on non-Row component '{}'", node.component));
+            }
+            for (const ast::Node& child : node.children) {
+                if (child.component == "Row" || !child.children.empty()) {
+                    throw std::logic_error("layout received a nested Row; the parser must reject it before layout");
+                }
+            }
+        }
+    }
+
+    /// Rejects the contradictory out-of-flow `position` plus `Fill` combination.
+    bool preflightPositionedFill(std::span<const ast::Node> nodes) {
+        for (const ast::Node& node : nodes) {
+            if (positionOf(node) != nullptr && (sizeOf(node, "width").fill || sizeOf(node, "height").fill)) {
+                // The common MedUI conformance case pins this declaration to MEDUI-E051. Keep the
+                // shared diagnostic even though the failure is detected before axis resolution.
+                report(Code::LayoutOverflow,
+                       positionFieldPosition(node),
+                       std::format("component '{}': position requires fixed width and height; "
+                                   "Fill is flow-only",
+                                   idOf(node)));
+                return false;
+            }
+            if (!preflightPositionedFill(node.children)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Rejects zero-sized fixed component dimensions before any rectangle is emitted.
+    bool preflightPositiveDimensions(std::span<const ast::Node> nodes) {
+        for (const ast::Node& node : nodes) {
+            const auto check = [&](std::string_view name) {
+                const ast::Size& size = sizeOf(node, name);
+                if (!size.fill && size.pixels <= 0) {
+                    report(Code::LayoutOverflow, size.position, std::format("component '{}' {} must be greater than zero", idOf(node), name));
+                    return false;
+                }
+                return true;
+            };
+
+            if (node.component == "Row") {
+                if (!check("height") || !preflightPositiveDimensions(node.children)) {
+                    return false;
+                }
+            } else if (!check("width") || !check("height")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Validates build dimensions and an optional authored surface pin.
+    bool readSurface(const ast::Screen& screen) {
+        if (inputs_.surfaceWidth <= 0 || inputs_.surfaceHeight <= 0 || inputs_.surfaceWidth > std::numeric_limits<std::int32_t>::max()
+            || inputs_.surfaceHeight > std::numeric_limits<std::int32_t>::max()) {
+            report(Code::SurfaceExceeded, screen.position, "build surface dimensions must be positive 32-bit pixel values");
+            return false;
+        }
+        if (screen.surface && (screen.surface->x != inputs_.surfaceWidth || screen.surface->y != inputs_.surfaceHeight)) {
+            report(Code::SurfaceExceeded,
+                   screen.surface->position,
+                   std::format("declared surface {}x{} does not match build surface {}x{}",
+                               screen.surface->x,
+                               screen.surface->y,
+                               inputs_.surfaceWidth,
+                               inputs_.surfaceHeight));
+            return false;
+        }
+        return true;
+    }
+
+    /// Reads Vertical layout configuration and rejects an empty padded content box.
+    bool readLayout(const ast::Screen& screen) {
+        if (screen.layoutKind != "Vertical") {
+            report(Code::ForbiddenConstruct,
+                   screen.layoutPosition,
+                   "the bounded layout solver accepts Vertical screens; Row supplies the only "
+                   "horizontal grouping");
+            return false;
+        }
+        const auto readPixel = [&](std::string_view name, std::int64_t defaultValue, std::int64_t& destination) {
+            const ast::Field* field = fieldFor(screen.layout, name);
+            if (field == nullptr) {
+                destination = defaultValue;
+                return true;
+            }
+            const ast::Value& value = valueOf(*field);
+            if (value.kind != ast::ValueKind::Size || value.size.fill || value.size.pixels < 0) {
+                report(Code::LayoutOverflow, value.position, std::format("layout {} must be a non-negative pixel size", name));
+                return false;
+            }
+            destination = value.size.pixels;
+            return true;
+        };
+        if (!readPixel("spacing", 0, spacing_) || !readPixel("padding", 0, padding_)) {
+            return false;
+        }
+        if (padding_ >= inputs_.surfaceWidth - padding_ || padding_ >= inputs_.surfaceHeight - padding_) {
+            report(Code::SurfaceExceeded, screen.layoutPosition, "layout padding leaves no surface content box");
+            return false;
+        }
+        return true;
+    }
+
+    /// Resolves fixed and Fill sizes using TrustSC's equal-share rule; any remainder stays unused.
+    [[nodiscard]] std::optional<std::vector<std::int64_t>>
+    resolveAxis(std::span<const ast::Size> dimensions, std::int64_t available, std::int64_t spacing, ast::Position position, std::string_view context) {
+        const std::int64_t gaps = dimensions.empty() ? 0 : static_cast<std::int64_t>(dimensions.size() - 1);
+        if (spacing > 0 && gaps > (available / spacing)) {
+            report(Code::LayoutOverflow, position, std::format("{} spacing exceeds its available space", context));
+            return std::nullopt;
+        }
+        const std::int64_t spacingTotal = spacing * gaps;
+        std::int64_t       fixedTotal   = 0;
+        std::int64_t       fillCount    = 0;
+        for (const ast::Size& dimension : dimensions) {
+            if (dimension.fill) {
+                ++fillCount;
+                continue;
+            }
+            if (dimension.pixels <= 0 || dimension.pixels > available - spacingTotal - fixedTotal) {
+                report(Code::LayoutOverflow, dimension.position, std::format("{} exceeds its available space", context));
+                return std::nullopt;
+            }
+            fixedTotal += dimension.pixels;
+        }
+        const std::int64_t remaining = available - spacingTotal - fixedTotal;
+        const std::int64_t fillSize  = fillCount == 0 ? 0 : remaining / fillCount;
+        if (fillCount > 0 && fillSize <= 0) {
+            report(Code::LayoutOverflow, position, std::format("Fill items in {} have no remaining space", context));
+            return std::nullopt;
+        }
+
+        std::vector<std::int64_t> result;
+        result.reserve(dimensions.size());
+        for (const ast::Size& dimension : dimensions) {
+            result.push_back(dimension.fill ? fillSize : dimension.pixels);
+        }
+        return result;
+    }
+
+    /// Resolves one Row to an optional Panel followed by its flat leaf children.
+    bool resolveRow(const ast::Node& row, LayoutRect bounds) {
+        const std::string rowId      = idOf(row);
+        std::int64_t      rowSpacing = 0;
+        if (const ast::Field* field = fieldFor(row, "spacing")) {
+            const ast::Value& value = valueOf(*field);
+            if (value.kind != ast::ValueKind::Size || value.size.fill || value.size.pixels < 0) {
+                report(Code::LayoutOverflow, value.position, std::format("Row '{}' spacing must be a non-negative pixel size", rowId));
+                return false;
+            }
+            rowSpacing = value.size.pixels;
+        }
+
+        if (fieldFor(row, "background") != nullptr) {
+            result_.nodes.push_back(
+                ResolvedNode{.id = rowId + "-background", .component = "Panel", .bounds = bounds, .source = row, .positioned = false, .synthetic = true});
+        }
+
+        std::vector<ast::Size> widths;
+        for (const ast::Node& child : row.children) {
+            if (positionOf(child) == nullptr) {
+                widths.push_back(sizeOf(child, "width"));
+            }
+        }
+        const auto resolvedWidths = resolveAxis(widths, bounds.width, rowSpacing, row.position, std::format("Row '{}'", rowId));
+        if (!resolvedWidths) {
+            return false;
+        }
+
+        std::int64_t cursorX   = bounds.x;
+        std::size_t  flowIndex = 0;
+        for (const ast::Node& child : row.children) {
+            if (const ast::Point* position = positionOf(child)) {
+                const LayoutRect childBounds{.x = position->x, .y = position->y, .width = fixedSize(child, "width"), .height = fixedSize(child, "height")};
+                if (!contains(bounds, childBounds)) {
+                    report(Code::LayoutOverflow, positionFieldPosition(child), std::format("component '{}' escapes Row '{}'", idOf(child), rowId));
+                    return false;
+                }
+                appendLeaf(child, childBounds, true);
+                continue;
+            }
+
+            const ast::Size&   height         = sizeOf(child, "height");
+            const std::int64_t resolvedHeight = height.fill ? bounds.height : height.pixels;
+            if (resolvedHeight <= 0 || resolvedHeight > bounds.height) {
+                report(Code::LayoutOverflow, height.position, std::format("component '{}' is taller than Row '{}'", idOf(child), rowId));
+                return false;
+            }
+            const LayoutRect childBounds{.x = cursorX, .y = bounds.y, .width = (*resolvedWidths)[flowIndex], .height = resolvedHeight};
+            appendLeaf(child, childBounds, false);
+            cursorX += childBounds.width + rowSpacing;
+            ++flowIndex;
+        }
+        return true;
+    }
+
+    /// Returns a positioned node's fixed size after preflight validation.
+    [[nodiscard]] std::int64_t fixedSize(const ast::Node& node, std::string_view name) const {
+        const ast::Size& size = sizeOf(node, name);
+        if (size.fill) {
+            throw std::logic_error("positioned Fill reached layout after the preflight check");
+        }
+        return size.pixels;
+    }
+
+    /// Appends an owned authored leaf to the flat result.
+    void appendLeaf(const ast::Node& node, LayoutRect bounds, bool positioned) {
+        result_.nodes.push_back(
+            ResolvedNode{.id = idOf(node), .component = node.component, .bounds = bounds, .source = node, .positioned = positioned, .synthetic = false});
+    }
+
+    /// Rechecks identifiers after synthetic background nodes have been added.
+    bool validateUniqueIds() {
+        std::map<std::string_view, ast::Position> seen;
+        for (const ResolvedNode& node : result_.nodes) {
+            const ast::Position idPosition  = idFieldPosition(node.source);
+            const auto [previous, inserted] = seen.emplace(node.id, idPosition);
+            if (!inserted) {
+                report(Code::DuplicateNodeId,
+                       idPosition,
+                       std::format("resolved node id '{}' is already used at line {}, column {}", node.id, previous->second.line, previous->second.column));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Rejects overlap involving a positioned node; synthetic backgrounds are underlays.
+    bool validatePositionedOverlap() {
+        for (std::size_t first = 0; first < result_.nodes.size(); ++first) {
+            for (std::size_t second = first + 1; second < result_.nodes.size(); ++second) {
+                const ResolvedNode& a = result_.nodes[first];
+                const ResolvedNode& b = result_.nodes[second];
+                if (a.synthetic || b.synthetic || (!a.positioned && !b.positioned) || !overlaps(a.bounds, b.bounds)) {
+                    continue;
+                }
+                const ResolvedNode& positioned = a.positioned ? a : b;
+                const ResolvedNode& other      = a.positioned ? b : a;
+                report(Code::LayoutOverflow,
+                       positionFieldPosition(positioned.source),
+                       std::format("positioned component '{}' overlaps component '{}'", positioned.id, other.id));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Records one finding and discards every partial rectangle produced before it.
+    void report(Code code, ast::Position position, std::string message) {
+        result_.nodes.clear();
+        result_.diagnostics.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
+    }
+
+    std::string  file_;
+    LayoutInputs inputs_{};
+    LayoutResult result_{};
+    std::int64_t spacing_{0};
+    std::int64_t padding_{0};
+};
+
+}  // namespace
+
+/// Implements the public layout-module entry point.
+LayoutResult resolveLayout(const ast::Screen& screen, std::string file, LayoutInputs inputs) {
+    return Solver{std::move(file), inputs}.run(screen);
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Layout.cppm
+++ b/tools/medui/Layout.cppm
@@ -1,6 +1,6 @@
 /**
- * @brief Integer-only build-time layout resolution for `.medui` screens.
  * @file Layout.cppm
+ * @brief Integer-only build-time layout resolution for `.medui` screens.
  *
  * @compliance ADR-004 Trust zones in C++ (host tools zone)
  * @compliance ADR-011 The deterministic `.medui` compile boundary

--- a/tools/medui/Layout.cppm
+++ b/tools/medui/Layout.cppm
@@ -1,0 +1,88 @@
+/**
+ * @brief Integer-only build-time layout resolution for `.medui` screens.
+ * @file Layout.cppm
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * This host-only stage turns the parser's unresolved Vertical/Row tree into a flat sequence of
+ * absolute rectangles. It owns no device behavior: later compiler stages consume this result,
+ * while the governed runtime receives only emitted, already-resolved layout.
+ */
+module;
+
+export module mdux.tools.medui.layout;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+
+export namespace mdux::tools::medui {
+
+/// Build-selected surface dimensions. A source-level `surface:` declaration, when present, must
+/// agree with these values.
+struct LayoutInputs {
+    std::int64_t surfaceWidth{0};
+    std::int64_t surfaceHeight{0};
+};
+
+/// An absolute rectangle in integer surface pixels.
+struct LayoutRect {
+    std::int64_t x{0};
+    std::int64_t y{0};
+    std::int64_t width{0};
+    std::int64_t height{0};
+
+    auto operator<=>(const LayoutRect&) const = default;
+};
+
+/**
+ * @brief One flat compiled-layout entry.
+ *
+ * `source` is an owned copy, not a pointer into the input screen, so a result remains valid after
+ * its AST is released. For an authored leaf, `id` and `component` match `source`. A Row background
+ * is represented as a synthetic `Panel`: `source` is the originating Row and `id` is
+ * `<row-id>-background`.
+ */
+struct ResolvedNode {
+    std::string id;
+    std::string component;
+    LayoutRect  bounds{};
+    ast::Node   source;
+    bool        positioned{false};
+    bool        synthetic{false};
+};
+
+/// Flat nodes and any diagnostic that prevented a complete layout. `nodes` is empty whenever a
+/// diagnostic is present, so a caller cannot accidentally consume a partial screen.
+struct LayoutResult {
+    std::int64_t                              surfaceWidth{0};
+    std::int64_t                              surfaceHeight{0};
+    std::vector<ResolvedNode>                 nodes;
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Resolves a semantically-valid screen to flat absolute rectangles.
+ *
+ * The algorithm uses integer arithmetic only. Multiple `Fill` items receive equal integer shares;
+ * an indivisible trailing remainder stays unused, matching the TrustSC reference behavior. Flow
+ * overflow, a `Fill` that resolves to no space, containment failures, and positioned overlaps are
+ * diagnostics; dimensions are never clamped.
+ * Positioned nodes are removed from flow. Their coordinates are absolute surface coordinates;
+ * top-level nodes must remain inside the padded content box, and Row children inside the Row's
+ * already-resolved absolute band. A Row contributes one vertical flow item and its children are
+ * resolved horizontally in the same single pass.
+ *
+ * The parser already rejects nested Row. Because the AST is public and can be built directly,
+ * this function checks that invariant and throws `std::logic_error` if a caller bypassed the
+ * parser. Other malformed-AST conditions are treated the same way: semantic analysis is a
+ * required gate before layout.
+ */
+[[nodiscard]] LayoutResult resolveLayout(const ast::Screen& screen, std::string file, LayoutInputs inputs);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Lexer.cpp
+++ b/tools/medui/Lexer.cpp
@@ -1,0 +1,283 @@
+/**
+ * @file Lexer.cpp
+ * @brief The `.medui` lexer.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * One pass, one character of lookahead, no backtracking. The grammar does not need more, and a
+ * lexer a reviewer can hold in their head is worth more here than one that is clever.
+ */
+module;
+
+module mdux.tools.medui.lexer;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// An identifier body. Hyphens are included because node ids use them - `id: sedation-index;` in
+/// the skill's own example - and excluding them would force quotes on every id.
+[[nodiscard]] constexpr bool isIdentifierChar(char c) noexcept {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' ||
+           c == '-';
+}
+
+/// An identifier start. A digit cannot begin one, or `1920px` would lex as one identifier rather
+/// than a number followed by a unit - and the parser needs those separate to reject `1920rem`.
+[[nodiscard]] constexpr bool isIdentifierStart(char c) noexcept {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+}
+
+[[nodiscard]] constexpr bool isDigit(char c) noexcept { return c >= '0' && c <= '9'; }
+
+/**
+ * @brief Validates UTF-8 and reports the byte offset of the first bad sequence.
+ *
+ * Written out rather than delegated: the standard library has no UTF-8 validator, and the
+ * alternative is a SOUP entry for one function. Rejects overlong encodings, surrogates and
+ * out-of-range code points, because "it decoded to something" is not the same as "it was valid" -
+ * an overlong NUL is the classic way a filter is bypassed, and this text ends up in a committed
+ * artifact.
+ */
+[[nodiscard]] std::optional<std::size_t> firstInvalidUtf8(std::string_view s) noexcept {
+    std::size_t i = 0;
+    while (i < s.size()) {
+        const auto b0 = static_cast<unsigned char>(s[i]);
+        std::size_t extra = 0;
+        std::uint32_t cp = 0;
+        std::uint32_t lowest = 0;
+
+        if (b0 < 0x80) {
+            i += 1;
+            continue;
+        }
+        if ((b0 & 0xE0u) == 0xC0u) { extra = 1; cp = b0 & 0x1Fu; lowest = 0x80; }
+        else if ((b0 & 0xF0u) == 0xE0u) { extra = 2; cp = b0 & 0x0Fu; lowest = 0x800; }
+        else if ((b0 & 0xF8u) == 0xF0u) { extra = 3; cp = b0 & 0x07u; lowest = 0x10000; }
+        else { return i; }
+
+        if (i + extra >= s.size()) {
+            return i;
+        }
+        for (std::size_t k = 1; k <= extra; ++k) {
+            const auto bk = static_cast<unsigned char>(s[i + k]);
+            if ((bk & 0xC0u) != 0x80u) {
+                return i;
+            }
+            cp = (cp << 6) | (bk & 0x3Fu);
+        }
+        if (cp < lowest || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)) {
+            return i;  // overlong, out of range, or a surrogate
+        }
+        i += extra + 1;
+    }
+    return std::nullopt;
+}
+
+/// Tracks the cursor and its 1-based position, so every token can be stamped without recomputing.
+class Cursor {
+public:
+    explicit Cursor(std::string_view source) noexcept : source_{source} {}
+
+    [[nodiscard]] bool atEnd() const noexcept { return offset_ >= source_.size(); }
+    [[nodiscard]] char peek() const noexcept { return atEnd() ? '\0' : source_[offset_]; }
+    [[nodiscard]] char peekNext() const noexcept {
+        return offset_ + 1 < source_.size() ? source_[offset_ + 1] : '\0';
+    }
+    [[nodiscard]] std::size_t offset() const noexcept { return offset_; }
+    [[nodiscard]] std::size_t line() const noexcept { return line_; }
+    [[nodiscard]] std::size_t column() const noexcept { return column_; }
+
+    char advance() noexcept {
+        const char c = peek();
+        ++offset_;
+        if (c == '\n') {
+            ++line_;
+            column_ = 1;
+        } else {
+            ++column_;
+        }
+        return c;
+    }
+
+private:
+    std::string_view source_;
+    std::size_t offset_{0};
+    std::size_t line_{1};
+    std::size_t column_{1};
+};
+
+}  // namespace
+
+std::string_view describe(TokenKind kind) noexcept {
+    switch (kind) {
+        case TokenKind::Identifier: return "an identifier";
+        case TokenKind::Number:     return "a number";
+        case TokenKind::String:     return "a string";
+        case TokenKind::At:         return "'@'";
+        case TokenKind::LBrace:     return "'{'";
+        case TokenKind::RBrace:     return "'}'";
+        case TokenKind::LParen:     return "'('";
+        case TokenKind::RParen:     return "')'";
+        case TokenKind::LBracket:   return "'['";
+        case TokenKind::RBracket:   return "']'";
+        case TokenKind::Colon:      return "':'";
+        case TokenKind::Semicolon:  return "';'";
+        case TokenKind::Comma:      return "','";
+        case TokenKind::Dot:        return "'.'";
+        case TokenKind::EndOfFile:  return "end of file";
+    }
+    return "an unknown token";
+}
+
+LexResult lex(std::string_view source, std::string file) {
+    LexResult result;
+
+    if (const std::optional<std::size_t> bad = firstInvalidUtf8(source)) {
+        // Rejected whole rather than at the offending byte. Past an invalid sequence there are no
+        // defined character boundaries, so every column after it would be a guess.
+        result.diagnostics.push_back(diagnose(
+            Code::SourceNotUtf8, std::move(file), 0, 0,
+            std::format("not valid UTF-8: the first invalid byte sequence begins at offset {}",
+                        *bad)));
+        return result;
+    }
+
+    Cursor cursor{source};
+    const auto push = [&result](TokenKind kind, std::string text, std::size_t line,
+                                std::size_t column) {
+        result.tokens.push_back(Token{.kind = kind,
+                                      .text = std::move(text),
+                                      .line = line,
+                                      .column = column});
+    };
+
+    while (!cursor.atEnd()) {
+        const char c = cursor.peek();
+
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+            static_cast<void>(cursor.advance());
+            continue;
+        }
+        if (c == '/' && cursor.peekNext() == '/') {
+            while (!cursor.atEnd() && cursor.peek() != '\n') {
+                static_cast<void>(cursor.advance());
+            }
+            continue;
+        }
+
+        const std::size_t line = cursor.line();
+        const std::size_t column = cursor.column();
+
+        if (isIdentifierStart(c)) {
+            const std::size_t start = cursor.offset();
+            while (!cursor.atEnd() && isIdentifierChar(cursor.peek())) {
+                static_cast<void>(cursor.advance());
+            }
+            push(TokenKind::Identifier,
+                 std::string{source.substr(start, cursor.offset() - start)}, line, column);
+            continue;
+        }
+
+        if (isDigit(c)) {
+            const std::size_t start = cursor.offset();
+            while (!cursor.atEnd() && isDigit(cursor.peek())) {
+                static_cast<void>(cursor.advance());
+            }
+            push(TokenKind::Number, std::string{source.substr(start, cursor.offset() - start)},
+                 line, column);
+            continue;
+        }
+
+        if (c == '"') {
+            static_cast<void>(cursor.advance());  // the opening quote
+            std::string value;
+            bool terminated = false;
+            while (!cursor.atEnd()) {
+                const char ch = cursor.peek();
+                if (ch == '"') {
+                    static_cast<void>(cursor.advance());
+                    terminated = true;
+                    break;
+                }
+                if (ch == '\n') {
+                    break;  // a string does not span lines; report it at the opening quote
+                }
+                if (ch == '\\') {
+                    // A backslash at end of line or end of file is not an escape. Consuming the
+                    // next byte regardless let a string swallow its own newline and run on into
+                    // the following line, skewing every position after it - and the unterminated
+                    // string would then be reported somewhere the author never wrote one.
+                    const char next = cursor.peekNext();
+                    if (next == '\n' || next == '\0') {
+                        break;  // leaves `terminated` false: reported at the opening quote
+                    }
+                    static_cast<void>(cursor.advance());
+                    const char esc = cursor.peek();
+                    switch (esc) {
+                        case '"':  value += '"';  static_cast<void>(cursor.advance()); break;
+                        case '\\': value += '\\'; static_cast<void>(cursor.advance()); break;
+                        case 'n':  value += '\n'; static_cast<void>(cursor.advance()); break;
+                        case 't':  value += '\t'; static_cast<void>(cursor.advance()); break;
+                        default:
+                            // An unknown escape is an error rather than a literal backslash. A
+                            // silently-kept `\d` in a requirement id is the kind of thing that
+                            // survives review and then fails a trace years later.
+                            result.diagnostics.push_back(diagnose(
+                                Code::UnexpectedToken, file, cursor.line(), cursor.column(),
+                                std::format("unknown escape '\\{}' in a string",
+                                            esc == '\0' ? '?' : esc),
+                                "the supported escapes are \\\" \\\\ \\n and \\t"));
+                            static_cast<void>(cursor.advance());
+                            break;
+                    }
+                    continue;
+                }
+                value += cursor.advance();
+            }
+            if (!terminated) {
+                result.diagnostics.push_back(diagnose(
+                    Code::UnexpectedToken, file, line, column, "unterminated string",
+                    "add the closing quote; a string may not span lines"));
+                continue;
+            }
+            push(TokenKind::String, std::move(value), line, column);
+            continue;
+        }
+
+        const auto single = [&](TokenKind kind) {
+            static_cast<void>(cursor.advance());
+            push(kind, std::string{c}, line, column);
+        };
+
+        switch (c) {
+            case '@': single(TokenKind::At);        continue;
+            case '{': single(TokenKind::LBrace);    continue;
+            case '}': single(TokenKind::RBrace);    continue;
+            case '(': single(TokenKind::LParen);    continue;
+            case ')': single(TokenKind::RParen);    continue;
+            case '[': single(TokenKind::LBracket);  continue;
+            case ']': single(TokenKind::RBracket);  continue;
+            case ':': single(TokenKind::Colon);     continue;
+            case ';': single(TokenKind::Semicolon); continue;
+            case ',': single(TokenKind::Comma);     continue;
+            case '.': single(TokenKind::Dot);       continue;
+            default: break;
+        }
+
+        result.diagnostics.push_back(diagnose(
+            Code::UnexpectedToken, file, line, column,
+            std::format("unexpected character '{}'", c)));
+        static_cast<void>(cursor.advance());
+    }
+
+    push(TokenKind::EndOfFile, {}, cursor.line(), cursor.column());
+    return result;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Lexer.cppm
+++ b/tools/medui/Lexer.cppm
@@ -109,7 +109,7 @@ struct LexResult {
  * cannot report more than one problem per run. It lexes as far as it can, so a run reports several
  * findings rather than one at a time.
  *
- * A source that is not valid UTF-8 is rejected whole, with `MDX-E004`. Continuing past that would
+ * A source that is not valid UTF-8 is rejected whole, with `MEDUI-E004`. Continuing past that would
  * mean reporting columns into a byte sequence that has no defined character boundaries.
  */
 [[nodiscard]] LexResult lex(std::string_view source, std::string file);

--- a/tools/medui/Lexer.cppm
+++ b/tools/medui/Lexer.cppm
@@ -1,0 +1,117 @@
+/**
+ * @file Lexer.cppm
+ * @brief Hand-written `.medui` lexer: source text to positioned tokens.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Host-only, like the rest of the compiler. Hand-written rather than generated, for the reason
+ * `mdux.tools.truetype` and `mdux.tools.toml` are: a generator is a SOUP entry, a build-time
+ * dependency and a second language in the tree, and this grammar is small enough that none of that
+ * buys anything. It is also the shape a reviewer can read.
+ *
+ * ## Every token carries a line and a column
+ *
+ * Not a convenience. The shared diagnostic envelope (#118) defines `line` and `column` as
+ * independent, 1-based, with 0 meaning "no precise position on this axis" - and #192 requires a
+ * fixture to assert the position rather than only the code. A lexer that tracked lines alone would
+ * make that impossible for every diagnostic downstream, so positions are carried from the first
+ * stage rather than reconstructed later.
+ *
+ * Columns count UTF-8 *bytes*, not code points, and the header comment on `Token` says so. A
+ * multi-byte character before a token therefore shifts its reported column. That is the same
+ * convention `mdux-docs-lint` and `mdux-governed-lint` use, and matching them matters more than
+ * being clever: an agent consuming the shared envelope should not need to know which tool produced
+ * a finding to interpret its column.
+ *
+ * ## Comments
+ *
+ * `//` to end of line. The `medui-authoring` skill's grammar block does not show a comment, and
+ * this is the one place the lexer accepts something the skill does not illustrate. It is included
+ * deliberately: a screen carries `requirement:` strings and `@safety_critical` annotations, and a
+ * language for describing safety-relevant UI in which an author cannot write down *why* is a
+ * language that pushes that reasoning somewhere the compiler never sees. Recorded here rather than
+ * assumed, so the decision is reviewable; if it is rejected, deleting `skipComment()` and the
+ * fixture that covers it is the whole change.
+ *
+ * Block comments are deliberately absent. They need nesting rules, they invite commented-out
+ * screens, and nothing here needs them.
+ */
+module;
+
+export module mdux.tools.medui.lexer;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.diagnostics;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief What a token is.
+ *
+ * Deliberately small. The parser decides what an identifier *means* - `Screen`, `Row`, a component
+ * name, a field name and a theme token are all `Identifier` here - because a lexer that classified
+ * them would need the component dictionary, and the dictionary belongs to a later stage (#193).
+ * Keeping that knowledge out means adding a component never touches this file.
+ */
+enum class TokenKind : std::uint8_t {
+    Identifier,   ///< `Screen`, `NumericDisplay`, `width`, `Fill`, `sedation-index`
+    Number,       ///< an integer literal; `px` arrives as a separate Identifier token
+    String,       ///< `"REQ-NS-001"`, with the quotes removed and escapes resolved
+    At,           ///< `@`, opening an annotation
+    LBrace,       ///< `{`
+    RBrace,       ///< `}`
+    LParen,       ///< `(`
+    RParen,       ///< `)`
+    LBracket,     ///< `[`
+    RBracket,     ///< `]`
+    Colon,        ///< `:`
+    Semicolon,    ///< `;`
+    Comma,        ///< `,`
+    Dot,          ///< `.`, joining `Theme.Colors.<Token>`
+    EndOfFile,
+};
+
+[[nodiscard]] std::string_view describe(TokenKind kind) noexcept;
+
+/**
+ * @brief One token, with where it started.
+ *
+ * `line` and `column` are 1-based, matching the shared envelope. `column` counts UTF-8 bytes from
+ * the line start, not code points - see the file header.
+ *
+ * `text` borrows from the source buffer for identifiers and numbers, and owns for strings, whose
+ * escapes are resolved during lexing. One `std::string` either way keeps the type simple; this is
+ * a host tool compiling one screen, and a borrow-versus-own union would be optimising the wrong
+ * thing.
+ */
+struct Token {
+    TokenKind kind{TokenKind::EndOfFile};
+    std::string text;
+    std::size_t line{0};
+    std::size_t column{0};
+};
+
+/// The tokens of one source, or the diagnostics that stopped it being tokenised.
+struct LexResult {
+    std::vector<Token> tokens;
+    std::vector<cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept { return diagnostics.empty(); }
+};
+
+/**
+ * @brief Tokenises `source`, attributing every diagnostic to `file`.
+ *
+ * Never throws for malformed input: a bad character or an unterminated string becomes a
+ * diagnostic, because a compiler that throws on the input it exists to reject is a compiler that
+ * cannot report more than one problem per run. It lexes as far as it can, so a run reports several
+ * findings rather than one at a time.
+ *
+ * A source that is not valid UTF-8 is rejected whole, with `MDX-E004`. Continuing past that would
+ * mean reporting columns into a byte sequence that has no defined character boundaries.
+ */
+[[nodiscard]] LexResult lex(std::string_view source, std::string file);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/MeduiCheckMain.cpp
+++ b/tools/medui/MeduiCheckMain.cpp
@@ -1,0 +1,125 @@
+/**
+ * @file MeduiCheckMain.cpp
+ * @brief `mdux-medui-check` entry point: validate one `.medui` file, print diagnostics, exit.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Its own grammar rather than the shared `bake`/`verify` one, because this is neither: it takes a
+ * file and produces no artifact. What it does share is the envelope - `cli::render` and
+ * `cli::exitStatus` - so an agent parsing `--format=json` here parses what every other MduX tool
+ * emits, which is the whole point of #118.
+ *
+ * Exit status is `cli::exitStatus`'s: non-zero when anything of error severity was reported, zero
+ * otherwise. The notes about what a single file cannot cover do not fail a check; they are
+ * statements about the run, and a run that could not check locales still checked everything else.
+ */
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.check;
+
+namespace {
+
+namespace cli   = mdux::tools::cli;
+namespace medui = mdux::tools::medui;
+
+[[nodiscard]] std::string usage() {
+    return std::format("usage:\n"
+                       "  {} <screen.medui> [--format=json|text]\n"
+                       "\n"
+                       "Validates one .medui file and prints what it finds. Writes nothing.\n"
+                       "\n"
+                       "Checked: the grammar, the component dictionary, field value domains,\n"
+                       "hardcoded strings, theme tokens, the @safety_critical rules, and - when the\n"
+                       "file declares a `surface:` - bounded layout and the golden set.\n"
+                       "\n"
+                       "Not checked, and reported as notes: text keys and text budgets, which need\n"
+                       "the approved locales a recipe names. Compile through mdux-meduic for those.\n"
+                       "\n"
+                       "Exits non-zero when anything of error severity was found.\n",
+                       medui::checkToolName);
+}
+
+[[nodiscard]] std::optional<std::string> readFile(const std::filesystem::path& path) {
+    std::ifstream file{path, std::ios::binary | std::ios::ate};
+    if (!file) {
+        return std::nullopt;
+    }
+    // tellg() answers -1 on a stream error rather than throwing, and sizing the string before the
+    // check would turn that into a request for 2^64-1 bytes.
+    const std::streamoff size = file.tellg();
+    if (size < 0 || !file.seekg(0)) {
+        return std::nullopt;
+    }
+    std::string text(static_cast<std::size_t>(size), '\0');
+    if (size > 0) {
+        file.read(text.data(), size);
+        if (!file) {
+            return std::nullopt;
+        }
+    }
+    return text;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    std::vector<std::string_view> positional;
+    cli::Format                   format = cli::Format::Text;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view argument{argv[i]};
+        if (argument == "--help" || argument == "-h") {
+            std::print(std::cout, "{}", usage());
+            return 0;
+        }
+        if (argument == "--format=json") {
+            format = cli::Format::Json;
+            continue;
+        }
+        if (argument == "--format=text") {
+            // Assigned rather than skipped, so that last flag wins.
+            format = cli::Format::Text;
+            continue;
+        }
+        if (argument.starts_with("-")) {
+            std::println(std::cerr, "unrecognized option '{}'\n\n{}", argument, usage());
+            return 2;
+        }
+        positional.push_back(argument);
+    }
+
+    if (positional.size() != 1) {
+        std::println(std::cerr, "expected exactly one file, got {}\n\n{}", positional.size(), usage());
+        return 2;
+    }
+
+    const std::string                path{positional[0]};
+    const std::optional<std::string> source = readFile(path);
+    if (!source.has_value()) {
+        // Reported through the envelope rather than as a bare message, so a caller parsing JSON
+        // gets a finding here exactly as it would for a syntax error.
+        cli::Diagnostic unreadable;
+        unreadable.file     = path;
+        unreadable.code     = "MEDUI-E003";
+        unreadable.severity = cli::Severity::Error;
+        unreadable.message  = "the .medui source could not be opened";
+        unreadable.fixHint  = "check the path, and that the file is readable";
+
+        const std::array<cli::Diagnostic, 1> diagnostics{std::move(unreadable)};
+        std::print(std::cout, "{}", cli::render(diagnostics, format, medui::checkToolName));
+        return cli::exitStatus(diagnostics);
+    }
+
+    const medui::CheckResult result = medui::checkScreen(*source, path);
+
+    const std::string rendered = cli::render(result.diagnostics, format, medui::checkToolName);
+    if (!rendered.empty()) {
+        std::print(std::cout, "{}", rendered);
+    }
+    if (format == cli::Format::Text && result.ok()) {
+        std::println(std::cout, "{}: OK ({})", medui::checkToolName, path);
+    }
+
+    return cli::exitStatus(result.diagnostics);
+}

--- a/tools/medui/MeduicMain.cpp
+++ b/tools/medui/MeduicMain.cpp
@@ -1,0 +1,131 @@
+/**
+ * @file MeduicMain.cpp
+ * @brief `mdux-meduic` entry point: the `.medui` compiler as a baker.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Split library-and-executable like every other baker, so tests drive `run()`, `write()` and
+ * `verify()` as calls. Spawning this process per case would make a failing assertion report that an
+ * exit status was wrong, which is the least useful thing it could say about a compiler.
+ *
+ * It speaks the shared `bake`/`verify` grammar, so `mdux_bake_artifact()` registers a screen the
+ * same way it registers a font or a shader, and `--format=json` produces the same envelope every
+ * other MduX tool produces.
+ */
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.compile;
+
+namespace {
+
+namespace cli   = mdux::tools::cli;
+namespace medui = mdux::tools::medui;
+
+/// Reads the recipe and runs every compiler stage. Shared by both modes: `verify` must produce the
+/// same bytes `bake` would before it can compare them to what is committed.
+[[nodiscard]] std::optional<medui::CompileOutputs> produce(const std::string& recipePath, std::vector<cli::Diagnostic>& diagnostics) {
+    const std::optional<std::vector<std::byte>> recipeBytes = medui::readFile(recipePath);
+    if (!recipeBytes.has_value()) {
+        // The one diagnostic this tool raises itself; every other one comes from a stage.
+        cli::Diagnostic unreadable;
+        unreadable.file     = recipePath;
+        unreadable.code     = "MEDUI-E000";
+        unreadable.severity = cli::Severity::Error;
+        unreadable.message  = "the recipe file could not be opened";
+        unreadable.fixHint  = "check the path passed on the command line, and that the file is readable";
+        diagnostics.push_back(std::move(unreadable));
+        return std::nullopt;
+    }
+
+    const std::string_view             recipeText{reinterpret_cast<const char*>(recipeBytes->data()), recipeBytes->size()};
+    const std::optional<medui::Recipe> recipe = medui::parseRecipe(recipeText, recipePath, diagnostics);
+    if (!recipe.has_value()) {
+        return std::nullopt;
+    }
+
+    // The working directory is the repository root - `mdux_bake_artifact()` runs every baker that
+    // way - so every path the recipe names and every path the report records stays repository
+    // relative, which is what keeps a report free of absolute paths.
+    return medui::run(*recipe, recipePath, *recipeBytes, std::filesystem::current_path(), diagnostics);
+}
+
+/**
+ * @brief Runs the compile and returns the summary line, or nothing when a diagnostic was reported.
+ *
+ * The `try` is an outermost boundary for a *bug*, not for author input. Every recipe-controlled
+ * failure - a malformed slug, an unusable budget, a locale the font does not approve - is a
+ * diagnostic the driver reports, so an escaping exception means a gate was bypassed or an invariant
+ * this compiler believes in does not hold. Even then the tool has to fail like a tool: a consumer
+ * that asked for `--format=json` is entitled to an envelope, not a terminate handler's message.
+ */
+[[nodiscard]] std::string compile(const cli::Invocation& invocation, const std::string& recipePath, std::vector<cli::Diagnostic>& diagnostics) {
+    try {
+        auto outputs = produce(recipePath, diagnostics);
+        if (!outputs.has_value()) {
+            return {};
+        }
+
+        bool ok = false;
+        if (invocation.mode == cli::Mode::Bake) {
+            ok = medui::write(*outputs, invocation.bake.outputDir, diagnostics);
+        } else {
+            // The shared grammar carries two output paths and a screen has three. The goldens
+            // sidecar is not an independent fact: ADR-012 puts all three files in one directory, so
+            // it is read from beside the package rather than named a second time on a command line
+            // where the two could disagree.
+            const std::filesystem::path packagePath{invocation.verify.packagePath};
+            const std::filesystem::path goldensPath = packagePath.parent_path() / "goldens.json";
+            ok                                      = medui::verify(*outputs, packagePath, goldensPath, invocation.verify.reportPath, diagnostics);
+        }
+        if (!ok) {
+            return {};
+        }
+        return std::format("{}: OK ({} {}: {} nodes, {} golden references)",
+                           medui::compilerToolName,
+                           invocation.mode == cli::Mode::Bake ? "compiled" : "verified",
+                           outputs->screenId,
+                           outputs->nodeCount,
+                           outputs->goldenCount);
+    } catch (const std::exception& error) {
+        cli::Diagnostic internal;
+        internal.file     = recipePath;
+        internal.code     = "MEDUI-E000";
+        internal.severity = cli::Severity::Error;
+        internal.message  = std::format("the compiler stopped on an internal error: {}", error.what());
+        internal.fixHint  = "this is a defect in mdux-meduic rather than in the recipe; please report it with the recipe attached";
+        diagnostics.push_back(std::move(internal));
+        return {};
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    cli::Invocation invocation;
+    try {
+        invocation = cli::parse(medui::compilerToolName, argc, argv);
+    } catch (const cli::UsageError& error) {
+        std::println(std::cerr, "{}", error.what());
+        return 2;
+    }
+
+    std::vector<cli::Diagnostic> diagnostics;
+
+    const std::string& recipePath = invocation.mode == cli::Mode::Bake ? invocation.bake.recipe : invocation.verify.recipe;
+
+    const std::string summary = compile(invocation, recipePath, diagnostics);
+
+    // Both formats go to stdout, matching every other MduX tool: an agent should not have to know
+    // which stream each one uses, which is what the shared envelope exists to remove.
+    const std::string rendered = cli::render(diagnostics, invocation.format, medui::compilerToolName);
+    if (!rendered.empty()) {
+        std::print(std::cout, "{}", rendered);
+    }
+    if (invocation.format == cli::Format::Text && !summary.empty()) {
+        std::println(std::cout, "{}", summary);
+    }
+
+    return cli::exitStatus(diagnostics);
+}

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -1,0 +1,861 @@
+/**
+ * @file Package.cpp
+ * @brief Implementation of the compiled-screen document and its canonical JSON form.
+ */
+
+module;
+
+module mdux.tools.medui.package;
+
+import std;
+import mdux.draw;
+import mdux.evidence.json;
+import mdux.evidence.report;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+namespace ms   = mdux::medui;
+namespace json = mdux::evidence::json;
+
+/// Stable diagnostic codes for a malformed committed artifact. Local to this tool, as
+/// `mdux-shaderemit`'s `SHE0NN` are; see the interface comment for why these are not `MEDUI-E0NN`.
+constexpr std::string_view bytesUnparsed = "SCP001";
+constexpr std::string_view memberWrong   = "SCP002";
+constexpr std::string_view memberUnknown = "SCP003";
+constexpr std::string_view kindUnknown   = "SCP004";
+constexpr std::string_view schemaRefused = "SCP005";
+
+// ---------------------------------------------------------------------------
+// Reading the AST a resolved node carries
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
+    const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
+    return found == node.fields.end() ? nullptr : &*found;
+}
+
+/// The text a field carries, or empty when the component did not declare it.
+///
+/// Every name-valued domain - `String`, `TextKey`, `ImageRef`, `ColorToken`, `Identifier` - stores
+/// its characters in the same AST member, so one accessor serves all five. A field holding some
+/// other domain means semantic analysis did not run, which is a bypassed gate rather than a
+/// malformed screen.
+[[nodiscard]] std::string_view textOf(const ast::Node& node, std::string_view name) {
+    const ast::Field* field = fieldFor(node, name);
+    if (field == nullptr || field->value == nullptr) {
+        return {};
+    }
+    switch (field->value->kind) {
+        case ast::ValueKind::String:
+        case ast::ValueKind::TextKey:
+        case ast::ValueKind::ImageRef:
+        case ast::ValueKind::ColorToken:
+        case ast::ValueKind::Identifier:
+            return field->value->text;
+        default:
+            throw std::logic_error(std::format("field '{}' on {} does not hold a name: semantic analysis is a required gate", name, node.component));
+    }
+}
+
+[[nodiscard]] std::int64_t numberOf(const ast::Node& node, std::string_view name) {
+    const ast::Field* field = fieldFor(node, name);
+    if (field == nullptr || field->value == nullptr) {
+        return 0;
+    }
+    if (field->value->kind != ast::ValueKind::Number) {
+        throw std::logic_error(std::format("field '{}' on {} does not hold a number: semantic analysis is a required gate", name, node.component));
+    }
+    return field->value->number;
+}
+
+/// The names in a list-valued field, in source order. Empty when the component declared none.
+[[nodiscard]] std::vector<std::string> listOf(const ast::Node& node, std::string_view name) {
+    const ast::Field* field = fieldFor(node, name);
+    if (field == nullptr || field->value == nullptr) {
+        return {};
+    }
+    if (field->value->kind != ast::ValueKind::List) {
+        throw std::logic_error(std::format("field '{}' on {} does not hold a list: semantic analysis is a required gate", name, node.component));
+    }
+    std::vector<std::string> names;
+    names.reserve(field->value->list.size());
+    for (const std::shared_ptr<ast::Value>& element : field->value->list) {
+        if (element == nullptr) {
+            throw std::logic_error(std::format("field '{}' on {} holds an empty list element", name, node.component));
+        }
+        // Checked for the same reason `textOf()` checks: an element of some other domain carries no
+        // text, so taking it silently would put an empty name in a state key and surface as the
+        // schema refusing the package - a confusing report of a bypassed gate rather than a clear one.
+        switch (element->kind) {
+            case ast::ValueKind::String:
+            case ast::ValueKind::TextKey:
+            case ast::ValueKind::ImageRef:
+            case ast::ValueKind::ColorToken:
+            case ast::ValueKind::Identifier:
+                names.push_back(element->text);
+                break;
+            default:
+                throw std::logic_error(
+                    std::format("field '{}' on {} lists a value that is not a name: semantic analysis is a required gate", name, node.component));
+        }
+    }
+    return names;
+}
+
+/**
+ * @brief The typed payload for one resolved node.
+ *
+ * The mapping from a dictionary field to a spec member is the whole content of this function, and
+ * it is spelled once here rather than being derivable: `text` on a `Label` and `label` on a
+ * `Button` are both a `textKey`, while `source` means a data stream on one component and an image
+ * package on another. A table keyed by field name could not express that.
+ */
+[[nodiscard]] ms::NodePayload payloadFor(const ResolvedNode& resolved, ScreenDocument& document) {
+    const ast::Node& source = resolved.source;
+    const auto       name   = [&](std::string_view field) {
+        return document.intern(textOf(source, field));
+    };
+
+    // The only synthetic node the solver produces, and the only way a Panel is ever compiled: an
+    // author cannot write one, because `Panel` is not in the component dictionary.
+    if (resolved.component == "Panel") {
+        return ms::PanelSpec{.colorToken = name("background")};
+    }
+    if (resolved.component == "Label") {
+        return ms::LabelSpec{.textKey = name("text"), .colorToken = name("color")};
+    }
+    if (resolved.component == "Clock") {
+        return ms::ClockSpec{.format = name("format")};
+    }
+    if (resolved.component == "Image") {
+        return ms::ImageSpec{.source = name("source")};
+    }
+    if (resolved.component == "VulkanViewport") {
+        return ms::VulkanViewportSpec{.streamSource = name("stream_source")};
+    }
+    if (resolved.component == "SignalTrace") {
+        return ms::SignalTraceSpec{.streamSource = name("stream_source"), .colorToken = name("color")};
+    }
+    if (resolved.component == "Button") {
+        return ms::ButtonSpec{.labelKey = name("label"), .colorToken = name("color"), .source = name("source"), .requirement = name("requirement")};
+    }
+    if (resolved.component == "CriticalButton") {
+        return ms::CriticalButtonSpec{.requirement = name("requirement"), .labelKey = name("label"), .colorToken = name("color"), .onPress = name("on_press")};
+    }
+    if (resolved.component == "NumericDisplay") {
+        return ms::NumericDisplaySpec{.requirement = name("requirement"),
+                                      .templateId  = name("template"),
+                                      .source      = name("source"),
+                                      .colorToken  = name("color")};
+    }
+    if (resolved.component == "StatusIndicator") {
+        return ms::StatusIndicatorSpec{.requirement = name("requirement"),
+                                       .source      = name("source"),
+                                       .stateKeys   = document.internList(listOf(source, "states")),
+                                       .colorTokens = document.internList(listOf(source, "colors"))};
+    }
+    if (resolved.component == "TextInput") {
+        return ms::TextInputSpec{.source      = name("source"),
+                                 .colorToken  = name("color"),
+                                 .maxLength   = numberOf(source, "max_length"),
+                                 .charset     = name("charset"),
+                                 .requirement = name("requirement")};
+    }
+    // `Row` reaches here only if the solver stopped flattening: a Row contributes its children and
+    // at most one synthetic background, never itself. Anything else is a component semantic
+    // analysis would have refused.
+    throw std::logic_error(std::format("no compiled payload for component '{}': semantic analysis is a required gate", resolved.component));
+}
+
+/// Narrows a solved coordinate to what the compiled schema carries.
+///
+/// The layout solver already refuses a surface wider than `std::int32_t` and every rectangle it
+/// resolves lies inside that surface, so a value out of range here means layout was bypassed.
+[[nodiscard]] std::int32_t narrow(std::int64_t value, std::string_view what) {
+    if (value < std::numeric_limits<std::int32_t>::min() || value > std::numeric_limits<std::int32_t>::max()) {
+        throw std::logic_error(std::format("{} is {}, which a compiled screen cannot carry: layout is a required gate", what, value));
+    }
+    return static_cast<std::int32_t>(value);
+}
+
+// ---------------------------------------------------------------------------
+// Writing
+// ---------------------------------------------------------------------------
+
+/// Inserts a member, turning the writer's `Result` into the exception a host tool may throw.
+void put(json::Value& object, std::string key, json::Value value) {
+    if (const auto inserted = object.set(std::move(key), std::move(value)); !inserted.has_value()) {
+        throw std::logic_error(std::format("canonical JSON refused a member: {}", json::describe(inserted.error().code)));
+    }
+}
+
+void putName(json::Value& object, std::string_view key, std::string_view value) {
+    // An optional name the component did not declare is omitted rather than written empty, as
+    // `goldens.json` omits an absent `textKey`. A required name is never empty in a validated
+    // package, so this cannot drop one.
+    if (value.empty()) {
+        return;
+    }
+    put(object, std::string{key}, json::Value::string(std::string{value}));
+}
+
+/// One rectangle, from the compiled schema's `NodeRect` or from the solver's `LayoutRect`.
+///
+/// A template rather than two overloads: the two types spell their members identically and differ
+/// only in integer width, so two bodies would be two places for the member names of a byte-compared
+/// artifact to drift apart.
+template <typename Rect>
+[[nodiscard]] json::Value writeRect(const Rect& bounds) {
+    json::Value object = json::Value::emptyObject();
+    put(object, "x", json::Value::integer(bounds.x));
+    put(object, "y", json::Value::integer(bounds.y));
+    put(object, "width", json::Value::integer(bounds.width));
+    put(object, "height", json::Value::integer(bounds.height));
+    return object;
+}
+
+[[nodiscard]] json::Value writeNames(std::span<const std::string_view> names) {
+    std::vector<json::Value> elements;
+    elements.reserve(names.size());
+    for (const std::string_view name : names) {
+        elements.push_back(json::Value::string(std::string{name}));
+    }
+    return json::Value::array(std::move(elements));
+}
+
+/// The `spec` object for one payload: the component's own fields, and nothing shared.
+[[nodiscard]] json::Value writeSpec(const ms::NodePayload& payload) {
+    json::Value spec = json::Value::emptyObject();
+
+    if (const auto* panel = std::get_if<ms::PanelSpec>(&payload)) {
+        putName(spec, "colorToken", panel->colorToken);
+    } else if (const auto* label = std::get_if<ms::LabelSpec>(&payload)) {
+        putName(spec, "colorToken", label->colorToken);
+        putName(spec, "textKey", label->textKey);
+    } else if (const auto* clock = std::get_if<ms::ClockSpec>(&payload)) {
+        putName(spec, "format", clock->format);
+    } else if (const auto* image = std::get_if<ms::ImageSpec>(&payload)) {
+        putName(spec, "source", image->source);
+    } else if (const auto* viewport = std::get_if<ms::VulkanViewportSpec>(&payload)) {
+        putName(spec, "streamSource", viewport->streamSource);
+    } else if (const auto* trace = std::get_if<ms::SignalTraceSpec>(&payload)) {
+        putName(spec, "colorToken", trace->colorToken);
+        putName(spec, "streamSource", trace->streamSource);
+    } else if (const auto* button = std::get_if<ms::ButtonSpec>(&payload)) {
+        putName(spec, "colorToken", button->colorToken);
+        putName(spec, "labelKey", button->labelKey);
+        putName(spec, "requirement", button->requirement);
+        putName(spec, "source", button->source);
+    } else if (const auto* critical = std::get_if<ms::CriticalButtonSpec>(&payload)) {
+        putName(spec, "colorToken", critical->colorToken);
+        putName(spec, "labelKey", critical->labelKey);
+        putName(spec, "onPress", critical->onPress);
+        putName(spec, "requirement", critical->requirement);
+    } else if (const auto* numeric = std::get_if<ms::NumericDisplaySpec>(&payload)) {
+        putName(spec, "colorToken", numeric->colorToken);
+        putName(spec, "requirement", numeric->requirement);
+        putName(spec, "source", numeric->source);
+        putName(spec, "templateId", numeric->templateId);
+    } else if (const auto* status = std::get_if<ms::StatusIndicatorSpec>(&payload)) {
+        // Written even when empty, unlike a name: an empty list is the component declaring no
+        // per-state tint, which is a different statement from a name it does not have.
+        put(spec, "colorTokens", writeNames(status->colorTokens));
+        putName(spec, "requirement", status->requirement);
+        putName(spec, "source", status->source);
+        put(spec, "stateKeys", writeNames(status->stateKeys));
+    } else if (const auto* input = std::get_if<ms::TextInputSpec>(&payload)) {
+        putName(spec, "charset", input->charset);
+        putName(spec, "colorToken", input->colorToken);
+        put(spec, "maxLength", json::Value::integer(input->maxLength));
+        putName(spec, "requirement", input->requirement);
+        putName(spec, "source", input->source);
+    } else {
+        // Unreachable for a validated package: `validate()` refuses an unknown payload, and
+        // `writePackage()` validates before rendering.
+        throw std::logic_error("a node carries a payload this writer does not know");
+    }
+    return spec;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// ScreenDocument
+// ---------------------------------------------------------------------------
+
+std::string_view ScreenDocument::intern(std::string_view text) {
+    if (text.empty()) {
+        return {};
+    }
+    return text_.emplace_back(text);
+}
+
+std::span<const std::string_view> ScreenDocument::internList(std::span<const std::string> items) {
+    std::vector<std::string_view>& views = lists_.emplace_back();
+    views.reserve(items.size());
+    for (const std::string& item : items) {
+        views.push_back(intern(item));
+    }
+    return views;
+}
+
+void ScreenDocument::setHeader(std::string_view id, std::int32_t surfaceWidth, std::int32_t surfaceHeight, mdux::draw::DrawBudget budget) {
+    id_            = intern(id);
+    surfaceWidth_  = surfaceWidth;
+    surfaceHeight_ = surfaceHeight;
+    budget_        = budget;
+}
+
+void ScreenDocument::addNode(ms::CompiledNode node) {
+    nodes_.push_back(std::move(node));
+}
+
+ms::ScreenPackage ScreenDocument::package() const noexcept {
+    return ms::ScreenPackage{.id            = id_,
+                             .schemaVersion = mdux::evidence::kSchemaVersion,
+                             .surfaceWidth  = surfaceWidth_,
+                             .surfaceHeight = surfaceHeight_,
+                             .nodes         = nodes_,
+                             .budget        = budget_};
+}
+
+// ---------------------------------------------------------------------------
+// Building from a resolved layout
+// ---------------------------------------------------------------------------
+
+ScreenDocument buildPackage(const LayoutResult& layout, PackageInputs inputs) {
+    if (!layout.ok()) {
+        throw std::logic_error("buildPackage was given a layout that did not resolve: layout is a required gate");
+    }
+
+    ScreenDocument document;
+    document.setHeader(inputs.id, narrow(layout.surfaceWidth, "surface width"), narrow(layout.surfaceHeight, "surface height"), inputs.budget);
+
+    for (const ResolvedNode& resolved : layout.nodes) {
+        document.addNode(ms::CompiledNode{
+            .id      = document.intern(resolved.id),
+            .bounds  = ms::NodeRect{.x      = narrow(resolved.bounds.x, "node x"),
+                                    .y      = narrow(resolved.bounds.y, "node y"),
+                                    .width  = narrow(resolved.bounds.width, "node width"),
+                                    .height = narrow(resolved.bounds.height, "node height")},
+            .payload = payloadFor(resolved, document)
+        });
+    }
+
+    if (const auto valid = document.package().validate(); !valid.has_value()) {
+        throw std::logic_error(std::format("the compiled screen does not satisfy its own schema: {}", ms::describe(valid.error())));
+    }
+    return document;
+}
+
+// ---------------------------------------------------------------------------
+// Writing
+// ---------------------------------------------------------------------------
+
+std::string writePackage(const ms::ScreenPackage& package) {
+    if (const auto valid = package.validate(); !valid.has_value()) {
+        throw std::logic_error(std::format("refusing to write a screen the schema rejects: {}", ms::describe(valid.error())));
+    }
+
+    std::vector<json::Value> nodes;
+    nodes.reserve(package.nodes.size());
+    for (const ms::CompiledNode& node : package.nodes) {
+        json::Value entry = json::Value::emptyObject();
+        put(entry, "bounds", writeRect(node.bounds));
+        put(entry, "id", json::Value::string(std::string{node.id}));
+        put(entry, "kind", json::Value::string(std::string{ms::kindName(node)}));
+        put(entry, "spec", writeSpec(node.payload));
+        nodes.push_back(std::move(entry));
+    }
+
+    json::Value budget = json::Value::emptyObject();
+    put(budget, "maxCommands", json::Value::unsignedInteger(package.budget.maxCommands));
+    put(budget, "maxIndices", json::Value::unsignedInteger(package.budget.maxIndices));
+    put(budget, "maxVertices", json::Value::unsignedInteger(package.budget.maxVertices));
+
+    json::Value root = json::Value::emptyObject();
+    put(root, "budget", std::move(budget));
+    put(root, "id", json::Value::string(std::string{package.id}));
+    put(root, "kind", json::Value::string(std::string{ms::packageKind}));
+    put(root, "nodes", json::Value::array(std::move(nodes)));
+    put(root, "schemaVersion", json::Value::unsignedInteger(package.schemaVersion));
+    put(root, "surfaceHeight", json::Value::integer(package.surfaceHeight));
+    put(root, "surfaceWidth", json::Value::integer(package.surfaceWidth));
+
+    auto written = json::write(root);
+    if (!written.has_value()) {
+        throw std::logic_error(std::format("canonical JSON refused the screen: {}", json::describe(written.error().code)));
+    }
+    return std::move(*written);
+}
+
+std::string writeGoldens(std::span<const GoldenReference> goldens) {
+    std::vector<json::Value> entries;
+    entries.reserve(goldens.size());
+    for (const GoldenReference& golden : goldens) {
+        std::vector<json::Value> checks;
+        checks.reserve(golden.cvChecks.size());
+        for (const CvCheck check : golden.cvChecks) {
+            checks.push_back(json::Value::string(std::string{spell(check)}));
+        }
+
+        json::Value entry = json::Value::emptyObject();
+        put(entry, "bounds", writeRect(golden.bounds));
+        putName(entry, "colorToken", golden.colorToken);
+        put(entry, "cvChecks", json::Value::array(std::move(checks)));
+        put(entry, "nodeId", json::Value::string(golden.nodeId));
+        putName(entry, "textKey", golden.textKey);
+        entries.push_back(std::move(entry));
+    }
+
+    // An empty array rather than no file: ADR-012 makes all three outputs unconditional, because
+    // `mdux_bake_artifact()` declares each as a build output and a skipped one breaks the
+    // byte-comparison test rather than meaning "this screen pins nothing".
+    auto written = json::write(json::Value::array(std::move(entries)));
+    if (!written.has_value()) {
+        throw std::logic_error(std::format("canonical JSON refused the golden references: {}", json::describe(written.error().code)));
+    }
+    return std::move(*written);
+}
+
+
+// ---------------------------------------------------------------------------
+// Reading
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Where a read failure goes, and the file it names.
+///
+/// Every helper returns false or nullopt after reporting, so a caller stops at the first failure.
+/// Deliberately not an accumulating pass like the authoring stages: those report on a source a
+/// human is editing, where a list of problems saves round trips. This reads a generated, reviewed,
+/// byte-compared artifact - if it is malformed at all, the first place it stops being canonical is
+/// the actionable fact.
+class Sink {
+public:
+    Sink(std::string file, std::vector<mdux::tools::cli::Diagnostic>& diagnostics) : file_{std::move(file)}, diagnostics_{&diagnostics} {}
+
+    bool fail(std::string_view code, std::string message, std::string fixHint = {}) const {
+        diagnostics_->push_back(mdux::tools::cli::Diagnostic{.file     = file_,
+                                                             .code     = std::string{code},
+                                                             .severity = mdux::tools::cli::Severity::Error,
+                                                             .message  = std::move(message),
+                                                             .fixHint  = std::move(fixHint)});
+        return false;
+    }
+
+private:
+    std::string                                file_;
+    std::vector<mdux::tools::cli::Diagnostic>* diagnostics_;
+};
+
+/// Checks that `value` is an object and carries no member outside `allowed`.
+///
+/// Rejecting an unknown member is the fail-closed direction for a reviewed artifact: a member this
+/// reader ignored would be one a reviewer believed was doing something.
+[[nodiscard]] bool expectObject(const json::Value& value, std::string_view what, std::span<const std::string_view> allowed, const Sink& sink) {
+    if (value.kind() != json::Value::Kind::Object) {
+        return sink.fail(memberWrong, std::format("{} is not an object", what));
+    }
+    for (const json::Member& member : value.members()) {
+        if (std::ranges::find(allowed, member.key) == allowed.end()) {
+            return sink.fail(memberUnknown,
+                             std::format("{} carries a member '{}' the compiled-screen format does not define", what, member.key),
+                             "the format is fixed by ADR-012; a member that is not in it means the file was hand-edited or written by "
+                             "another tool");
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::optional<std::string> readName(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        return std::string{};
+    }
+    const auto text = member->asString();
+    if (!text.has_value()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not a string", what, key));
+        return std::nullopt;
+    }
+    return std::string{*text};
+}
+
+[[nodiscard]] std::optional<std::int64_t> readInteger(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        sink.fail(memberWrong, std::format("{} is missing the member '{}'", what, key));
+        return std::nullopt;
+    }
+    const auto number = member->asInt();
+    if (!number.has_value()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not an integer", what, key));
+        return std::nullopt;
+    }
+    return *number;
+}
+
+[[nodiscard]] std::optional<std::int32_t> readInt32(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const auto number = readInteger(object, key, what, sink);
+    if (!number.has_value()) {
+        return std::nullopt;
+    }
+    if (*number < std::numeric_limits<std::int32_t>::min() || *number > std::numeric_limits<std::int32_t>::max()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is {}, which a compiled screen cannot carry", what, key, *number));
+        return std::nullopt;
+    }
+    return static_cast<std::int32_t>(*number);
+}
+
+[[nodiscard]] std::optional<std::uint32_t> readUInt32(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const auto number = readInteger(object, key, what, sink);
+    if (!number.has_value()) {
+        return std::nullopt;
+    }
+    if (*number < 0 || *number > std::numeric_limits<std::uint32_t>::max()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is {}, which is outside a draw budget's range", what, key, *number));
+        return std::nullopt;
+    }
+    return static_cast<std::uint32_t>(*number);
+}
+
+/// A list-valued spec member, absent meaning empty.
+[[nodiscard]] std::optional<std::vector<std::string>> readNames(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        return std::vector<std::string>{};
+    }
+    if (member->kind() != json::Value::Kind::Array) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not an array", what, key));
+        return std::nullopt;
+    }
+    std::vector<std::string> names;
+    names.reserve(member->elements().size());
+    for (const json::Value& element : member->elements()) {
+        const auto text = element.asString();
+        if (!text.has_value()) {
+            sink.fail(memberWrong, std::format("{} member '{}' holds a value that is not a string", what, key));
+            return std::nullopt;
+        }
+        names.emplace_back(*text);
+    }
+    return names;
+}
+
+[[nodiscard]] std::optional<ms::NodeRect> readRect(const json::Value& node, std::string_view what, const Sink& sink) {
+    static constexpr std::array<std::string_view, 4> allowed{"height", "width", "x", "y"};
+    const json::Value*                               member = node.find("bounds");
+    if (member == nullptr) {
+        sink.fail(memberWrong, std::format("{} is missing the member 'bounds'", what));
+        return std::nullopt;
+    }
+    if (!expectObject(*member, std::format("{} bounds", what), allowed, sink)) {
+        return std::nullopt;
+    }
+    const auto x      = readInt32(*member, "x", what, sink);
+    const auto y      = readInt32(*member, "y", what, sink);
+    const auto width  = readInt32(*member, "width", what, sink);
+    const auto height = readInt32(*member, "height", what, sink);
+    if (!x.has_value() || !y.has_value() || !width.has_value() || !height.has_value()) {
+        return std::nullopt;
+    }
+    return ms::NodeRect{.x = *x, .y = *y, .width = *width, .height = *height};
+}
+
+/**
+ * @brief Reads one node's `spec` into the payload its `kind` names.
+ *
+ * Every name is read as optional here, and that is not laxity: which names a component *must*
+ * declare is fixed by the dictionary and enforced by `validatePayload()`, which runs over the whole
+ * package a few lines later. Listing the required ones again in this reader would be a second
+ * authority on the same question, free to drift from the first.
+ */
+[[nodiscard]] bool
+readSpec(const json::Value& node, std::string_view kind, std::string_view what, ScreenDocument& document, ms::NodePayload& payload, const Sink& sink) {
+    const json::Value* spec = node.find("spec");
+    if (spec == nullptr) {
+        return sink.fail(memberWrong, std::format("{} is missing the member 'spec'", what));
+    }
+    const std::string where = std::format("{} spec", what);
+
+    // One list per kind, in the order `writeSpec()` writes them. The round-trip scenario in
+    // PackageTests executes both directions over one screen, which is what keeps these in step -
+    // an assertion on either half alone could not.
+    static constexpr std::array<std::string_view, 1> panelMembers{"colorToken"};
+    static constexpr std::array<std::string_view, 2> labelMembers{"colorToken", "textKey"};
+    static constexpr std::array<std::string_view, 1> clockMembers{"format"};
+    static constexpr std::array<std::string_view, 1> imageMembers{"source"};
+    static constexpr std::array<std::string_view, 1> viewportMembers{"streamSource"};
+    static constexpr std::array<std::string_view, 2> traceMembers{"colorToken", "streamSource"};
+    static constexpr std::array<std::string_view, 4> buttonMembers{"colorToken", "labelKey", "requirement", "source"};
+    static constexpr std::array<std::string_view, 4> criticalMembers{"colorToken", "labelKey", "onPress", "requirement"};
+    static constexpr std::array<std::string_view, 4> numericMembers{"colorToken", "requirement", "source", "templateId"};
+    static constexpr std::array<std::string_view, 4> statusMembers{"colorTokens", "requirement", "source", "stateKeys"};
+    static constexpr std::array<std::string_view, 5> inputMembers{"charset", "colorToken", "maxLength", "requirement", "source"};
+
+    // Interns one spec name. The member set has already been checked by `expectObject()` on the
+    // branch that calls this, so what remains is reading the names the kind admits.
+    const auto name = [&](std::string_view key) -> std::optional<std::string_view> {
+        const auto text = readName(*spec, key, where, sink);
+        if (!text.has_value()) {
+            return std::nullopt;
+        }
+        return document.intern(*text);
+    };
+
+    if (kind == "Panel") {
+        if (!expectObject(*spec, where, panelMembers, sink)) {
+            return false;
+        }
+        const auto colorToken = name("colorToken");
+        if (!colorToken.has_value()) {
+            return false;
+        }
+        payload = ms::PanelSpec{.colorToken = *colorToken};
+        return true;
+    }
+    if (kind == "Label") {
+        if (!expectObject(*spec, where, labelMembers, sink)) {
+            return false;
+        }
+        const auto textKey    = name("textKey");
+        const auto colorToken = name("colorToken");
+        if (!textKey.has_value() || !colorToken.has_value()) {
+            return false;
+        }
+        payload = ms::LabelSpec{.textKey = *textKey, .colorToken = *colorToken};
+        return true;
+    }
+    if (kind == "Clock") {
+        if (!expectObject(*spec, where, clockMembers, sink)) {
+            return false;
+        }
+        const auto format = name("format");
+        if (!format.has_value()) {
+            return false;
+        }
+        payload = ms::ClockSpec{.format = *format};
+        return true;
+    }
+    if (kind == "Image") {
+        if (!expectObject(*spec, where, imageMembers, sink)) {
+            return false;
+        }
+        const auto source = name("source");
+        if (!source.has_value()) {
+            return false;
+        }
+        payload = ms::ImageSpec{.source = *source};
+        return true;
+    }
+    if (kind == "VulkanViewport") {
+        if (!expectObject(*spec, where, viewportMembers, sink)) {
+            return false;
+        }
+        const auto streamSource = name("streamSource");
+        if (!streamSource.has_value()) {
+            return false;
+        }
+        payload = ms::VulkanViewportSpec{.streamSource = *streamSource};
+        return true;
+    }
+    if (kind == "SignalTrace") {
+        if (!expectObject(*spec, where, traceMembers, sink)) {
+            return false;
+        }
+        const auto streamSource = name("streamSource");
+        const auto colorToken   = name("colorToken");
+        if (!streamSource.has_value() || !colorToken.has_value()) {
+            return false;
+        }
+        payload = ms::SignalTraceSpec{.streamSource = *streamSource, .colorToken = *colorToken};
+        return true;
+    }
+    if (kind == "Button") {
+        if (!expectObject(*spec, where, buttonMembers, sink)) {
+            return false;
+        }
+        const auto labelKey    = name("labelKey");
+        const auto colorToken  = name("colorToken");
+        const auto source      = name("source");
+        const auto requirement = name("requirement");
+        if (!labelKey.has_value() || !colorToken.has_value() || !source.has_value() || !requirement.has_value()) {
+            return false;
+        }
+        payload = ms::ButtonSpec{.labelKey = *labelKey, .colorToken = *colorToken, .source = *source, .requirement = *requirement};
+        return true;
+    }
+    if (kind == "CriticalButton") {
+        if (!expectObject(*spec, where, criticalMembers, sink)) {
+            return false;
+        }
+        const auto requirement = name("requirement");
+        const auto labelKey    = name("labelKey");
+        const auto colorToken  = name("colorToken");
+        const auto onPress     = name("onPress");
+        if (!requirement.has_value() || !labelKey.has_value() || !colorToken.has_value() || !onPress.has_value()) {
+            return false;
+        }
+        payload = ms::CriticalButtonSpec{.requirement = *requirement, .labelKey = *labelKey, .colorToken = *colorToken, .onPress = *onPress};
+        return true;
+    }
+    if (kind == "NumericDisplay") {
+        if (!expectObject(*spec, where, numericMembers, sink)) {
+            return false;
+        }
+        const auto requirement = name("requirement");
+        const auto templateId  = name("templateId");
+        const auto source      = name("source");
+        const auto colorToken  = name("colorToken");
+        if (!requirement.has_value() || !templateId.has_value() || !source.has_value() || !colorToken.has_value()) {
+            return false;
+        }
+        payload = ms::NumericDisplaySpec{.requirement = *requirement, .templateId = *templateId, .source = *source, .colorToken = *colorToken};
+        return true;
+    }
+    if (kind == "StatusIndicator") {
+        if (!expectObject(*spec, where, statusMembers, sink)) {
+            return false;
+        }
+        const auto requirement = name("requirement");
+        const auto source      = name("source");
+        const auto stateKeys   = readNames(*spec, "stateKeys", where, sink);
+        const auto colorTokens = readNames(*spec, "colorTokens", where, sink);
+        if (!requirement.has_value() || !source.has_value() || !stateKeys.has_value() || !colorTokens.has_value()) {
+            return false;
+        }
+        payload = ms::StatusIndicatorSpec{.requirement = *requirement,
+                                          .source      = *source,
+                                          .stateKeys   = document.internList(*stateKeys),
+                                          .colorTokens = document.internList(*colorTokens)};
+        return true;
+    }
+    if (kind == "TextInput") {
+        if (!expectObject(*spec, where, inputMembers, sink)) {
+            return false;
+        }
+        const auto source      = name("source");
+        const auto colorToken  = name("colorToken");
+        const auto maxLength   = readInteger(*spec, "maxLength", where, sink);
+        const auto charset     = name("charset");
+        const auto requirement = name("requirement");
+        if (!source.has_value() || !colorToken.has_value() || !maxLength.has_value() || !charset.has_value() || !requirement.has_value()) {
+            return false;
+        }
+        payload = ms::TextInputSpec{.source = *source, .colorToken = *colorToken, .maxLength = *maxLength, .charset = *charset, .requirement = *requirement};
+        return true;
+    }
+    return sink.fail(kindUnknown,
+                     std::format("{} names the component '{}', which is not in the dictionary", what, kind),
+                     "a compiled node's kind is one of the eleven ADR-011 fixes");
+}
+
+}  // namespace
+
+PackageReadResult readPackage(std::string_view text, std::string file) {
+    PackageReadResult result;
+    const Sink        sink{std::move(file), result.diagnostics};
+
+    auto parsed = json::parse(text);
+    if (!parsed.has_value()) {
+        sink.fail(bytesUnparsed,
+                  std::format("the file is not canonical JSON: {} at byte {}", json::describe(parsed.error().code), parsed.error().offset),
+                  "canonical form is what mdux.evidence.json writes; re-bake rather than editing the artifact");
+        return result;
+    }
+
+    static constexpr std::array<std::string_view, 7> rootMembers{"budget", "id", "kind", "nodes", "schemaVersion", "surfaceHeight", "surfaceWidth"};
+    static constexpr std::array<std::string_view, 3> budgetMembers{"maxCommands", "maxIndices", "maxVertices"};
+    static constexpr std::array<std::string_view, 4> nodeMembers{"bounds", "id", "kind", "spec"};
+
+    const json::Value& root = *parsed;
+    if (!expectObject(root, "the package", rootMembers, sink)) {
+        return result;
+    }
+
+    const auto id            = readName(root, "id", "the package", sink);
+    const auto kind          = readName(root, "kind", "the package", sink);
+    const auto schemaVersion = readInteger(root, "schemaVersion", "the package", sink);
+    const auto surfaceWidth  = readInt32(root, "surfaceWidth", "the package", sink);
+    const auto surfaceHeight = readInt32(root, "surfaceHeight", "the package", sink);
+    if (!id.has_value() || !kind.has_value() || !schemaVersion.has_value() || !surfaceWidth.has_value() || !surfaceHeight.has_value()) {
+        return result;
+    }
+    if (*kind != ms::packageKind) {
+        sink.fail(memberWrong, std::format("the package names the kind '{}' rather than '{}'", *kind, ms::packageKind));
+        return result;
+    }
+    if (static_cast<std::uint64_t>(*schemaVersion) != mdux::evidence::kSchemaVersion) {
+        sink.fail(memberWrong,
+                  std::format("the package declares schema version {}, and this build reads version {}", *schemaVersion, mdux::evidence::kSchemaVersion));
+        return result;
+    }
+
+    const json::Value* budgetValue = root.find("budget");
+    if (budgetValue == nullptr) {
+        sink.fail(memberWrong, "the package is missing the member 'budget'");
+        return result;
+    }
+    if (!expectObject(*budgetValue, "the budget", budgetMembers, sink)) {
+        return result;
+    }
+    const auto maxVertices = readUInt32(*budgetValue, "maxVertices", "the budget", sink);
+    const auto maxIndices  = readUInt32(*budgetValue, "maxIndices", "the budget", sink);
+    const auto maxCommands = readUInt32(*budgetValue, "maxCommands", "the budget", sink);
+    if (!maxVertices.has_value() || !maxIndices.has_value() || !maxCommands.has_value()) {
+        return result;
+    }
+
+    ScreenDocument document;
+    document.setHeader(*id,
+                       *surfaceWidth,
+                       *surfaceHeight,
+                       mdux::draw::DrawBudget{.maxVertices = *maxVertices, .maxIndices = *maxIndices, .maxCommands = *maxCommands});
+
+    const json::Value* nodes = root.find("nodes");
+    if (nodes == nullptr || nodes->kind() != json::Value::Kind::Array) {
+        sink.fail(memberWrong, "the package member 'nodes' is missing or is not an array");
+        return result;
+    }
+
+    for (std::size_t index = 0; index < nodes->elements().size(); ++index) {
+        const json::Value& entry = nodes->elements()[index];
+        const std::string  what  = std::format("node {}", index);
+        if (!expectObject(entry, what, nodeMembers, sink)) {
+            return result;
+        }
+        const auto nodeId   = readName(entry, "id", what, sink);
+        const auto nodeKind = readName(entry, "kind", what, sink);
+        const auto bounds   = readRect(entry, what, sink);
+        if (!nodeId.has_value() || !nodeKind.has_value() || !bounds.has_value()) {
+            return result;
+        }
+        ms::NodePayload payload;
+        if (!readSpec(entry, *nodeKind, what, document, payload, sink)) {
+            return result;
+        }
+        document.addNode(ms::CompiledNode{.id = document.intern(*nodeId), .bounds = *bounds, .payload = payload});
+    }
+
+    // The same check a device runs, and the reason this reader does not repeat the dictionary's
+    // required-name rules itself: one authority decides what a compiled screen must contain.
+    if (const auto valid = document.package().validate(); !valid.has_value()) {
+        sink.fail(schemaRefused,
+                  std::format("the screen the file describes is not valid: {}", ms::describe(valid.error())),
+                  "re-bake the screen from its source rather than editing the artifact");
+        return result;
+    }
+
+    result.document = std::move(document);
+    return result;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Package.cppm
+++ b/tools/medui/Package.cppm
@@ -1,0 +1,230 @@
+/**
+ * @file Package.cppm
+ * @brief The compiled screen as a document a host tool owns, and as the canonical JSON bytes that
+ *        document is committed as.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine (canonical form, byte-identity)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Host-only, and the stage where the compiler's own types stop and the shared ones begin. Every
+ * earlier stage works on the AST and the layout: types that own their strings, carry positions, and
+ * exist to produce diagnostics. `mdux::medui::ScreenPackage` is none of those things - it is what a
+ * device holds, non-owning and `constexpr`-constructible, so that a generated translation unit can
+ * place one in read-only memory. This module is the join.
+ *
+ * ## Why a document, and not just a package
+ *
+ * `ScreenPackage` is a view: `std::string_view` names and `std::span` nodes, pointing at storage
+ * somebody else owns. That is exactly right for generated code, where the storage is namespace-scope
+ * `constexpr` data with static lifetime, and unusable on the host, where the strings are built at run
+ * time from a file.
+ *
+ * `ScreenDocument` is that missing owner. It holds the text and the nodes, and hands out a
+ * `ScreenPackage` viewing them - so the host compiler and the device runtime share **one** definition
+ * of what a compiled screen is, which is the property #197 exists to deliver. The alternative, a
+ * second host-side screen type with owning members, is two definitions that agree until they do not.
+ *
+ * Text is interned in a `std::deque<std::string>` rather than a `std::vector<std::string>`, and the
+ * reason is not style. A `std::string` short enough for the small-string optimisation stores its
+ * characters inside the object, so moving that object moves the characters and every `string_view`
+ * onto them dangles. A deque never relocates an element it already holds, and the container
+ * requirements keep references to its elements valid across both the deque's move construction and
+ * its move assignment - the latter because `std::allocator` propagates on move assignment, which
+ * makes that operation an adoption of the existing storage rather than a relocation of elements. So
+ * a document may be returned by value, which every function here does, and move-assigned into a
+ * result, which `readPackage()` does, without invalidating the package it hands out.
+ *
+ * That is the whole justification for the defaulted move operations on a type full of views, so it
+ * is asserted rather than argued: a scenario moves a document both ways and reads every name back
+ * through the package afterwards.
+ *
+ * Copying is deleted for the same reason, stated as a rule rather than left to be discovered: a
+ * copied document would hold copied strings while its nodes still viewed the original's. There is no
+ * correct memberwise copy, so there is none.
+ *
+ * ## What the artifact contains, and what it deliberately does not
+ *
+ * `package.json` carries the compiled nodes, their absolute rectangles, the draw budget, and the
+ * validated names each node draws with. It carries no resolved colour, no glyph run, no locale and
+ * no vertex - ADR-011 fixes that boundary and ADR-012 explains it. One consequence is worth naming
+ * because it is unusual for this repository: **a screen package contains no floating-point number at
+ * all**, so the `{"bits": N}` encoding that ADR-007 requires for a float never appears in one. Every
+ * number here is an integer the layout solver computed in integer arithmetic.
+ *
+ * ## The JSON shape
+ *
+ * Members are camelCase, as ADR-012 decision 1 fixes for all three files in a screen's directory.
+ * A node names its component in `kind` and carries that component's own fields in `spec`:
+ *
+ * ```json
+ * { "bounds": { "height": 60, "width": 120, "x": 250, "y": 60 },
+ *   "id": "score",
+ *   "kind": "NumericDisplay",
+ *   "spec": { "colorToken": "Theme.Colors.ScoreDigits",
+ *             "requirement": "REQ-NS-001",
+ *             "source": "SEDATION_INDEX",
+ *             "templateId": "TPL-SEDATION-INDEX-160" } }
+ * ```
+ *
+ * One member name for the payload rather than eleven named after their components: a reader that
+ * switches on `kind` reads `spec` whatever the answer, and adding a component to the dictionary adds
+ * no member name to the file format. The variant's alternative *index* is never written - `kind`
+ * holds the dictionary spelling, so an alternative may be added to `NodePayload` without renumbering
+ * a committed artifact.
+ *
+ * The example is in the byte order the file actually has, because `mdux.evidence.json` sorts every
+ * object's members lexicographically and these artifacts are byte-compared across toolchains. An
+ * optional name the component did not declare is omitted rather than written empty, matching what
+ * `goldens.json` already does with `textKey` and `colorToken`.
+ *
+ * ## Reading is as strict as writing
+ *
+ * `readPackage()` rejects a member it does not know, in either the package or a spec. That is
+ * deliberate and it is the fail-closed direction: these files are reviewed and byte-compared, so a
+ * member the reader silently ignored would be a member a reviewer believed was doing something. It
+ * also rejects a `kind` outside the dictionary, a spec whose shape does not match its `kind`, and a
+ * package the schema refuses - the same `validate()` a device would run, so a hand-edited artifact
+ * fails here rather than at the `static_assert` in generated code with no file name attached.
+ */
+module;
+
+export module mdux.tools.medui.package;
+
+import std;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.goldens;
+import mdux.tools.medui.layout;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief What a compiled screen needs that its source does not carry.
+ *
+ * `id` is the artifact slug - `generated/screen/<id>/` - which ADR-012 requires to match
+ * `^[a-z0-9][a-z0-9-]*$` while a screen's name in the grammar is CamelCase. The mapping is the
+ * recipe's business (#198); this stage records the slug it is given.
+ *
+ * `budget` is **declared, not computed**. Computing it needs a per-component cost model, and that
+ * model is the runtime's: #199 owns how a node becomes vertices, and a bound this stage invented
+ * would be a second answer to a question the runtime has not yet answered once. Until then the
+ * product declares its ceiling in the recipe, the schema refuses an empty one on a screen with
+ * nodes, and `DrawList` fails closed against it at run time.
+ */
+struct PackageInputs {
+    std::string_view       id;
+    mdux::draw::DrawBudget budget{};
+};
+
+/**
+ * @brief A compiled screen with its storage: the owner a `ScreenPackage` view points into.
+ *
+ * Move-only. See the module comment for why copying cannot be written correctly and why the text
+ * lives in a deque.
+ */
+class ScreenDocument {
+public:
+    ScreenDocument() = default;
+
+    ScreenDocument(const ScreenDocument&)            = delete;
+    ScreenDocument& operator=(const ScreenDocument&) = delete;
+
+    /// Moving is safe, and not by accident: see the module comment for why a deque's elements
+    /// survive both move operations, and `medui-package-survives-a-move` for the assertion of it.
+    ScreenDocument(ScreenDocument&&)            = default;
+    ScreenDocument& operator=(ScreenDocument&&) = default;
+    ~ScreenDocument()                           = default;
+
+    /// The screen, as the device's own type. Views this document; valid while it lives.
+    [[nodiscard]] mdux::medui::ScreenPackage package() const noexcept;
+
+    /// Records the header. Interns `id`, so the caller's storage need not outlive the call.
+    void setHeader(std::string_view id, std::int32_t surfaceWidth, std::int32_t surfaceHeight, mdux::draw::DrawBudget budget);
+
+    /// Appends a node. Its views must already point into this document - `intern()` produces them.
+    ///
+    /// Invalidates any package previously obtained from `package()`, whose node span is a view of a
+    /// vector this grows. Call it again after the last node rather than holding one across a build.
+    void addNode(mdux::medui::CompiledNode node);
+
+    /// Interns text and returns a stable view of the copy this document now owns.
+    ///
+    /// Empty text interns to an empty view without storing anything: "absent" is a legal value for
+    /// every optional name, and it is not worth a deque entry.
+    [[nodiscard]] std::string_view intern(std::string_view text);
+
+    /// Interns a list of names and returns a stable span of the views, for a `StatusIndicator`'s
+    /// parallel `stateKeys` and `colorTokens`.
+    [[nodiscard]] std::span<const std::string_view> internList(std::span<const std::string> items);
+
+private:
+    std::deque<std::string>                   text_;
+    std::deque<std::vector<std::string_view>> lists_;
+    std::vector<mdux::medui::CompiledNode>    nodes_;
+    std::string_view                          id_;
+    std::int32_t                              surfaceWidth_{0};
+    std::int32_t                              surfaceHeight_{0};
+    mdux::draw::DrawBudget                    budget_{};
+};
+
+/**
+ * @brief Builds the compiled screen from a resolved layout.
+ *
+ * Returns a document rather than a result type with a diagnostic list, for the reason
+ * `collectGoldens()` gives: every rule that can reject a screen was decided by an earlier stage, and
+ * a permanently empty diagnostic vector would suggest this one can reject a screen when it cannot.
+ * The component dictionary was checked by semantic analysis, the rectangles by the layout solver,
+ * and - the case #197 raised as an open gap - **compiled** id uniqueness by the layout solver too,
+ * which re-runs it after synthesising a Row's background node (`Layout.cpp`, `validateUniqueIds()`).
+ * That gap is therefore closed upstream, and this stage inherits the guarantee rather than repeating
+ * the check.
+ *
+ * A screen reaching here that breaks any of those means a gate was bypassed - the AST is public and
+ * can be built by hand - and throws, as layout and goldens do for the same reason. So does a budget
+ * the schema refuses: `PackageInputs` documents it as a precondition the recipe reader diagnoses,
+ * because this stage has no diagnostic code for a recipe's value and inventing one is the mistake
+ * #219 exists to avoid repeating.
+ *
+ * @throws std::logic_error if a gate was bypassed, or if the resulting package does not validate.
+ */
+[[nodiscard]] ScreenDocument buildPackage(const LayoutResult& layout, PackageInputs inputs);
+
+/// The canonical `package.json` bytes for a validated screen, trailing newline included.
+///
+/// @throws std::logic_error if the package does not validate, or if a name is not valid UTF-8 - both
+///         of which mean it did not come from `buildPackage()` or `readPackage()`.
+[[nodiscard]] std::string writePackage(const mdux::medui::ScreenPackage& package);
+
+/// The canonical `goldens.json` bytes: ADR-012's sidecar, written as `[]` when a screen pins nothing.
+///
+/// @throws std::logic_error if a reference carries text that is not valid UTF-8.
+[[nodiscard]] std::string writeGoldens(std::span<const GoldenReference> goldens);
+
+/// A screen read back from committed bytes, and any diagnostic that prevented one.
+///
+/// `document` is meaningful only when `diagnostics` is empty; a failed read leaves it empty rather
+/// than partially filled, so a caller cannot consume half a screen.
+struct PackageReadResult {
+    ScreenDocument                            document;
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Parses canonical `package.json` bytes into a document.
+ *
+ * Strict in the ways the module comment describes. Diagnostics carry `SCP0NN` codes, a family local
+ * to this tool in the same sense as `mdux-shaderemit`'s `SHE0NN` - the `MEDUI-E0NN` registry is the
+ * shared contract for what a *screen source* may say, and a malformed committed artifact is not that.
+ *
+ * @param file the path to name in diagnostics, e.g. `generated/screen/neurosense-500/package.json`
+ */
+[[nodiscard]] PackageReadResult readPackage(std::string_view text, std::string file);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Parser.cpp
+++ b/tools/medui/Parser.cpp
@@ -432,7 +432,26 @@ private:
             return value;
         }
         if (at(TokenKind::Number)) {
-            const Token& number = current();
+            const Token number = current();
+            // A standalone integer is a semantic value form (`max_length: 16`). An identifier
+            // immediately after it still means the author attempted a unit, so route that shape
+            // through parsePixels() to retain the precise unknown-unit diagnostic.
+            if (!peekIs(TokenKind::Identifier)) {
+                std::int64_t parsed = 0;
+                const auto [ptr, ec] = std::from_chars(
+                    number.text.data(), number.text.data() + number.text.size(), parsed);
+                if (ec != std::errc{} || ptr != number.text.data() + number.text.size()) {
+                    report(Code::UnexpectedToken,
+                           std::format("'{}' is not an integer this compiler can represent",
+                                       number.text));
+                    return nullptr;
+                }
+                static_cast<void>(advance());
+                value->kind = ast::ValueKind::Number;
+                value->number = parsed;
+                return value;
+            }
+
             std::optional<std::int64_t> pixels = parsePixels();
             if (pixels) {
                 // `Xpx, Ypx` is a point; a lone `Xpx` is a size. The comma decides.
@@ -451,12 +470,7 @@ private:
                                         .position = value->position};
                 return value;
             }
-            // parsePixels() already reported. Fall back to a bare number so the AST stays usable.
-            value->kind = ast::ValueKind::Number;
-            static_cast<void>(std::from_chars(number.text.data(),
-                                              number.text.data() + number.text.size(),
-                                              value->number));
-            return value;
+            return nullptr;
         }
         if (at(TokenKind::Identifier)) {
             if (rejectIfForbidden()) {
@@ -475,6 +489,17 @@ private:
                 value->text = key->text;
                 return value;
             }
+            if (word == "img" && peekIs(TokenKind::LParen)) {
+                static_cast<void>(advance());  // 'img'
+                static_cast<void>(advance());  // '('
+                const Token* key = expect(TokenKind::String, "an image reference, as img(\"ID\")");
+                if (key == nullptr || expect(TokenKind::RParen, "')' closing img(") == nullptr) {
+                    return nullptr;
+                }
+                value->kind = ast::ValueKind::ImageRef;
+                value->text = key->text;
+                return value;
+            }
             if (word == "Fill") {
                 static_cast<void>(advance());
                 value->kind = ast::ValueKind::Size;
@@ -484,7 +509,6 @@ private:
 
             // A dotted path: `Theme.Colors.ScoreDigits`. Kept whole and unresolved (#193).
             std::string path = advance().text;
-            bool dotted = false;
             while (at(TokenKind::Dot)) {
                 static_cast<void>(advance());
                 const Token* part = expect(TokenKind::Identifier, "a name after '.'");
@@ -493,7 +517,6 @@ private:
                 }
                 path += '.';
                 path += part->text;
-                dotted = true;
             }
             // A dotted path is only a *colour token* when it is one. `Foo.Bar` and a truncated
             // `Theme.Colors` were both classified as ColorToken, which would have sent #193 to the
@@ -501,18 +524,9 @@ private:
             // governed table" for what is really a malformed value.
             const bool isThemeColor = path.starts_with("Theme.Colors.") &&
                                       path.size() > std::string_view{"Theme.Colors."}.size();
-            // `dotted` no longer decides anything: an unqualified dotted path and a bare word are
-            // both just identifiers for #193 to interpret. Kept as a named variable only for the
-            // diagnostic below, so the reader is told which shape was seen.
+            // Any other dotted path is an Identifier for #193 to interpret. This is syntactically
+            // valid: whether a particular field admits a named value is a semantic-domain check.
             value->kind = isThemeColor ? ast::ValueKind::ColorToken : ast::ValueKind::Identifier;
-            if (dotted && !isThemeColor) {
-                // Not an error here - #193 owns what a field may hold - but worth saying, because
-                // a dotted path that is not a theme colour is almost always a mistyped one.
-                report(Code::UnexpectedToken,
-                       std::format("'{}' is not a Theme.Colors token", path),
-                       "colours are written Theme.Colors.<Token>; other dotted paths have no "
-                       "meaning in this grammar");
-            }
             value->text = std::move(path);
             return value;
         }

--- a/tools/medui/Parser.cpp
+++ b/tools/medui/Parser.cpp
@@ -308,7 +308,7 @@ private:
             if (at(TokenKind::At)) {
                 // Only a Row has children. The unannotated branch above already enforced that;
                 // this one did not, so `Card { @x Label { } }` was accepted and - worse -
-                // `Card { @x Row { } }` placed a Row at depth two with no MDX-E015, because the
+                // `Card { @x Row { } }` placed a Row at depth two with no MEDUI-E015, because the
                 // annotated path also passed insideRow=false. Reported independently by three
                 // reviewers on #209, and the AST contract in Ast.cppm says children is non-empty
                 // only for Row, which #194's single-pass solver relies on.
@@ -497,7 +497,7 @@ private:
             }
             // A dotted path is only a *colour token* when it is one. `Foo.Bar` and a truncated
             // `Theme.Colors` were both classified as ColorToken, which would have sent #193 to the
-            // theme table for a value that never named a colour - and produced MDX-E030 "not in the
+            // theme table for a value that never named a colour - and produced MEDUI-E030 "not in the
             // governed table" for what is really a malformed value.
             const bool isThemeColor = path.starts_with("Theme.Colors.") &&
                                       path.size() > std::string_view{"Theme.Colors."}.size();

--- a/tools/medui/Parser.cpp
+++ b/tools/medui/Parser.cpp
@@ -1,0 +1,587 @@
+/**
+ * @file Parser.cpp
+ * @brief The `.medui` recursive-descent parser.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+module;
+
+module mdux.tools.medui.parser;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.lexer;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// Words that must never appear. Not a style rule - see ADR-011 decision 5 and the module header.
+///
+/// Matched on identifiers only, so a *field* called `for` would also be rejected. That is intended:
+/// the point is that the language has no control flow, and a field named after a construct the
+/// language does not have is at best confusing.
+constexpr std::array<std::string_view, 11> forbiddenWords{
+    "if", "else", "for", "while", "loop", "match", "fn", "let", "return", "import", "while_let",
+};
+
+[[nodiscard]] bool isForbidden(std::string_view word) noexcept {
+    return std::ranges::find(forbiddenWords, word) != forbiddenWords.end();
+}
+
+class Parser {
+public:
+    Parser(std::vector<Token> tokens, std::string file)
+        : tokens_{std::move(tokens)}, file_{std::move(file)} {}
+
+    [[nodiscard]] std::vector<cli::Diagnostic> take() { return std::move(diagnostics_); }
+
+    [[nodiscard]] std::optional<ast::Screen> parseScreen() {
+        // Captured before expectWord() consumes it: Ast.cppm says a node carries the position of
+        // the token that introduced it, and parseLayout/parseSurface both do this. This one read
+        // the position *after* advancing, so it pointed at the screen name.
+        const ast::Position screenKeyword = position();
+        if (!expectWord("Screen")) {
+            return std::nullopt;
+        }
+        ast::Screen screen;
+        screen.position = screenKeyword;
+
+        const Token* name = expect(TokenKind::Identifier, "a screen name");
+        if (name == nullptr) {
+            return std::nullopt;
+        }
+        screen.name = name->text;
+
+        if (expect(TokenKind::LBrace, "'{' after the screen name") == nullptr) {
+            return std::nullopt;
+        }
+
+        while (!at(TokenKind::RBrace) && !at(TokenKind::EndOfFile)) {
+            if (!parseScreenMember(screen)) {
+                recover();
+            }
+        }
+        static_cast<void>(expect(TokenKind::RBrace, "'}' closing the screen"));
+
+        // A source declares exactly one screen. Without this, `Screen A { } Screen B { }` and
+        // `Screen A { } garbage` both parsed clean and returned a screen - the trailing content was
+        // simply never looked at. #200's file checker would have reported such a file as valid.
+        if (!at(TokenKind::EndOfFile)) {
+            report(Code::UnexpectedToken,
+                   std::format("unexpected {} after the screen's closing brace",
+                               describe(current().kind)),
+                   "a .medui source declares exactly one Screen, and nothing follows it");
+        }
+
+        checkDuplicateIds(screen);
+        return screen;
+    }
+
+private:
+    // -- token access -------------------------------------------------------
+
+    [[nodiscard]] const Token& current() const noexcept { return tokens_[index_]; }
+    [[nodiscard]] bool at(TokenKind kind) const noexcept { return current().kind == kind; }
+    [[nodiscard]] ast::Position position() const noexcept {
+        return ast::Position{.line = current().line, .column = current().column};
+    }
+
+    const Token& advance() noexcept {
+        const Token& t = tokens_[index_];
+        if (index_ + 1 < tokens_.size()) {
+            ++index_;
+        }
+        return t;
+    }
+
+    void report(Code code, std::string message, std::string fixHint = {}) {
+        diagnostics_.push_back(
+            diagnose(code, file_, current().line, current().column, std::move(message),
+                     std::move(fixHint)));
+    }
+
+    const Token* expect(TokenKind kind, std::string_view what) {
+        if (at(kind)) {
+            return &advance();
+        }
+        report(Code::UnexpectedToken,
+               std::format("expected {}, found {}", what, describe(current().kind)));
+        return nullptr;
+    }
+
+    bool expectWord(std::string_view word) {
+        if (at(TokenKind::Identifier) && current().text == word) {
+            static_cast<void>(advance());
+            return true;
+        }
+        report(Code::UnexpectedToken,
+               std::format("expected '{}', found {}", word, describe(current().kind)));
+        return false;
+    }
+
+    /// Skips to just past the next `;`, or to a `}` which the caller's loop will see.
+    void recover() {
+        while (!at(TokenKind::EndOfFile)) {
+            if (at(TokenKind::Semicolon)) {
+                static_cast<void>(advance());
+                return;
+            }
+            if (at(TokenKind::RBrace)) {
+                return;
+            }
+            static_cast<void>(advance());
+        }
+    }
+
+    /// Rejects a control-flow word wherever an identifier may appear. Returns true if it fired.
+    bool rejectIfForbidden() {
+        if (at(TokenKind::Identifier) && isForbidden(current().text)) {
+            report(Code::ForbiddenConstruct,
+                   std::format("'{}' is not part of the .medui language", current().text));
+            return true;
+        }
+        return false;
+    }
+
+    // -- grammar ------------------------------------------------------------
+
+    bool parseScreenMember(ast::Screen& screen) {
+        if (rejectIfForbidden()) {
+            return false;
+        }
+        if (at(TokenKind::At)) {
+            std::vector<ast::Annotation> annotations;
+            while (at(TokenKind::At)) {
+                std::optional<ast::Annotation> annotation = parseAnnotation();
+                if (!annotation) {
+                    return false;
+                }
+                annotations.push_back(std::move(*annotation));
+            }
+            return parseNodeInto(screen.nodes, std::move(annotations), /*insideRow=*/false);
+        }
+        if (!at(TokenKind::Identifier)) {
+            report(Code::UnexpectedToken,
+                   std::format("expected a component, 'layout' or 'surface', found {}",
+                               describe(current().kind)));
+            return false;
+        }
+
+        const std::string word = current().text;
+        if (word == "layout") {
+            return parseLayout(screen);
+        }
+        if (word == "surface") {
+            return parseSurface(screen);
+        }
+        return parseNodeInto(screen.nodes, {}, /*insideRow=*/false);
+    }
+
+    bool parseLayout(ast::Screen& screen) {
+        screen.layoutPosition = position();
+        static_cast<void>(advance());  // 'layout'
+        if (expect(TokenKind::Colon, "':' after 'layout'") == nullptr) {
+            return false;
+        }
+        // Before expect(): a forbidden word is an Identifier, so without this `layout: if { }`
+        // parsed clean. "Wherever an identifier may appear" has to include this one.
+        if (rejectIfForbidden()) {
+            return false;
+        }
+        const Token* kind = expect(TokenKind::Identifier, "a layout kind such as 'Vertical'");
+        if (kind == nullptr) {
+            return false;
+        }
+        screen.layoutKind = kind->text;
+
+        if (at(TokenKind::LBrace)) {
+            static_cast<void>(advance());
+            while (!at(TokenKind::RBrace) && !at(TokenKind::EndOfFile)) {
+                std::optional<ast::Field> field = parseField();
+                if (!field) {
+                    recover();
+                    continue;
+                }
+                screen.layout.push_back(std::move(*field));
+            }
+            static_cast<void>(expect(TokenKind::RBrace, "'}' closing the layout block"));
+        }
+        if (at(TokenKind::Semicolon)) {
+            static_cast<void>(advance());
+        }
+        return true;
+    }
+
+    bool parseSurface(ast::Screen& screen) {
+        const ast::Position where = position();
+        static_cast<void>(advance());  // 'surface'
+        if (expect(TokenKind::Colon, "':' after 'surface'") == nullptr) {
+            return false;
+        }
+        std::optional<std::int64_t> width = parsePixels();
+        if (!width || expect(TokenKind::Comma, "',' between the surface dimensions") == nullptr) {
+            return false;
+        }
+        std::optional<std::int64_t> height = parsePixels();
+        if (!height) {
+            return false;
+        }
+        screen.surface = ast::Point{.x = *width, .y = *height, .position = where};
+        static_cast<void>(expect(TokenKind::Semicolon, "';' after the surface"));
+        return true;
+    }
+
+    std::optional<ast::Annotation> parseAnnotation() {
+        ast::Annotation annotation;
+        annotation.position = position();
+        static_cast<void>(advance());  // '@'
+
+        const Token* name = expect(TokenKind::Identifier, "an annotation name");
+        if (name == nullptr) {
+            return std::nullopt;
+        }
+        annotation.name = name->text;
+
+        if (at(TokenKind::LParen)) {
+            static_cast<void>(advance());
+            while (!at(TokenKind::RParen) && !at(TokenKind::EndOfFile)) {
+                std::optional<ast::Field> argument = parseField(/*terminated=*/false);
+                if (!argument) {
+                    return std::nullopt;
+                }
+                annotation.arguments.push_back(std::move(*argument));
+                if (at(TokenKind::Comma)) {
+                    static_cast<void>(advance());
+                }
+            }
+            if (expect(TokenKind::RParen, "')' closing the annotation") == nullptr) {
+                return std::nullopt;
+            }
+        }
+        return annotation;
+    }
+
+    bool parseNodeInto(std::vector<ast::Node>& into, std::vector<ast::Annotation> annotations,
+                       bool insideRow) {
+        if (rejectIfForbidden()) {
+            return false;
+        }
+        const Token* component = expect(TokenKind::Identifier, "a component name");
+        if (component == nullptr) {
+            return false;
+        }
+
+        ast::Node node;
+        node.component = component->text;
+        node.position = ast::Position{.line = component->line, .column = component->column};
+        node.annotations = std::move(annotations);
+
+        const bool isRow = node.component == "Row";
+        if (isRow && insideRow) {
+            // ADR-011 decision 5: a solver restriction, not a budget one. The hint says so, and
+            // deliberately does not borrow the budget argument, which does not apply here.
+            diagnostics_.push_back(diagnose(
+                Code::NestedRow, file_, node.position.line, node.position.column,
+                "a Row cannot contain another Row"));
+        }
+
+        if (expect(TokenKind::LBrace, "'{' after the component name") == nullptr) {
+            return false;
+        }
+
+        while (!at(TokenKind::RBrace) && !at(TokenKind::EndOfFile)) {
+            if (rejectIfForbidden()) {
+                recover();
+                continue;
+            }
+            // A nested component inside a Row is `Identifier {`; a field is `Identifier :`.
+            if (isRow && at(TokenKind::Identifier) && peekIsBrace()) {
+                if (!parseNodeInto(node.children, {}, /*insideRow=*/true)) {
+                    recover();
+                }
+                continue;
+            }
+            if (at(TokenKind::At)) {
+                // Only a Row has children. The unannotated branch above already enforced that;
+                // this one did not, so `Card { @x Label { } }` was accepted and - worse -
+                // `Card { @x Row { } }` placed a Row at depth two with no MDX-E015, because the
+                // annotated path also passed insideRow=false. Reported independently by three
+                // reviewers on #209, and the AST contract in Ast.cppm says children is non-empty
+                // only for Row, which #194's single-pass solver relies on.
+                if (!isRow) {
+                    report(Code::UnexpectedToken,
+                           std::format("'{}' cannot contain another component", node.component),
+                           "only a Row holds child components; move this out, or make the parent "
+                           "a Row");
+                    recover();
+                    continue;
+                }
+                std::vector<ast::Annotation> childAnnotations;
+                bool bad = false;
+                while (at(TokenKind::At)) {
+                    std::optional<ast::Annotation> annotation = parseAnnotation();
+                    if (!annotation) { bad = true; break; }
+                    childAnnotations.push_back(std::move(*annotation));
+                }
+                if (bad || !parseNodeInto(node.children, std::move(childAnnotations),
+                                          /*insideRow=*/true)) {
+                    recover();
+                }
+                continue;
+            }
+            std::optional<ast::Field> field = parseField();
+            if (!field) {
+                recover();
+                continue;
+            }
+            node.fields.push_back(std::move(*field));
+        }
+        static_cast<void>(expect(TokenKind::RBrace, "'}' closing the component"));
+
+        into.push_back(std::move(node));
+        return true;
+    }
+
+    [[nodiscard]] bool peekIsBrace() const noexcept {
+        return index_ + 1 < tokens_.size() && tokens_[index_ + 1].kind == TokenKind::LBrace;
+    }
+
+    std::optional<ast::Field> parseField(bool terminated = true) {
+        if (rejectIfForbidden()) {
+            return std::nullopt;
+        }
+        const Token* name = expect(TokenKind::Identifier, "a field name");
+        if (name == nullptr) {
+            return std::nullopt;
+        }
+        ast::Field field;
+        field.name = name->text;
+        field.namePosition = ast::Position{.line = name->line, .column = name->column};
+
+        if (expect(TokenKind::Colon, "':' after the field name") == nullptr) {
+            return std::nullopt;
+        }
+        std::shared_ptr<ast::Value> value = parseValue();
+        if (value == nullptr) {
+            return std::nullopt;
+        }
+        field.value = std::move(value);
+
+        if (terminated) {
+            static_cast<void>(expect(TokenKind::Semicolon, "';' after the field"));
+        }
+        return field;
+    }
+
+    std::optional<std::int64_t> parsePixels() {
+        const Token* number = expect(TokenKind::Number, "a pixel count");
+        if (number == nullptr) {
+            return std::nullopt;
+        }
+        if (!at(TokenKind::Identifier) || current().text != "px") {
+            report(Code::UnexpectedToken,
+                   std::format("expected 'px' after {}, found {}", number->text,
+                               describe(current().kind)),
+                   "lengths are written as Npx, e.g. 512px; there are no other units");
+            return std::nullopt;
+        }
+        static_cast<void>(advance());  // 'px'
+
+        std::int64_t pixels = 0;
+        const auto [ptr, ec] = std::from_chars(
+            number->text.data(), number->text.data() + number->text.size(), pixels);
+        if (ec != std::errc{}) {
+            report(Code::UnexpectedToken,
+                   std::format("'{}' is not a pixel count this compiler can represent",
+                               number->text));
+            return std::nullopt;
+        }
+        static_cast<void>(ptr);
+        return pixels;
+    }
+
+    std::shared_ptr<ast::Value> parseValue() {
+        auto value = std::make_shared<ast::Value>();
+        value->position = position();
+
+        if (at(TokenKind::String)) {
+            value->kind = ast::ValueKind::String;
+            value->text = advance().text;
+            return value;
+        }
+        if (at(TokenKind::LBracket)) {
+            static_cast<void>(advance());
+            value->kind = ast::ValueKind::List;
+            while (!at(TokenKind::RBracket) && !at(TokenKind::EndOfFile)) {
+                std::shared_ptr<ast::Value> element = parseValue();
+                if (element == nullptr) {
+                    return nullptr;
+                }
+                value->list.push_back(std::move(element));
+                if (at(TokenKind::Comma)) {
+                    static_cast<void>(advance());
+                }
+            }
+            if (expect(TokenKind::RBracket, "']' closing the list") == nullptr) {
+                return nullptr;
+            }
+            return value;
+        }
+        if (at(TokenKind::Number)) {
+            const Token& number = current();
+            std::optional<std::int64_t> pixels = parsePixels();
+            if (pixels) {
+                // `Xpx, Ypx` is a point; a lone `Xpx` is a size. The comma decides.
+                if (at(TokenKind::Comma)) {
+                    static_cast<void>(advance());
+                    std::optional<std::int64_t> y = parsePixels();
+                    if (!y) {
+                        return nullptr;
+                    }
+                    value->kind = ast::ValueKind::Point;
+                    value->point = ast::Point{.x = *pixels, .y = *y, .position = value->position};
+                    return value;
+                }
+                value->kind = ast::ValueKind::Size;
+                value->size = ast::Size{.fill = false, .pixels = *pixels,
+                                        .position = value->position};
+                return value;
+            }
+            // parsePixels() already reported. Fall back to a bare number so the AST stays usable.
+            value->kind = ast::ValueKind::Number;
+            static_cast<void>(std::from_chars(number.text.data(),
+                                              number.text.data() + number.text.size(),
+                                              value->number));
+            return value;
+        }
+        if (at(TokenKind::Identifier)) {
+            if (rejectIfForbidden()) {
+                return nullptr;
+            }
+            const std::string word = current().text;
+
+            if (word == "t" && peekIs(TokenKind::LParen)) {
+                static_cast<void>(advance());  // 't'
+                static_cast<void>(advance());  // '('
+                const Token* key = expect(TokenKind::String, "a text key, as t(\"STR-KEY\")");
+                if (key == nullptr || expect(TokenKind::RParen, "')' closing t(") == nullptr) {
+                    return nullptr;
+                }
+                value->kind = ast::ValueKind::TextKey;
+                value->text = key->text;
+                return value;
+            }
+            if (word == "Fill") {
+                static_cast<void>(advance());
+                value->kind = ast::ValueKind::Size;
+                value->size = ast::Size{.fill = true, .pixels = 0, .position = value->position};
+                return value;
+            }
+
+            // A dotted path: `Theme.Colors.ScoreDigits`. Kept whole and unresolved (#193).
+            std::string path = advance().text;
+            bool dotted = false;
+            while (at(TokenKind::Dot)) {
+                static_cast<void>(advance());
+                const Token* part = expect(TokenKind::Identifier, "a name after '.'");
+                if (part == nullptr) {
+                    return nullptr;
+                }
+                path += '.';
+                path += part->text;
+                dotted = true;
+            }
+            // A dotted path is only a *colour token* when it is one. `Foo.Bar` and a truncated
+            // `Theme.Colors` were both classified as ColorToken, which would have sent #193 to the
+            // theme table for a value that never named a colour - and produced MDX-E030 "not in the
+            // governed table" for what is really a malformed value.
+            const bool isThemeColor = path.starts_with("Theme.Colors.") &&
+                                      path.size() > std::string_view{"Theme.Colors."}.size();
+            // `dotted` no longer decides anything: an unqualified dotted path and a bare word are
+            // both just identifiers for #193 to interpret. Kept as a named variable only for the
+            // diagnostic below, so the reader is told which shape was seen.
+            value->kind = isThemeColor ? ast::ValueKind::ColorToken : ast::ValueKind::Identifier;
+            if (dotted && !isThemeColor) {
+                // Not an error here - #193 owns what a field may hold - but worth saying, because
+                // a dotted path that is not a theme colour is almost always a mistyped one.
+                report(Code::UnexpectedToken,
+                       std::format("'{}' is not a Theme.Colors token", path),
+                       "colours are written Theme.Colors.<Token>; other dotted paths have no "
+                       "meaning in this grammar");
+            }
+            value->text = std::move(path);
+            return value;
+        }
+
+        report(Code::UnexpectedToken,
+               std::format("expected a value, found {}", describe(current().kind)));
+        return nullptr;
+    }
+
+    [[nodiscard]] bool peekIs(TokenKind kind) const noexcept {
+        return index_ + 1 < tokens_.size() && tokens_[index_ + 1].kind == kind;
+    }
+
+    // -- post-parse structural checks ---------------------------------------
+
+    /// Ids must be unique across the whole screen, not merely within a parent: golden references
+    /// (#196) and requirement traces address a node by id alone.
+    void checkDuplicateIds(const ast::Screen& screen) {
+        std::map<std::string, ast::Position> seen;
+        const auto visit = [&](auto&& self, const ast::Node& node) -> void {
+            for (const ast::Field& field : node.fields) {
+                if (field.name != "id" || field.value == nullptr) {
+                    continue;
+                }
+                const std::string& id = field.value->text;
+                if (id.empty()) {
+                    continue;
+                }
+                const auto [it, inserted] = seen.emplace(id, field.namePosition);
+                if (!inserted) {
+                    diagnostics_.push_back(diagnose(
+                        Code::DuplicateNodeId, file_, field.namePosition.line,
+                        field.namePosition.column,
+                        std::format("node id '{}' is already used at line {}, column {}", id,
+                                    it->second.line, it->second.column)));
+                }
+            }
+            for (const ast::Node& child : node.children) {
+                self(self, child);
+            }
+        };
+        for (const ast::Node& node : screen.nodes) {
+            visit(visit, node);
+        }
+    }
+
+    std::vector<Token> tokens_;
+    std::string file_;
+    std::size_t index_{0};
+    std::vector<cli::Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+ParseResult parse(std::string_view source, std::string file) {
+    ParseResult result;
+
+    LexResult lexed = lex(source, file);
+    result.diagnostics = std::move(lexed.diagnostics);
+    if (lexed.tokens.empty()) {
+        return result;  // only when the source was rejected whole, e.g. bad UTF-8
+    }
+
+    Parser parser{std::move(lexed.tokens), std::move(file)};
+    result.screen = parser.parseScreen();
+    std::vector<cli::Diagnostic> parsed = parser.take();
+    result.diagnostics.insert(result.diagnostics.end(), std::make_move_iterator(parsed.begin()),
+                              std::make_move_iterator(parsed.end()));
+    return result;
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Parser.cppm
+++ b/tools/medui/Parser.cppm
@@ -1,0 +1,79 @@
+/**
+ * @file Parser.cppm
+ * @brief Recursive-descent `.medui` parser: tokens to an unresolved AST.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Host-only, hand-written, one token of lookahead. What it enforces and what it deliberately does
+ * not are both worth stating, because the boundary is the design.
+ *
+ * ## What it enforces
+ *
+ * - The shape: one `Screen`, an optional `layout:` and `surface:`, then nodes with fields.
+ * - **No control flow.** `if`, `else`, `for`, `while`, `loop`, `match`, `fn`, `let`, `return` and
+ *   `import` are rejected with `MDX-E016` wherever they appear. ADR-011 decision 5: each makes the
+ *   primitive count depend on data the compiler cannot see, and a `DrawBudget` that cannot be
+ *   computed exactly is not a budget.
+ * - **No nested `Row`** (`MDX-E015`). ADR-011 is explicit that this one is a *solver* restriction,
+ *   not a budget one - a nested Row's depth is visible and the primitive count stays exact - so the
+ *   diagnostic says flatten it, and does not cite the budget argument that does not apply.
+ * - **No duplicate node ids within a screen** (`MDX-E014`). Ids address nodes in golden references
+ *   (#196) and requirement traces, so a duplicate makes those ambiguous.
+ *
+ * ## What it does not
+ *
+ * Component names, field names and theme tokens are carried unresolved. The component dictionary
+ * and the theme table belong to #193, and a parser that consulted them would have to change every
+ * time a component is added. See `Ast.cppm` for the argument in full.
+ *
+ * ## Whitespace, and a one-way portability note
+ *
+ * This parser is token-based, so `width: 512px; height: 512px;` on one line parses exactly as the
+ * two-line form. TrustSC's reference implementation is *line*-based: it splits a component body
+ * line by line and takes each line's first `:`, so the one-line form is read there as a width of
+ * `512px; height: 512px` and rejected.
+ *
+ * That makes MduX's accepted grammar a strict superset, and portability one-way: every screen
+ * TrustSC accepts compiles here, and a screen written with two properties on a line does not
+ * compile there. The superset is not the problem - a token-based parser is the better tool, and
+ * narrowing it to match a line-based one would buy nothing. What matters is that authored screens
+ * stay portable, so the `medui-authoring` skill now documents one property per line and the
+ * fixture corpus is written that way.
+ *
+ * ## Recovery
+ *
+ * On an unexpected token the parser skips to the next `;` or `}` and continues, so one run reports
+ * several problems rather than the first. A compiler that stops at the first error makes fixing a
+ * screen an iterative guessing game, and #200's `mdux-medui-check` exists precisely to give an
+ * author everything at once.
+ */
+module;
+
+export module mdux.tools.medui.parser;
+
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+
+export namespace mdux::tools::medui {
+
+/// The parsed screen, or the diagnostics that stopped it parsing.
+struct ParseResult {
+    std::optional<ast::Screen> screen;
+    std::vector<cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept { return screen.has_value() && diagnostics.empty(); }
+};
+
+/**
+ * @brief Lexes and parses `source`, attributing diagnostics to `file`.
+ *
+ * Never throws for malformed input. A `screen` is returned whenever enough parsed to be worth
+ * examining, *even alongside diagnostics* - #200 wants to report a text-budget problem and a
+ * syntax problem in the same run where it can. Callers must therefore check `ok()` or the
+ * diagnostics, not merely whether `screen` is engaged.
+ */
+[[nodiscard]] ParseResult parse(std::string_view source, std::string file);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Parser.cppm
+++ b/tools/medui/Parser.cppm
@@ -12,13 +12,13 @@
  *
  * - The shape: one `Screen`, an optional `layout:` and `surface:`, then nodes with fields.
  * - **No control flow.** `if`, `else`, `for`, `while`, `loop`, `match`, `fn`, `let`, `return` and
- *   `import` are rejected with `MDX-E016` wherever they appear. ADR-011 decision 5: each makes the
+ *   `import` are rejected with `MEDUI-E016` wherever they appear. ADR-011 decision 5: each makes the
  *   primitive count depend on data the compiler cannot see, and a `DrawBudget` that cannot be
  *   computed exactly is not a budget.
- * - **No nested `Row`** (`MDX-E015`). ADR-011 is explicit that this one is a *solver* restriction,
+ * - **No nested `Row`** (`MEDUI-E015`). ADR-011 is explicit that this one is a *solver* restriction,
  *   not a budget one - a nested Row's depth is visible and the primitive count stays exact - so the
  *   diagnostic says flatten it, and does not cite the budget argument that does not apply.
- * - **No duplicate node ids within a screen** (`MDX-E014`). Ids address nodes in golden references
+ * - **No duplicate node ids within a screen** (`MEDUI-E014`). Ids address nodes in golden references
  *   (#196) and requirement traces, so a duplicate makes those ambiguous.
  *
  * ## What it does not

--- a/tools/medui/ScreenEmitMain.cpp
+++ b/tools/medui/ScreenEmitMain.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file ScreenEmitMain.cpp
+ * @brief `mdux-screenemit` entry point.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Its own executable rather than a mode of the compiler, for the reason `mdux-shaderemit` is its
+ * own: compiling a `.medui` source and rendering a committed package are different jobs with
+ * different inputs, and the second must remain runnable on an artifact whose source is not present.
+ * That is what lets a device build regenerate its screens from the reviewed JSON alone.
+ *
+ * Diagnostics go through `cli::Diagnostic`, `cli::render` and `cli::exitStatus`, so `--format=json`
+ * here is the same envelope every other MduX tool emits.
+ */
+import std;
+import mdux.tools.cli;
+import mdux.tools.medui.emit;
+
+namespace {
+
+namespace cli  = mdux::tools::cli;
+namespace emit = mdux::tools::medui;
+
+[[nodiscard]] std::string usage() {
+    return std::format("usage:\n"
+                       "  {} <package.json> <output-dir> [--format=json|text]\n"
+                       "\n"
+                       "Renders a committed screen package as a C++ module interface and a header,\n"
+                       "both written into <output-dir>. The generated source carries a static_assert\n"
+                       "that the screen satisfies its schema, so a malformed screen is a build error\n"
+                       "in whatever links it.\n"
+                       "\n"
+                       "Generated code belongs in the build tree and is never committed; see\n"
+                       "tools/medui/Emit.cppm.\n",
+                       emit::emitToolName);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    std::vector<std::string_view> positional;
+    cli::Format                   format = cli::Format::Text;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view argument{argv[i]};
+        if (argument == "--help" || argument == "-h") {
+            std::print(std::cout, "{}", usage());
+            return 0;
+        }
+        if (argument == "--format=json") {
+            format = cli::Format::Json;
+            continue;
+        }
+        if (argument == "--format=text") {
+            // Assigned rather than skipped, so that last flag wins.
+            format = cli::Format::Text;
+            continue;
+        }
+        if (argument.starts_with("-")) {
+            std::println(std::cerr, "unrecognized option '{}'\n\n{}", argument, usage());
+            return 2;
+        }
+        positional.push_back(argument);
+    }
+
+    if (positional.size() != 2) {
+        std::println(std::cerr, "expected exactly 2 arguments, got {}\n\n{}", positional.size(), usage());
+        return 2;
+    }
+
+    std::vector<cli::Diagnostic> diagnostics;
+    std::string                  summary;
+    if (auto outputs = emit::renderScreen(std::filesystem::path{positional[0]}, diagnostics); outputs.has_value()) {
+        if (emit::writeScreen(*outputs, std::filesystem::path{positional[1]}, diagnostics)) {
+            summary = std::format("{}: OK (emitted {} and {}.hpp)", emit::emitToolName, outputs->moduleName, outputs->stem);
+        }
+    }
+
+    const std::string rendered = cli::render(diagnostics, format, emit::emitToolName);
+    if (!rendered.empty()) {
+        std::print(std::cout, "{}", rendered);
+    }
+    if (format == cli::Format::Text && !summary.empty()) {
+        std::println(std::cout, "{}", summary);
+    }
+
+    return cli::exitStatus(diagnostics);
+}

--- a/tools/medui/Semantic.cpp
+++ b/tools/medui/Semantic.cpp
@@ -204,6 +204,14 @@ private:
     }
 
     void analyzeTextKey(const ast::Value& value) {
+        // Asked for, never inferred. An empty package span still means "an approved set with no
+        // locale in it" - so every key is absent from all of them - and only a caller that says so
+        // explicitly gets the check skipped. Reading permission out of the span would have handed
+        // every other caller a weaker check with nothing in the result to say so.
+        if (inputs_.locales == LocalePolicy::Skipped) {
+            return;
+        }
+
         std::vector<std::string_view> missingLocales;
         bool                          foundAnywhere = false;
         for (const mdux::text::TextPackage& package : inputs_.textPackages) {
@@ -225,20 +233,16 @@ private:
     void analyzeText(const ast::Value& value, FieldDomain domain) {
         if (domain == TextKeyList && value.kind == ast::ValueKind::List) {
             if (value.list.empty()) {
-                report(Code::FieldValueKind, value.position,
-                       std::format("text field requires {}", describe(domain)));
+                report(Code::FieldValueKind, value.position, std::format("text field requires {}", describe(domain)));
                 return;
             }
             for (const std::shared_ptr<ast::Value>& element : value.list) {
                 if (element == nullptr) {
-                    report(Code::FieldValueKind, value.position,
-                           std::format("text field requires {}", describe(domain)));
+                    report(Code::FieldValueKind, value.position, std::format("text field requires {}", describe(domain)));
                 } else if (element->kind == ast::ValueKind::String) {
-                    report(Code::HardcodedString, element->position,
-                           "literal text cannot be checked against every approved locale");
+                    report(Code::HardcodedString, element->position, "literal text cannot be checked against every approved locale");
                 } else if (element->kind != ast::ValueKind::TextKey) {
-                    report(Code::FieldValueKind, element->position,
-                           std::format("text field requires {}", describe(domain)));
+                    report(Code::FieldValueKind, element->position, std::format("text field requires {}", describe(domain)));
                 } else {
                     analyzeTextKey(*element);
                 }

--- a/tools/medui/Semantic.cpp
+++ b/tools/medui/Semantic.cpp
@@ -1,0 +1,332 @@
+/**
+ * @file Semantic.cpp
+ * @brief Component-dictionary, value-domain, theme-token, and locale-key semantic checks.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+module;
+
+module mdux.tools.medui.semantic;
+
+import std;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+using enum FieldDomain;
+
+constexpr FieldRule field(std::string_view name, bool required, FieldDomain domain) {
+    return FieldRule{.name = name, .required = required, .domain = domain};
+}
+
+constexpr std::array rowFields{field("id", true, Identifier),
+                               field("height", true, Size),
+                               field("spacing", false, Size),
+                               field("background", false, ColorToken)};
+constexpr std::array criticalButtonFields{field("id", true, Identifier),
+                                          field("requirement", true, String),
+                                          field("width", true, Size),
+                                          field("height", true, Size),
+                                          field("label", true, TextKey),
+                                          field("color", true, ColorToken),
+                                          field("on_press", true, Identifier),
+                                          field("position", false, Point)};
+constexpr std::array buttonFields{field("id", true, Identifier),
+                                  field("width", true, Size),
+                                  field("height", true, Size),
+                                  field("label", true, TextKey),
+                                  field("color", true, ColorToken),
+                                  field("source", true, String),
+                                  field("position", false, Point),
+                                  field("requirement", false, String)};
+constexpr std::array viewportFields{field("id", true, Identifier),
+                                    field("width", true, Size),
+                                    field("height", true, Size),
+                                    field("stream_source", true, String),
+                                    field("position", false, Point)};
+constexpr std::array signalTraceFields{field("id", true, Identifier),
+                                       field("width", true, Size),
+                                       field("height", true, Size),
+                                       field("stream_source", true, String),
+                                       field("color", true, ColorToken),
+                                       field("position", false, Point)};
+constexpr std::array numericDisplayFields{field("id", true, Identifier),
+                                          field("width", true, Size),
+                                          field("height", true, Size),
+                                          field("requirement", true, String),
+                                          field("template", true, String),
+                                          field("source", true, String),
+                                          field("color", true, ColorToken),
+                                          field("position", false, Point)};
+constexpr std::array statusIndicatorFields{field("id", true, Identifier),
+                                           field("width", true, Size),
+                                           field("height", true, Size),
+                                           field("requirement", true, String),
+                                           field("source", true, String),
+                                           field("states", true, TextKeyList),
+                                           field("position", false, Point),
+                                           field("colors", false, ColorTokenList)};
+constexpr std::array labelFields{field("id", true, Identifier),
+                                 field("width", true, Size),
+                                 field("height", true, Size),
+                                 field("text", true, TextKey),
+                                 field("color", true, ColorToken),
+                                 field("position", false, Point)};
+constexpr std::array clockFields{field("id", true, Identifier),
+                                 field("width", true, Size),
+                                 field("height", true, Size),
+                                 field("format", true, Identifier),
+                                 field("position", false, Point)};
+constexpr std::array imageFields{field("id", true, Identifier),
+                                 field("width", true, Size),
+                                 field("height", true, Size),
+                                 field("source", true, ImageRef),
+                                 field("position", false, Point)};
+constexpr std::array textInputFields{field("id", true, Identifier),
+                                     field("width", true, Size),
+                                     field("height", true, Size),
+                                     field("source", true, String),
+                                     field("max_length", true, Number),
+                                     field("color", true, ColorToken),
+                                     field("position", false, Point),
+                                     field("charset", false, Identifier),
+                                     field("requirement", false, String)};
+
+constexpr std::array<ComponentRule, 11> componentRules{
+    {
+     {"Row", rowFields},
+     {"CriticalButton", criticalButtonFields},
+     {"Button", buttonFields},
+     {"VulkanViewport", viewportFields},
+     {"SignalTrace", signalTraceFields},
+     {"NumericDisplay", numericDisplayFields},
+     {"StatusIndicator", statusIndicatorFields},
+     {"Label", labelFields},
+     {"Clock", clockFields},
+     {"Image", imageFields},
+     {"TextInput", textInputFields},
+     }
+};
+
+[[nodiscard]] const ComponentRule* ruleFor(std::string_view component) noexcept {
+    const auto found = std::ranges::find(componentRules, component, &ComponentRule::name);
+    return found == componentRules.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const FieldRule* ruleFor(const ComponentRule& component, std::string_view name) noexcept {
+    const auto found = std::ranges::find(component.fields, name, &FieldRule::name);
+    return found == component.fields.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const ast::Field* fieldFor(const ast::Node& node, std::string_view name) noexcept {
+    const auto found = std::ranges::find(node.fields, name, &ast::Field::name);
+    return found == node.fields.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool listContains(const ast::Value& value, ast::ValueKind kind) noexcept {
+    return value.kind == ast::ValueKind::List && !value.list.empty() && std::ranges::all_of(value.list, [kind](const std::shared_ptr<ast::Value>& element) {
+               return element != nullptr && element->kind == kind;
+           });
+}
+
+[[nodiscard]] bool matches(const ast::Value& value, FieldDomain domain) noexcept {
+    switch (domain) {
+        case Identifier:
+            return value.kind == ast::ValueKind::Identifier;
+        case Size:
+            return value.kind == ast::ValueKind::Size;
+        case Point:
+            return value.kind == ast::ValueKind::Point;
+        case String:
+            return value.kind == ast::ValueKind::String;
+        case TextKey:
+            return value.kind == ast::ValueKind::TextKey;
+        case TextKeyList:
+            return listContains(value, ast::ValueKind::TextKey);
+        case ColorToken:
+            return value.kind == ast::ValueKind::ColorToken;
+        case ColorTokenList:
+            return listContains(value, ast::ValueKind::ColorToken);
+        case ImageRef:
+            return value.kind == ast::ValueKind::ImageRef;
+        case Number:
+            return value.kind == ast::ValueKind::Number && value.number > 0;
+    }
+    return false;
+}
+
+[[nodiscard]] std::string_view describe(FieldDomain domain) noexcept {
+    switch (domain) {
+        case Identifier:
+            return "a named value";
+        case Size:
+            return "a pixel size or Fill";
+        case Point:
+            return "a pixel coordinate pair";
+        case String:
+            return "a quoted string";
+        case TextKey:
+            return "t(\"KEY\")";
+        case TextKeyList:
+            return "a non-empty list of t(\"KEY\") values";
+        case ColorToken:
+            return "Theme.Colors.<Token>";
+        case ColorTokenList:
+            return "a non-empty list of Theme.Colors.<Token> values";
+        case ImageRef:
+            return "img(\"ID\")";
+        case Number:
+            return "a positive integer";
+    }
+    return "the field's declared value domain";
+}
+
+class Analyzer {
+public:
+    Analyzer(std::string file, SemanticInputs inputs) : file_{std::move(file)}, inputs_{inputs} {}
+
+    [[nodiscard]] SemanticResult run(const ast::Screen& screen) {
+        for (const ast::Node& node : screen.nodes) {
+            analyzeNode(node);
+        }
+        return SemanticResult{.diagnostics = std::move(diagnostics_)};
+    }
+
+private:
+    void report(Code code, ast::Position position, std::string message) {
+        diagnostics_.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
+    }
+
+    void analyzeTextKey(const ast::Value& value) {
+        std::vector<std::string_view> missingLocales;
+        bool                          foundAnywhere = false;
+        for (const mdux::text::TextPackage& package : inputs_.textPackages) {
+            if (package.find(value.text) != nullptr) {
+                foundAnywhere = true;
+            } else {
+                missingLocales.push_back(package.locale);
+            }
+        }
+        if (!foundAnywhere) {
+            report(Code::UnknownTextKey, value.position, std::format("text key '{}' is absent from every approved locale", value.text));
+            return;
+        }
+        for (std::string_view locale : missingLocales) {
+            report(Code::TextKeyMissingForLocale, value.position, std::format("text key '{}' is missing for approved locale '{}'", value.text, locale));
+        }
+    }
+
+    void analyzeText(const ast::Value& value, FieldDomain domain) {
+        if (domain == TextKeyList && value.kind == ast::ValueKind::List) {
+            if (value.list.empty()) {
+                report(Code::FieldValueKind, value.position,
+                       std::format("text field requires {}", describe(domain)));
+                return;
+            }
+            for (const std::shared_ptr<ast::Value>& element : value.list) {
+                if (element == nullptr) {
+                    report(Code::FieldValueKind, value.position,
+                           std::format("text field requires {}", describe(domain)));
+                } else if (element->kind == ast::ValueKind::String) {
+                    report(Code::HardcodedString, element->position,
+                           "literal text cannot be checked against every approved locale");
+                } else if (element->kind != ast::ValueKind::TextKey) {
+                    report(Code::FieldValueKind, element->position,
+                           std::format("text field requires {}", describe(domain)));
+                } else {
+                    analyzeTextKey(*element);
+                }
+            }
+            return;
+        }
+        if (value.kind == ast::ValueKind::String) {
+            report(Code::HardcodedString, value.position, "literal text cannot be checked against every approved locale");
+            return;
+        }
+        if (!matches(value, domain)) {
+            report(Code::FieldValueKind, value.position, std::format("text field requires {}", describe(domain)));
+            return;
+        }
+        analyzeTextKey(value);
+    }
+
+    void analyzeColor(const ast::Value& value, FieldDomain domain) {
+        if (!matches(value, domain)) {
+            report(Code::FieldValueKind, value.position, std::format("colour field requires {}", describe(domain)));
+            return;
+        }
+        const auto check = [&](const ast::Value& token) {
+            if (std::ranges::find(inputs_.themeTokens, token.text) == inputs_.themeTokens.end()) {
+                report(Code::UnknownColorToken, token.position, std::format("theme token '{}' is not in the governed table", token.text));
+            }
+        };
+        if (domain == ColorToken) {
+            check(value);
+        } else {
+            for (const std::shared_ptr<ast::Value>& element : value.list) {
+                check(*element);
+            }
+        }
+    }
+
+    void analyzeNode(const ast::Node& node) {
+        const ComponentRule* component = ruleFor(node.component);
+        if (component == nullptr) {
+            report(Code::UnknownComponent, node.position, std::format("component '{}' is not in the component dictionary", node.component));
+        } else {
+            for (const FieldRule& fieldRule : component->fields) {
+                if (fieldRule.required && fieldFor(node, fieldRule.name) == nullptr) {
+                    report(Code::MissingRequiredField, node.position, std::format("component '{}' requires field '{}'", node.component, fieldRule.name));
+                }
+            }
+
+            for (const ast::Field& fieldValue : node.fields) {
+                const FieldRule* fieldRule = ruleFor(*component, fieldValue.name);
+                if (fieldRule == nullptr) {
+                    report(Code::UnknownField,
+                           fieldValue.namePosition,
+                           std::format("field '{}' is not defined for component '{}'", fieldValue.name, node.component));
+                    continue;
+                }
+                if (fieldValue.value == nullptr) {
+                    continue;
+                }
+                if (fieldRule->domain == TextKey || fieldRule->domain == TextKeyList) {
+                    analyzeText(*fieldValue.value, fieldRule->domain);
+                } else if (fieldRule->domain == ColorToken || fieldRule->domain == ColorTokenList) {
+                    analyzeColor(*fieldValue.value, fieldRule->domain);
+                } else if (!matches(*fieldValue.value, fieldRule->domain)) {
+                    report(Code::FieldValueKind,
+                           fieldValue.value->position,
+                           std::format("field '{}' requires {}", fieldValue.name, describe(fieldRule->domain)));
+                }
+            }
+        }
+
+        for (const ast::Node& child : node.children) {
+            analyzeNode(child);
+        }
+    }
+
+    std::string                  file_;
+    SemanticInputs               inputs_;
+    std::vector<cli::Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+std::span<const ComponentRule> componentDictionary() noexcept {
+    return componentRules;
+}
+
+SemanticResult analyze(const ast::Screen& screen, std::string file, SemanticInputs inputs) {
+    return Analyzer{std::move(file), inputs}.run(screen);
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Semantic.cppm
+++ b/tools/medui/Semantic.cppm
@@ -1,0 +1,93 @@
+/**
+ * @file Semantic.cppm
+ * @brief Build-time semantic analysis for parsed `.medui` screens.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * This stage validates the component dictionary, field value domains, and external names but
+ * deliberately does not substitute them. The AST remains the author's unresolved description;
+ * later compiler stages receive it only after this result is successful and perform layout and
+ * emission against their own governed inputs.
+ */
+module;
+
+export module mdux.tools.medui.semantic;
+
+import std;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+
+export namespace mdux::tools::medui {
+
+/// The syntactic value form one component field admits during semantic analysis.
+enum class FieldDomain : std::uint8_t {
+    Identifier,
+    Size,
+    Point,
+    String,
+    TextKey,
+    TextKeyList,
+    ColorToken,
+    ColorTokenList,
+    ImageRef,
+    Number,
+};
+
+/// One field admitted by a component and the value form that field accepts.
+struct FieldRule {
+    /// Field spelling from the canonical component dictionary.
+    std::string_view name;
+    /// Whether every instance of the component must carry this field.
+    bool required{false};
+    /// Syntactic value form accepted for this field.
+    FieldDomain domain{FieldDomain::Identifier};
+};
+
+/// One component and its complete closed set of fields.
+struct ComponentRule {
+    /// Component spelling from the canonical component dictionary.
+    std::string_view name;
+    /// Complete required and optional field set for the component.
+    std::span<const FieldRule> fields;
+};
+
+/**
+ * @brief The closed component dictionary implemented by this semantic stage.
+ *
+ * Exposed so the pinned shared-conformance test can compare the transcription with the contract
+ * it implements. Consumers should still treat Compliatory/MedUI as the canonical definition.
+ */
+[[nodiscard]] std::span<const ComponentRule> componentDictionary() noexcept;
+
+/**
+ * @brief External name tables against which one screen is checked.
+ *
+ * Text packages are prevalidated, one per approved locale, with unique locale names. The
+ * analyzer reads only each package's locale and run IDs. Theme tokens are full names such as
+ * `Theme.Colors.Title`; their concrete colour values belong to the later emitter stage.
+ */
+struct SemanticInputs {
+    std::span<const std::string_view>        themeTokens;
+    std::span<const mdux::text::TextPackage> textPackages;
+};
+
+/// Accumulated semantic diagnostics; an empty result admits the screen to the next stage.
+struct SemanticResult {
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Validates component fields and values, theme tokens, and locale-complete text keys.
+ *
+ * Diagnostics accumulate in source traversal order. The screen is never modified and resolved
+ * values are not returned: successful semantic validation is a gate, not a substitution pass.
+ */
+[[nodiscard]] SemanticResult analyze(const ast::Screen& screen, std::string file, SemanticInputs inputs);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/Semantic.cppm
+++ b/tools/medui/Semantic.cppm
@@ -62,6 +62,24 @@ struct ComponentRule {
 [[nodiscard]] std::span<const ComponentRule> componentDictionary() noexcept;
 
 /**
+ * @brief Whether a caller is entitled to skip the locale-completeness check.
+ *
+ * The default is the one that fails closed. An empty `textPackages` span under `Required` means an
+ * approved set containing no locale, so every key is absent from all of them - which is what a
+ * compile must see rather than a clean result.
+ *
+ * `Skipped` exists for one caller: `mdux-medui-check` validates a file that may belong to no recipe,
+ * so there are no approved locales to check against and reporting every `t("STR-KEY")` as absent
+ * would be a vacuous truth dressed as a finding. It is a *mode a caller asks for*, not a meaning
+ * read into an empty span, because the second kind would hand every present and future caller a
+ * silently weaker check with nothing in the result to say so.
+ */
+enum class LocalePolicy : std::uint8_t {
+    Required,  ///< keys must resolve in every approved locale; no locales means none resolve
+    Skipped,   ///< the caller has no approved locale set and accepts that keys go unchecked
+};
+
+/**
  * @brief External name tables against which one screen is checked.
  *
  * Text packages are prevalidated, one per approved locale, with unique locale names. The
@@ -71,6 +89,7 @@ struct ComponentRule {
 struct SemanticInputs {
     std::span<const std::string_view>        themeTokens;
     std::span<const mdux::text::TextPackage> textPackages;
+    LocalePolicy                             locales{LocalePolicy::Required};
 };
 
 /// Accumulated semantic diagnostics; an empty result admits the screen to the next stage.

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -1,0 +1,467 @@
+/**
+ * @file TextBudget.cpp
+ * @brief Widest-approved-translation measurement and dynamic-text charset validation.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-010 No on-device text shaping
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ */
+module;
+
+module mdux.tools.medui.textbudget;
+
+import std;
+import mdux.font.schema;
+import mdux.text.draw;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.ast;
+import mdux.tools.medui.diagnostics;
+import mdux.tools.medui.layout;
+import mdux.tools.medui.semantic;
+
+namespace mdux::tools::medui {
+
+namespace {
+
+/// One component field whose value names a dynamic-text source.
+///
+/// Both entries are `Identifier`-domain fields in the shared component model, and both describe
+/// text the baker never positioned. `NumericDisplay`'s `template:` and every quoted `source:` are
+/// absent on purpose - see the module comment for why a product identifier cannot be expanded into
+/// code points here.
+struct DynamicField {
+    std::string_view component;
+    std::string_view field;
+};
+
+constexpr std::array dynamicFields{
+    DynamicField{    .component = "Clock",  .field = "format"},
+    DynamicField{.component = "TextInput", .field = "charset"}
+};
+
+[[nodiscard]] bool namesDynamicText(std::string_view component, std::string_view field) noexcept {
+    return std::ranges::any_of(dynamicFields, [component, field](const DynamicField& entry) {
+        return entry.component == component && entry.field == field;
+    });
+}
+
+/// Finds a component in the dictionary semantic analysis published, rather than a second copy of it.
+[[nodiscard]] const ComponentRule* ruleFor(std::string_view component) noexcept {
+    const std::span<const ComponentRule> dictionary = componentDictionary();
+    const auto                           found      = std::ranges::find(dictionary, component, &ComponentRule::name);
+    return found == dictionary.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const FieldRule* ruleFor(const ComponentRule& component, std::string_view field) noexcept {
+    const auto found = std::ranges::find(component.fields, field, &FieldRule::name);
+    return found == component.fields.end() ? nullptr : &*found;
+}
+
+/**
+ * @brief The first code point in an ascending range that is not a Unicode scalar value, if any.
+ *
+ * Two shapes are not characters and cannot be drawn by anything: the surrogate block U+D800..U+DFFF,
+ * which exists only to encode other code points in UTF-16, and anything past U+10FFFF. The lowest
+ * one a range names is returned, so the diagnostic points at the first offending code point rather
+ * than at whichever rule happened to be tested first.
+ *
+ * `range` is assumed ascending; a descending range names nothing and is the caller's to skip.
+ */
+[[nodiscard]] std::optional<std::uint32_t> firstNonScalar(mdux::font::CharsetRange range) noexcept {
+    constexpr std::uint32_t firstSurrogate  = 0xD800;
+    constexpr std::uint32_t lastSurrogate   = 0xDFFF;
+    constexpr std::uint32_t lastScalarValue = 0x10FFFF;
+
+    const auto first = static_cast<std::uint32_t>(range.first);
+    const auto last  = static_cast<std::uint32_t>(range.last);
+
+    if (first <= lastSurrogate && last >= firstSurrogate) {
+        return std::max(first, firstSurrogate);
+    }
+    if (last > lastScalarValue) {
+        return std::max(first, lastScalarValue + 1);
+    }
+    return std::nullopt;
+}
+
+/**
+ * @brief Measures the ink one baked run paints.
+ *
+ * The decode is `mdux::text::draw::decodeRecord()` and the placement arithmetic is
+ * `addGlyphRect()`'s: the pen plus the glyph's `bitmapOriginX`, and `bitmapOriginY` *above* the
+ * record's baseline. Restating either would be the second path this stage exists to avoid, so what
+ * is restated is only the part that has no shared helper - taking the union of the rectangles.
+ *
+ * Blank glyphs are skipped exactly as `recordRun()` skips them: they paint nothing, so they cannot
+ * overflow a box visibly, and counting a trailing space as ink would reject screens that render
+ * correctly.
+ */
+[[nodiscard]] TextExtent measureRun(const mdux::font::FontPackage& fontPackage, std::span<const std::byte> records) {
+    if (records.size() % mdux::text::draw::recordSize != 0) {
+        throw std::logic_error(
+            std::format("text budget received {} bytes, which is not a whole number of {}-byte run records", records.size(), mdux::text::draw::recordSize));
+    }
+
+    bool         inked{false};
+    std::int64_t left{0};
+    std::int64_t right{0};
+    std::int64_t top{0};
+    std::int64_t bottom{0};
+
+    for (std::size_t offset = 0; offset < records.size(); offset += mdux::text::draw::recordSize) {
+        const auto placement = mdux::text::draw::decodeRecord(records.subspan(offset, mdux::text::draw::recordSize));
+        if (!placement.has_value()) {
+            throw std::logic_error(
+                std::format("text budget could not decode the run record at byte {}: {}", offset, mdux::text::draw::describe(placement.error())));
+        }
+        if (placement->packageIndex >= fontPackage.glyphs.size()) {
+            throw std::logic_error(std::format("run record at byte {} names glyph {} but font package '{}' holds {}",
+                                               offset,
+                                               placement->packageIndex,
+                                               fontPackage.id,
+                                               fontPackage.glyphs.size()));
+        }
+
+        const mdux::font::GlyphRecord& glyph = fontPackage.glyphs[placement->packageIndex];
+        if (glyph.isBlank()) {
+            continue;
+        }
+
+        const std::int64_t glyphLeft   = std::int64_t{placement->x} + glyph.bitmapOriginX;
+        const std::int64_t glyphTop    = std::int64_t{placement->y} - glyph.bitmapOriginY;
+        const std::int64_t glyphRight  = glyphLeft + glyph.width;
+        const std::int64_t glyphBottom = glyphTop + glyph.height;
+
+        if (!inked) {
+            inked  = true;
+            left   = glyphLeft;
+            right  = glyphRight;
+            top    = glyphTop;
+            bottom = glyphBottom;
+            continue;
+        }
+        left   = std::min(left, glyphLeft);
+        right  = std::max(right, glyphRight);
+        top    = std::min(top, glyphTop);
+        bottom = std::max(bottom, glyphBottom);
+    }
+
+    if (!inked) {
+        return TextExtent{};
+    }
+    return TextExtent{.width = right - left, .height = bottom - top};
+}
+
+/// One fail-closed budget pass over a resolved screen.
+class Checker {
+public:
+    /// Captures the diagnostic path and the packages a screen is measured against.
+    Checker(std::string file, TextBudgetInputs inputs) : file_{std::move(file)}, inputs_{inputs} {
+        if (inputs_.font == nullptr) {
+            throw std::logic_error("text budget requires the font package the approved locales were baked into");
+        }
+        checkFontCharset();
+        checkLocaleWiring();
+    }
+
+    /// Checks one resolved screen, returning no measurements on any diagnostic.
+    [[nodiscard]] TextBudgetResult run(const LayoutResult& layout) {
+        for (const ResolvedNode& node : layout.nodes) {
+            checkNode(node);
+        }
+        if (!diagnostics_.empty()) {
+            measurements_.clear();
+        }
+        return TextBudgetResult{.measurements = std::move(measurements_), .diagnostics = std::move(diagnostics_)};
+    }
+
+private:
+    /**
+     * @brief Checks that the font package's own charset table is walkable, once.
+     *
+     * The charset walk in `checkDynamicText()` advances by jumping to the end of the range that
+     * admitted a code point. That is only a *step* if the range ends somewhere below the type's
+     * maximum: a range ending at `0xFFFFFFFF` would make `last + 1` wrap to zero and select the same
+     * range forever, so a malformed table would hang the compiler rather than fail it.
+     *
+     * `FontPackage::validate()` rejects such a range, but this stage takes the package by pointer
+     * and never re-validates it - the same reason the produced ranges are treated as untrusted.
+     * Trusting one table while distrusting the other was the inconsistency this check removes.
+     *
+     * Only what the walk relies on is checked: an ascending range that stops at a Unicode scalar
+     * value. Sortedness, overlap and glyph coverage belong to `validate()` and are not restated
+     * here, because a second partial copy of that contract is worse than none.
+     */
+    void checkFontCharset() const {
+        constexpr std::uint32_t lastScalarValue = 0x10FFFF;
+        for (const mdux::font::CharsetRange& range : inputs_.font->restrictedCharset) {
+            if (range.last < range.first) {
+                throw std::logic_error(std::format("font package '{}' declares a charset range from U+{:04X} down to U+{:04X}",
+                                                   inputs_.font->id,
+                                                   static_cast<std::uint32_t>(range.first),
+                                                   static_cast<std::uint32_t>(range.last)));
+            }
+            if (static_cast<std::uint32_t>(range.last) > lastScalarValue) {
+                throw std::logic_error(std::format("font package '{}' declares a charset range ending at U+{:04X}, past the last Unicode scalar value",
+                                                   inputs_.font->id,
+                                                   static_cast<std::uint32_t>(range.last)));
+            }
+        }
+    }
+
+    /**
+     * @brief Checks the supplied locales against the set the font package approves, once.
+     *
+     * A budget is a claim about the *worst* approved translation, so the set it was measured over
+     * has to be the approved one. Accepting a subset would let a caller hand over the locale it was
+     * looking at and receive a screen certified against a set nobody approved - and the omitted
+     * translation is precisely the one that overflows, because a locale nobody measured is a locale
+     * nobody sized for.
+     *
+     * Each package's own wiring is checked here too, rather than at the point some key happens to
+     * be measured: identity against the font, and a sidecar whose size is the one the package
+     * declares. A truncated sidecar that still contains the first run would otherwise measure that
+     * run and mismeasure everything after it, which is the failure this check exists to make loud.
+     */
+    void checkLocaleWiring() const {
+        std::vector<std::string_view> supplied;
+        supplied.reserve(inputs_.locales.size());
+
+        for (const LocaleText& locale : inputs_.locales) {
+            if (locale.package == nullptr) {
+                throw std::logic_error("text budget received an approved locale with no text package");
+            }
+            const std::string_view tag = locale.package->locale;
+
+            if (locale.package->atlasId != inputs_.font->id) {
+                throw std::logic_error(
+                    std::format("locale '{}' was baked against font package '{}', not '{}'", tag, locale.package->atlasId, inputs_.font->id));
+            }
+            if (locale.sidecar.size() != locale.package->sidecarByteLength) {
+                throw std::logic_error(std::format("locale '{}' declares a {}-byte sidecar and was given {} bytes",
+                                                   tag,
+                                                   locale.package->sidecarByteLength,
+                                                   locale.sidecar.size()));
+            }
+            if (std::ranges::any_of(supplied, [tag](std::string_view seen) {
+                    return seen == tag;
+                })) {
+                throw std::logic_error(std::format("locale '{}' was supplied twice", tag));
+            }
+            if (!std::ranges::any_of(inputs_.font->locales, [tag](std::string_view approved) {
+                    return approved == tag;
+                })) {
+                throw std::logic_error(std::format("locale '{}' is not approved by font package '{}'", tag, inputs_.font->id));
+            }
+            supplied.push_back(tag);
+        }
+
+        for (const std::string& approved : inputs_.font->locales) {
+            if (!std::ranges::any_of(supplied, [&approved](std::string_view seen) {
+                    return seen == approved;
+                })) {
+                throw std::logic_error(std::format("font package '{}' approves locale '{}', which was not supplied; a "
+                                                   "budget measured over a subset of the approved locales is not a budget",
+                                                   inputs_.font->id,
+                                                   approved));
+            }
+        }
+    }
+
+    void report(Code code, ast::Position position, std::string message) {
+        diagnostics_.push_back(diagnose(code, file_, position.line, position.column, std::move(message)));
+    }
+
+    void checkNode(const ResolvedNode& node) {
+        // An unknown component is MEDUI-E011 and belongs to semantic analysis; a synthetic Row
+        // background resolves to its originating Row, which carries no text.
+        const ComponentRule* component = ruleFor(node.source.component);
+        if (component == nullptr) {
+            return;
+        }
+
+        for (const ast::Field& field : node.source.fields) {
+            const FieldRule* fieldRule = ruleFor(*component, field.name);
+            if (fieldRule == nullptr || field.value == nullptr) {
+                continue;
+            }
+            if (fieldRule->domain == FieldDomain::TextKey) {
+                checkTextKey(node, field, *field.value);
+            } else if (fieldRule->domain == FieldDomain::TextKeyList) {
+                for (const std::shared_ptr<ast::Value>& element : field.value->list) {
+                    if (element != nullptr) {
+                        checkTextKey(node, field, *element);
+                    }
+                }
+            } else if (namesDynamicText(node.source.component, field.name)) {
+                checkDynamicText(field, *field.value);
+            }
+        }
+    }
+
+    /// Measures one key in every approved locale, reporting each locale that does not fit.
+    void checkTextKey(const ResolvedNode& node, const ast::Field& field, const ast::Value& value) {
+        if (value.kind != ast::ValueKind::TextKey) {
+            // MEDUI-E017 or MEDUI-E033, already reported by analyze(): there is no key to measure.
+            return;
+        }
+        if (inputs_.locales.empty()) {
+            throw std::logic_error(std::format("text budget was given no approved locale to measure text key '{}' against", value.text));
+        }
+
+        TextExtent  worst{};
+        std::string widestLocale;
+        // An explicit "nothing measured yet" flag rather than `widestLocale.empty()`. The tag would
+        // read as a sentinel only for as long as no approved locale has an empty one - and this
+        // stage takes packages by pointer without re-validating them, so an unvalidated package
+        // with an empty `locale` would make every later locale overwrite the widest measurement
+        // with a narrower one. Under-reporting the worst case is the one direction a budget check
+        // must not fail in.
+        bool measured{false};
+
+        for (const LocaleText& locale : inputs_.locales) {
+            const TextExtent extent = measure(locale, value.text);
+
+            if (extent.width > node.bounds.width) {
+                report(Code::TextBudgetExceeded,
+                       value.position,
+                       std::format("text key '{}' in locale '{}' needs {}px of width, and '{}' resolved to {}px",
+                                   value.text,
+                                   locale.package->locale,
+                                   extent.width,
+                                   node.id,
+                                   node.bounds.width));
+            }
+            if (extent.height > node.bounds.height) {
+                report(Code::TextBudgetExceeded,
+                       value.position,
+                       std::format("text key '{}' in locale '{}' needs {}px of height, and '{}' resolved to {}px",
+                                   value.text,
+                                   locale.package->locale,
+                                   extent.height,
+                                   node.id,
+                                   node.bounds.height));
+            }
+
+            if (!measured || extent.width > worst.width) {
+                worst.width  = extent.width;
+                widestLocale = locale.package->locale;
+            }
+            worst.height = std::max(worst.height, extent.height);
+            measured     = true;
+        }
+
+        measurements_.push_back(
+            TextMeasurement{.nodeId = node.id, .field = field.name, .textKey = value.text, .locale = std::move(widestLocale), .extent = worst});
+    }
+
+    /// Measures one key against one locale's committed package.
+    ///
+    /// The package's identity, and that its sidecar is whole, were settled by `checkLocaleWiring()`
+    /// before any node was read. What is left here is the range this key actually names.
+    [[nodiscard]] TextExtent measure(const LocaleText& locale, std::string_view key) const {
+        const mdux::text::TextRun* run = locale.package->find(key);
+        if (run == nullptr) {
+            throw std::logic_error(std::format("text key '{}' has no run in approved locale '{}'; semantic analysis is a required gate before the budget check",
+                                               key,
+                                               locale.package->locale));
+        }
+        if (run->byteEnd() > locale.sidecar.size()) {
+            throw std::logic_error(std::format("locale '{}' declares run '{}' at bytes {}..{} of a sidecar that is {} bytes long",
+                                               locale.package->locale,
+                                               key,
+                                               run->byteOffset,
+                                               run->byteEnd(),
+                                               locale.sidecar.size()));
+        }
+
+        return measureRun(*inputs_.font, locale.sidecar.subspan(static_cast<std::size_t>(run->byteOffset), static_cast<std::size_t>(run->byteLength)));
+    }
+
+    /// Checks that a named dynamic-text source can only produce glyphs the font package holds.
+    void checkDynamicText(const ast::Field& field, const ast::Value& value) {
+        if (value.kind != ast::ValueKind::Identifier) {
+            // MEDUI-E033's, reported by analyze(): there is no name to resolve.
+            return;
+        }
+
+        // Searched as a `string_view` on both sides: the projection yields one, and comparing it
+        // with the AST's `std::string` would rest on a heterogeneous comparison the range concepts
+        // do not owe us.
+        const auto found = std::ranges::find(inputs_.dynamicText, std::string_view{value.text}, &DynamicTextRule::name);
+        if (found == inputs_.dynamicText.end()) {
+            report(Code::CharsetEscape,
+                   value.position,
+                   std::format("'{}' is not in the governed dynamic-text table, so what '{}' can produce is not bounded", value.text, field.name));
+            return;
+        }
+
+        // One diagnostic per field rather than per code point: a charset that escapes usually
+        // escapes over a whole range, and an author fixes the range rather than each character.
+        //
+        // The walk counts in `std::uint32_t` rather than `char32_t` because a supplied range is not
+        // `FontPackage::validate()`'d: `last` may be anything the type holds, and `point <= last`
+        // with `last` at the type's maximum would never terminate. `firstNonScalar()` below bounds
+        // every range that reaches the walk to U+10FFFF, so the counting type is now belt as well as
+        // braces - and it stays, because the bound is one edit away from being someone else's
+        // assumption. A descending range produces nothing and is skipped rather than reported: what
+        // a `.medui` author wrote is a name, and the shape of the table behind it is not theirs to
+        // fix.
+        for (const mdux::font::CharsetRange& range : found->produces) {
+            if (range.last < range.first) {
+                continue;
+            }
+
+            // A range that names something which is not a character is reported before it is
+            // walked, and reported as what it is. Two shapes qualify: a code point past U+10FFFF,
+            // and the surrogate block, which exists only to encode other code points in UTF-16 and
+            // is not a scalar value either. Asking `permits()` about those would be asking the
+            // wrong question - a font package cannot draw them whatever its table claims, and a
+            // package whose table did claim them would answer yes.
+            if (const auto offending = firstNonScalar(range)) {
+                report(Code::CharsetEscape,
+                       value.position,
+                       std::format("'{}' can produce U+{:04X}, which is not a Unicode scalar value", value.text, *offending));
+                return;
+            }
+
+            const auto    last  = static_cast<std::uint32_t>(range.last);
+            std::uint32_t point = static_cast<std::uint32_t>(range.first);
+
+            while (point <= last) {
+                if (!inputs_.font->permits(static_cast<char32_t>(point))) {
+                    report(Code::CharsetEscape,
+                           value.position,
+                           std::format("'{}' can produce U+{:04X}, which font package '{}' cannot draw", value.text, point, inputs_.font->id));
+                    return;
+                }
+                // `permits()` decides; this only chooses the next point worth asking about. A
+                // produced range covering the whole plane would otherwise cost a million binary
+                // searches per field, where the answer changes only at a charset-range edge.
+                const auto covering = std::ranges::find_if(inputs_.font->restrictedCharset, [point](const mdux::font::CharsetRange& admitted) {
+                    return admitted.contains(static_cast<char32_t>(point));
+                });
+                // The step is strictly forward, and both branches are bounded: `checkFontCharset()`
+                // has established that every charset range ends at a scalar value, so `last + 1`
+                // cannot wrap, and `point` is itself bounded by `last` above. `permits()` just said
+                // yes, so a covering range exists; stepping by one where it does not keeps the walk
+                // finite rather than trusting two lookups to agree.
+                point = covering == inputs_.font->restrictedCharset.end() ? point + 1 : static_cast<std::uint32_t>(covering->last) + 1;
+            }
+        }
+    }
+
+    std::string                  file_;
+    TextBudgetInputs             inputs_;
+    std::vector<TextMeasurement> measurements_;
+    std::vector<cli::Diagnostic> diagnostics_;
+};
+
+}  // namespace
+
+TextBudgetResult checkTextBudgets(const LayoutResult& layout, std::string file, TextBudgetInputs inputs) {
+    return Checker{std::move(file), inputs}.run(layout);
+}
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -464,4 +464,45 @@ TextBudgetResult checkTextBudgets(const LayoutResult& layout, std::string file, 
     return Checker{std::move(file), inputs}.run(layout);
 }
 
+
+bool needsTextBudget(const ast::Screen& screen) {
+    // Walks the authored tree rather than a resolved layout: the question is asked before layout
+    // runs, because its answer decides whether the recipe is complete enough to compile at all.
+    const auto carriesMeasurableText = [](const ast::Node& node) {
+        for (const ast::Field& field : node.fields) {
+            if (field.value == nullptr) {
+                continue;
+            }
+            if (field.value->kind == ast::ValueKind::TextKey) {
+                return true;
+            }
+            if (field.value->kind == ast::ValueKind::List) {
+                for (const std::shared_ptr<ast::Value>& element : field.value->list) {
+                    if (element != nullptr && element->kind == ast::ValueKind::TextKey) {
+                        return true;
+                    }
+                }
+            }
+            // Asked through the same predicate the measuring pass uses, so a third dynamic-text
+            // field reaches this question without anyone having to remember it.
+            if (namesDynamicText(node.component, field.name)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    for (const ast::Node& node : screen.nodes) {
+        if (carriesMeasurableText(node)) {
+            return true;
+        }
+        for (const ast::Node& child : node.children) {
+            if (carriesMeasurableText(child)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 }  // namespace mdux::tools::medui

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -1,0 +1,229 @@
+/**
+ * @file TextBudget.cppm
+ * @brief Build-time text-budget validation: does a resolved box contain the widest approved
+ *        translation, and can a dynamic-text source produce a character nobody baked.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host tools zone)
+ * @compliance ADR-010 No on-device text shaping
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ *
+ * Host-only, and the last check before emission. It runs after `resolveLayout()` because a budget
+ * is a statement about a *resolved* rectangle: `width: Fill` has no width until the solver has run,
+ * and most text in a real screen sits in one.
+ *
+ * ## Why this stage exists at all
+ *
+ * A compiled screen is locale-free (ADR-011, as amended by #203): it carries `text_key` rather than
+ * glyph runs, and the device joins the two for the locale it is running. That amendment moved the
+ * *substitution* to the device and deliberately left this check behind:
+ *
+ * > The compiler still validates every key against every approved locale, and still validates text
+ * > budgets against the widest approved translation (#195).
+ *
+ * So the screen a device holds is one rectangle per node for all locales, and the rectangle has to
+ * be the one that survives the worst translation. German and Finnish routinely run half again the
+ * length of English; a box sized against the authoring locale renders a clipped word on a shipped
+ * device, in a language the author does not read, on a screen nobody re-reviewed. This project
+ * treats that as a usability risk to be controlled at build time, and ADR-011's answer is to make
+ * it fail to compile rather than to mitigate it downstream. Where that decision sits against the
+ * standards corpus is ADR-011's to record, not this module's to assert.
+ *
+ * ## What "measure" means here, and what it does not
+ *
+ * There is no shaping in this stage, and no second metrics path. The text package already holds
+ * the runs `mdux-textbake` positioned for each locale, and the font package already holds the glyph
+ * table those runs index. Measuring is therefore reading: decode each 6-byte record through
+ * `mdux::text::draw::decodeRecord()` - the same decoder the device draws with, so the byte-order
+ * and baseline contracts have one implementation - look each glyph up in the same
+ * `mdux::font::FontPackage` the runtime will, and take the extent of the rectangles that result.
+ *
+ * Re-deriving the extent from advance widths and a string would be the second path, and it would be
+ * the wrong one twice over: it would not see the baker's kerning decisions, and a disagreement
+ * between it and the baked runs would surface as a device-time clip that the compiler had certified.
+ *
+ * The extent measured is the *ink* box - what coverage the atlas actually paints - because that is
+ * what a viewer sees leave the box. `recordRun()` skips blank glyphs rather than recording empty
+ * rectangles, and this measurement skips exactly the same ones for exactly the same reason: a
+ * trailing space is not visible, so it cannot overflow visibly.
+ *
+ * Only the extent is checked, never the placement. Where a run sits inside its box - leading,
+ * centred, trailing - is the emitter's decision (#197), and a stage that assumed one alignment
+ * would reject screens the emitter would have laid out correctly.
+ *
+ * ## Dynamic text and the restricted charset
+ *
+ * Static text is safe by construction: the baker positioned it, so every glyph exists. Dynamic text
+ * is not. A `Clock` formatting a time, or a `TextInput` echoing an operator, can reach a code point
+ * nobody baked, and ADR-010 leaves the runtime no fallback - having one would mean mapping code
+ * points on device.
+ *
+ * `FontPackage::restrictedCharset` is the declared answer and `permits()` is the test. What this
+ * stage adds is the *source* side of it: a named dynamic-text value (`format:` on `Clock`,
+ * `charset:` on `TextInput`) is checked against the governed table in `TextBudgetInputs`, and every
+ * code point that table says the name can produce must be one the font package can draw.
+ *
+ * A produced range that names something which is not a character - the surrogate block, or anything
+ * past U+10FFFF - is `MEDUI-E053` before the font package is consulted at all. Nothing can draw a
+ * non-character, so `permits()` is the wrong question to ask about one, and a package whose table
+ * claimed such a code point would answer yes.
+ *
+ * A name absent from the table is `MEDUI-E053` too, and that is a deliberate fail-closed reading:
+ * "this name does not resolve" means the compiler cannot bound what it produces, which is
+ * indistinguishable, from here, from a name that produces something unbakeable. The alternative -
+ * passing a name over in silence because no rule described it - is how a device-time surprise gets
+ * a compiler's signature on it.
+ *
+ * A `TextInput` with no `charset:` field is not checked and is not an error. The field is optional
+ * in the shared component model, and its absence means the component is restricted to the font
+ * package's own charset - which cannot escape itself. An author names a charset to *narrow* the
+ * set, never to widen it.
+ *
+ * ## What this stage deliberately does not check
+ *
+ * `TextInput` carries `max_length`, and the shared component model asks that "bounded-dynamic" text
+ * fit its box in the worst case as well. Sizing that worst case means deciding how the runtime
+ * advances the pen for text no baker positioned, and no such rule exists yet - the components that
+ * would need it are #17. Inventing one here would pin a policy in a diagnostic before the code that
+ * has to honour it is written, so the check waits for the runtime rule rather than guessing at it.
+ * `NumericDisplay`'s `template:` is left for the same reason: it is a product template identifier,
+ * and the compiler cannot expand it into code points without a table nobody has defined.
+ *
+ * ## Why the shared conformance suite does not cover these two codes
+ *
+ * `MEDUI-E050` and `MEDUI-E053` are in the pinned contract's code table, but a case cannot exercise
+ * them yet: `schemas/case.schema.json` lets a case carry theme tokens and per-locale *keys*, and
+ * neither font metrics nor a charset table. A case therefore has no way to state what a translation
+ * measures or what a format can produce. The codes are the contract's, the checks are here, and the
+ * tests below stand in until the case schema can express the inputs.
+ */
+module;
+
+export module mdux.tools.medui.textbudget;
+
+import std;
+import mdux.font.schema;
+import mdux.text.schema;
+import mdux.tools.cli;
+import mdux.tools.medui.layout;
+
+export namespace mdux::tools::medui {
+
+/**
+ * @brief One approved locale: its baked text package, and the sidecar bytes its runs address.
+ *
+ * The package and the sidecar are separate because that is how they are committed - `package.json`
+ * beside `runs.bin` - and the caller is what reads them. `sidecar` must be the whole file: run
+ * ranges are absolute offsets into it, exactly as `TextPackage::validate()` checked them, and
+ * `checkTextBudgets()` refuses a span whose size is not the package's own `sidecarByteLength`.
+ *
+ * Refusing on the *whole* length rather than on each run's end is the difference between a check
+ * that holds and one that happens to hold: a truncated sidecar whose first run survives the cut
+ * would measure that run correctly and mismeasure - or silently skip - every run after it.
+ */
+struct LocaleText {
+    const mdux::text::TextPackage* package{nullptr};
+    std::span<const std::byte>     sidecar{};
+};
+
+/**
+ * @brief One named dynamic-text source, and every code point it is able to produce.
+ *
+ * The governed table an author's `format: HH_MM` or `charset: LATIN_BASIC` is resolved against.
+ * It is an input rather than a constant here for the same reason `themeTokens` is an input to
+ * semantic analysis: the names belong to a product's governed tables, not to the language, and a
+ * compiler that shipped its own list would be authoritative about a set it does not own.
+ *
+ * `produces` is stated as charset ranges rather than a code-point list because a set is reviewed
+ * as ranges - "U+0030..U+0039, U+003A" is checkable by eye - and because it is then the same shape
+ * as the font package's own `restrictedCharset` that it is compared against.
+ */
+struct DynamicTextRule {
+    std::string_view                          name;
+    std::span<const mdux::font::CharsetRange> produces;
+};
+
+/**
+ * @brief Everything one screen is measured against.
+ *
+ * `font` is the committed font package the approved locales were baked into, and it is required:
+ * there is no measurement without metrics, and a defaulted one would be a second metrics path.
+ *
+ * `locales` must be *exactly* the set the font package approves - one entry per tag in
+ * `FontPackage::locales`, none missing, none repeated, none outside it - and that is checked rather
+ * than assumed. A budget is a claim about the worst approved translation, so a caller that supplied
+ * only the locale it happened to be looking at would get a screen certified against a set nobody
+ * approved: the omitted German or Finnish translation is exactly the one that overflows, and it
+ * would overflow on a device with the compiler's blessing. Requiring the whole set makes that
+ * particular silence impossible.
+ */
+struct TextBudgetInputs {
+    const mdux::font::FontPackage*   font{nullptr};
+    std::span<const LocaleText>      locales;
+    std::span<const DynamicTextRule> dynamicText;
+};
+
+/// The ink one baked run paints, in surface pixels.
+struct TextExtent {
+    std::int64_t width{0};
+    std::int64_t height{0};
+
+    auto operator<=>(const TextExtent&) const = default;
+};
+
+/**
+ * @brief The worst approved case for one authored text value.
+ *
+ * `extent` is the per-axis maximum across every approved locale, which is what a locale-free screen
+ * has to reserve, and what #197's `DrawBudget` computation consumes rather than measuring again.
+ * `locale` names the locale that produced the widest width - the one an author needs to open when
+ * a budget fails - so on a screen whose tallest and widest translations differ, `extent.height` may
+ * come from a locale this field does not name. Width is what a budget conversation is almost always
+ * about, and naming two locales in one record would make the common case read like an edge case.
+ */
+struct TextMeasurement {
+    std::string nodeId;
+    std::string field;  ///< the authored field, e.g. `text` or `label`
+    std::string textKey;
+    std::string locale;
+    TextExtent  extent{};
+};
+
+/**
+ * @brief Measurements and any diagnostic that stopped the screen.
+ *
+ * `measurements` is empty whenever a diagnostic is present, matching `LayoutResult`: a caller
+ * cannot accidentally consume the budget of a screen that failed its budget check.
+ */
+struct TextBudgetResult {
+    std::vector<TextMeasurement>              measurements;
+    std::vector<mdux::tools::cli::Diagnostic> diagnostics;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return diagnostics.empty();
+    }
+};
+
+/**
+ * @brief Checks every text budget on a resolved screen, and every dynamic-text charset on it.
+ *
+ * Diagnostics accumulate in resolved-node order, then field order within a node, then the input
+ * order of `locales` within a field - so a screen with three bad boxes reports all three, and an
+ * author reading top to bottom reads them in the order they were written.
+ *
+ * The stage assumes its gates: `analyze()` has accepted the screen, so every text key resolves in
+ * every approved locale, and `resolveLayout()` has produced these bounds. An approved locale that
+ * was not supplied, a supplied locale the font package does not approve, a duplicate locale, a
+ * sidecar whose size is not the one its package declares, a key with no run, a text package baked
+ * against a different font, a font package whose restricted charset descends or reaches past the
+ * last Unicode scalar value, or a record naming a glyph outside the package all mean a caller wired
+ * the stages together wrongly rather than an author writing a bad screen, and each throws
+ * `std::logic_error` rather than being reported as a diagnostic an author cannot act on.
+ *
+ * The locale, sidecar, font-identity and duplicate checks run once, before any node is looked at,
+ * so a miswired call fails on the wiring rather than on whichever screen happened to have text.
+ *
+ * @throws std::logic_error if `inputs.font` is null, or if any gate above was bypassed.
+ */
+[[nodiscard]] TextBudgetResult checkTextBudgets(const LayoutResult& layout, std::string file, TextBudgetInputs inputs);
+
+}  // namespace mdux::tools::medui

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -13,7 +13,7 @@
  *
  * ## Why this stage exists at all
  *
- * A compiled screen is locale-free (ADR-011, as amended by #203): it carries `text_key` rather than
+ * A compiled screen is locale-free (ADR-011, as amended by #203): it carries `textKey` rather than
  * glyph runs, and the device joins the two for the locale it is running. That amendment moved the
  * *substitution* to the device and deliberately left this check behind:
  *

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -104,6 +104,7 @@ import std;
 import mdux.font.schema;
 import mdux.text.schema;
 import mdux.tools.cli;
+import mdux.tools.medui.ast;
 import mdux.tools.medui.layout;
 
 export namespace mdux::tools::medui {
@@ -156,10 +157,14 @@ struct DynamicTextRule {
  * would overflow on a device with the compiler's blessing. Requiring the whole set makes that
  * particular silence impossible.
  */
+// Every member carries a default initialiser. `-Wmissing-field-initializers` is an error in this
+// tree, so a type whose optional members still have to be spelled at every call site is a trap - and
+// an omitted `dynamicText` is fail-closed anyway: a name with no rule behind it is `MEDUI-E053`
+// rather than a name silently accepted.
 struct TextBudgetInputs {
     const mdux::font::FontPackage*   font{nullptr};
-    std::span<const LocaleText>      locales;
-    std::span<const DynamicTextRule> dynamicText;
+    std::span<const LocaleText>      locales{};
+    std::span<const DynamicTextRule> dynamicText{};
 };
 
 /// The ink one baked run paints, in surface pixels.
@@ -225,5 +230,19 @@ struct TextBudgetResult {
  * @throws std::logic_error if `inputs.font` is null, or if any gate above was bypassed.
  */
 [[nodiscard]] TextBudgetResult checkTextBudgets(const LayoutResult& layout, std::string file, TextBudgetInputs inputs);
+
+/**
+ * @brief Whether this screen has anything for the budget stage to measure.
+ *
+ * True when the screen carries a text key, or a field whose value names a dynamic-text source -
+ * `Clock`'s `format:` and `TextInput`'s `charset:`, the two the table in this module's
+ * implementation lists. Both are things `checkTextBudgets()` checks and nothing else does.
+ *
+ * Exported so a compiler driver can decide whether a recipe *must* supply a font package and its
+ * approved locales, rather than deciding by inspecting the screen itself. The list of dynamic-text
+ * fields would otherwise exist in two places, and the second copy is the one that would go stale the
+ * day a third field joins them.
+ */
+[[nodiscard]] bool needsTextBudget(const ast::Screen& screen);
 
 }  // namespace mdux::tools::medui

--- a/tools/text/AtlasPacker.cppm
+++ b/tools/text/AtlasPacker.cppm
@@ -10,12 +10,15 @@
  *
  * ## Why this is host-tools rather than governed
  *
- * `mdux.text.raster` (#159) is governed because a device path could conceivably need to
- * rasterise, and ADR-008 decision 1 says that would have to be *this* module rather than a second
- * one. Packing has no such future: an atlas is chosen once, at build time, and a device consumes
- * the slot rectangles the baker recorded. Nothing on a device ever packs, so a governed packer
- * would be a promise with no caller - and every module in the governed zone is a module a
- * reviewer has to reason about for device behaviour.
+ * An atlas is chosen once, at build time, and a device consumes the slot rectangles the baker
+ * recorded. Nothing on a device ever packs, so a governed packer would be a promise with no
+ * caller - and every module in the governed zone is a module a reviewer has to reason about for
+ * device behaviour.
+ *
+ * `mdux.text.raster` (#159) sits in this zone for the same reason as of #116. It was governed
+ * on the argument that a device path might one day rasterise, which ADR-008 decision 1 would
+ * then require to be *that* module rather than a second one - but it allocates, so it has to
+ * catch at its `noexcept` boundary, which ADR-005 forbids in governed code. See `Raster.cppm`.
  *
  * ## Shelf placement, and why not something better
  *

--- a/tools/text/Raster.cpp
+++ b/tools/text/Raster.cpp
@@ -1,10 +1,9 @@
 /**
  * @file Raster.cpp
- * @brief Implementation of the governed-zone glyph rasteriser.
+ * @brief Implementation of the host-tools glyph rasteriser.
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
  * @compliance ADR-007 Evidence pipeline doctrine
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010)
  * @compliance ADR-010 No on-device text shaping
  *
  * Four passes, in order:
@@ -578,8 +577,12 @@ Result<CoverageBitmap, RasterError> rasterise(const RasterRequest& request) noex
     //
     // `std::length_error` is caught alongside `bad_alloc` because `resize()` raises it when a
     // request exceeds `max_size()`, which is the same condition arriving by a different name.
-    // The final `catch (...)` is defensive: nothing in the governed zone throws anything else,
-    // and if that ever stops being true this still returns rather than terminating.
+    // The final `catch (...)` is defensive: nothing else on this path throws anything else, and
+    // if that ever stops being true this still returns rather than terminating.
+    //
+    // This block is what put the module in the host-tools zone (#116): governed code does not
+    // throw, and ADR-005 makes that a rule rather than a preference. See Raster.cppm on why the
+    // zone moved rather than the code.
     try {
         return rasteriseImpl(request);
     } catch (const std::bad_alloc&) {

--- a/tools/text/Raster.cppm
+++ b/tools/text/Raster.cppm
@@ -1,28 +1,38 @@
 /**
  * @file Raster.cppm
- * @brief Governed-zone glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
+ * @brief Host-tools glyph rasteriser: outlines to an R8 coverage bitmap, integer arithmetic
  *        only, so the same glyph produces the same bytes on every supported toolchain.
  *
- * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
- * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone: runs at build time, never on a device)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept entry point)
  * @compliance ADR-007 Evidence pipeline doctrine (the bytes this produces get committed)
- * @compliance ADR-008 Zero-SOUP ML inference (decision 1, mirrored to text by ADR-010: one
- *             module, not a host implementation and a device one that could drift)
  * @compliance ADR-010 No on-device text shaping
  *
- * Part of MduXCore. The font baker (#160, S4) imports this to fill an atlas; if a device path
- * ever needs to rasterise, it imports *this* module rather than growing a second implementation.
- * That is ADR-008 decision 1 applied to text, and it is why this file is governed rather than
- * sitting in `tools/` next to the parser that feeds it.
+ * Part of `MduXTextBakeLib`. The font baker (#160, S4) imports this to fill an atlas.
+ *
+ * ## Why this is host-tools code and not governed
+ *
+ * It was governed until issue #116, on the argument that a device path might one day want to
+ * rasterise and should import *this* module rather than grow a second implementation - ADR-008
+ * decision 1 applied to text. The argument was speculative and the cost was not: `rasterise()`
+ * allocates, and a `std::vector` reports failure by throwing, so the `noexcept` entry point below
+ * has to catch. ADR-005 forbids exactly that in the governed zone, and #116 made the rule
+ * mechanical - `mdux-governed-lint` rejects `try`/`catch` in governed source, and on GCC/Clang
+ * `governed.noThrow.symbolScan` rejects the resulting `__cxa_throw` reference in the object. A
+ * present rule outranks a hypothetical consumer.
+ *
+ * Nothing about the module's determinism changes with the move. The integer-only rule below is a
+ * property of the source, and the committed atlas bytes it produces are byte-compared in CI
+ * exactly as before.
  *
  * ## Why it does not take a `truetype::SimpleGlyph`
  *
- * `mdux.tools.truetype` (#158) is host-tools-zone code. ADR-004 forbids a governed module from
- * importing one, and the rule is mechanically checked by `mdux_verify_trust_zones()` - so this
- * module cannot name that type even though it is the obvious input. It takes `Outline` instead:
- * the same TrueType shape (points, per-contour end indices, on/off-curve flags) expressed in
- * governed types, with the baker doing a flat conversion. That indirection is the trust-zone
- * boundary made visible, not an abstraction for its own sake.
+ * It could now - `mdux.tools.truetype` (#158) is in this same zone, and the trust-zone rule that
+ * forbade naming that type no longer applies. The `Outline` input is kept anyway: it is the same
+ * TrueType shape (points, per-contour end indices, on/off-curve flags) in types that carry no
+ * parser with them, so this module stays movable back into `MduXCore` if a device path is ever
+ * built and made allocation-free. What used to be a constraint is now a deliberately preserved
+ * option, and the distinction is worth stating rather than leaving for a reader to infer.
  *
  * ## The determinism rule
  *
@@ -144,8 +154,10 @@ struct OutlinePoint {
 /**
  * @brief A glyph outline in font units: points, plus the index of each contour's last point.
  *
- * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in governed types because a
- * governed module may not import a host-tools one (ADR-004). `contourEnds[i]` is the index of
+ * The shape `mdux.tools.truetype`'s `SimpleGlyph` carries, restated in parser-independent types.
+ * Until #116 that restatement was forced - a governed module may not import a host-tools one
+ * (ADR-004) - and it is now kept by choice, so this module stays movable back into `MduXCore` if
+ * a device path is ever built and made allocation-free. `contourEnds[i]` is the index of
  * the final point of contour `i`, so contour 0 is `points[0 .. contourEnds[0]]` and contour `i`
  * is `points[contourEnds[i-1] + 1 .. contourEnds[i]]` - TrueType's own convention, kept rather
  * than converted to offsets so the baker's translation stays a copy rather than a computation.

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -470,9 +470,12 @@ struct BakedGlyph {
                 continue;
             }
 
-            // Translate the parser's outline into the rasteriser's governed input type. This copy
-            // is the trust-zone boundary made concrete: mdux.text.raster is governed and cannot
-            // name a host-tools type, so the baker is what bridges them (ADR-004).
+            // Translate the parser's outline into the rasteriser's own input type. This copy was
+            // the trust-zone boundary made concrete until #116, when mdux.text.raster joined this
+            // zone; the rasteriser could now name `truetype::GlyphPoint` directly. It is kept
+            // because the decoupling is what would let the rasteriser move back into MduXCore if a
+            // device path is ever built (see Raster.cppm), and the copy costs one pass per glyph
+            // at build time.
             std::vector<raster::OutlinePoint> points;
             points.reserve(outline->points.size());
             for (const truetype::GlyphPoint& gp : outline->points) {


### PR DESCRIPTION
Wave 5, cut by [`docs/release-process.md`](docs/release-process.md) — written last week, executed
here for the first time.

## Read the diff in two parts

**This PR's diff is everything since v0.5.0**, because it merges `develop` into `master`. That is
32 commits: the whole of Wave 5. An earlier version of this description said "ten files", which
described the *release commit* and was misleading for anyone applying the release-process checks to
the PR in front of them.

- **The release commits** — `e5a480a`, `3b13f5e`, `bab7adc` — are what the procedure governs: the
  version, the six `report.json` files that record it, the changelog date, the roadmap, and the
  corrections review found in the procedure itself.
- **Everything else** is Wave 5, already reviewed and merged into `develop` PR by PR:
  [`CHANGELOG.md`](CHANGELOG.md) is the summary of it.

## The release-only diff, and the rule it satisfies

```console
$ git diff --stat develop...HEAD          # what this release adds over what was already reviewed
$ git diff generated/ | grep '^[-+]' | grep -v toolVersion | grep -v '^[-+][-+]'
```

The second prints nothing: **every changed artifact differs in `toolVersion` and nothing else**,
which is the review rule step 4 states.

## The deviation, now defined rather than recorded

Step 4 says run `mdux-bake-update`. I cannot build this tree — the GCC 16 floor means CI is the only
place it compiles — so the six fields were written directly.

Review was right that a documented ad-hoc deviation should not become the next release's precedent,
so the procedure now **defines the fallback**: bounded to a pure version bump, where `toolVersion` is
the only field that can move and the expected bytes are derivable by inspection, and gated on
`evidence.<kind>.<id>` passing on both toolchain legs — which re-bakes every artifact from its recipe
and byte-compares. It does not extend to a release that changes a recipe, an input or an option.

Worth stating precisely, because it changes what kind of deviation this is: ADR-007 does not forbid
this. It lists a hand-edited file under `generated/` as a **risk**, whose mitigation is that
"re-baking overwrites the edit while the byte-comparison fails the PR". That mitigation is exactly
what ran here, on two toolchains, and it passed.

## What executing the procedure corrected in it

Three things, all found by following it rather than by reading it:

- **Step 3 was wrong.** It said `CMakeLists.txt` is the only file to edit. Three tests hard-code the
  version — including `IEC 62304 Version Traceability` — and went red after every evidence comparison
  had passed. They should keep hard-coding it: that case exists to check the version a build *reports*
  is the version the project *declares*, and deriving it from the same macro would assert nothing.
- **Step 9 was in the wrong place.** The roadmap update belongs on the release branch, and the text
  said so while the numbering put it after the tag. It is step 6 now.
- **The roadmap contradicted itself**, in the tree this tag will name: the introduction still said
  Waves 1–3 had shipped and #15 was underway. That is the precise failure the reordering exists to
  prevent, and it happened in the same PR.

## After this merges

```console
$ git switch master && git pull
$ git tag -a v0.6.0 -m "MduX v0.6.0"
$ git push origin v0.6.0
$ git switch develop && git merge --no-ff master && git push
```

## Regulatory impact

The first release cut against a written procedure, with one deviation that is now defined rather than
improvised. §5.8's three requirements are answered mechanically: what is included is the composition
every `report.json` identifies by digest, the known anomalies are the changelog's limits section, and
the configuration it was built from is re-derived and byte-compared on two toolchains before the tag
exists.
