### PR TITLE
Position a text run from a string [#235]

### DIFF
--- a/tests/text/TextBakeTests.cpp
+++ b/tests/text/TextBakeTests.cpp
@@ -775,7 +775,9 @@ struct FixtureFont {
     /// uses; the other two exist to prove refusals that are *not* about a missing glyph.
     enum class Shape {
         Plain,
-        WithUnsupportedScripts,  ///< also bakes an Arabic letter and a combining acute
+        WithExtraScripts,        ///< also bakes Greek and Cyrillic letters, two combining marks
+                                 ///< and an Arabic letter - all of them present, so a refusal
+                                 ///< among them cannot be a missing glyph
         WithRunawayKerning,      ///< A->B kerns far enough left to drive the pen past the origin
     };
 
@@ -786,9 +788,9 @@ struct FixtureFont {
         font.pixelSize  = pixelSize;
         font.locales    = {"en-US"};
 
-        // 16x16 rather than the 8x8 the three Latin glyphs need: `Shape::WithUnsupportedScripts`
-        // packs two more below them, and `validate()` refuses a slot that leaves the sheet. One
-        // size for every shape keeps the fixture a single code path.
+        // 16x16 rather than the 8x8 the three Latin glyphs need: `Shape::WithExtraScripts` packs
+        // five more beside and below them, and `validate()` refuses a slot that leaves the sheet.
+        // One size for every shape keeps the fixture a single code path.
         const std::vector<std::byte> sheet(256, std::byte{0});
         const auto                   hex = mdux::evidence::toHex(mdux::evidence::sha256(sheet));
         font.atlas.path             = "atlas.bin";
@@ -811,16 +813,32 @@ struct FixtureFont {
         font.kerning           = {{.left = U'A', .right = U'B', .adjustment = kernAB}};
         font.restrictedCharset = {{.first = U' ', .last = U' '}, {.first = U'A', .last = U'B'}};
 
-        if (shape == Shape::WithUnsupportedScripts) {
-            // Both are legitimately bakeable and legitimately unrenderable by an identity pen walk:
-            // U+0301 belongs over the preceding base rather than after its advance, and U+0627 runs
-            // right to left and joins its neighbours. `find()` succeeds for both, which is exactly
-            // what makes them the right fixture - a refusal here cannot be a missing glyph.
+        if (shape == Shape::WithExtraScripts) {
+            // Five more glyphs, in code-point order, covering both directions of the repertoire
+            // rule. Every one of them is bakeable and every one resolves through `find()`, which is
+            // what makes this the right fixture: a refusal among them cannot be a missing glyph,
+            // and an acceptance among them cannot be an accident of the charset.
+            //
+            //   U+0301  combining acute      - refused: belongs over the base, not after it
+            //   U+03B1  Greek small alpha    - accepted: ADR-010 names Greek in the v1 scope
+            //   U+0416  Cyrillic capital Zhe - accepted: likewise Cyrillic
+            //   U+0483  combining titlo      - refused, and it sits *inside* the Cyrillic block,
+            //                                  which is why that block is admitted with a hole
+            //   U+0627  Arabic alef          - refused: right to left, and it joins its neighbours
             font.glyphs.push_back({.codePoint = U'\u0301', .glyphIndex = 6, .advanceWidth = 0, .leftSideBearing = 0,
                                    .x = 0, .y = 6, .width = 3, .height = 2, .bitmapOriginX = -3, .bitmapOriginY = 8});
-            font.glyphs.push_back({.codePoint = U'\u0627', .glyphIndex = 7, .advanceWidth = 400, .leftSideBearing = 0,
-                                   .x = 4, .y = 6, .width = 2, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6});
+            font.glyphs.push_back({.codePoint = U'\u03B1', .glyphIndex = 7, .advanceWidth = 600, .leftSideBearing = 0,
+                                   .x = 8, .y = 0, .width = 4, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6});
+            font.glyphs.push_back({.codePoint = U'\u0416', .glyphIndex = 8, .advanceWidth = 900, .leftSideBearing = 0,
+                                   .x = 0, .y = 8, .width = 6, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6});
+            font.glyphs.push_back({.codePoint = U'\u0483', .glyphIndex = 9, .advanceWidth = 0, .leftSideBearing = 0,
+                                   .x = 8, .y = 6, .width = 3, .height = 2, .bitmapOriginX = -3, .bitmapOriginY = 8});
+            font.glyphs.push_back({.codePoint = U'\u0627', .glyphIndex = 10, .advanceWidth = 400, .leftSideBearing = 0,
+                                   .x = 12, .y = 0, .width = 2, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6});
             font.restrictedCharset.push_back({.first = U'\u0301', .last = U'\u0301'});
+            font.restrictedCharset.push_back({.first = U'\u03B1', .last = U'\u03B1'});
+            font.restrictedCharset.push_back({.first = U'\u0416', .last = U'\u0416'});
+            font.restrictedCharset.push_back({.first = U'\u0483', .last = U'\u0483'});
             font.restrictedCharset.push_back({.first = U'\u0627', .last = U'\u0627'});
         }
         if (shape == Shape::WithRunawayKerning) {
@@ -1101,59 +1119,83 @@ font = "font.json"
             .Execute();
     }};
 
-const mdux::spec::Register unsupportedShapingIsRefused{
-    "A code point the pen walk cannot render is refused even when the font bakes it", "evidence-unit", [] {
+const mdux::spec::Register repertoireMatchesTheAdr{
+    "The enforced repertoire is ADR-010's v1 scope: Greek and Cyrillic bake, their marks do not",
+    "evidence-unit", [] {
         return speclab::Test("text-bake-strings-repertoire")
-            .Given("a font package that also bakes a combining acute and an Arabic letter", [] {})
-            .When("strings using them are baked", [] {})
-            .Then("each is TXT026, and the glyph is demonstrably present",
+            .Given("a font package baking Greek, Cyrillic, two combining marks and an Arabic letter", [] {})
+            .When("a string of each is baked", [] {})
+            .Then("the three scripts ADR-010 names position, and the rest are TXT026",
                   [] {
                       mdux::spec::Checks checks;
                       const auto         dir      = freshTempDir("repertoire");
-                      const auto         fontName = FixtureFont::writeInto(dir, FixtureFont::Shape::WithUnsupportedScripts);
+                      const auto         fontName = FixtureFont::writeInto(dir, FixtureFont::Shape::WithExtraScripts);
 
-                      // The premise first. If these ever stopped resolving, the refusals below
-                      // would still pass and would be proving something else entirely - a missing
-                      // glyph rather than an unsupported shaping model.
-                      const auto font = FixtureFont::package(FixtureFont::Shape::WithUnsupportedScripts);
-                      checks.expect(font.find(U'\u0301') != nullptr, "the combining acute is in the package");
-                      checks.expect(font.find(U'\u0627') != nullptr, "the Arabic letter is in the package");
+                      // The premise first. Every code point below resolves, so neither half of this
+                      // scenario can be an accident of the charset: a refusal is about the shaping
+                      // model rather than a missing glyph, and an acceptance is about the
+                      // repertoire rather than a lucky lookup.
+                      const auto font = FixtureFont::package(FixtureFont::Shape::WithExtraScripts);
+                      for (const char32_t point : {U'\u0301', U'\u03B1', U'\u0416', U'\u0483', U'\u0627'}) {
+                          checks.expect(font.find(point) != nullptr,
+                                        std::format("U+{:04X} is in the package", static_cast<std::uint32_t>(point)));
+                      }
 
                       struct Case {
                           std::string_view what;
+                          std::string_view expectedCode;  ///< "none" means it is expected to bake
                           std::string      recipe;
                       };
                       const std::vector<Case> cases{
-                          // A base plus a combining mark: a pen walk parks the accent after the
-                          // base's advance instead of over it.
+                          // ADR-010's Context and Decision 5 name Latin, Cyrillic and Greek LTR as
+                          // the whole of the v1 scope. An implementation enforcing less than that
+                          // ships a rendering nobody reviewed; one enforcing more refuses text the
+                          // accepted architecture promises. These two cases pin the second half.
+                          //
                           // Written with the TOML parser's own \u escapes rather than as literal
                           // UTF-8, so this source file stays ASCII: MSVC reads a file with no BOM
                           // in the system code page unless told otherwise, and a mangled byte here
                           // would make the scenario prove something other than what it says.
-                          {"a combining mark after a base", textRecipeText(fontName, R"(keys   = ["STR-ACUTE"]
+                          {"a Greek letter", "none", textRecipeText(fontName, R"(keys   = ["STR-GREEK"]
+values = ["\u03B1"])")},
+                          {"a Cyrillic letter", "none", textRecipeText(fontName, R"(keys   = ["STR-CYRILLIC"]
+values = ["\u0416"])")},
+                          // A base plus a combining mark: a pen walk parks the accent after the
+                          // base's advance instead of over it.
+                          {"a combining mark after a base", "TXT026", textRecipeText(fontName, R"(keys   = ["STR-ACUTE"]
 values = ["A\u0301"])")},
+                          // The same defect inside the Cyrillic block, which is why that block is
+                          // admitted with U+0483..U+0489 carved out rather than whole.
+                          {"a combining mark inside the Cyrillic block", "TXT026",
+                           textRecipeText(fontName, R"(keys   = ["STR-TITLO"]
+values = ["\u0416\u0483"])")},
                           // Right to left, and joining. A pen walk emits isolated forms in logical
                           // order, which is wrong twice over.
-                          {"an Arabic letter", textRecipeText(fontName, R"(keys   = ["STR-ARABIC"]
+                          {"an Arabic letter", "TXT026", textRecipeText(fontName, R"(keys   = ["STR-ARABIC"]
 values = ["\u0627"])")},
                       };
 
                       for (const Case& entry : cases) {
                           std::vector<cli::Diagnostic> diagnostics;
                           auto recipe = bake::parseRecipe(entry.recipe, "fixture.toml", diagnostics);
+                          bool baked  = false;
                           if (recipe.has_value()) {
                               const auto bytes = std::as_bytes(std::span{entry.recipe.data(), entry.recipe.size()});
-                              auto       out   = bake::run(*recipe, "fixture.toml", bytes, dir, diagnostics);
-                              checks.expect(!out.has_value(), std::format("{}: the bake succeeded unexpectedly", entry.what));
+                              baked = bake::run(*recipe, "fixture.toml", bytes, dir, diagnostics).has_value();
                           }
-                          const bool sawCode = std::ranges::any_of(
-                              diagnostics, [](const cli::Diagnostic& d) { return d.code == "TXT026"; });
-                          checks.expect(sawCode, std::format("{}: expected TXT026, got [{}]", entry.what,
-                                                             diagnostics.empty() ? std::string{"none"}
-                                                                                 : diagnostics.front().code));
-                          // Not TXT024. The distinction is the whole point of the scenario: the
-                          // author is told their text needs shaping this baker does not do, not
-                          // sent to widen a charset that already covers it.
+                          const std::string got =
+                              diagnostics.empty() ? std::string{"none"} : diagnostics.front().code;
+
+                          if (entry.expectedCode == "none") {
+                              checks.expect(baked, std::format("{}: expected a package, got [{}]", entry.what, got));
+                              continue;
+                          }
+                          checks.expect(!baked, std::format("{}: the bake succeeded unexpectedly", entry.what));
+                          checks.expect(got == entry.expectedCode,
+                                        std::format("{}: expected {}, got [{}]", entry.what, entry.expectedCode, got));
+                          // Not TXT024. The distinction is the whole point: the author is told
+                          // their text needs shaping this baker does not do, not sent to widen a
+                          // charset that already covers it.
                           const bool sawNotDrawable = std::ranges::any_of(
                               diagnostics, [](const cli::Diagnostic& d) { return d.code == "TXT024"; });
                           checks.expect(!sawNotDrawable, std::format("{}: reported as a missing glyph", entry.what));
@@ -1264,8 +1306,29 @@ values = ["A"])";
                       // A backslash resolves on Windows and does not on Linux, and a report may not
                       // record one at all - so it is refused at the path rule, giving one answer
                       // everywhere rather than a TXT021 here and a TXT005 there.
-                      checks.expect(codeFor("sub\\font.json") == "TXT021",
-                                    std::format("a backslash path: got {}", codeFor("sub\\font.json")));
+                      //
+                      // Four backslashes, deliberately. C++ turns them into two, which the TOML
+                      // parser turns into one. Writing two here would put a lone `\f` in the TOML,
+                      // and `\f` is a *recognised escape* that decodes to a form feed - so the
+                      // recipe would hold no backslash at all, this case would pass because a file
+                      // named with a control character is absent, and deleting the rule it claims
+                      // to test would leave it green.
+                      const std::string backslashRecipe = textRecipeText("sub\\\\font.json", strings);
+                      std::vector<cli::Diagnostic> backslashDiagnostics;
+                      auto backslashParsed = bake::parseRecipe(backslashRecipe, "fixture.toml", backslashDiagnostics);
+                      checks.expect(backslashParsed.has_value(), "the backslash recipe parses");
+                      if (backslashParsed.has_value()) {
+                          // The assertion that keeps the case honest: the path really did survive
+                          // both layers as a backslash.
+                          checks.expect(backslashParsed->fontPackage.find('\\') != std::string::npos,
+                                        std::format("the parsed path keeps its backslash, got '{}'",
+                                                    backslashParsed->fontPackage));
+                          const auto bytes = std::as_bytes(std::span{backslashRecipe.data(), backslashRecipe.size()});
+                          static_cast<void>(bake::run(*backslashParsed, "fixture.toml", bytes, dir, backslashDiagnostics));
+                      }
+                      const std::string backslashCode =
+                          backslashDiagnostics.empty() ? std::string{"none"} : backslashDiagnostics.front().code;
+                      checks.expect(backslashCode == "TXT021", std::format("a backslash path: got {}", backslashCode));
 
                       // The symlink case. Windows needs a privilege for this and usually refuses,
                       // so the scenario asserts only when the link was actually created - a test
@@ -1277,6 +1340,10 @@ values = ["A"])";
                       std::error_code linkError;
                       std::filesystem::create_symlink(outside / "font.json", dir / "escape.json", linkError);
                       if (!linkError) {
+                          // Asserted rather than assumed: if the copy had failed, the control case
+                          // below would be reading a file that is not there and would agree with
+                          // the escape case for the wrong reason.
+                          checks.expect(!copyError, "the outside-the-root copy was made");
                           checks.expect(codeFor("escape.json") == "TXT021",
                                         std::format("a symlink leaving the root: got {}", codeFor("escape.json")));
                           // ...and the control: the same file, read directly, bakes.

--- a/tests/text/TextBakeTests.cpp
+++ b/tests/text/TextBakeTests.cpp
@@ -771,7 +771,15 @@ struct FixtureFont {
     static constexpr std::uint32_t pixelSize  = 10;
     static constexpr std::int16_t  kernAB     = -50;
 
-    [[nodiscard]] static mdux::font::FontPackage package() {
+    /// How the fixture is built. `Plain` is the three-glyph Latin font every positioning case
+    /// uses; the other two exist to prove refusals that are *not* about a missing glyph.
+    enum class Shape {
+        Plain,
+        WithUnsupportedScripts,  ///< also bakes an Arabic letter and a combining acute
+        WithRunawayKerning,      ///< A->B kerns far enough left to drive the pen past the origin
+    };
+
+    [[nodiscard]] static mdux::font::FontPackage package(Shape shape = Shape::Plain) {
         mdux::font::FontPackage font;
         font.id         = "fixture-ui";
         font.unitsPerEm = unitsPerEm;
@@ -799,12 +807,31 @@ struct FixtureFont {
         };
         font.kerning           = {{.left = U'A', .right = U'B', .adjustment = kernAB}};
         font.restrictedCharset = {{.first = U' ', .last = U' '}, {.first = U'A', .last = U'B'}};
+
+        if (shape == Shape::WithUnsupportedScripts) {
+            // Both are legitimately bakeable and legitimately unrenderable by an identity pen walk:
+            // U+0301 belongs over the preceding base rather than after its advance, and U+0627 runs
+            // right to left and joins its neighbours. `find()` succeeds for both, which is exactly
+            // what makes them the right fixture - a refusal here cannot be a missing glyph.
+            font.glyphs.push_back({.codePoint = U'\u0301', .glyphIndex = 6, .advanceWidth = 0, .leftSideBearing = 0,
+                                   .x = 0, .y = 6, .width = 3, .height = 2, .bitmapOriginX = -3, .bitmapOriginY = 8});
+            font.glyphs.push_back({.codePoint = U'\u0627', .glyphIndex = 7, .advanceWidth = 400, .leftSideBearing = 0,
+                                   .x = 4, .y = 6, .width = 2, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6});
+            font.restrictedCharset.push_back({.first = U'\u0301', .last = U'\u0301'});
+            font.restrictedCharset.push_back({.first = U'\u0627', .last = U'\u0627'});
+        }
+        if (shape == Shape::WithRunawayKerning) {
+            // 'A' advances 700 and this pulls back 900, so the pen lands 200 units left of where
+            // the run began. `FontPackage::validate()` permits it: it constrains the adjustment to
+            // an int16 and says nothing about `advance + kerning`.
+            font.kerning = {{.left = U'A', .right = U'B', .adjustment = -900}};
+        }
         return font;
     }
 
     /// Writes the package into `dir` and returns its bare filename.
-    [[nodiscard]] static std::string writeInto(const std::filesystem::path& dir) {
-        auto text = package().write();
+    [[nodiscard]] static std::string writeInto(const std::filesystem::path& dir, Shape shape = Shape::Plain) {
+        auto text = package(shape).write();
         if (!text.has_value()) {
             throw speclab::core::AssertionFailure("the fixture font package is not valid",
                                                   std::source_location::current());
@@ -1066,6 +1093,197 @@ font = "font.json"
                       // because a locale with nothing to say yet is a legitimate package.
                       checks.expect(parseCode(validRecipe()) == "ok",
                                     "a recipe with neither still parses");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unsupportedShapingIsRefused{
+    "A code point the pen walk cannot render is refused even when the font bakes it", "evidence-unit", [] {
+        return speclab::Test("text-bake-strings-repertoire")
+            .Given("a font package that also bakes a combining acute and an Arabic letter", [] {})
+            .When("strings using them are baked", [] {})
+            .Then("each is TXT026, and the glyph is demonstrably present",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         dir      = freshTempDir("repertoire");
+                      const auto         fontName = FixtureFont::writeInto(dir, FixtureFont::Shape::WithUnsupportedScripts);
+
+                      // The premise first. If these ever stopped resolving, the refusals below
+                      // would still pass and would be proving something else entirely - a missing
+                      // glyph rather than an unsupported shaping model.
+                      const auto font = FixtureFont::package(FixtureFont::Shape::WithUnsupportedScripts);
+                      checks.expect(font.find(U'\u0301') != nullptr, "the combining acute is in the package");
+                      checks.expect(font.find(U'\u0627') != nullptr, "the Arabic letter is in the package");
+
+                      struct Case {
+                          std::string_view what;
+                          std::string      recipe;
+                      };
+                      const std::vector<Case> cases{
+                          // A base plus a combining mark: a pen walk parks the accent after the
+                          // base's advance instead of over it.
+                          // Written with the TOML parser's own \u escapes rather than as literal
+                          // UTF-8, so this source file stays ASCII: MSVC reads a file with no BOM
+                          // in the system code page unless told otherwise, and a mangled byte here
+                          // would make the scenario prove something other than what it says.
+                          {"a combining mark after a base", textRecipeText(fontName, R"(keys   = ["STR-ACUTE"]
+values = ["A\u0301"])")},
+                          // Right to left, and joining. A pen walk emits isolated forms in logical
+                          // order, which is wrong twice over.
+                          {"an Arabic letter", textRecipeText(fontName, R"(keys   = ["STR-ARABIC"]
+values = ["\u0627"])")},
+                      };
+
+                      for (const Case& entry : cases) {
+                          std::vector<cli::Diagnostic> diagnostics;
+                          auto recipe = bake::parseRecipe(entry.recipe, "fixture.toml", diagnostics);
+                          if (recipe.has_value()) {
+                              const auto bytes = std::as_bytes(std::span{entry.recipe.data(), entry.recipe.size()});
+                              auto       out   = bake::run(*recipe, "fixture.toml", bytes, dir, diagnostics);
+                              checks.expect(!out.has_value(), std::format("{}: the bake succeeded unexpectedly", entry.what));
+                          }
+                          const bool sawCode = std::ranges::any_of(
+                              diagnostics, [](const cli::Diagnostic& d) { return d.code == "TXT026"; });
+                          checks.expect(sawCode, std::format("{}: expected TXT026, got [{}]", entry.what,
+                                                             diagnostics.empty() ? std::string{"none"}
+                                                                                 : diagnostics.front().code));
+                          // Not TXT024. The distinction is the whole point of the scenario: the
+                          // author is told their text needs shaping this baker does not do, not
+                          // sent to widen a charset that already covers it.
+                          const bool sawNotDrawable = std::ranges::any_of(
+                              diagnostics, [](const cli::Diagnostic& d) { return d.code == "TXT024"; });
+                          checks.expect(!sawNotDrawable, std::format("{}: reported as a missing glyph", entry.what));
+                      }
+
+                      std::error_code ignored;
+                      std::filesystem::remove_all(dir, ignored);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register negativePenIsRefused{
+    "Kerning that drives the pen left of the run's origin is refused, not encoded", "evidence-unit", [] {
+        return speclab::Test("text-bake-strings-negative-pen")
+            .Given("a valid font package whose A->B kerning outweighs A's advance", [] {})
+            .When("a string using that pair is baked", [] {})
+            .Then("it is TXT027 and nothing is produced",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         dir      = freshTempDir("negative-pen");
+                      const auto         fontName = FixtureFont::writeInto(dir, FixtureFont::Shape::WithRunawayKerning);
+
+                      // The package really is valid: this is a legal artifact, not a corrupt one,
+                      // which is why the baker rather than the schema has to be the one to refuse.
+                      checks.expect(FixtureFont::package(FixtureFont::Shape::WithRunawayKerning).validate().has_value(),
+                                    "the runaway-kerning package validates");
+
+                      const std::string src = textRecipeText(fontName, R"(keys   = ["STR-AB"]
+values = ["AB"])");
+                      std::vector<cli::Diagnostic> diagnostics;
+                      auto recipe = bake::parseRecipe(src, "fixture.toml", diagnostics);
+                      checks.expect(recipe.has_value(), "the recipe parses");
+                      if (recipe.has_value()) {
+                          const auto bytes = std::as_bytes(std::span{src.data(), src.size()});
+                          auto       out   = bake::run(*recipe, "fixture.toml", bytes, dir, diagnostics);
+                          checks.expect(!out.has_value(), "the bake produced nothing");
+                      }
+                      const bool sawCode = std::ranges::any_of(
+                          diagnostics, [](const cli::Diagnostic& d) { return d.code == "TXT027"; });
+                      checks.expect(sawCode, std::format("expected TXT027, got [{}]",
+                                                         diagnostics.empty() ? std::string{"none"}
+                                                                             : diagnostics.front().code));
+
+                      std::error_code ignored;
+                      std::filesystem::remove_all(dir, ignored);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register mixedRecipeFormIsRefused{
+    "A recipe carrying both the font form and the text form is refused", "evidence-unit", [] {
+        return speclab::Test("text-bake-recipe-mixed-form")
+            .Given("a font recipe that also carries [strings] and a font package reference", [] {})
+            .When("it is parsed", [] {})
+            .Then("it is TXT028 rather than a font bake that silently drops the strings",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string mixed = R"([package]
+id = "fixture-ui"
+source = "recipes/font/dejavu-ui/DejaVuSans.ttf"
+pixelSize = 16
+locales = ["en-US"]
+font = "generated/font/dejavu-ui/package.json"
+
+[charset]
+names           = ["latin"]
+firstCodePoints = [32]
+lastCodePoints  = [126]
+
+[strings]
+keys   = ["STR-A"]
+values = ["A"]
+)";
+                      checks.expect(parseCode(mixed) == "TXT028",
+                                    std::format("a mixed recipe: got {}", parseCode(mixed)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register pathRulesAreCrossPlatform{
+    "A repository path is rejected for the same reason on every toolchain", "evidence-unit", [] {
+        return speclab::Test("text-bake-strings-path-rules")
+            .Given("recipes naming a font package by a Windows path and through a symlink", [] {})
+            .When("each is baked", [] {})
+            .Then("both are TXT021, on Linux and on Windows alike",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         dir      = freshTempDir("path-rules");
+                      const auto         fontName = FixtureFont::writeInto(dir, FixtureFont::Shape::Plain);
+
+                      const std::string strings = R"(keys   = ["STR-A"]
+values = ["A"])";
+
+                      const auto codeFor = [&](std::string_view fontPath) {
+                          const std::string            src = textRecipeText(fontPath, strings);
+                          std::vector<cli::Diagnostic> diagnostics;
+                          auto recipe = bake::parseRecipe(src, "fixture.toml", diagnostics);
+                          if (recipe.has_value()) {
+                              const auto bytes = std::as_bytes(std::span{src.data(), src.size()});
+                              static_cast<void>(bake::run(*recipe, "fixture.toml", bytes, dir, diagnostics));
+                          }
+                          return diagnostics.empty() ? std::string{"none"} : diagnostics.front().code;
+                      };
+
+                      // A backslash resolves on Windows and does not on Linux, and a report may not
+                      // record one at all - so it is refused at the path rule, giving one answer
+                      // everywhere rather than a TXT021 here and a TXT005 there.
+                      checks.expect(codeFor("sub\\font.json") == "TXT021",
+                                    std::format("a backslash path: got {}", codeFor("sub\\font.json")));
+
+                      // The symlink case. Windows needs a privilege for this and usually refuses,
+                      // so the scenario asserts only when the link was actually created - a test
+                      // that silently passed on a platform it never exercised would be worse than
+                      // one that says it did not run.
+                      const auto outside = freshTempDir("path-rules-outside");
+                      std::error_code copyError;
+                      std::filesystem::copy_file(dir / fontName, outside / "font.json", copyError);
+                      std::error_code linkError;
+                      std::filesystem::create_symlink(outside / "font.json", dir / "escape.json", linkError);
+                      if (!linkError) {
+                          checks.expect(codeFor("escape.json") == "TXT021",
+                                        std::format("a symlink leaving the root: got {}", codeFor("escape.json")));
+                          // ...and the control: the same file, read directly, bakes.
+                          checks.expect(codeFor(fontName) == "none",
+                                        std::format("the same package read in place: got {}", codeFor(fontName)));
+                      }
+
+                      std::error_code ignored;
+                      std::filesystem::remove_all(dir, ignored);
+                      std::filesystem::remove_all(outside, ignored);
                       checks.raise();
                   })
             .Execute();

--- a/tests/text/TextBakeTests.cpp
+++ b/tests/text/TextBakeTests.cpp
@@ -786,14 +786,17 @@ struct FixtureFont {
         font.pixelSize  = pixelSize;
         font.locales    = {"en-US"};
 
-        const std::vector<std::byte> sheet(64, std::byte{0});
+        // 16x16 rather than the 8x8 the three Latin glyphs need: `Shape::WithUnsupportedScripts`
+        // packs two more below them, and `validate()` refuses a slot that leaves the sheet. One
+        // size for every shape keeps the fixture a single code path.
+        const std::vector<std::byte> sheet(256, std::byte{0});
         const auto                   hex = mdux::evidence::toHex(mdux::evidence::sha256(sheet));
         font.atlas.path             = "atlas.bin";
-        font.atlas.width            = 8;
-        font.atlas.height           = 8;
+        font.atlas.width            = 16;
+        font.atlas.height           = 16;
         font.atlas.byteLength       = sheet.size();
         font.atlas.sha256           = std::string{hex.data(), hex.size()};
-        font.atlas.occupancyPercent = 75;
+        font.atlas.occupancyPercent = 19;
 
         // Sorted by code point, which is what `find()`'s binary search requires - and the order
         // that makes a record's packageIndex the glyph's position in this list.

--- a/tests/text/TextBakeTests.cpp
+++ b/tests/text/TextBakeTests.cpp
@@ -19,6 +19,7 @@ import speclab;
 import mdux.evidence.digest;
 import mdux.evidence.json;
 import mdux.evidence.report;
+import mdux.font.schema;
 import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.textbake;
@@ -746,6 +747,325 @@ lastCodePoints  = [32])")},
                           checks.expect(sawCode, std::format("{}: expected {}, got [{}]", entry.what, entry.code,
                                                              diagnostics.empty() ? std::string{"none"} : diagnostics.front().code));
                       }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// [strings]: parsing, and the pen walk that turns one into positioned records (#235)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// A three-glyph font package written to disk, so the baker reads a real committed-shape file
+/// rather than a value a test handed it directly. Built through `mdux::font::FontPackage` and
+/// `write()` rather than as raw JSON: `write()` validates, so a fixture that stops being a legal
+/// package fails here instead of teaching the baker to accept one that is not.
+///
+/// The numbers are chosen so the pen arithmetic is checkable by hand. `unitsPerEm` is 1000 against
+/// a `pixelSize` of 10, so one pixel is exactly 100 font units and the expected x of every record
+/// below can be read off the advances without a calculator.
+struct FixtureFont {
+    static constexpr std::uint16_t unitsPerEm = 1000;
+    static constexpr std::uint32_t pixelSize  = 10;
+    static constexpr std::int16_t  kernAB     = -50;
+
+    [[nodiscard]] static mdux::font::FontPackage package() {
+        mdux::font::FontPackage font;
+        font.id         = "fixture-ui";
+        font.unitsPerEm = unitsPerEm;
+        font.pixelSize  = pixelSize;
+        font.locales    = {"en-US"};
+
+        const std::vector<std::byte> sheet(64, std::byte{0});
+        const auto                   hex = mdux::evidence::toHex(mdux::evidence::sha256(sheet));
+        font.atlas.path             = "atlas.bin";
+        font.atlas.width            = 8;
+        font.atlas.height           = 8;
+        font.atlas.byteLength       = sheet.size();
+        font.atlas.sha256           = std::string{hex.data(), hex.size()};
+        font.atlas.occupancyPercent = 75;
+
+        // Sorted by code point, which is what `find()`'s binary search requires - and the order
+        // that makes a record's packageIndex the glyph's position in this list.
+        font.glyphs = {
+            {.codePoint = U' ', .glyphIndex = 3, .advanceWidth = 250, .leftSideBearing = 0,
+             .x = 0, .y = 0, .width = 0, .height = 0, .bitmapOriginX = 0, .bitmapOriginY = 0},
+            {.codePoint = U'A', .glyphIndex = 4, .advanceWidth = 700, .leftSideBearing = 0,
+             .x = 0, .y = 0, .width = 4, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6},
+            {.codePoint = U'B', .glyphIndex = 5, .advanceWidth = 650, .leftSideBearing = 0,
+             .x = 4, .y = 0, .width = 4, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6},
+        };
+        font.kerning           = {{.left = U'A', .right = U'B', .adjustment = kernAB}};
+        font.restrictedCharset = {{.first = U' ', .last = U' '}, {.first = U'A', .last = U'B'}};
+        return font;
+    }
+
+    /// Writes the package into `dir` and returns its bare filename.
+    [[nodiscard]] static std::string writeInto(const std::filesystem::path& dir) {
+        auto text = package().write();
+        if (!text.has_value()) {
+            throw speclab::core::AssertionFailure("the fixture font package is not valid",
+                                                  std::source_location::current());
+        }
+        std::ofstream out{dir / "font.json", std::ios::binary | std::ios::trunc};
+        out << *text;
+        out.close();
+        return "font.json";
+    }
+};
+
+/// A text recipe naming `fontPath` under the fixture font, with whatever `[strings]` body is given.
+[[nodiscard]] std::string textRecipeText(std::string_view fontPath, std::string_view stringsBody,
+                                         std::string_view atlas = "fixture-ui", std::string_view locale = "en-US") {
+    return std::format(R"([package]
+id = "fixture-text"
+atlas = "{}"
+locale = "{}"
+font = "{}"
+sidecar = "runs.bin"
+
+[strings]
+{}
+)",
+                       atlas, locale, fontPath, stringsBody);
+}
+
+/// One byte of a v1 record, as hex, so a mismatch reads as bytes rather than as a length.
+[[nodiscard]] std::string hexBytes(std::span<const std::byte> bytes) {
+    std::string out;
+    for (const std::byte b : bytes) {
+        out += std::format("{:02x} ", std::to_integer<std::uint8_t>(b));
+    }
+    return out;
+}
+
+}  // namespace
+
+const mdux::spec::Register stringsPositionIntoRecords{
+    "A [strings] table bakes into v1 records at the advances the font package declares", "evidence-unit", [] {
+        struct State {
+            std::filesystem::path        dir;
+            std::optional<bake::Recipe>  recipe;
+            std::optional<bake::BakeOutputs> outputs;
+            std::vector<cli::Diagnostic> diagnostics;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("text-bake-strings-positioned")
+            .Given("a font package on disk and a recipe naming two strings", [state] {
+                state->dir            = freshTempDir("strings");
+                const auto fontName   = FixtureFont::writeInto(state->dir);
+                const std::string src = textRecipeText(fontName, R"(keys   = ["STR-AB", "STR-A"]
+values = ["AB A",  "A"])");
+                state->recipe = bake::parseRecipe(src, "fixture.toml", state->diagnostics);
+                if (!state->recipe.has_value()) {
+                    throw speclab::core::AssertionFailure("the recipe did not parse",
+                                                          std::source_location::current());
+                }
+                const auto bytes = std::as_bytes(std::span{src.data(), src.size()});
+                state->outputs   = bake::run(*state->recipe, "fixture.toml", bytes, state->dir, state->diagnostics);
+                if (!state->outputs.has_value()) {
+                    throw speclab::core::AssertionFailure(
+                        std::format("the bake failed: {}", state->diagnostics.empty()
+                                                               ? std::string{"(no diagnostic)"}
+                                                               : state->diagnostics.back().message),
+                        std::source_location::current());
+                }
+            })
+            .When("the package and its sidecar are read back", [] {})
+            .Then("each run holds one record per code point, at the expected pen positions",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      const auto&        out = *state->outputs;
+
+                      // The expected bytes, derived by hand from the fixture's own advances rather
+                      // than from the implementation's formula - a test that recomputed the formula
+                      // would agree with a wrong one. One pixel is 100 font units here.
+                      //
+                      //   'A' at pen 0                            -> x = 0
+                      //   pen += 700, kern(A,B) = -50             -> pen 650
+                      //   'B' at pen 650                          -> x = 7  (650/100, rounded)
+                      //   pen += 650                              -> pen 1300
+                      //   ' ' at pen 1300                         -> x = 13
+                      //   pen += 250                              -> pen 1550
+                      //   'A' at pen 1550                         -> x = 16 (15.5, rounded half up)
+                      //
+                      // packageIndex is the glyph's position in the package's sorted glyph list:
+                      // space 0, 'A' 1, 'B' 2 - not the font's own glyphIndex (3, 4, 5).
+                      const std::vector<std::uint8_t> expected{
+                          0x01, 0x00, 0x00, 0x00, 0x00, 0x00,  // 'A' at x=0
+                          0x02, 0x00, 0x07, 0x00, 0x00, 0x00,  // 'B' at x=7
+                          0x00, 0x00, 0x0D, 0x00, 0x00, 0x00,  // ' ' at x=13
+                          0x01, 0x00, 0x10, 0x00, 0x00, 0x00,  // 'A' at x=16
+                      };
+
+                      checks.expect(out.runCount == 2, std::format("two runs, got {}", out.runCount));
+                      checks.expect(out.sidecar.size() == expected.size() + text::recordSize,
+                                    std::format("{} sidecar bytes, got {}", expected.size() + text::recordSize,
+                                                out.sidecar.size()));
+
+                      const auto parsed = text::TextPackage::parse(out.packageJson);
+                      checks.expect(parsed.has_value(), "the produced package.json parses");
+                      if (parsed.has_value() && parsed->runs.size() == 2) {
+                          checks.expect(parsed->runs[0].id == "STR-AB", "the first run keeps its key");
+                          checks.expect(parsed->runs[1].id == "STR-A", "the second run keeps its key");
+                          checks.expect(parsed->runs[0].byteOffset == 0, "the first run starts at zero");
+                          checks.expect(parsed->runs[0].byteLength == expected.size(),
+                                        std::format("the first run is {} bytes", expected.size()));
+                          // Contiguous: the second run starts where the first ended, so every byte
+                          // of the sidecar belongs to exactly one run.
+                          checks.expect(parsed->runs[1].byteOffset == expected.size(),
+                                        "the second run starts where the first ended");
+                      }
+
+                      if (out.sidecar.size() >= expected.size()) {
+                          const std::span<const std::byte> first{out.sidecar.data(), expected.size()};
+                          std::vector<std::byte>           want;
+                          for (const std::uint8_t b : expected) {
+                              want.push_back(static_cast<std::byte>(b));
+                          }
+                          checks.expect(std::ranges::equal(first, want),
+                                        std::format("records are [{}], got [{}]", hexBytes(want), hexBytes(first)));
+                      }
+
+                      // The bake's one input is the font package, so re-baking the font invalidates
+                      // this artifact rather than leaving it describing an atlas that moved.
+                      const auto report = mdux::evidence::BakeReport::parse(out.reportJson);
+                      checks.expect(report.has_value(), "the produced report.json parses");
+                      if (report.has_value()) {
+                          checks.expect(report->inputs.size() == 1,
+                                        std::format("one input, got {}", report->inputs.size()));
+                          if (report->inputs.size() == 1) {
+                              checks.expect(report->inputs.front().path == "font.json",
+                                            "the input is the font package");
+                          }
+                      }
+
+                      std::error_code ignored;
+                      std::filesystem::remove_all(state->dir, ignored);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register stringsRejections{
+    "A malformed or unbakeable [strings] table reports its own stable code", "evidence-unit", [] {
+        return speclab::Test("text-bake-strings-rejections")
+            .Given("a corpus of broken [strings] tables", [] {})
+            .When("each is parsed and baked against the fixture font", [] {})
+            .Then("each reports its own code",
+                  [] {
+                      struct Case {
+                          std::string_view what;
+                          std::string_view expectedCode;
+                          std::string      recipe;
+                      };
+
+                      mdux::spec::Checks checks;
+                      const auto         dir      = freshTempDir("strings-bad");
+                      const auto         fontName = FixtureFont::writeInto(dir);
+
+                      // Built here rather than as a namespace-scope corpus because every recipe
+                      // has to name the font package this scenario just wrote.
+                      const std::vector<Case> cases{
+                          {"parallel arrays of different lengths", "TXT020",
+                           textRecipeText(fontName, R"(keys   = ["A", "B"]
+values = ["only one"])")},
+                          {"a [strings] table with no keys", "TXT020",
+                           textRecipeText(fontName, R"(keys   = []
+values = [])")},
+                          {"an empty key", "TXT020",
+                           textRecipeText(fontName, R"(keys   = [""]
+values = ["A"])")},
+                          // An empty translation bakes a zero-length run: it validates, draws
+                          // nothing, and ships as a blank label. Refused at the recipe rather than
+                          // discovered on a device.
+                          {"an empty value", "TXT020",
+                           textRecipeText(fontName, R"(keys   = ["STR-A"]
+values = [""])")},
+                          {"a key named twice", "TXT020",
+                           textRecipeText(fontName, R"(keys   = ["STR-A", "STR-A"]
+values = ["A",     "B"])")},
+                          // The fixture bakes the space, 'A' and 'B'. ADR-010 leaves the runtime no
+                          // fallback, so a character nobody baked is a bake failure rather than a
+                          // substitution.
+                          {"a character the font package cannot draw", "TXT024",
+                           textRecipeText(fontName, R"(keys   = ["STR-C"]
+values = ["C"])")},
+                          {"a locale the font package does not approve", "TXT023",
+                           textRecipeText(fontName, R"(keys   = ["STR-A"]
+values = ["A"])",
+                                          "fixture-ui", "de-DE")},
+                          {"an atlas id that is not the one in the font package", "TXT022",
+                           textRecipeText(fontName, R"(keys   = ["STR-A"]
+values = ["A"])",
+                                          "some-other-font")},
+                          // std::filesystem's operator/ replaces the left operand when the right is
+                          // absolute, so an unchecked join would read this and ignore the root.
+                          {"a font package path that escapes the root", "TXT021",
+                           textRecipeText("../../etc/passwd", R"(keys   = ["STR-A"]
+values = ["A"])")},
+                          {"a font package that is not there", "TXT021",
+                           textRecipeText("absent.json", R"(keys   = ["STR-A"]
+values = ["A"])")},
+                      };
+
+                      for (const Case& entry : cases) {
+                          std::vector<cli::Diagnostic> diagnostics;
+                          auto recipe = bake::parseRecipe(entry.recipe, "fixture.toml", diagnostics);
+                          if (recipe.has_value()) {
+                              const auto bytes = std::as_bytes(std::span{entry.recipe.data(), entry.recipe.size()});
+                              auto       out   = bake::run(*recipe, "fixture.toml", bytes, dir, diagnostics);
+                              checks.expect(!out.has_value(),
+                                            std::format("{}: the bake succeeded unexpectedly", entry.what));
+                          }
+                          const bool sawCode = std::ranges::any_of(
+                              diagnostics, [&entry](const cli::Diagnostic& d) { return d.code == entry.expectedCode; });
+                          checks.expect(sawCode,
+                                        std::format("{}: expected {}, got [{}]", entry.what, entry.expectedCode,
+                                                    diagnostics.empty() ? std::string{"none"} : diagnostics.front().code));
+                      }
+
+                      std::error_code ignored;
+                      std::filesystem::remove_all(dir, ignored);
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register halfARecipeIsRejected{
+    "A recipe with strings and no font, or a font and no strings, is refused", "evidence-unit", [] {
+        return speclab::Test("text-bake-strings-half-recipe")
+            .Given("two half-written recipes", [] {})
+            .When("each is parsed", [] {})
+            .Then("both report TXT020, and the pre-#235 no-strings recipe still parses",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const std::string stringsOnly = R"([package]
+id = "fixture-text"
+atlas = "fixture-ui"
+locale = "en-US"
+
+[strings]
+keys   = ["STR-A"]
+values = ["A"]
+)";
+                      const std::string fontOnly = R"([package]
+id = "fixture-text"
+atlas = "fixture-ui"
+locale = "en-US"
+font = "font.json"
+)";
+                      checks.expect(parseCode(stringsOnly) == "TXT020",
+                                    std::format("strings without a font: got {}", parseCode(stringsOnly)));
+                      checks.expect(parseCode(fontOnly) == "TXT020",
+                                    std::format("a font without strings: got {}", parseCode(fontOnly)));
+                      // The shape every text recipe had before #235: neither table. Still valid,
+                      // because a locale with nothing to say yet is a legitimate package.
+                      checks.expect(parseCode(validRecipe()) == "ok",
+                                    "a recipe with neither still parses");
                       checks.raise();
                   })
             .Execute();

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -66,6 +66,16 @@ constexpr std::string_view recipePixelSizeInvalid = "TXT018";
 // the fix is a different font, not a different charset.
 constexpr std::string_view tabularFiguresMismatch = "TXT019";
 
+// #235's text path. A font recipe's own "cannot read the font" is TXT012, which is about a
+// TrueType file; these are about a baked font *package*, which fails in different ways and sends
+// an author somewhere else - so they get their own codes rather than overloading TXT012/TXT013.
+constexpr std::string_view recipeStringsMalformed  = "TXT020";
+constexpr std::string_view recipeFontPackageUnread = "TXT021";
+constexpr std::string_view fontPackageUnparsed     = "TXT022";
+constexpr std::string_view localeNotApproved       = "TXT023";
+constexpr std::string_view stringNotDrawable       = "TXT024";
+constexpr std::string_view runTooWide              = "TXT025";
+
 void report(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::size_t line,
              std::string_view code, std::string message, std::string fixHint = {}) {
     diagnostics.push_back(cli::Diagnostic{.file = std::move(file),
@@ -91,6 +101,36 @@ void report(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::si
     return std::as_bytes(std::span{text.data(), text.size()});
 }
 
+/**
+ * @brief Resolves `relativePath` under `root`, or nullopt when it would escape.
+ *
+ * `root / relativePath` is not the containment it looks like: std::filesystem's operator/
+ * *replaces* the left operand when the right is absolute, so `source = "/etc/shadow"` reads that
+ * file and ignores `root` entirely. A relative path with `..` components escapes the same way by a
+ * different route. The recipe is repository content rather than network input, so this is not a
+ * live attack surface today - but a baker that will one day run over a recipe somebody else wrote
+ * should not have "the recipe is trusted" as its only defence.
+ *
+ * Shared by the font path's `source` and the text path's `font`, so the two cannot drift into
+ * disagreeing about what is inside the repository.
+ */
+[[nodiscard]] std::optional<std::filesystem::path> confine(const std::filesystem::path& root,
+                                                            std::string_view relativePath) {
+    if (relativePath.empty() || std::filesystem::path{relativePath}.is_absolute()) {
+        return std::nullopt;
+    }
+    const std::filesystem::path resolved   = (root / relativePath).lexically_normal();
+    const std::filesystem::path normalRoot = root.lexically_normal();
+    // lexically_relative() gives the path from root to the target; a result that starts with ".."
+    // means the target is outside root. Comparing the normalised forms is what makes `a/../../b`
+    // fail rather than pass on a string prefix check.
+    const auto relative = resolved.lexically_relative(normalRoot);
+    if (relative.empty() || *relative.begin() == "..") {
+        return std::nullopt;
+    }
+    return resolved;
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -103,6 +143,15 @@ json::Value Recipe::toOptions() const {
     static_cast<void>(options.set("atlas", json::Value::string(atlas)));
     static_cast<void>(options.set("locale", json::Value::string(locale)));
     static_cast<void>(options.set("sidecar", json::Value::string(sidecar)));
+    if (!font.has_value()) {
+        // The resolved font package path, and how many runs were asked for. Not the strings
+        // themselves: they are the recipe's own content, the recipe's digest is recorded a few
+        // lines above this in every report, and their keys are already `package.json`'s run ids.
+        // Copying them here would make one edited translation appear in three places of the same
+        // artifact diff, which makes the diff harder to read rather than more complete.
+        static_cast<void>(options.set("font", json::Value::string(fontPackage)));
+        static_cast<void>(options.set("strings", json::Value::integer(strings.size())));
+    }
     if (font.has_value()) {
         // Every resolved knob, because ADR-007's rule is that a silently changed default must not
         // leave every report looking unchanged. The charset is recorded as its ranges rather than
@@ -314,6 +363,86 @@ namespace {
     return spec;
 }
 
+/**
+ * @brief Reads a text recipe's `[strings]` table and its `[package] font` key into `recipe`.
+ *
+ * Both are optional together and required together. A recipe with neither is the S1 shape - a
+ * package with no runs - which stays valid because a locale can legitimately have nothing to say
+ * yet, and because every text package in this repository was that shape until #235. A recipe with
+ * one and not the other is a half-written recipe, and saying so here is more useful than baking an
+ * empty package and leaving the author to wonder where their strings went.
+ */
+[[nodiscard]] bool parseStrings(const toml::Document& document, const toml::Table& package, Recipe& recipe,
+                                std::string_view recipePath, std::vector<cli::Diagnostic>& diagnostics) {
+    const toml::Table* strings = document.table("strings");
+    const toml::Value* font    = package.find("font");
+
+    if (strings == nullptr && font == nullptr) {
+        return true;
+    }
+    if (strings == nullptr || font == nullptr) {
+        report(diagnostics, std::string{recipePath}, 0, recipeStringsMalformed,
+               strings == nullptr ? "recipe names a font package and has no [strings] table"
+                                  : "recipe has a [strings] table and names no font package",
+               "A run is a string positioned against a font package: neither is meaningful alone.");
+        return false;
+    }
+
+    std::vector<std::string> keys;
+    std::vector<std::string> values;
+    try {
+        recipe.fontPackage = font->asString();
+        keys               = strings->require("keys").asStringArray();
+        values             = strings->require("values").asStringArray();
+    } catch (const toml::TomlError& error) {
+        report(diagnostics, std::string{recipePath}, error.line(), recipeStringsMalformed, error.what(),
+               "[strings] needs parallel 'keys' and 'values' string arrays.");
+        return false;
+    }
+
+    if (keys.size() != values.size()) {
+        report(diagnostics, std::string{recipePath}, 0, recipeStringsMalformed,
+               std::format("[strings] has {} keys and {} values", keys.size(), values.size()),
+               "The two arrays are parallel: one value per key, in the same order.");
+        return false;
+    }
+    if (keys.empty()) {
+        report(diagnostics, std::string{recipePath}, 0, recipeStringsMalformed,
+               "[strings] is present and empty",
+               "Remove the table to bake a package with no runs, or give it a key.");
+        return false;
+    }
+
+    for (std::size_t i = 0; i < keys.size(); ++i) {
+        // Empty on either side, refused here rather than at schema validation. An empty key cannot
+        // be named by `t("")`; an empty value would bake a zero-length run, which validates and
+        // draws nothing, so a missing translation would ship as a blank label rather than as a
+        // build failure. Both are recipe-authoring mistakes, and a diagnostic naming the index is
+        // more actionable than a schema error at line 0.
+        if (keys[i].empty()) {
+            report(diagnostics, std::string{recipePath}, 0, recipeStringsMalformed,
+                   std::format("[strings] key {} is empty", i));
+            return false;
+        }
+        if (values[i].empty()) {
+            report(diagnostics, std::string{recipePath}, 0, recipeStringsMalformed,
+                   std::format("[strings] value for '{}' is empty", keys[i]),
+                   "An empty translation bakes a run that draws nothing, which ships as a blank label.");
+            return false;
+        }
+        for (std::size_t j = 0; j < i; ++j) {
+            if (keys[j] == keys[i]) {
+                report(diagnostics, std::string{recipePath}, 0, recipeStringsMalformed,
+                       std::format("[strings] names the key '{}' twice", keys[i]),
+                       "A key becomes a run id, which is unique within a package.");
+                return false;
+            }
+        }
+        recipe.strings.push_back(TextString{.key = keys[i], .text = values[i]});
+    }
+    return true;
+}
+
 }  // namespace
 
 std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipePath,
@@ -367,6 +496,8 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
             return std::nullopt;
         }
         recipe.font = std::move(*spec);
+    } else if (!parseStrings(document, *package, recipe, recipePath, diagnostics)) {
+        return std::nullopt;
     }
 
     if (!isFontRecipe && recipe.atlas.empty()) {
@@ -678,32 +809,16 @@ using SlotIndex = std::vector<const atlas::GlyphSlot*>;
                                                      std::vector<cli::Diagnostic>& diagnostics) {
     const FontSpec& spec = *recipe.font;
 
-    // Confine the source path to the repository before opening it.
-    //
-    // `root / spec.source` is not the containment it looks like: std::filesystem's operator/
-    // *replaces* the left operand when the right is absolute, so `source = "/etc/shadow"` reads
-    // that file and ignores `root` entirely. A relative path with `..` components escapes the
-    // same way by a different route. The recipe is repository content rather than network input,
-    // so this is not a live attack surface today - but a baker that will one day run over a
-    // recipe somebody else wrote should not have "the recipe is trusted" as its only defence.
-    if (spec.source.empty() || std::filesystem::path{spec.source}.is_absolute()) {
+    // Confine the source path to the repository before opening it. See `confine()` for why the
+    // obvious `root / spec.source` is not containment.
+    const auto sourcePath = confine(root, spec.source);
+    if (!sourcePath.has_value()) {
         report(diagnostics, std::string{recipePath}, 0, recipeFontUnreadable,
-               std::format("font path '{}' must be relative to the repository root", spec.source));
-        return std::nullopt;
-    }
-    const std::filesystem::path sourcePath = (root / spec.source).lexically_normal();
-    const std::filesystem::path normalRoot = root.lexically_normal();
-    // lexically_relative() gives the path from root to source; a result that starts with ".."
-    // means source is outside root. Comparing the normalised forms is what makes `a/../../b`
-    // fail rather than pass on a string prefix check.
-    const auto relative = sourcePath.lexically_relative(normalRoot);
-    if (relative.empty() || *relative.begin() == "..") {
-        report(diagnostics, std::string{recipePath}, 0, recipeFontUnreadable,
-               std::format("font path '{}' resolves outside the repository root", spec.source));
+               std::format("font path '{}' must be relative to the repository root and stay inside it", spec.source));
         return std::nullopt;
     }
 
-    auto fontBytes = readFile(sourcePath);
+    auto fontBytes = readFile(*sourcePath);
     if (!fontBytes.has_value()) {
         report(diagnostics, std::string{recipePath}, 0, recipeFontUnreadable,
                std::format("cannot read font '{}'", spec.source),
@@ -784,6 +899,212 @@ using SlotIndex = std::vector<const atlas::GlyphSlot*>;
     return outputs;
 }
 
+/// Decodes UTF-8 into scalar values, or nullopt at the first malformed byte.
+///
+/// A local decoder rather than a shared one: the only other UTF-8 code in the tools is the medui
+/// lexer's `firstInvalidUtf8()`, which validates without decoding, and a shared decoder would be a
+/// module boundary for forty lines. It rejects what the standard rejects - overlong forms,
+/// surrogates, and anything past U+10FFFF - because each of those is a byte sequence that some
+/// other decoder accepts and turns into a different character, and this one's output ends up in a
+/// committed artifact.
+[[nodiscard]] std::optional<std::vector<char32_t>> decodeUtf8(std::string_view input) {
+    std::vector<char32_t> points;
+    points.reserve(input.size());
+
+    std::size_t i = 0;
+    while (i < input.size()) {
+        const auto    lead = static_cast<std::uint32_t>(static_cast<std::uint8_t>(input[i]));
+        std::size_t   length = 0;
+        std::uint32_t point  = 0;
+        std::uint32_t lowest = 0;  ///< the smallest scalar this length may legally encode
+        if (lead < 0x80u) {
+            length = 1; point = lead;         lowest = 0u;
+        } else if ((lead & 0xE0u) == 0xC0u) {
+            length = 2; point = lead & 0x1Fu; lowest = 0x80u;
+        } else if ((lead & 0xF0u) == 0xE0u) {
+            length = 3; point = lead & 0x0Fu; lowest = 0x800u;
+        } else if ((lead & 0xF8u) == 0xF0u) {
+            length = 4; point = lead & 0x07u; lowest = 0x10000u;
+        } else {
+            return std::nullopt;  // a continuation byte, or a lead no encoding uses
+        }
+        if (i + length > input.size()) {
+            return std::nullopt;
+        }
+        for (std::size_t k = 1; k < length; ++k) {
+            const auto continuation = static_cast<std::uint32_t>(static_cast<std::uint8_t>(input[i + k]));
+            if ((continuation & 0xC0u) != 0x80u) {
+                return std::nullopt;
+            }
+            point = (point << 6u) | (continuation & 0x3Fu);
+        }
+        // `lowest` is what rejects the overlong forms: U+0041 encoded in two bytes decodes to 65
+        // just as the one-byte form does, and a decoder that accepted both would let two different
+        // recipes bake byte-different sidecars for the same string.
+        if (point < lowest || point > 0x10FFFFu || (point >= 0xD800u && point <= 0xDFFFu)) {
+            return std::nullopt;
+        }
+        points.push_back(static_cast<char32_t>(point));
+        i += length;
+    }
+    return points;
+}
+
+/// Encodes one v1 record: little-endian `uint16 packageIndex`, `int16 x`, `int16 y`.
+///
+/// Spelled out byte by byte rather than memcpy'd from a struct, for the reason
+/// `mdux::text::draw::decodeRecord()` gives for decoding the same way: the sidecar is committed
+/// bytes compared across toolchains, so the encoding must not inherit the host's byte order or its
+/// struct padding. Two toolchains disagreeing here would move glyphs, not fail.
+void appendRecord(std::vector<std::byte>& out, std::uint16_t packageIndex, std::int16_t x, std::int16_t y) {
+    const auto emit16 = [&out](std::uint16_t value) {
+        out.push_back(static_cast<std::byte>(value & 0xFFu));
+        out.push_back(static_cast<std::byte>((value >> 8) & 0xFFu));
+    };
+    emit16(packageIndex);
+    emit16(std::bit_cast<std::uint16_t>(x));
+    emit16(std::bit_cast<std::uint16_t>(y));
+}
+
+/// Font units to pixels, rounded half up, in integers throughout.
+///
+/// `pen` is non-negative for every run this baker produces - the pen starts at zero and advances -
+/// so half-up and half-away-from-zero are the same rule here. Written as half-up because that is
+/// what the expression says, rather than implying a negative case that cannot arise.
+[[nodiscard]] std::int64_t toPixels(std::int64_t pen, std::uint32_t pixelSize, std::uint16_t unitsPerEm) noexcept {
+    const auto scaled = pen * static_cast<std::int64_t>(pixelSize) + static_cast<std::int64_t>(unitsPerEm) / 2;
+    return scaled / static_cast<std::int64_t>(unitsPerEm);
+}
+
+/// A font package and the bytes it was parsed from.
+///
+/// The bytes are carried rather than re-read for the report's input record. Reading the file twice
+/// would digest something the bake did not necessarily use - a file that changed between the two
+/// reads would produce a report attesting to a bake that never happened, which is the one thing an
+/// evidence artifact may not do.
+struct LoadedFont {
+    fontpkg::FontPackage   package;
+    std::vector<std::byte> bytes;
+};
+
+/// Reads and validates the font package a text recipe names, checking it is the one the recipe
+/// says it is and that it approves the recipe's locale.
+[[nodiscard]] std::optional<LoadedFont> loadFontPackage(const Recipe& recipe, std::string_view recipePath,
+                                                         const std::filesystem::path& root,
+                                                         std::vector<cli::Diagnostic>& diagnostics) {
+    const auto path = confine(root, recipe.fontPackage);
+    if (!path.has_value()) {
+        report(diagnostics, std::string{recipePath}, 0, recipeFontPackageUnread,
+               std::format("font package path '{}' must be relative to the repository root and stay inside it",
+                           recipe.fontPackage));
+        return std::nullopt;
+    }
+    auto bytes = readFile(*path);
+    if (!bytes.has_value()) {
+        report(diagnostics, std::string{recipePath}, 0, recipeFontPackageUnread,
+               std::format("cannot read font package '{}'", recipe.fontPackage),
+               "Bake the font package first; the path is resolved against the repository root.");
+        return std::nullopt;
+    }
+    // Not named `text`: that is the enclosing `mdux::text` namespace's name, and a local shadowing
+    // it is C4459 on MSVC, where warnings are errors.
+    const std::string_view packageText{reinterpret_cast<const char*>(bytes->data()), bytes->size()};
+    auto package = fontpkg::FontPackage::parse(packageText);
+    if (!package.has_value()) {
+        report(diagnostics, std::string{recipePath}, 0, fontPackageUnparsed,
+               std::format("'{}': {}", recipe.fontPackage, fontpkg::describe(package.error())));
+        return std::nullopt;
+    }
+
+    // The recipe names the atlas twice - once as an id the package records, once as a path to read.
+    // Checking they agree is what stops a recipe from recording runs as belonging to one font while
+    // having measured them against another, which no consumer could detect: the compiler's own
+    // wiring check (`checkLocaleWiring()`) compares the text package's `atlas` to the font it was
+    // handed, and would pass on a package whose id was right and whose positions were not.
+    if (package->id != recipe.atlas) {
+        report(diagnostics, std::string{recipePath}, 0, fontPackageUnparsed,
+               std::format("recipe's atlas is '{}' and '{}' holds the font package '{}'", recipe.atlas,
+                           recipe.fontPackage, package->id),
+               "The 'atlas' id and the 'font' path must name the same package.");
+        return std::nullopt;
+    }
+    // A v1 record addresses a glyph with a `std::uint16_t`, so a package with more glyphs than
+    // that cannot be indexed by one. Checked once here rather than per glyph: the alternative is a
+    // static_cast that truncates, and a truncated index draws a different character rather than
+    // failing - which is precisely the confusion `GlyphPlacement::packageIndex` is named to avoid.
+    if (package->glyphs.size() > std::numeric_limits<std::uint16_t>::max()) {
+        report(diagnostics, std::string{recipePath}, 0, fontPackageUnparsed,
+               std::format("the font package '{}' holds {} glyphs, more than a v1 record can index",
+                           package->id, package->glyphs.size()));
+        return std::nullopt;
+    }
+    if (std::ranges::find(package->locales, recipe.locale) == package->locales.end()) {
+        report(diagnostics, std::string{recipePath}, 0, localeNotApproved,
+               std::format("the font package '{}' does not approve the locale '{}'", package->id, recipe.locale),
+               "Add the locale to the font recipe, or bake this text against a font that approves it.");
+        return std::nullopt;
+    }
+    return LoadedFont{.package = std::move(*package), .bytes = std::move(*bytes)};
+}
+
+/// Positions one string into v1 records. See TextBake.cppm for why this is a pen walk rather than
+/// shaping, and why the pen accumulates in font units.
+[[nodiscard]] std::optional<std::vector<std::byte>> positionRun(const fontpkg::FontPackage& font, const TextString& entry,
+                                                                 std::string_view recipePath,
+                                                                 std::vector<cli::Diagnostic>& diagnostics) {
+    const auto points = decodeUtf8(entry.text);
+    if (!points.has_value()) {
+        report(diagnostics, std::string{recipePath}, 0, recipeStringsMalformed,
+               std::format("the value for '{}' is not valid UTF-8", entry.key));
+        return std::nullopt;
+    }
+
+    std::vector<std::byte> records;
+    records.reserve(points->size() * text::recordSize);
+    std::int64_t pen = 0;  // font units
+
+    for (std::size_t i = 0; i < points->size(); ++i) {
+        const char32_t point = (*points)[i];
+        const fontpkg::GlyphRecord* glyph = font.find(point);
+        if (glyph == nullptr) {
+            // Fail rather than substitute. ADR-010 leaves the runtime no fallback, so a glyph this
+            // baker cannot place is one that would be missing on the device - and a package that
+            // silently dropped it would ship a word with a hole in it that nobody reviewed.
+            report(diagnostics, std::string{recipePath}, 0, stringNotDrawable,
+                   std::format("the value for '{}' contains U+{:04X}, which the font package '{}' cannot draw",
+                               entry.key, static_cast<std::uint32_t>(point), font.id),
+                   "Widen the font recipe's charset, or write the string with characters it bakes.");
+            return std::nullopt;
+        }
+
+        // The record's index is into the *package's* glyph list, not the font's own glyph id -
+        // `mdux::text::draw::GlyphPlacement` documents the distinction, and swapping the two draws
+        // the wrong character rather than failing. `find()` returns a pointer into `font.glyphs`,
+        // so the index is that pointer's offset.
+        const auto packageIndex = static_cast<std::uint16_t>(glyph - font.glyphs.data());
+
+        const std::int64_t x = toPixels(pen, font.pixelSize, font.unitsPerEm);
+        if (x > std::numeric_limits<std::int16_t>::max()) {
+            report(diagnostics, std::string{recipePath}, 0, runTooWide,
+                   std::format("the value for '{}' reaches x={}px, past the {}px a v1 record can hold", entry.key, x,
+                               std::numeric_limits<std::int16_t>::max()),
+                   "Split the string, or shorten it.");
+            return std::nullopt;
+        }
+
+        // y is the baseline, and it is zero for every record this baker writes: a run's own origin
+        // is its baseline, and where the run sits on a screen is the emitter's decision, applied as
+        // `originY` at draw time. A baker that baked a y offset in would be deciding layout.
+        appendRecord(records, packageIndex, static_cast<std::int16_t>(x), std::int16_t{0});
+
+        pen += glyph->advanceWidth;
+        if (i + 1 < points->size()) {
+            pen += font.kerningFor(point, (*points)[i + 1]);
+        }
+    }
+    return records;
+}
+
 }  // namespace
 
 std::optional<BakeOutputs> run(const Recipe& recipe, std::string_view recipePath,
@@ -793,10 +1114,19 @@ std::optional<BakeOutputs> run(const Recipe& recipe, std::string_view recipePath
     if (recipe.font.has_value()) {
         return runFontBake(recipe, recipePath, recipeBytes, root, diagnostics);
     }
-    static_cast<void>(root);  // A text bake reads no source files; the font path uses `root`.
 
     BakeOutputs outputs;
     outputs.sidecarName = recipe.sidecar;
+
+    // The font package, read once and shared by every run. Absent when the recipe carries no
+    // strings, which is the pre-#235 shape and still valid: a package with no runs reads nothing.
+    std::optional<LoadedFont> font;
+    if (!recipe.strings.empty()) {
+        font = loadFontPackage(recipe, recipePath, root, diagnostics);
+        if (!font.has_value()) {
+            return std::nullopt;
+        }
+    }
 
     text::TextPackage package;
     package.header.id = recipe.id;
@@ -804,9 +1134,27 @@ std::optional<BakeOutputs> run(const Recipe& recipe, std::string_view recipePath
     package.atlasId = recipe.atlas;
     package.locale = recipe.locale;
     package.sidecarPath = recipe.sidecar;
-    package.sidecarByteLength = 0;  // S1: no runs. The first real artifact is S4 (#160).
+
+    for (const TextString& entry : recipe.strings) {
+        auto records = positionRun(font->package, entry, recipePath, diagnostics);
+        if (!records.has_value()) {
+            return std::nullopt;
+        }
+        // Appended in recipe order, each run starting where the last one ended. Contiguous rather
+        // than padded: the schema's overlap and bounds rules are about ranges, not alignment, and
+        // a gap would be bytes no run accounts for in an artifact whose whole point is that every
+        // byte is accounted for.
+        text::TextRun positioned;
+        positioned.id         = entry.key;
+        positioned.byteOffset = outputs.sidecar.size();
+        positioned.byteLength = records->size();
+        positioned.sha256     = evidence::sha256(*records);
+        outputs.sidecar.insert(outputs.sidecar.end(), records->begin(), records->end());
+        package.runs.push_back(std::move(positioned));
+    }
+
+    package.sidecarByteLength = outputs.sidecar.size();
     package.sidecarSha256 = evidence::sha256(outputs.sidecar);
-    // No runs are appended; the package validates with an empty run list, by design.
 
     auto packageText = package.write();
     if (!packageText.has_value()) {
@@ -819,10 +1167,15 @@ std::optional<BakeOutputs> run(const Recipe& recipe, std::string_view recipePath
     outputs.packageId = package.header.id;
     outputs.runCount = package.runs.size();
 
-    // No inputs at S1: a no-run package reads no source files. S4's font pipeline will record its
-    // TrueType and rasteriser inputs here; recording an empty list now keeps the report's inputs
-    // array present and structured rather than omitted.
+    // The font package is this bake's one input, and recording it is what makes the evidence chain
+    // hold: re-baking the font changes its package.json, which changes this report's input digest,
+    // which fails `evidence.text.<id>` until the runs are re-positioned against the new atlas. A
+    // package with no runs reads nothing and records an empty list - present and structured rather
+    // than omitted, so a reader distinguishes "no inputs" from "inputs not recorded".
     std::vector<evidence::FileRecord> inputs;
+    if (font.has_value()) {
+        inputs.push_back(fileRecord(recipe.fontPackage, font->bytes));
+    }
 
     evidence::BakeReport bakeReport;
     bakeReport.tool = std::string{toolName};

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -75,6 +75,9 @@ constexpr std::string_view fontPackageUnparsed     = "TXT022";
 constexpr std::string_view localeNotApproved       = "TXT023";
 constexpr std::string_view stringNotDrawable       = "TXT024";
 constexpr std::string_view runTooWide              = "TXT025";
+constexpr std::string_view unsupportedRepertoire   = "TXT026";
+constexpr std::string_view runOriginNegative       = "TXT027";
+constexpr std::string_view recipeFormAmbiguous     = "TXT028";
 
 void report(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::size_t line,
              std::string_view code, std::string message, std::string fixHint = {}) {
@@ -119,6 +122,15 @@ void report(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::si
     if (relativePath.empty() || std::filesystem::path{relativePath}.is_absolute()) {
         return std::nullopt;
     }
+    // A backslash is refused rather than translated. A recipe records repository paths with `/` on
+    // every platform, because `BakeReport::validate()` rejects a backslash in a recorded path - so
+    // a Windows-spelled recipe that resolved here would read its file and then fail much later, as
+    // a generic "the report is not valid", with nothing pointing at the recipe line that caused it.
+    // Refusing early gives that recipe one answer on both toolchains.
+    if (relativePath.find('\\') != std::string_view::npos) {
+        return std::nullopt;
+    }
+
     const std::filesystem::path resolved   = (root / relativePath).lexically_normal();
     const std::filesystem::path normalRoot = root.lexically_normal();
     // lexically_relative() gives the path from root to the target; a result that starts with ".."
@@ -126,6 +138,30 @@ void report(std::vector<cli::Diagnostic>& diagnostics, std::string file, std::si
     // fail rather than pass on a string prefix check.
     const auto relative = resolved.lexically_relative(normalRoot);
     if (relative.empty() || *relative.begin() == "..") {
+        return std::nullopt;
+    }
+
+    // Lexical containment is not containment. A tracked entry can be a symlink - `assets/external
+    // -> /outside/root` is lexically under the root and reads bytes that are not - and the report
+    // would then record the repository-relative spelling while digesting host state nobody
+    // committed. That is an artifact whose reproducibility depends on the machine, which is the
+    // failure ADR-007 exists to prevent, so the check is repeated against the resolved forms.
+    //
+    // The root is canonicalised too, and that is not symmetry for its own sake: this repository is
+    // built under paths that are themselves symlinks - macOS resolves /tmp to /private/tmp, and
+    // CI's workspace is a mount - so canonicalising only the target would put every legitimate
+    // path outside a root spelled differently.
+    std::error_code    ec;
+    const auto canonicalRoot   = std::filesystem::weakly_canonical(normalRoot, ec);
+    if (ec) {
+        return std::nullopt;
+    }
+    const auto canonicalTarget = std::filesystem::weakly_canonical(resolved, ec);
+    if (ec) {
+        return std::nullopt;
+    }
+    const auto canonicalRelative = canonicalTarget.lexically_relative(canonicalRoot);
+    if (canonicalRelative.empty() || *canonicalRelative.begin() == "..") {
         return std::nullopt;
     }
     return resolved;
@@ -149,6 +185,13 @@ json::Value Recipe::toOptions() const {
         // lines above this in every report, and their keys are already `package.json`'s run ids.
         // Copying them here would make one edited translation appear in three places of the same
         // artifact diff, which makes the diff harder to read rather than more complete.
+        //
+        // Both members are always present, including for a recipe with no strings - where they
+        // read `""` and `0`. That pair is not ambiguous, because `parseStrings()` accepts the two
+        // together or neither, so an empty path always means "this package positions nothing".
+        // Emitting the members conditionally would instead give text reports two shapes, and a
+        // reader comparing two of them would have to establish which shape they were looking at
+        // before reading either.
         static_cast<void>(options.set("font", json::Value::string(fontPackage)));
         static_cast<void>(options.set("strings", json::Value::integer(static_cast<std::int64_t>(strings.size()))));
     }
@@ -491,6 +534,17 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
     }
 
     if (isFontRecipe) {
+        // A recipe carrying both forms is refused rather than resolved. Dispatching on [charset]
+        // alone would make a font recipe that also had [strings] bake a perfectly valid font
+        // package and silently drop every string - and a merge or a copy/paste is all it takes to
+        // produce one. For a tool whose output is evidence, an artifact of the wrong kind that
+        // passes every check is worse than a stopped build.
+        if (document.table("strings") != nullptr || package->find("font") != nullptr) {
+            report(diagnostics, std::string{recipePath}, 0, recipeFormAmbiguous,
+                   "recipe carries both the font form ([charset]) and the text form ([strings] / 'font')",
+                   "A recipe bakes an atlas or positions runs against one, never both. Split it in two.");
+            return std::nullopt;
+        }
         auto spec = parseFontSpec(document, *package, recipePath, diagnostics);
         if (!spec.has_value()) {
             return std::nullopt;
@@ -814,7 +868,8 @@ using SlotIndex = std::vector<const atlas::GlyphSlot*>;
     const auto sourcePath = confine(root, spec.source);
     if (!sourcePath.has_value()) {
         report(diagnostics, std::string{recipePath}, 0, recipeFontUnreadable,
-               std::format("font path '{}' must be relative to the repository root and stay inside it", spec.source));
+               std::format("font path '{}' is not a usable repository path", spec.source),
+               "It must be relative, spelled with '/', and resolve inside the repository - symlinks included.");
         return std::nullopt;
     }
 
@@ -968,9 +1023,11 @@ void appendRecord(std::vector<std::byte>& out, std::uint16_t packageIndex, std::
 
 /// Font units to pixels, rounded half up, in integers throughout.
 ///
-/// `pen` is non-negative for every run this baker produces - the pen starts at zero and advances -
-/// so half-up and half-away-from-zero are the same rule here. Written as half-up because that is
-/// what the expression says, rather than implying a negative case that cannot arise.
+/// **Precondition: `pen >= 0`.** The `+ unitsPerEm / 2` before the division is a half-*up* rule,
+/// which is only half-away-from-zero while the input is non-negative; on a negative pen it would
+/// bias toward zero and place a glyph a pixel right of where the same magnitude places it left.
+/// `positionRun()` enforces the precondition rather than this function widening to handle a case
+/// the format has no meaning for - see the pen check there.
 [[nodiscard]] std::int64_t toPixels(std::int64_t pen, std::uint32_t pixelSize, std::uint16_t unitsPerEm) noexcept {
     const auto scaled = pen * static_cast<std::int64_t>(pixelSize) + static_cast<std::int64_t>(unitsPerEm) / 2;
     return scaled / static_cast<std::int64_t>(unitsPerEm);
@@ -995,8 +1052,8 @@ struct LoadedFont {
     const auto path = confine(root, recipe.fontPackage);
     if (!path.has_value()) {
         report(diagnostics, std::string{recipePath}, 0, recipeFontPackageUnread,
-               std::format("font package path '{}' must be relative to the repository root and stay inside it",
-                           recipe.fontPackage));
+               std::format("font package path '{}' is not a usable repository path", recipe.fontPackage),
+               "It must be relative, spelled with '/', and resolve inside the repository - symlinks included.");
         return std::nullopt;
     }
     auto bytes = readFile(*path);
@@ -1049,6 +1106,46 @@ struct LoadedFont {
 
 /// Positions one string into v1 records. See TextBake.cppm for why this is a pen walk rather than
 /// shaping, and why the pen accumulates in font units.
+/**
+ * @brief The code points a v1 record and an identity pen walk can actually render.
+ *
+ * `font.find()` proves an atlas slot exists. It does not prove that emitting that glyph at the pen,
+ * left to right, in logical order, is a correct rendering of the string - and a `FontPackage` is
+ * free to bake anything. An Arabic letter has a glyph, and a pen walk emits it isolated,
+ * unjoined, and in the wrong direction. A combining acute has a glyph, and a pen walk places it
+ * *after* the base's advance instead of over it. Both cases produce a package that validates,
+ * byte-compares, and renders wrongly on a device - which is exactly what ADR-010 and this module's
+ * contract say must not happen.
+ *
+ * So the repertoire is declared rather than inferred, and it is deliberately narrow: the scripts
+ * below are left-to-right, need no joining or reordering, and contain no combining marks, so the
+ * identity walk is the whole of their shaping. Everything else - including scripts this baker
+ * could one day support - is refused, because widening the model is a decision that deserves the
+ * same review as the code that implements it, not a side effect of a font recipe growing a range.
+ *
+ * The two carve-outs inside Latin-1 are not fussiness. U+00AD SOFT HYPHEN is a format character
+ * whose whole meaning is conditional: it renders as nothing unless a line breaks there, and a pen
+ * walk has no line breaking, so it would bake a visible hyphen into a word. It is excluded with
+ * U+00A1's neighbour rather than by category, because there is no Unicode database here to ask.
+ */
+struct RepertoireRange {
+    char32_t first;
+    char32_t last;
+};
+
+constexpr std::array<RepertoireRange, 4> v1Repertoire{{
+    {U'\u0020', U'\u007E'},  // Basic Latin, printable
+    {U'\u00A0', U'\u00AC'},  // Latin-1 Supplement, up to but not including the soft hyphen
+    {U'\u00AE', U'\u00FF'},  // ...and past it
+    {U'\u0100', U'\u024F'},  // Latin Extended-A and -B, which are contiguous
+}};
+
+[[nodiscard]] constexpr bool inV1Repertoire(char32_t point) noexcept {
+    return std::ranges::any_of(v1Repertoire, [point](const RepertoireRange& range) noexcept {
+        return point >= range.first && point <= range.last;
+    });
+}
+
 [[nodiscard]] std::optional<std::vector<std::byte>> positionRun(const fontpkg::FontPackage& font, const TextString& entry,
                                                                  std::string_view recipePath,
                                                                  std::vector<cli::Diagnostic>& diagnostics) {
@@ -1065,6 +1162,19 @@ struct LoadedFont {
 
     for (std::size_t i = 0; i < points->size(); ++i) {
         const char32_t point = (*points)[i];
+
+        // Asked before `find()`, on purpose. A code point outside the model is refused whether or
+        // not the font happens to bake it, and reporting "the font cannot draw this" for a glyph
+        // that is plainly in the atlas would send an author to widen a charset that is already
+        // wide enough.
+        if (!inV1Repertoire(point)) {
+            report(diagnostics, std::string{recipePath}, 0, unsupportedRepertoire,
+                   std::format("the value for '{}' contains U+{:04X}, which this baker's shaping model does not cover",
+                               entry.key, static_cast<std::uint32_t>(point)),
+                   "v1 positions Latin left to right with no joining, reordering or mark attachment.");
+            return std::nullopt;
+        }
+
         const fontpkg::GlyphRecord* glyph = font.find(point);
         if (glyph == nullptr) {
             // Fail rather than substitute. ADR-010 leaves the runtime no fallback, so a glyph this
@@ -1083,6 +1193,21 @@ struct LoadedFont {
         // so the index is that pointer's offset.
         const auto packageIndex = static_cast<std::uint16_t>(glyph - font.glyphs.data());
 
+        // The pen is the invariant `toPixels()` rounds against, and the one that makes the upper
+        // bound below the only bound worth checking. `FontPackage::validate()` accepts any int16
+        // kerning adjustment and does not require `advance + kerning >= 0`, so a valid package can
+        // drive the pen left of where the run starts. Refused rather than encoded: a run's origin
+        // is its own left edge, and a glyph before it is a package whose author meant something
+        // this format cannot express.
+        if (pen < 0) {
+            report(diagnostics, std::string{recipePath}, 0, runOriginNegative,
+                   std::format("in the value for '{}', kerning moves the pen to {} font units, left of the run's origin",
+                               entry.key, pen),
+                   "A run starts at its own left edge; adjust the font package's kerning.");
+            return std::nullopt;
+        }
+
+        // Non-negative by the check above, so x is too, and only the upper bound can be exceeded.
         const std::int64_t x = toPixels(pen, font.pixelSize, font.unitsPerEm);
         if (x > std::numeric_limits<std::int16_t>::max()) {
             report(diagnostics, std::string{recipePath}, 0, runTooWide,

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -1117,27 +1117,44 @@ struct LoadedFont {
  * byte-compares, and renders wrongly on a device - which is exactly what ADR-010 and this module's
  * contract say must not happen.
  *
- * So the repertoire is declared rather than inferred, and it is deliberately narrow: the scripts
- * below are left-to-right, need no joining or reordering, and contain no combining marks, so the
- * identity walk is the whole of their shaping. Everything else - including scripts this baker
- * could one day support - is refused, because widening the model is a decision that deserves the
- * same review as the code that implements it, not a side effect of a font recipe growing a range.
+ * So the repertoire is declared rather than inferred, and what it declares is ADR-010's own v1
+ * scope: "Latin/Cyrillic/Greek LTR text with no ligatures, no GPOS, no contextual forms and no
+ * RTL/contextual behaviour". Those three scripts are left-to-right and need no joining or
+ * reordering, so once their combining marks are excluded the identity walk is the whole of their
+ * shaping. Everything else is refused - and widening this is a change to ADR-010 followed by a
+ * change here, never a side effect of a font recipe growing a range.
  *
- * The two carve-outs inside Latin-1 are not fussiness. U+00AD SOFT HYPHEN is a format character
- * whose whole meaning is conditional: it renders as nothing unless a line breaks there, and a pen
- * walk has no line breaking, so it would bake a visible hyphen into a word. It is excluded with
- * U+00A1's neighbour rather than by category, because there is no Unicode database here to ask.
+ * The carve-outs are the marks and the one format character, all excluded by range because there
+ * is no Unicode database here to ask by category:
+ *
+ * - **U+00AD SOFT HYPHEN.** A format character whose meaning is conditional: it renders as nothing
+ *   unless a line breaks there, and a pen walk has no line breaking, so it would bake a visible
+ *   hyphen into the middle of a word.
+ * - **U+0483..U+0489.** The Cyrillic block's own combining marks (Mn and Me), which belong over
+ *   the preceding base rather than after its advance - the same defect as U+0301, inside a block
+ *   that is otherwise entirely identity-safe.
+ *
+ * The blocks are the principal ones of each script rather than every block that has ever carried a
+ * Latin, Greek or Cyrillic character. Cyrillic Extended-A (U+2DE0..U+2DFF) is *entirely* combining
+ * marks and Extended-B carries several, so both are left out until somebody carves them by hand;
+ * omitting a block costs a build error, and admitting one wrongly costs a device rendering nobody
+ * reviewed.
  */
 struct RepertoireRange {
     char32_t first;
     char32_t last;
 };
 
-constexpr std::array<RepertoireRange, 4> v1Repertoire{{
+constexpr std::array<RepertoireRange, 9> v1Repertoire{{
     {U'\u0020', U'\u007E'},  // Basic Latin, printable
     {U'\u00A0', U'\u00AC'},  // Latin-1 Supplement, up to but not including the soft hyphen
     {U'\u00AE', U'\u00FF'},  // ...and past it
     {U'\u0100', U'\u024F'},  // Latin Extended-A and -B, which are contiguous
+    {U'\u1E00', U'\u1EFF'},  // Latin Extended Additional: precomposed, so no marks to attach
+    {U'\u0370', U'\u03FF'},  // Greek and Coptic
+    {U'\u0400', U'\u0482'},  // Cyrillic, up to its combining marks
+    {U'\u048A', U'\u04FF'},  // ...and past U+0483..U+0489, which are Mn and Me
+    {U'\u0500', U'\u052F'},  // Cyrillic Supplement, which is letters only
 }};
 
 [[nodiscard]] constexpr bool inV1Repertoire(char32_t point) noexcept {
@@ -1171,7 +1188,8 @@ constexpr std::array<RepertoireRange, 4> v1Repertoire{{
             report(diagnostics, std::string{recipePath}, 0, unsupportedRepertoire,
                    std::format("the value for '{}' contains U+{:04X}, which this baker's shaping model does not cover",
                                entry.key, static_cast<std::uint32_t>(point)),
-                   "v1 positions Latin left to right with no joining, reordering or mark attachment.");
+                   "ADR-010's v1 scope is Latin, Greek and Cyrillic left to right, with no joining, "
+                   "reordering or mark attachment.");
             return std::nullopt;
         }
 

--- a/tools/text/TextBake.cpp
+++ b/tools/text/TextBake.cpp
@@ -150,7 +150,7 @@ json::Value Recipe::toOptions() const {
         // Copying them here would make one edited translation appear in three places of the same
         // artifact diff, which makes the diff harder to read rather than more complete.
         static_cast<void>(options.set("font", json::Value::string(fontPackage)));
-        static_cast<void>(options.set("strings", json::Value::integer(strings.size())));
+        static_cast<void>(options.set("strings", json::Value::integer(static_cast<std::int64_t>(strings.size()))));
     }
     if (font.has_value()) {
         // Every resolved knob, because ADR-007's rule is that a silently changed default must not

--- a/tools/text/TextBake.cppm
+++ b/tools/text/TextBake.cppm
@@ -74,9 +74,14 @@
  * succeeds while the pen walk is wrong - isolated unjoined letters running the wrong way, an
  * accent parked after the base rather than over it. Either would produce a package that validates,
  * byte-compares across both toolchains, and renders incorrectly on a device, which is precisely
- * the outcome ADR-010 exists to prevent. So a code point outside the repertoire this baker can
- * actually position is refused *before* the font is consulted, and widening that repertoire is a
- * reviewed change to the baker rather than a side effect of a font recipe growing a range.
+ * the outcome ADR-010 exists to prevent. So a code point outside the repertoire is refused
+ * *before* the font is consulted.
+ *
+ * The repertoire is ADR-010's v1 scope and nothing else - Latin, Greek and Cyrillic, left to
+ * right, with those blocks' combining marks carved out. It is not this file's to widen or narrow:
+ * a baker enforcing less than the ADR ships a rendering nobody reviewed, and one enforcing more
+ * refuses text the accepted architecture promises. Both are the same defect in opposite
+ * directions, so a change to the repertoire is a change to ADR-010 first.
  *
  * The pen accumulates in **font units** and converts to pixels per glyph, rather than converting
  * each advance and accumulating pixels. Both are defensible; only the first keeps a rounding error

--- a/tools/text/TextBake.cppm
+++ b/tools/text/TextBake.cppm
@@ -31,22 +31,57 @@
  * for this explicitly, and the reason is worth restating: if verify were a second implementation,
  * a CI check comparing a baker against a different baker would prove nothing about either.
  *
- * ## A recipe
+ * ## A text recipe
  *
  * ```toml
  * [package]
  * id      = "label-welcome"
- * atlas   = "roboto-ui"     # references a font package id produced by S4 (#160)
+ * atlas   = "roboto-ui"     # the font package id these runs are positioned against
  * locale  = "en-US"
+ * font    = "generated/font/roboto-ui/package.json"
  * sidecar = "runs.bin"
+ *
+ * [strings]
+ * keys   = ["STR-TITLE", "STR-SUBTITLE"]
+ * values = ["Welcome",   "Select a patient"]
  * ```
  *
- * No `[runs]` table at S1: positioned glyph runs are produced by the `.medui` compiler (#15),
- * not by this baker. S4 (#160) extends the recipe with the font pipeline's inputs; S5 (#161)
- * adds the restricted-charset validation that turns "no shaping on device" into a build-time
- * error. Two parallel arrays rather than `[[runs]]` array-of-tables TOML would normally use:
+ * Two parallel arrays rather than the `[[strings]]` array-of-tables TOML would normally use:
  * `mdux.tools.toml` implements a deliberate subset with no arrays of tables - see
  * `tools/common/Toml.cppm:13`, where it is listed as unsupported on purpose.
+ *
+ * A key becomes a run id, which is what `t("STR-TITLE")` resolves against in a `.medui` source.
+ * The value is the translation for this package's one locale; a second locale is a second recipe
+ * and a second package, because a text package is one locale's worth of runs (`mdux.text.schema`).
+ *
+ * S1 (#157) landed the recipe and the surrounding machinery with the run list empty, because
+ * nothing could position a run until a font package existed to position it against. #235 fills
+ * it in: `font` names that package, and the baker walks each value's code points through its
+ * glyph table.
+ *
+ * ## Positioning, and why it is arithmetic rather than shaping
+ *
+ * ADR-010 puts shaping on the host, and this is the host side of it - but "shaping" is more than
+ * this baker does and more than the format can carry. A v1 record is a glyph and a position, so
+ * what happens here is a pen walk: look each code point up in the font package, emit a record at
+ * the pen, advance the pen by the glyph's advance width plus whatever kerning the package baked
+ * for the pair. No reordering, no substitution, no ligatures, no bidirectional resolution. A
+ * script needing any of those is not writable by this baker, and the honest form of that limit is
+ * that it produces no package rather than a plausible wrong one - the charset check refuses every
+ * code point the font cannot draw, which includes every script nobody baked.
+ *
+ * The pen accumulates in **font units** and converts to pixels per glyph, rather than converting
+ * each advance and accumulating pixels. Both are defensible; only the first keeps a rounding error
+ * from compounding along a line, so a long string does not drift by a pixel per word. The
+ * conversion is integer throughout - `(pen * pixelSize + unitsPerEm / 2) / unitsPerEm`, in
+ * `std::int64_t` - because the sidecar is committed bytes compared across toolchains, and a float
+ * would make the artifact depend on the host's rounding mode.
+ *
+ * A record is emitted for every code point, including the blanks. Neither consumer draws them -
+ * `mdux::text::draw::recordRun()` skips a glyph with no coverage, and #195's budget measurement
+ * skips exactly the same ones - so the six bytes buy nothing at run time. They buy something at
+ * review time: a run's record count is its character count, so a sidecar that lost a character is
+ * visible in `package.json` as a byte length that no longer matches the string.
  */
 module;
 
@@ -97,6 +132,16 @@ struct FontSpec {
     [[nodiscard]] std::uint32_t codePointCount() const noexcept;
 };
 
+/// One entry of a text recipe's `[strings]` table: the key a `.medui` source names with
+/// `t("...")`, and the translation for this package's locale.
+///
+/// The key becomes the run id in `package.json`, so it inherits the schema's rules for one:
+/// non-empty, and unique within the package.
+struct TextString {
+    std::string key;
+    std::string text;
+};
+
 /// A parsed and resolved recipe. Every default is expanded here rather than at the point of use,
 /// so `report.json`'s `options` records what the bake actually did - ADR-007's rule that a
 /// silently changed default must not leave every report looking unchanged.
@@ -105,6 +150,14 @@ struct Recipe {
     std::string atlas;
     std::string locale;
     std::string sidecar{"runs.bin"};
+
+    /// Repository-relative path to the committed font package these runs are positioned against.
+    /// Empty for a font recipe, and for a text recipe carrying no strings.
+    std::string fontPackage;
+
+    /// The strings to position, in recipe order - which is the order their runs appear in the
+    /// sidecar, so the file reads in the order the recipe was written.
+    std::vector<TextString> strings;
 
     /// Set when this recipe carries a `[charset]` table, which is what makes it a font recipe.
     /// `run()` dispatches on it.
@@ -152,20 +205,24 @@ struct BakeOutputs {
  * @brief Produces every output byte for `recipe`.
  *
  * Dispatches on `Recipe::font`. A font recipe rasterises its charset, packs the glyphs and fills
- * the sidecar with the atlas sheet; a text recipe produces a run package, which at S1 is still a
- * no-run one whose sidecar is zero bytes until the run pipeline lands.
+ * the sidecar with the atlas sheet; a text recipe reads the font package its recipe names and
+ * positions one run per string, filling the sidecar with v1 records. A text recipe with no
+ * `[strings]` table still produces a valid package, with no runs and an empty sidecar.
  *
  * @param recipe      the resolved recipe
  * @param recipePath  repository-relative, for `report.json`'s recipe record and for diagnostics
  * @param recipeBytes the recipe's own bytes, for its digest
- * @param root        the directory a font recipe's `source` resolves against - the repository
- *                    root. The path is confined to it: absolute paths and `..` escapes are
- *                    refused rather than followed.
+ * @param root        the directory a recipe's file references resolve against - the repository
+ *                    root, for a font recipe's `source` and a text recipe's `font` alike. Both
+ *                    are confined to it: absolute paths and `..` escapes are refused rather than
+ *                    followed.
  * @param diagnostics appended to on any problem
  *
  * Returns nullopt when the recipe fails to build a valid package - which for a font recipe
  * includes a character the font cannot draw, an outline it refuses, or a glyph set the atlas
- * budget cannot hold. Every such refusal appends its own `TXT` diagnostic.
+ * budget cannot hold, and for a text recipe includes a font package it cannot read, a locale that
+ * package does not approve, and a string reaching a code point nobody baked. Every such refusal
+ * appends its own `TXT` diagnostic.
  */
 [[nodiscard]] std::optional<BakeOutputs> run(const Recipe& recipe, std::string_view recipePath,
                                               std::span<const std::byte> recipeBytes,

--- a/tools/text/TextBake.cppm
+++ b/tools/text/TextBake.cppm
@@ -65,10 +65,18 @@
  * this baker does and more than the format can carry. A v1 record is a glyph and a position, so
  * what happens here is a pen walk: look each code point up in the font package, emit a record at
  * the pen, advance the pen by the glyph's advance width plus whatever kerning the package baked
- * for the pair. No reordering, no substitution, no ligatures, no bidirectional resolution. A
- * script needing any of those is not writable by this baker, and the honest form of that limit is
- * that it produces no package rather than a plausible wrong one - the charset check refuses every
- * code point the font cannot draw, which includes every script nobody baked.
+ * for the pair. No reordering, no substitution, no ligatures, no mark attachment, no bidirectional
+ * resolution.
+ *
+ * The limit is enforced, not merely documented, and it is enforced against a **declared
+ * repertoire** rather than against the font's charset. The distinction is the whole point: a font
+ * package is free to bake Arabic, or a combining acute, and for both of those the glyph lookup
+ * succeeds while the pen walk is wrong - isolated unjoined letters running the wrong way, an
+ * accent parked after the base rather than over it. Either would produce a package that validates,
+ * byte-compares across both toolchains, and renders incorrectly on a device, which is precisely
+ * the outcome ADR-010 exists to prevent. So a code point outside the repertoire this baker can
+ * actually position is refused *before* the font is consulted, and widening that repertoire is a
+ * reviewed change to the baker rather than a side effect of a font recipe growing a range.
  *
  * The pen accumulates in **font units** and converts to pixels per glyph, rather than converting
  * each advance and accumulating pixels. Both are defensible; only the first keeps a rounding error


### PR DESCRIPTION
First of two for #235. This is the tool half; the committed artifact and the screen that carries a `Label` follow on top of it.

## What was missing

`mdux-textbake` has produced text packages since #157, but never a *run*. The text path assembled a package with an empty run list and a comment pointing elsewhere for the runs — and the two docs disagreed about where: `TextBake.cppm` said the `.medui` compiler produced them, `TextBudget.cppm` said "the text package already holds the runs `mdux-textbake` positioned". Neither was true. Nothing could position a run until a font package existed to position it against, and one has since #160.

## What this adds

```toml
[package]
id     = "label-welcome"
atlas  = "roboto-ui"
locale = "en-US"
font   = "generated/font/roboto-ui/package.json"

[strings]
keys   = ["STR-TITLE", "STR-SUBTITLE"]
values = ["Welcome",   "Select a patient"]
```

A key becomes a run id, which is what `t("STR-KEY")` resolves against. A value becomes v1 records: look each code point up in the font package, emit a record at the pen, advance by the advance width plus whatever kerning the package baked for the pair.

**It is a pen walk, not shaping** — no reordering, substitution, ligatures or bidi. A script needing any of those is not writable by this baker, and the honest form of that limit is producing no package rather than a plausible wrong one. ADR-010 leaves the runtime no fallback, so a code point the font cannot draw is `TXT024` rather than a substitution.

**The pen accumulates in font units** and converts per glyph, rather than converting each advance and accumulating pixels — only the first keeps a rounding error from compounding along a line. Integer throughout: the sidecar is committed bytes compared across toolchains, and a float would make the artifact depend on the host.

**A record per code point, blanks included.** Neither consumer draws them, so the six bytes buy nothing at run time; they buy something at review time, since a run' record count is its character count.

## Evidence

The font package is the bake' one input, digested from the bytes that were *parsed* rather than from a second read — so re-baking the font invalidates the text package rather than leaving it describing an atlas that moved, and a file that changed mid-bake cannot produce a report attesting to a bake that never happened.

## Tests

A three-glyph fixture font written through `mdux::font::FontPackage::write()` (so a fixture that stops being a legal package fails here rather than teaching the baker to accept one), with `unitsPerEm` 1000 against `pixelSize` 10 — one pixel is exactly 100 font units, so the expected x of every record is readable by hand. The expected bytes are derived from the fixture' advances rather than from the implementation' formula: a test that recomputed the formula would agree with a wrong one.

Ten rejection cases, each pinned to its stable code, covering the six new diagnostics plus the two path escapes.

## Not verified locally

Still no local build: Homebrew now ships GCC 16, and the configure now succeeds, but its `bits/std.cc` is a **1-byte stub**, so `import std` has nothing to scan. CI is the compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized string entries to text recipes.
  * Added font-package loading and validation for glyph availability, locale, path safety, and package integrity.
  * Generated deterministic positioned glyph data, including advances and kerning, for baked text.
  * Added font-package details to bake reports and package metadata.

* **Bug Fixes**
  * Added diagnostics for unsupported scripts, combining marks, negative pen positions, malformed recipes, invalid packages, atlas mismatches, and excessive run widths.
  * Strengthened repository path protection, including symlink and cross-platform path escapes.
  * Preserved empty-text and legacy recipe support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->