### PR TITLE
Draw a Label, so a compiled screen's text reaches pixels [#242]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -37,11 +37,14 @@ font approves, and the screen recipe's `[text]` table naming them — a locale t
 no package listed is a build error, because a budget checked against fewer locales than were approved
 is a claim nobody made.
 
-One limit is worth knowing before you write a screen: the runtime draws a `Panel`; every other
-component, a `Label` included, is visited, counted in `FrameStats::deferred` and left undrawn.
-Drawing text means joining a locale-free compiled screen to a text package for the locale the device
-is running, which is [#17](https://github.com/ambroise-leclerc/MduX/issues/17); live-data components
-have no geometry until the frame does.
+The runtime draws a `Panel` and, given a `TextBinding`, a `Label` (#242) — the join a locale-free
+compiled screen needs to reach glyphs: the font package, the text package for the locale the device
+is running, and its sidecar. Without one, a label is deferred rather than refused.
+
+One limit is worth knowing before you write a screen: every other component is visited, counted in
+`FrameStats::deferred` and left undrawn. A `Button` is more than its text — it has a face nothing in
+this project has decided — and live-data components have no geometry until the frame does. Both are
+[#17](https://github.com/ambroise-leclerc/MduX/issues/17).
 
 The HTML/CSS path that used to stand in for all of this - `UiFileWatcher::loadContent()`, which
 sniffed a file extension and stored the file as a string, with no parsing, layout or rendering

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -63,8 +63,8 @@ A `.medui` file builds something in MduX today, and it reaches the screen: regis
 `mdux_compile_screen()` and it becomes a committed, byte-compared artifact plus generated C++ a
 device links, which the governed runtime draws and `ScreenPixelTests` compares pixel by pixel under
 lavapipe. It carries text too, since #235: a `t("STR-KEY")` compiles, and the box holding it is
-measured against every approved locale's widest translation. What it cannot yet do is *draw* that
-text, for the reason above.
+measured against every approved locale's widest translation. Since #242 the runtime draws it — bind
+the packages with `TextBinding::create()` and a label's glyphs reach the frame.
 
 ## Grammar shape
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ target ever reaches Vulkan or a windowing library.
 
 **What it is not:** a UI toolkit. The component dictionary is closed and compiled — a `Label`, a
 `Button`, a `NumericDisplay` and the rest are validated, laid out and budget-checked at build time —
-but the runtime draws only a `Panel`, so nothing else has an appearance yet. See
+but the runtime draws only a `Panel` and a `Label`, so most of the dictionary has no appearance
+yet. See
 [Implementation status](#implementation-status). It is also not a quality-management system, a risk
 engine, or a lifecycle framework; there is no `mdux::risk`, `mdux::qms` or `mdux::lifecycle`
 namespace, and no code here generates a Design History File, a Risk Management File, or an audit
@@ -171,11 +172,13 @@ chain and compares the result pixel by pixel under lavapipe in CI.
 A **font** package and a **text** package are both baked and committed
 (`generated/font/dejavu-ui/`, `generated/text/endoscope-monitor-en-us/`), so the committed screen
 carries a `t("STR-KEY")` and its box is measured, at build time, against the widest translation every
-approved locale holds. One limit is worth stating beside that: the runtime draws a `Panel` while
-counting every other component as deferred — drawing text means joining a locale-free screen to a
-text package at run time, which is [#17](https://github.com/ambroise-leclerc/MduX/issues/17), and
-live-data components have no geometry until a frame exists. The committed screen therefore renders
-one bar — from a file an author wrote, through every stage, with nothing hand-carried between them.
+approved locale holds, and its label reaches the display: the governed runtime joins the compiled
+screen to the text package for the locale it is running and records the baked glyph runs
+([#242](https://github.com/ambroise-leclerc/MduX/issues/242)). One limit is worth stating beside
+that: the remaining components are still counted as deferred, because a `Button` is more than its
+text and live-data components have no geometry until a frame exists
+([#17](https://github.com/ambroise-leclerc/MduX/issues/17)). The committed screen renders a bar and
+a title — from files an author wrote, through every stage, with nothing hand-carried between them.
 
 The HTML/CSS path that earlier revisions described was **deleted** by
 [#127](https://github.com/ambroise-leclerc/MduX/issues/127) — `MedicalUiRenderer::render()` recorded

--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ Derived from the targets and tests that build on `develop`.
 | `mdux-shaderbake`, `mdux-shaderemit` | Implemented | SPIR-V reflection, byte-verified packages, generated C++ |
 | `mdux-mlbake` | Implemented | safetensors import, golden generation, byte-verified model packages |
 | `MduXMeduiLib` | Implemented | The `.medui` compiler end to end: parsing, semantic validation, integer-only bounded layout, per-locale text budgets, golden references, the canonical package, two C++ emitters, and the `mdux-meduic` / `mdux-medui-check` tools ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
+| Text and glyph rendering | Implemented | host-side shaping into baked runs, an R8 coverage atlas, and a governed draw path; a compiled screen's `Label` is joined to a text package at run time and drawn ([#14](https://github.com/ambroise-leclerc/MduX/issues/14), [#242](https://github.com/ambroise-leclerc/MduX/issues/242)). A `Button`'s text is not drawn, because a button is more than its text ([#17](https://github.com/ambroise-leclerc/MduX/issues/17)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |
 | Software Development File | Documentation only | templates and records under `software_development_file/` |
 | Risk management, QMS, lifecycle *code* | **Not started** | no `mdux::risk`, `mdux::qms` or `mdux::lifecycle` exists |
 | **Not started** | | |
-| Text and glyph rendering | Planned | [#14](https://github.com/ambroise-leclerc/MduX/issues/14) |
 | Content components (`SignalTrace`, `StatusIndicator`, …) | Planned | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) |
 
 `.medui` reaches pixels today, and the path is built rather than planned. An authored screen is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -265,7 +265,7 @@ tracking issue; the issue is authoritative for what remains.
 
 | Planned | Issue | Note |
 |---|---|---|
-| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | complete front to back: parsing, semantic validation, bounded layout, text budgets, golden references, the canonical package, both C++ emitters, `mdux-meduic`, `mdux-medui-check`, and a governed runtime that draws a compiled screen. One committed screen reaches pixels in `ScreenPixelTests`, carrying a text key measured against a committed text package (#235); what remains is the components' own geometry (#17) |
+| `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | complete front to back: parsing, semantic validation, bounded layout, text budgets, golden references, the canonical package, both C++ emitters, `mdux-meduic`, `mdux-medui-check`, and a governed runtime that draws a compiled screen. One committed screen reaches pixels in `ScreenPixelTests`, carrying a text key measured against a committed text package (#235) and drawn from it by the governed runtime (#242); what remains is the other components' own geometry (#17) |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
 | Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
 | `constexpr` ML package emitter | [#153](https://github.com/ambroise-leclerc/MduX/issues/153) | would remove the startup JSON parse |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,8 +23,9 @@ device links without a parser. The first compiled screen is committed under
 cover. With #201 the chain reaches pixels: `ScreenPixelTests` renders the committed screen through
 the governed runtime and compares the frame pixel by pixel under lavapipe. What the epic leaves for
 its successors is content rather than path: #235 has since baked a text package, so the committed
-screen carries a `t("STR-KEY")` measured against it, and what is left is that the runtime draws a
-`Panel` while counting every other component - the label included - as deferred (#17). The golden
+screen carries a `t("STR-KEY")` measured against it, and #242 has since drawn it: the governed
+runtime joins the compiled screen to a text package and the title reaches the display. What is left
+is the rest of the dictionary, still counted as deferred (#17). The golden
 sidecar gains a static consumer in `ScreenPixelTests` and still awaits the rendered one ADR-012
 describes, which is #16 over content #17 teaches to draw.
 
@@ -45,7 +46,7 @@ the whole of Track C.
 
 | Area | MduX today | TrustSC today |
 |---|---|---|
-| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build, and an authored screen reaches pixels through the governed runtime in `ScreenPixelTests` (#201). A text package is baked and the committed screen carries a `t("STR-KEY")` measured against it (#235). What is still ahead is content rather than path: the components' own geometry (#17). | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
+| UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build, and an authored screen reaches pixels through the governed runtime in `ScreenPixelTests` (#201). A text package is baked, the committed screen carries a `t("STR-KEY")` measured against it (#235), and the governed runtime draws it (#242) - so a label authored in `.medui` reaches pixels through every stage. What is still ahead is content rather than path: the rest of the components' own geometry (#17). | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
 | Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Seven artifacts committed under `generated/`, re-derived and byte-compared on both CI legs. | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -54,6 +54,13 @@
  * property the compiler checked and the property the frame has the identical property. Centring, or
  * a baseline offset, would leave the build-time guarantee true of a rectangle nobody draws.
  *
+ * That argument holds only while the bound package is the one the compiler measured, and nothing in
+ * the artifacts says so (see `TextBinding`). So the same box is measured again here and refused as
+ * `TextOverflowsNode` when it does not fit, which costs one comparison over a walk the placement
+ * needs anyway. The build-time check remains the one that reports a *useful* diagnostic, at the
+ * right time, to the person who can fix it; this one exists so that a screen can never draw text
+ * over its neighbours because it was joined to the wrong package.
+ *
  * Two consequences worth stating rather than discovering. Leading placement means a right-to-left
  * locale would need a different rule - and cannot arrive without one, since `mdux-textbake` refuses
  * every RTL code point (ADR-010's v1 repertoire). And ink placement means a label whose text has no
@@ -122,7 +129,21 @@ enum class ScreenError : std::uint8_t {
     UnknownTextKey,       ///< a bound text package carries no run for a node's `textKey`
     MalformedTextRun,     ///< a run's range leaves the sidecar, or its bytes are not whole records
     RunTooLong,           ///< a run holds more than `maxGlyphsPerRun` records
+    AtlasMismatch,        ///< the text package was baked against a different font package
+    SidecarMismatch,      ///< the sidecar is not the one the text package describes
+    TextOverflowsNode,    ///< a run's ink is wider or taller than the node that names it
 };
+
+// The two token failures are kept apart because the schema keeps them apart, and for its reason: a
+// malformed name is a defect in whatever emitted the screen, while an absent one is a table that
+// does not define it. Collapsing them would tell an integrator to look in the wrong place.
+
+[[nodiscard]] std::string_view describe(ScreenError error) noexcept;
+
+// `AtlasMismatch` and `SidecarMismatch` are `create()`'s, not a frame's: both are properties of the
+// three artifacts a caller bound together, decided once. `TextOverflowsNode` is a frame's, and is
+// the check that makes the placement rule below safe against a binding this module cannot
+// authenticate - see `TextBinding` for what that means and what it does not.
 
 /**
  * @brief The largest run this runtime will draw, in records.
@@ -139,51 +160,93 @@ enum class ScreenError : std::uint8_t {
 inline constexpr std::size_t maxGlyphsPerRun = 256;
 
 /**
- * @brief The packages a locale-free compiled screen is joined to so its text can be drawn.
+ * @brief The packages a locale-free compiled screen is joined to, once its consistency is proved.
  *
  * A compiled screen carries `textKey` rather than glyphs (ADR-011 as amended by #203), which is what
  * lets one screen serve every approved locale. The join is the device's, once, for the locale it is
  * running - and it is passed rather than looked up because this module performs no I/O and holds no
  * state.
  *
- * All three members travel together and are checked together. A default-constructed binding means
- * "this caller has no text", which is not an error: every text node is deferred, exactly as it was
- * before #242, and a screen with no text nodes costs nothing either way.
+ * ## Why this is not an aggregate
  *
- * Nothing here is owned. The packages outlive the frame - on a device they are static - and the
- * spans are the caller's storage, so `render()` allocates nothing by construction rather than by
+ * Three artifacts have to agree before any of them can be trusted, and none of the agreements can be
+ * checked cheaply enough to repeat per frame:
+ *
+ * - the text package must be the one baked against *this* font, or the run records index a glyph
+ *   table that assigns different shapes to the same numbers, and the frame draws a plausible
+ *   sentence made of the wrong letters;
+ * - the sidecar must be the one the package describes, which `sidecarByteLength` and
+ *   `sidecarSha256` state exactly - a different sidecar of the same length passes every structural
+ *   check and renders different words;
+ * - every run's range must lie inside it, be a whole number of records, and hash to what the
+ *   package recorded.
+ *
+ * So `create()` proves all of that once and is the only way to obtain a bound `TextBinding`. What
+ * `render()` does per frame is a key lookup and a bounds comparison, which is what keeps the
+ * bounded-work claim intact. A default-constructed binding is *unbound* and means "this caller has
+ * no text": every text node is deferred, exactly as before #242, which is not an error.
+ *
+ * ## What it still does not prove
+ *
+ * That this is the package the compiler measured. A second, individually valid package can carry the
+ * same key against the same font with different wording, and nothing in the artifacts links a
+ * compiled screen to the packages #195 checked it against. `render()` closes the *consequence* -
+ * text wider than its node is refused rather than drawn over its neighbours - but the identity
+ * itself needs the compiled screen to carry it, which is a change to what a screen emits (ADR-012)
+ * and is tracked separately.
+ *
+ * Nothing here is owned. The packages outlive the frame - on a device they are static - and the span
+ * is the caller's storage, so `render()` allocates nothing by construction rather than by
  * discipline.
  */
-struct TextBinding {
-    /// The font the runs were positioned against. Its glyph table supplies every rectangle's atlas
-    /// slot and origin.
-    const mdux::font::FontPackage* font{nullptr};
+class TextBinding {
+public:
+    /// An unbound binding: no text, every text node deferred.
+    constexpr TextBinding() noexcept = default;
 
-    /// The text package for the locale being run. Its run ids are the `textKey`s a screen names.
-    const mdux::text::TextPackage* text{nullptr};
+    /**
+     * @brief Proves `font`, `text` and `runs` describe each other, or says which one does not.
+     *
+     * Hashes the sidecar, so it is linear in its size - once, at start-up, never in a frame.
+     *
+     * @param font the font package the runs were positioned against
+     * @param text the text package for the locale being run
+     * @param runs the sidecar bytes `text` addresses ranges of
+     */
+    [[nodiscard]] static mdux::core::Result<TextBinding, ScreenError> create(const mdux::font::FontPackage& font,
+                                                                             const mdux::text::TextPackage& text,
+                                                                             std::span<const std::byte>     runs) noexcept;
 
-    /// The sidecar bytes `text` addresses ranges of - the committed `runs.bin`, or a mapping of it.
-    std::span<const std::byte> runs{};
+    /// Whether this binding carries packages. False for a default-constructed one.
+    [[nodiscard]] constexpr bool bound() const noexcept { return font_ != nullptr && text_ != nullptr; }
 
-    /// Whether all three are present. A partial binding is treated as no binding rather than as an
-    /// error: a caller assembling one incrementally should see deferred nodes, not a refused frame.
-    [[nodiscard]] constexpr bool complete() const noexcept {
-        return font != nullptr && text != nullptr && !runs.empty();
-    }
+    [[nodiscard]] constexpr const mdux::font::FontPackage* font() const noexcept { return font_; }
+    [[nodiscard]] constexpr const mdux::text::TextPackage* text() const noexcept { return text_; }
+    [[nodiscard]] constexpr std::span<const std::byte> runs() const noexcept { return runs_; }
+
+private:
+    constexpr TextBinding(const mdux::font::FontPackage* font, const mdux::text::TextPackage* text,
+                          std::span<const std::byte> runs) noexcept
+        : font_{font}, text_{text}, runs_{runs} {}
+
+    const mdux::font::FontPackage* font_{nullptr};
+    const mdux::text::TextPackage* text_{nullptr};
+    std::span<const std::byte>     runs_{};
 };
 
-// The two token failures are kept apart because the schema keeps them apart, and for its reason: a
-// malformed name is a defect in whatever emitted the screen, while an absent one is a table that
-// does not define it. Collapsing them would tell an integrator to look in the wrong place.
-
-[[nodiscard]] std::string_view describe(ScreenError error) noexcept;
+// The guarantee `create()` is documented to give, held by the language rather than by discipline.
+// A class with private data members is not an aggregate, so `TextBinding{...}` cannot brace-elide
+// its way past the checks - and if a future edit makes the members public "for convenience", this
+// fails here rather than silently reopening the bypass.
+static_assert(!std::is_aggregate_v<TextBinding>, "a TextBinding must only be obtainable through create()");
 
 /**
  * @brief What one frame did, and what it left undone.
  *
  * `deferred` is the honest half: it counts nodes this runtime visited and could not paint, for the
  * reasons the module comment gives one by one. A caller that expects a screen to be fully drawn can
- * assert it is zero; today, on any screen carrying text or live data, it will not be.
+ * assert it is zero; today, on any screen carrying live data, it will not be - and on one carrying
+ * text it will not be either unless a `TextBinding` was supplied.
  */
 struct FrameStats {
     std::uint32_t nodes{0};     ///< nodes visited

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -14,14 +14,18 @@
  *
  * ## What this runtime draws, and what it does not
  *
- * It draws a `Panel`: a filled rectangle in the colour its token resolves to. Every other component
- * is visited, counted, and left undrawn - and that is a stated limit rather than an omission, so it
- * is worth saying exactly why for each.
+ * It draws a `Panel`: a filled rectangle in the colour its token resolves to. It draws a `Label`
+ * too, when the caller supplies the packages a locale-free screen has to be joined to. Every other
+ * component is visited, counted, and left undrawn - and that is a stated limit rather than an
+ * omission, so it is worth saying exactly why for each.
  *
- * - `Label`, `Button`, `CriticalButton`, `TextInput` draw **text**. A compiled screen carries a
- *   `textKey`, not glyphs (ADR-011), so drawing them is a join with a baked text package for the
- *   locale the device is running. No text package is baked in this repository yet, so the join has
- *   nothing to join to; it belongs with #201, which lands the text half.
+ * - `Label` draws **text**, and does so through `TextBinding` (#242). A compiled screen carries a
+ *   `textKey`, not glyphs (ADR-011), so drawing one is a join with a baked text package for the
+ *   locale the device is running. Without a binding there is nothing to join to and the node is
+ *   deferred exactly as before, which is also what a screen with no text costs: nothing.
+ * - `Button`, `CriticalButton`, `TextInput` carry text keys as well, and are still deferred. Their
+ *   text is not the whole of their appearance - a button has a face, a text input has a caret and a
+ *   selection - and this module will not invent those. They arrive with #17.
  * - `Clock`, `NumericDisplay`, `SignalTrace`, `StatusIndicator` draw from **live data**. Their
  *   geometry does not exist until the frame does - that is ADR-012's reason a screen bakes layout
  *   rather than vertices - so what they paint is a function of a sample this module is not given.
@@ -35,6 +39,26 @@
  * authoritative over a question it has no evidence for, so it counts what it cannot decide and says
  * so in `FrameStats::deferred`. A device integrator sees "eleven nodes, one drawn" rather than a
  * screen that quietly renders less than it looks like it should.
+ *
+ * ## Where a label's glyphs go, and why that is not an invention
+ *
+ * Drawing text needs one decision this module cannot avoid making: where the run sits inside the
+ * node's rectangle. The shared component model does not say - it constrains which fields a `Label`
+ * carries and that its text must fit its box, and stops there - and the font package carries no
+ * ascent, so there is no baseline metric to derive a placement from either.
+ *
+ * The rule here is therefore chosen, and chosen to be the one that is **already validated**: the
+ * run's *ink* box is placed at the node's top-left corner. #195 measures ink - the union of the
+ * rectangles the atlas actually paints, blanks skipped - against the node's resolved bounds, and
+ * refuses the screen when it does not fit. Placing that same box at that same origin makes the
+ * property the compiler checked and the property the frame has the identical property. Centring, or
+ * a baseline offset, would leave the build-time guarantee true of a rectangle nobody draws.
+ *
+ * Two consequences worth stating rather than discovering. Leading placement means a right-to-left
+ * locale would need a different rule - and cannot arrive without one, since `mdux-textbake` refuses
+ * every RTL code point (ADR-010's v1 repertoire). And ink placement means a label whose text has no
+ * ink at all - a single space - draws nothing and is *not* deferred: it was joined, measured, and
+ * found to paint nothing, which is a different fact from having no package to join to.
  *
  * ## Bounded work, and the counter that proves it
  *
@@ -52,11 +76,16 @@
  *
  * What these tests establish is bounded, and the bound is worth stating rather than implying.
  * `steps` is self-reported: a future inner loop that performed work without incrementing it would
- * leave all three green. What they do establish is that the work this runtime performs does not vary
- * with a node's payload or geometry at equal node count, and scales linearly with the node count.
- * Making the per-node half a fact rather than a measurement needs a type-level cap - TrustSC does it
- * with `TextRuntime::<MAX_GLYPH_COMMANDS_PER_RUN>` - and that belongs with the first component whose
- * geometry is variable, which is #17's ground rather than this module's today.
+ * leave all three green. What they do establish is that the work this runtime performs scales
+ * linearly with the node count.
+ *
+ * A `Label` is the first component whose per-node work is *not* constant: it is proportional to the
+ * run's length. This paragraph used to promise the cap that fixes it - "a type-level cap, as TrustSC
+ * does with `TextRuntime::<MAX_GLYPH_COMMANDS_PER_RUN>`, belonging with the first component whose
+ * geometry is variable" - and `maxGlyphsPerRun` is it. A run longer than that is refused rather than
+ * truncated, so per-node work is bounded by a constant a device knows before it runs, and the bound
+ * on a frame is `nodes * maxGlyphsPerRun` rather than a number that depends on what a translator
+ * wrote.
  *
  * ## Two things this deliberately does not do
  *
@@ -78,7 +107,10 @@ import std;
 import mdux.core.result;
 import mdux.core.units;
 import mdux.draw;
+import mdux.font.schema;
 import mdux.medui.schema;
+import mdux.text.draw;
+import mdux.text.schema;
 
 export namespace mdux::medui {
 
@@ -87,6 +119,57 @@ enum class ScreenError : std::uint8_t {
     MalformedColorToken,  ///< a node's colour is not of the form `Theme.Colors.<Token>`
     UnknownColorToken,    ///< well-formed, and the governed table does not define it
     BudgetExhausted,      ///< a write would exceed a `DrawBudget` this frame is held to
+    UnknownTextKey,       ///< a bound text package carries no run for a node's `textKey`
+    MalformedTextRun,     ///< a run's range leaves the sidecar, or its bytes are not whole records
+    RunTooLong,           ///< a run holds more than `maxGlyphsPerRun` records
+};
+
+/**
+ * @brief The largest run this runtime will draw, in records.
+ *
+ * The type-level cap the bounded-work section above promises. Its job is not to be generous - it is
+ * to make per-node work a constant a device can multiply by its node count before it runs, rather
+ * than a number that moves when somebody edits a translation.
+ *
+ * 256 because it is comfortably past any label a 1280px panel can hold at a legible size - the
+ * committed screen's title is 17 - while staying a number a reviewer can multiply in their head
+ * against a `DrawBudget`. A run beyond it is `RunTooLong`, never truncated: half a sentence on a
+ * medical display reads as a whole one.
+ */
+inline constexpr std::size_t maxGlyphsPerRun = 256;
+
+/**
+ * @brief The packages a locale-free compiled screen is joined to so its text can be drawn.
+ *
+ * A compiled screen carries `textKey` rather than glyphs (ADR-011 as amended by #203), which is what
+ * lets one screen serve every approved locale. The join is the device's, once, for the locale it is
+ * running - and it is passed rather than looked up because this module performs no I/O and holds no
+ * state.
+ *
+ * All three members travel together and are checked together. A default-constructed binding means
+ * "this caller has no text", which is not an error: every text node is deferred, exactly as it was
+ * before #242, and a screen with no text nodes costs nothing either way.
+ *
+ * Nothing here is owned. The packages outlive the frame - on a device they are static - and the
+ * spans are the caller's storage, so `render()` allocates nothing by construction rather than by
+ * discipline.
+ */
+struct TextBinding {
+    /// The font the runs were positioned against. Its glyph table supplies every rectangle's atlas
+    /// slot and origin.
+    const mdux::font::FontPackage* font{nullptr};
+
+    /// The text package for the locale being run. Its run ids are the `textKey`s a screen names.
+    const mdux::text::TextPackage* text{nullptr};
+
+    /// The sidecar bytes `text` addresses ranges of - the committed `runs.bin`, or a mapping of it.
+    std::span<const std::byte> runs{};
+
+    /// Whether all three are present. A partial binding is treated as no binding rather than as an
+    /// error: a caller assembling one incrementally should see deferred nodes, not a refused frame.
+    [[nodiscard]] constexpr bool complete() const noexcept {
+        return font != nullptr && text != nullptr && !runs.empty();
+    }
 };
 
 // The two token failures are kept apart because the schema keeps them apart, and for its reason: a
@@ -116,6 +199,8 @@ struct FrameStats {
  *
  * @param screen a compiled screen, normally the `constexpr` one a generated translation unit holds
  * @param list   a draw list the caller created over storage sized from `screen.budget`
+ * @param text   the packages this screen's text keys resolve against; default means "no text", and
+ *               every text node is then deferred rather than refused
  *
  * Allocation-free and `noexcept`: the list is the only storage written, and it was sized before the
  * first frame. On any error the list is restored to its state at entry.
@@ -126,6 +211,7 @@ struct FrameStats {
  * list can carry several screens; without the second check the screen's declared budget would be
  * decorative, and a mistake in a baked budget would be bypassed rather than observed.
  */
-[[nodiscard]] mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list) noexcept;
+[[nodiscard]] mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list,
+                                                                 const TextBinding& text = {}) noexcept;
 
 }  // namespace mdux::medui

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -11,6 +11,7 @@ import std;
 import mdux.core.result;
 import mdux.core.units;
 import mdux.draw;
+import mdux.evidence.digest;
 import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.text.draw;
@@ -49,14 +50,19 @@ namespace {
                             .height = static_cast<mdux::core::Px>(bounds.height)};
 }
 
-/// The top-left corner of the ink one run paints, in the run's own coordinates.
+/// The box the ink of one run occupies, in the run's own coordinates.
 ///
 /// `inked` false means the run paints nothing at all - a single space, say - which is a legitimate
 /// run rather than an error, and one that produces no rectangles.
-struct InkOrigin {
-    bool             inked{false};
-    mdux::core::Px x{0};
-    mdux::core::Px y{0};
+struct InkBox {
+    bool           inked{false};
+    mdux::core::Px left{0};
+    mdux::core::Px top{0};
+    mdux::core::Px right{0};   ///< exclusive
+    mdux::core::Px bottom{0};  ///< exclusive
+
+    [[nodiscard]] constexpr mdux::core::Px width() const noexcept { return right - left; }
+    [[nodiscard]] constexpr mdux::core::Px height() const noexcept { return bottom - top; }
 };
 
 /**
@@ -70,9 +76,9 @@ struct InkOrigin {
  * Placement arithmetic is `addGlyphRect()`'s and is not restated: `bitmapOriginX` from the pen, and
  * `bitmapOriginY` measured *up* from the baseline, hence subtracted on a downward y axis.
  */
-[[nodiscard]] mdux::core::Result<InkOrigin, ScreenError> measureInk(const mdux::font::FontPackage& font,
-                                                                     std::span<const std::byte>     records) noexcept {
-    InkOrigin origin;
+[[nodiscard]] mdux::core::Result<InkBox, ScreenError> measureInk(const mdux::font::FontPackage& font,
+                                                                 std::span<const std::byte>     records) noexcept {
+    InkBox box;
     for (std::size_t offset = 0; offset < records.size(); offset += mdux::text::draw::recordSize) {
         const auto placement = mdux::text::draw::decodeRecord(records.subspan(offset, mdux::text::draw::recordSize));
         if (!placement.has_value()) {
@@ -85,31 +91,70 @@ struct InkOrigin {
         if (glyph.isBlank()) {
             continue;
         }
-        const auto left = static_cast<mdux::core::Px>(placement->x + glyph.bitmapOriginX);
-        const auto top  = static_cast<mdux::core::Px>(placement->y - glyph.bitmapOriginY);
-        if (!origin.inked) {
-            origin = InkOrigin{.inked = true, .x = left, .y = top};
+        const auto left   = static_cast<mdux::core::Px>(placement->x + glyph.bitmapOriginX);
+        const auto top    = static_cast<mdux::core::Px>(placement->y - glyph.bitmapOriginY);
+        const auto right  = static_cast<mdux::core::Px>(left + static_cast<mdux::core::Px>(glyph.width));
+        const auto bottom = static_cast<mdux::core::Px>(top + static_cast<mdux::core::Px>(glyph.height));
+        if (!box.inked) {
+            box = InkBox{.inked = true, .left = left, .top = top, .right = right, .bottom = bottom};
             continue;
         }
-        origin.x = left < origin.x ? left : origin.x;
-        origin.y = top < origin.y ? top : origin.y;
+        box.left   = left < box.left ? left : box.left;
+        box.top    = top < box.top ? top : box.top;
+        box.right  = right > box.right ? right : box.right;
+        box.bottom = bottom > box.bottom ? bottom : box.bottom;
     }
-    return origin;
+    return box;
 }
 
 /// The run a node's `textKey` names, as a span of the bound sidecar.
 ///
-/// Both failures are the caller's binding rather than the screen's: a key the package does not carry
-/// means the wrong package was bound for this screen, and a range leaving the sidecar means the
-/// package and the bytes handed with it do not belong together. Neither can be true of a package
-/// this repository baked, and both are cheap to refuse rather than to trust.
+/// A lookup and nothing else. Every structural property of the range - inside the sidecar, a whole
+/// number of records, within the cap, hashing to what the package recorded - was established once by
+/// `TextBinding::create()`, which is what a binding *is*. Repeating them here would put a hash in a
+/// frame; not establishing them anywhere would put a `subspan()` precondition in the hands of a
+/// package nobody checked.
+///
+/// The one failure left is the screen's rather than the binding's: a key this package does not
+/// carry means the wrong locale, or the wrong package, was bound for this screen.
 [[nodiscard]] mdux::core::Result<std::span<const std::byte>, ScreenError> runFor(const TextBinding& binding,
                                                                                   std::string_view   textKey) noexcept {
-    for (const mdux::text::TextRun& run : binding.text->runs) {
-        if (run.id != textKey) {
-            continue;
-        }
-        if (run.byteEnd() > binding.runs.size()) {
+    const mdux::text::TextRun* run = binding.text()->find(textKey);
+    if (run == nullptr) {
+        return mdux::core::err(ScreenError::UnknownTextKey);
+    }
+    return binding.runs().subspan(static_cast<std::size_t>(run->byteOffset), static_cast<std::size_t>(run->byteLength));
+}
+
+}  // namespace
+
+mdux::core::Result<TextBinding, ScreenError> TextBinding::create(const mdux::font::FontPackage& font,
+                                                                 const mdux::text::TextPackage& text,
+                                                                 std::span<const std::byte>     runs) noexcept {
+    // The runs index `font.glyphs` by position, so a package baked against another font names the
+    // same numbers for different shapes. Nothing downstream can detect that: every index would still
+    // be in range, and the frame would draw a plausible sentence made of the wrong letters.
+    if (text.atlasId != font.id) {
+        return mdux::core::err(ScreenError::AtlasMismatch);
+    }
+
+    // The sidecar the package describes, exactly. Length first because it is free and rules out the
+    // common mistake; the digest because a different sidecar of the same length passes every
+    // structural check there is and renders different words.
+    if (runs.size() != text.sidecarByteLength) {
+        return mdux::core::err(ScreenError::SidecarMismatch);
+    }
+    if (mdux::evidence::sha256(runs) != text.sidecarSha256) {
+        return mdux::core::err(ScreenError::SidecarMismatch);
+    }
+
+    for (const mdux::text::TextRun& run : text.runs) {
+        // Subtraction rather than `byteOffset + byteLength`, which wraps: a hand-built package with
+        // `byteOffset = UINT64_MAX - 5` and `byteLength = 6` sums to zero and would pass an addition
+        // form, then violate `subspan()`'s precondition. This is the form `TextPackage::validate()`
+        // already uses, for the same reason - a package that reached here without going through it
+        // is exactly the case this function exists for.
+        if (run.byteOffset > runs.size() || run.byteLength > runs.size() - run.byteOffset) {
             return mdux::core::err(ScreenError::MalformedTextRun);
         }
         if (run.byteLength % mdux::text::draw::recordSize != 0) {
@@ -118,12 +163,17 @@ struct InkOrigin {
         if (run.byteLength / mdux::text::draw::recordSize > maxGlyphsPerRun) {
             return mdux::core::err(ScreenError::RunTooLong);
         }
-        return binding.runs.subspan(static_cast<std::size_t>(run.byteOffset), static_cast<std::size_t>(run.byteLength));
+        // Each run's own digest as well as the sidecar's. The sidecar hash already covers these
+        // bytes, so this catches a package whose *ranges* were rewritten to point at each other's
+        // runs - which the whole-file hash cannot see.
+        const auto slice = runs.subspan(static_cast<std::size_t>(run.byteOffset), static_cast<std::size_t>(run.byteLength));
+        if (mdux::evidence::sha256(slice) != run.sha256) {
+            return mdux::core::err(ScreenError::SidecarMismatch);
+        }
     }
-    return mdux::core::err(ScreenError::UnknownTextKey);
-}
 
-}  // namespace
+    return TextBinding{&font, &text, runs};
+}
 
 std::string_view describe(ScreenError error) noexcept {
     switch (error) {
@@ -139,6 +189,12 @@ std::string_view describe(ScreenError error) noexcept {
             return "a run's range leaves the bound sidecar, or its bytes are not whole records";
         case ScreenError::RunTooLong:
             return "a run holds more records than this runtime will draw in one node";
+        case ScreenError::AtlasMismatch:
+            return "the text package was baked against a different font package";
+        case ScreenError::SidecarMismatch:
+            return "the sidecar is not the one the text package describes";
+        case ScreenError::TextOverflowsNode:
+            return "a run's ink is larger than the node that names it";
     }
     // Unreachable for a value of the enumeration, and named rather than defaulted so that adding an
     // enumerator without a case here is a warning at this switch instead of a blank string later.
@@ -181,7 +237,7 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
         ++stats.steps;
 
         if (const auto* label = std::get_if<LabelSpec>(&node.payload); label != nullptr) {
-            if (!text.complete()) {
+            if (!text.bound()) {
                 // Nothing to join to. Deferred rather than refused: a caller that has not bound a
                 // locale yet is in a normal state, not a broken one.
                 ++stats.deferred;
@@ -199,7 +255,7 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
                 return refuse(records.error());
             }
 
-            const auto ink = measureInk(*text.font, *records);
+            const auto ink = measureInk(*text.font(), *records);
             if (!ink.has_value()) {
                 return refuse(ink.error());
             }
@@ -216,14 +272,23 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
                 continue;
             }
 
+            // The check that makes the placement rule safe against a package this module cannot
+            // authenticate. #195 proved this box fits this rectangle for the package it measured;
+            // this proves it for the package actually bound, at the cost of one comparison over a
+            // walk the placement needs anyway. See Screen.cppm for why the two are not redundant.
+            if (ink->width() > static_cast<mdux::core::Px>(node.bounds.width)
+                || ink->height() > static_cast<mdux::core::Px>(node.bounds.height)) {
+                return refuse(ScreenError::TextOverflowsNode);
+            }
+
             // The ink box's corner goes to the node's corner. `originX`/`originY` are added to every
             // record, so subtracting where the ink starts puts that corner exactly on the origin.
-            const auto originX = static_cast<mdux::core::Px>(node.bounds.x) - ink->x;
-            const auto originY = static_cast<mdux::core::Px>(node.bounds.y) - ink->y;
+            const auto originX = static_cast<mdux::core::Px>(node.bounds.x) - ink->left;
+            const auto originY = static_cast<mdux::core::Px>(node.bounds.y) - ink->top;
 
             const std::size_t verticesBefore = list.vertices().size();
             if (const auto recorded =
-                    mdux::text::draw::recordRun(list, *text.font, *records, originX, originY, toColor(*labelColour));
+                    mdux::text::draw::recordRun(list, *text.font(), *records, originX, originY, toColor(*labelColour));
                 !recorded.has_value()) {
                 // `recordRun()` rolls its own run back and this rolls the whole frame back. Its error
                 // is not forwarded: every way it can fail here is either something `runFor()` and

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -11,7 +11,10 @@ import std;
 import mdux.core.result;
 import mdux.core.units;
 import mdux.draw;
+import mdux.font.schema;
 import mdux.medui.schema;
+import mdux.text.draw;
+import mdux.text.schema;
 
 namespace mdux::medui {
 
@@ -46,6 +49,80 @@ namespace {
                             .height = static_cast<mdux::core::Px>(bounds.height)};
 }
 
+/// The top-left corner of the ink one run paints, in the run's own coordinates.
+///
+/// `inked` false means the run paints nothing at all - a single space, say - which is a legitimate
+/// run rather than an error, and one that produces no rectangles.
+struct InkOrigin {
+    bool             inked{false};
+    mdux::core::Px x{0};
+    mdux::core::Px y{0};
+};
+
+/**
+ * @brief Measures where a run's ink begins, so it can be placed where the compiler measured it.
+ *
+ * The union of the glyph rectangles' left and top edges, blanks skipped - the same quantity #195's
+ * `measureRun()` takes the full extent of, computed the same way and for the same reason: the box
+ * the build-time budget proved fits is the box this places. See Screen.cppm, "Where a label's glyphs
+ * go", for why that pairing is the decision rather than an arbitrary one.
+ *
+ * Placement arithmetic is `addGlyphRect()`'s and is not restated: `bitmapOriginX` from the pen, and
+ * `bitmapOriginY` measured *up* from the baseline, hence subtracted on a downward y axis.
+ */
+[[nodiscard]] mdux::core::Result<InkOrigin, ScreenError> measureInk(const mdux::font::FontPackage& font,
+                                                                     std::span<const std::byte>     records) noexcept {
+    InkOrigin origin;
+    for (std::size_t offset = 0; offset < records.size(); offset += mdux::text::draw::recordSize) {
+        const auto placement = mdux::text::draw::decodeRecord(records.subspan(offset, mdux::text::draw::recordSize));
+        if (!placement.has_value()) {
+            return mdux::core::err(ScreenError::MalformedTextRun);
+        }
+        if (placement->packageIndex >= font.glyphs.size()) {
+            return mdux::core::err(ScreenError::MalformedTextRun);
+        }
+        const mdux::font::GlyphRecord& glyph = font.glyphs[placement->packageIndex];
+        if (glyph.isBlank()) {
+            continue;
+        }
+        const auto left = static_cast<mdux::core::Px>(placement->x + glyph.bitmapOriginX);
+        const auto top  = static_cast<mdux::core::Px>(placement->y - glyph.bitmapOriginY);
+        if (!origin.inked) {
+            origin = InkOrigin{.inked = true, .x = left, .y = top};
+            continue;
+        }
+        origin.x = left < origin.x ? left : origin.x;
+        origin.y = top < origin.y ? top : origin.y;
+    }
+    return origin;
+}
+
+/// The run a node's `textKey` names, as a span of the bound sidecar.
+///
+/// Both failures are the caller's binding rather than the screen's: a key the package does not carry
+/// means the wrong package was bound for this screen, and a range leaving the sidecar means the
+/// package and the bytes handed with it do not belong together. Neither can be true of a package
+/// this repository baked, and both are cheap to refuse rather than to trust.
+[[nodiscard]] mdux::core::Result<std::span<const std::byte>, ScreenError> runFor(const TextBinding& binding,
+                                                                                  std::string_view   textKey) noexcept {
+    for (const mdux::text::TextRun& run : binding.text->runs) {
+        if (run.id != textKey) {
+            continue;
+        }
+        if (run.byteEnd() > binding.runs.size()) {
+            return mdux::core::err(ScreenError::MalformedTextRun);
+        }
+        if (run.byteLength % mdux::text::draw::recordSize != 0) {
+            return mdux::core::err(ScreenError::MalformedTextRun);
+        }
+        if (run.byteLength / mdux::text::draw::recordSize > maxGlyphsPerRun) {
+            return mdux::core::err(ScreenError::RunTooLong);
+        }
+        return binding.runs.subspan(static_cast<std::size_t>(run.byteOffset), static_cast<std::size_t>(run.byteLength));
+    }
+    return mdux::core::err(ScreenError::UnknownTextKey);
+}
+
 }  // namespace
 
 std::string_view describe(ScreenError error) noexcept {
@@ -56,13 +133,20 @@ std::string_view describe(ScreenError error) noexcept {
             return "a node names a colour token the governed table does not define";
         case ScreenError::BudgetExhausted:
             return "the frame would exceed a draw budget it is held to";
+        case ScreenError::UnknownTextKey:
+            return "the bound text package carries no run for a node's text key";
+        case ScreenError::MalformedTextRun:
+            return "a run's range leaves the bound sidecar, or its bytes are not whole records";
+        case ScreenError::RunTooLong:
+            return "a run holds more records than this runtime will draw in one node";
     }
     // Unreachable for a value of the enumeration, and named rather than defaulted so that adding an
     // enumerator without a case here is a warning at this switch instead of a blank string later.
     return "unknown screen error";
 }
 
-mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list) noexcept {
+mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list,
+                                                   const TextBinding& text) noexcept {
     // Taken before anything is recorded: every refusal below rolls back to here, so a frame is
     // whole or absent. A half-drawn frame on a medical display is the worst outcome available,
     // because it looks like a reading.
@@ -95,6 +179,67 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
     for (const CompiledNode& node : screen.nodes) {
         ++stats.nodes;
         ++stats.steps;
+
+        if (const auto* label = std::get_if<LabelSpec>(&node.payload); label != nullptr) {
+            if (!text.complete()) {
+                // Nothing to join to. Deferred rather than refused: a caller that has not bound a
+                // locale yet is in a normal state, not a broken one.
+                ++stats.deferred;
+                continue;
+            }
+
+            const auto labelColour = resolveColorToken(label->colorToken);
+            if (!labelColour.has_value()) {
+                return refuse(labelColour.error() == ThemeError::MalformedToken ? ScreenError::MalformedColorToken
+                                                                                : ScreenError::UnknownColorToken);
+            }
+
+            const auto records = runFor(text, label->textKey);
+            if (!records.has_value()) {
+                return refuse(records.error());
+            }
+
+            const auto ink = measureInk(*text.font, *records);
+            if (!ink.has_value()) {
+                return refuse(ink.error());
+            }
+
+            // Counted per record, not per node: this is the payload-proportional work that
+            // `maxGlyphsPerRun` bounds, and `steps` has to say so or the bounded-work tests would be
+            // reporting a constant that stopped being one.
+            stats.steps += static_cast<std::uint32_t>(records->size() / mdux::text::draw::recordSize);
+
+            if (!ink->inked) {
+                // A run that paints nothing - a single space. Joined, measured, and found to have no
+                // ink, which is a different outcome from having no package to join to, so it is not
+                // counted as deferred.
+                continue;
+            }
+
+            // The ink box's corner goes to the node's corner. `originX`/`originY` are added to every
+            // record, so subtracting where the ink starts puts that corner exactly on the origin.
+            const auto originX = static_cast<mdux::core::Px>(node.bounds.x) - ink->x;
+            const auto originY = static_cast<mdux::core::Px>(node.bounds.y) - ink->y;
+
+            const std::size_t verticesBefore = list.vertices().size();
+            if (const auto recorded =
+                    mdux::text::draw::recordRun(list, *text.font, *records, originX, originY, toColor(*labelColour));
+                !recorded.has_value()) {
+                // `recordRun()` rolls its own run back and this rolls the whole frame back. Its error
+                // is not forwarded: every way it can fail here is either something `runFor()` and
+                // `measureInk()` already refused, or the list declining a write - and the second is
+                // the one a caller can do anything about.
+                return refuse(ScreenError::BudgetExhausted);
+            }
+            if (!withinScreenBudget()) {
+                return refuse(ScreenError::BudgetExhausted);
+            }
+            // Measured rather than predicted, for the reason the panel path gives below: a rectangle
+            // costs four vertices, and reading the delta keeps this from carrying a second copy of
+            // arithmetic `DrawList` owns. Blank glyphs record nothing, so this counts the inked ones.
+            stats.rects += static_cast<std::uint32_t>((list.vertices().size() - verticesBefore) / 4);
+            continue;
+        }
 
         const auto* panel = std::get_if<PanelSpec>(&node.payload);
         if (panel == nullptr) {

--- a/tests/medui/ScreenNoHeapTests.cpp
+++ b/tests/medui/ScreenNoHeapTests.cpp
@@ -18,8 +18,10 @@ import speclab;
 import mdux.core.units;
 import mdux.evidence.report;
 import mdux.draw;
+import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.medui.screen;
+import mdux.text.schema;
 
 #include "../framework/SpecLabBridge.hpp"
 
@@ -168,6 +170,99 @@ const mdux::spec::Register refusingAFrameAllocatesNothing{
                           checks.expect(!ms::describe(frame.error()).empty(), "the error describes itself");
                       }
                       checks.expect(after == before, std::format("the error path allocates nothing, counter went {} to {}", before, after));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register drawingTextAllocatesNothing{
+    "Rendering a frame that draws text allocates nothing",
+    "noheap",
+    [] {
+        return speclab::Test("medui-screen-noheap-render-text")
+            .Given("a screen whose label is joined to a font and text package", [] {})
+            .When("frames are recorded", [] {})
+            .Then("the allocation counter does not move",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The packages are built before the measurement, and they *do* allocate - a
+                      // FontPackage owns vectors. That is the caller's cost, paid once on a device
+                      // at start-up or not at all if the packages are `constexpr`. What is measured
+                      // is the join: `render()` reading them per frame.
+                      static const mdux::font::FontPackage font = [] {
+                          mdux::font::FontPackage built;
+                          built.id         = "noheap-ui";
+                          built.unitsPerEm = 1000;
+                          built.pixelSize  = 10;
+                          built.locales    = {"en-US"};
+                          built.atlas.path             = "atlas.bin";
+                          built.atlas.width            = 8;
+                          built.atlas.height           = 8;
+                          built.atlas.byteLength       = 64;
+                          built.atlas.sha256           = std::string(64, 'a');
+                          built.atlas.occupancyPercent = 25;
+                          built.glyphs = {{.codePoint = U'A', .glyphIndex = 4, .advanceWidth = 700, .leftSideBearing = 0,
+                                           .x = 0, .y = 0, .width = 4, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6}};
+                          built.restrictedCharset = {{.first = U'A', .last = U'A'}};
+                          return built;
+                      }();
+
+                      // One record: glyph 0 at the run's own origin, little-endian, as
+                      // `mdux::text::draw::decodeRecord()` reads it.
+                      static const std::array<std::byte, 6> records{std::byte{0}, std::byte{0}, std::byte{0},
+                                                                    std::byte{0}, std::byte{0}, std::byte{0}};
+
+                      static const mdux::text::TextPackage text = [] {
+                          mdux::text::TextPackage built;
+                          built.header.id        = "noheap-text";
+                          built.header.kind      = std::string{mdux::text::packageKind};
+                          built.atlasId          = "noheap-ui";
+                          built.locale           = "en-US";
+                          built.sidecarPath      = "runs.bin";
+                          built.sidecarByteLength = records.size();
+                          built.runs.push_back(mdux::text::TextRun{.id = "STR-TITLE", .byteOffset = 0, .byteLength = records.size()});
+                          return built;
+                      }();
+
+                      const ms::TextBinding binding{.font = &font, .text = &text, .runs = records};
+
+                      static std::array<mdux::draw::UiVertex, 512>   vertices{};
+                      static std::array<mdux::draw::Index, 768>      indices{};
+                      static std::array<mdux::draw::DrawCommand, 16> commands{};
+
+                      auto created = mdux::draw::DrawList::create(vertices, indices, commands, budget);
+                      if (!created.has_value()) {
+                          checks.expect(false, "the storage satisfies the budget");
+                          checks.raise();
+                          return;
+                      }
+                      mdux::draw::DrawList list = std::move(*created);
+
+                      // Nothing inside the measured loop may format a message, which is a rule this
+                      // scenario learned by breaking it: `std::format` allocates, so a per-frame
+                      // assertion carrying one would report the test's own allocation as the
+                      // runtime's. The outcome is captured and asserted after the counter is read.
+                      std::uint32_t lastRects = 0;
+                      bool          allRecorded = true;
+
+                      const std::size_t before = allocations();
+                      for (int frame = 0; frame < 8; ++frame) {
+                          list.reset();
+                          const auto recorded = ms::render(screen, list, binding);
+                          if (!recorded.has_value()) {
+                              allRecorded = false;
+                              continue;
+                          }
+                          lastRects = recorded->rects;
+                      }
+                      const std::size_t after = allocations();
+
+                      checks.expect(allRecorded, "each frame is recorded");
+                      // The label is drawn rather than deferred, so this scenario measures the text
+                      // path rather than the same deferred walk the case above measures.
+                      checks.expect(lastRects == 2, std::format("the panel and the glyph, got {}", lastRects));
+                      checks.expect(after == before, std::format("no allocation across eight frames, counter went {} to {}", before, after));
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/ScreenNoHeapTests.cpp
+++ b/tests/medui/ScreenNoHeapTests.cpp
@@ -16,6 +16,7 @@
 import std;
 import speclab;
 import mdux.core.units;
+import mdux.evidence.digest;
 import mdux.evidence.report;
 import mdux.draw;
 import mdux.font.schema;
@@ -221,11 +222,27 @@ const mdux::spec::Register drawingTextAllocatesNothing{
                           built.locale           = "en-US";
                           built.sidecarPath      = "runs.bin";
                           built.sidecarByteLength = records.size();
-                          built.runs.push_back(mdux::text::TextRun{.id = "STR-TITLE", .byteOffset = 0, .byteLength = records.size()});
+                          // The digests `create()` checks. Computed rather than written out, so the
+                          // fixture cannot drift from the bytes above and start exercising the
+                          // rejection path while claiming to measure the accepted one.
+                          built.sidecarSha256     = mdux::evidence::sha256(records);
+                          built.runs.push_back(mdux::text::TextRun{.id         = "STR-TITLE",
+                                                                   .byteOffset = 0,
+                                                                   .byteLength = records.size(),
+                                                                   .sha256     = mdux::evidence::sha256(records)});
                           return built;
                       }();
 
-                      const ms::TextBinding binding{.font = &font, .text = &text, .runs = records};
+                      // Through `create()`, which is the only way to obtain one - and which hashes
+                      // the sidecar. That cost is the caller's, once, and sits outside the counter
+                      // below on purpose: what this scenario measures is the frame, not the setup.
+                      const auto made = ms::TextBinding::create(font, text, records);
+                      if (!made.has_value()) {
+                          checks.expect(false, "the fixture binding is valid");
+                          checks.raise();
+                          return;
+                      }
+                      const ms::TextBinding binding = *made;
 
                       static std::array<mdux::draw::UiVertex, 512>   vertices{};
                       static std::array<mdux::draw::Index, 768>      indices{};

--- a/tests/medui/ScreenRuntimeTests.cpp
+++ b/tests/medui/ScreenRuntimeTests.cpp
@@ -18,8 +18,10 @@ import speclab;
 import mdux.core.units;
 import mdux.evidence.report;
 import mdux.draw;
+import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.medui.screen;
+import mdux.text.schema;
 
 #include "../framework/SpecLabBridge.hpp"
 
@@ -470,6 +472,217 @@ const mdux::spec::Register theScreensOwnBudgetBoundsTheFrame{
                                         std::format("reported as BudgetExhausted, got '{}'", ms::describe(frame.error())));
                       }
                       checks.expect(list.vertices().empty(), std::format("and nothing is left recorded, got {} vertices", list.vertices().size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Drawing a Label: the join, its refusals, and the cap (#242)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// A one-glyph font whose only character is a 4x6 block with its origin six pixels above the
+/// baseline, so an ink box computed from it is checkable by hand.
+[[nodiscard]] mdux::font::FontPackage textFixtureFont() {
+    mdux::font::FontPackage font;
+    font.id         = "runtime-ui";
+    font.unitsPerEm = 1000;
+    font.pixelSize  = 10;
+    font.locales    = {"en-US"};
+    font.atlas.path             = "atlas.bin";
+    font.atlas.width            = 8;
+    font.atlas.height           = 8;
+    font.atlas.byteLength       = 64;
+    font.atlas.sha256           = std::string(64, 'a');
+    font.atlas.occupancyPercent = 25;
+    font.glyphs = {
+        // A blank, so a run made only of these can be measured as painting nothing.
+        {.codePoint = U' ', .glyphIndex = 3, .advanceWidth = 250, .leftSideBearing = 0,
+         .x = 0, .y = 0, .width = 0, .height = 0, .bitmapOriginX = 0, .bitmapOriginY = 0},
+        {.codePoint = U'A', .glyphIndex = 4, .advanceWidth = 700, .leftSideBearing = 0,
+         .x = 0, .y = 0, .width = 4, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6},
+    };
+    font.restrictedCharset = {{.first = U' ', .last = U' '}, {.first = U'A', .last = U'A'}};
+    return font;
+}
+
+/// One v1 record, little-endian, as `mdux::text::draw::decodeRecord()` reads it.
+void appendRecord(std::vector<std::byte>& out, std::uint16_t index, std::int16_t x, std::int16_t y) {
+    const auto emit = [&out](std::uint16_t value) {
+        out.push_back(static_cast<std::byte>(value & 0xFFu));
+        out.push_back(static_cast<std::byte>((value >> 8) & 0xFFu));
+    };
+    emit(index);
+    emit(std::bit_cast<std::uint16_t>(x));
+    emit(std::bit_cast<std::uint16_t>(y));
+}
+
+/// A text package naming one run over `records`.
+[[nodiscard]] mdux::text::TextPackage textFixturePackage(std::string_view key, std::size_t byteLength) {
+    mdux::text::TextPackage package;
+    package.header.id       = "runtime-text";
+    package.header.kind     = std::string{mdux::text::packageKind};
+    package.atlasId         = "runtime-ui";
+    package.locale          = "en-US";
+    package.sidecarPath     = "runs.bin";
+    package.sidecarByteLength = byteLength;
+    package.runs.push_back(mdux::text::TextRun{.id = std::string{key}, .byteOffset = 0, .byteLength = byteLength});
+    return package;
+}
+
+constexpr ms::LabelSpec fixtureLabel{.textKey = "STR-A", .colorToken = "Theme.Colors.Title"};
+constexpr std::array<ms::CompiledNode, 1> labelOnly{
+    ms::CompiledNode{.id = "title", .bounds = {20, 30, 100, 40}, .payload = fixtureLabel}};
+constexpr ms::ScreenPackage labelScreen{.id            = "label",
+                                        .schemaVersion = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth  = 200,
+                                        .surfaceHeight = 100,
+                                        .nodes         = labelOnly,
+                                        .budget        = testBudget};
+
+}  // namespace
+
+const mdux::spec::Register labelInkLandsOnTheNodeCorner{
+    "A label's ink box is placed at the node's corner, which is what #195 measured", "evidence-unit", [] {
+        return speclab::Test("medui-screen-label-placement")
+            .Given("a run whose single glyph sits six pixels above its baseline", [] {})
+            .When("the screen is rendered with the run bound", [] {})
+            .Then("the glyph's rectangle starts exactly at the node's origin",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font = textFixtureFont();
+                      std::vector<std::byte>        records;
+                      appendRecord(records, 1, 0, 0);  // the 'A', at the run's own origin
+                      const mdux::text::TextPackage text = textFixturePackage("STR-A", records.size());
+
+                      Scratch              scratch;
+                      mdux::draw::DrawList list = scratch.list(testBudget);
+                      const auto           frame =
+                          ms::render(labelScreen, list, ms::TextBinding{.font = &font, .text = &text, .runs = records});
+
+                      checks.expect(frame.has_value(), "the frame was recorded");
+                      if (!frame.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(frame->rects == 1, std::format("one rectangle, got {}", frame->rects));
+                      checks.expect(frame->deferred == 0, std::format("nothing deferred, got {}", frame->deferred));
+
+                      // The ink box in run coordinates is (0, -6): x from the pen, y six pixels above
+                      // the baseline. Placing it at the node's corner therefore means the rectangle
+                      // lands at the node's own (20, 30) - not at (20, 24), which is where a baseline
+                      // placed on the node's top edge would have put it.
+                      const std::span<const mdux::draw::UiVertex> vertices = list.vertices();
+                      checks.expect(vertices.size() == 4, std::format("four vertices, got {}", vertices.size()));
+                      if (vertices.size() == 4) {
+                          checks.expect(vertices[0].x == 20.0F, std::format("left edge at 20, got {}", vertices[0].x));
+                          checks.expect(vertices[0].y == 30.0F, std::format("top edge at 30, got {}", vertices[0].y));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register labelRefusals{
+    "A binding that cannot serve the screen is refused rather than drawn around", "evidence-unit", [] {
+        return speclab::Test("medui-screen-label-refusals")
+            .Given("bindings that are wrong in one way each", [] {})
+            .When("the screen is rendered with each", [] {})
+            .Then("each reports its own error and records nothing",
+                  [] {
+                      mdux::spec::Checks            checks;
+                      const mdux::font::FontPackage font = textFixtureFont();
+
+                      std::vector<std::byte> records;
+                      appendRecord(records, 1, 0, 0);
+
+                      const auto renderWith = [&](const mdux::text::TextPackage& text, std::span<const std::byte> runs) {
+                          Scratch              scratch;
+                          mdux::draw::DrawList list = scratch.list(testBudget);
+                          const auto frame = ms::render(labelScreen, list, ms::TextBinding{.font = &font, .text = &text, .runs = runs});
+                          return std::pair{frame.has_value() ? ms::ScreenError::BudgetExhausted : frame.error(),
+                                           list.vertices().size()};
+                      };
+
+                      // A package for another screen: it parses, it validates, and it does not carry
+                      // this node's key.
+                      const auto wrongKey = renderWith(textFixturePackage("STR-SOMETHING-ELSE", records.size()), records);
+                      checks.expect(wrongKey.first == ms::ScreenError::UnknownTextKey, "an absent key is UnknownTextKey");
+                      checks.expect(wrongKey.second == 0, "and records nothing");
+
+                      // The package and the bytes handed with it do not belong together: the run's
+                      // range leaves the sidecar it was given.
+                      const auto shortSidecar = renderWith(textFixturePackage("STR-A", records.size()), std::span{records}.first(2));
+                      checks.expect(shortSidecar.first == ms::ScreenError::MalformedTextRun, "a range past the sidecar is MalformedTextRun");
+                      checks.expect(shortSidecar.second == 0, "and records nothing");
+
+                      // Past the cap. Built rather than described, so the constant and the refusal
+                      // cannot drift apart: one record more than the runtime will draw.
+                      std::vector<std::byte> tooMany;
+                      for (std::size_t i = 0; i <= ms::maxGlyphsPerRun; ++i) {
+                          appendRecord(tooMany, 1, static_cast<std::int16_t>(i), 0);
+                      }
+                      const auto overLong = renderWith(textFixturePackage("STR-A", tooMany.size()), tooMany);
+                      checks.expect(overLong.first == ms::ScreenError::RunTooLong,
+                                    std::format("{} records is RunTooLong", ms::maxGlyphsPerRun + 1));
+                      checks.expect(overLong.second == 0, "and records nothing");
+
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aRunOfBlanksDrawsNothing{
+    "A run that paints nothing is drawn, not deferred", "evidence-unit", [] {
+        return speclab::Test("medui-screen-label-blank-run")
+            .Given("a run made only of blank glyphs", [] {})
+            .When("the screen is rendered with it bound", [] {})
+            .Then("no rectangle is recorded and the node is not counted as deferred",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font = textFixtureFont();
+                      std::vector<std::byte>        records;
+                      appendRecord(records, 0, 0, 0);  // the space
+                      const mdux::text::TextPackage text = textFixturePackage("STR-A", records.size());
+
+                      Scratch              scratch;
+                      mdux::draw::DrawList list = scratch.list(testBudget);
+                      const auto           frame =
+                          ms::render(labelScreen, list, ms::TextBinding{.font = &font, .text = &text, .runs = records});
+
+                      checks.expect(frame.has_value(), "the frame was recorded");
+                      if (frame.has_value()) {
+                          checks.expect(frame->rects == 0, std::format("no rectangle, got {}", frame->rects));
+                          // The distinction the module documents: joined and found to paint nothing
+                          // is a different fact from having no package to join to.
+                          checks.expect(frame->deferred == 0, std::format("nothing deferred, got {}", frame->deferred));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anUnboundLabelIsDeferred{
+    "Without a binding a label is deferred exactly as it was before #242", "evidence-unit", [] {
+        return speclab::Test("medui-screen-label-unbound")
+            .Given("no text binding", [] {})
+            .When("the screen is rendered", [] {})
+            .Then("the label is deferred and the frame succeeds",
+                  [] {
+                      mdux::spec::Checks   checks;
+                      Scratch              scratch;
+                      mdux::draw::DrawList list  = scratch.list(testBudget);
+                      const auto           frame = ms::render(labelScreen, list);
+
+                      checks.expect(frame.has_value(), "the frame was recorded");
+                      if (frame.has_value()) {
+                          checks.expect(frame->deferred == 1, std::format("one deferred node, got {}", frame->deferred));
+                          checks.expect(frame->rects == 0, std::format("no rectangle, got {}", frame->rects));
+                      }
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/ScreenRuntimeTests.cpp
+++ b/tests/medui/ScreenRuntimeTests.cpp
@@ -16,6 +16,7 @@
 import std;
 import speclab;
 import mdux.core.units;
+import mdux.evidence.digest;
 import mdux.evidence.report;
 import mdux.draw;
 import mdux.font.schema;
@@ -519,17 +520,36 @@ void appendRecord(std::vector<std::byte>& out, std::uint16_t index, std::int16_t
     emit(std::bit_cast<std::uint16_t>(y));
 }
 
-/// A text package naming one run over `records`.
-[[nodiscard]] mdux::text::TextPackage textFixturePackage(std::string_view key, std::size_t byteLength) {
+/// A text package naming one run over the whole of `records`, with the digests `create()` checks.
+///
+/// The digests are computed from the bytes rather than written out: a fixture carrying a stale one
+/// would exercise the rejection path while claiming to be the accepted case, which is the way a
+/// suite quietly stops testing what it says it does.
+[[nodiscard]] mdux::text::TextPackage textFixturePackage(std::string_view key, std::span<const std::byte> records) {
     mdux::text::TextPackage package;
-    package.header.id       = "runtime-text";
-    package.header.kind     = std::string{mdux::text::packageKind};
-    package.atlasId         = "runtime-ui";
-    package.locale          = "en-US";
-    package.sidecarPath     = "runs.bin";
-    package.sidecarByteLength = byteLength;
-    package.runs.push_back(mdux::text::TextRun{.id = std::string{key}, .byteOffset = 0, .byteLength = byteLength});
+    package.header.id         = "runtime-text";
+    package.header.kind       = std::string{mdux::text::packageKind};
+    package.atlasId           = "runtime-ui";
+    package.locale            = "en-US";
+    package.sidecarPath       = "runs.bin";
+    package.sidecarByteLength = records.size();
+    package.sidecarSha256     = mdux::evidence::sha256(records);
+    package.runs.push_back(mdux::text::TextRun{.id         = std::string{key},
+                                               .byteOffset = 0,
+                                               .byteLength = records.size(),
+                                               .sha256     = mdux::evidence::sha256(records)});
     return package;
+}
+
+/// A binding built from a fixture, or a scenario failure naming what `create()` refused.
+[[nodiscard]] ms::TextBinding bindOrThrow(const mdux::font::FontPackage& font, const mdux::text::TextPackage& text,
+                                          std::span<const std::byte> records) {
+    auto made = ms::TextBinding::create(font, text, records);
+    if (!made.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("the fixture binding was refused: {}", ms::describe(made.error())),
+                                              std::source_location::current());
+    }
+    return *made;
 }
 
 constexpr ms::LabelSpec fixtureLabel{.textKey = "STR-A", .colorToken = "Theme.Colors.Title"};
@@ -556,12 +576,11 @@ const mdux::spec::Register labelInkLandsOnTheNodeCorner{
                       const mdux::font::FontPackage font = textFixtureFont();
                       std::vector<std::byte>        records;
                       appendRecord(records, 1, 0, 0);  // the 'A', at the run's own origin
-                      const mdux::text::TextPackage text = textFixturePackage("STR-A", records.size());
+                      const mdux::text::TextPackage text = textFixturePackage("STR-A", records);
 
                       Scratch              scratch;
-                      mdux::draw::DrawList list = scratch.list(testBudget);
-                      const auto           frame =
-                          ms::render(labelScreen, list, ms::TextBinding{.font = &font, .text = &text, .runs = records});
+                      mdux::draw::DrawList list  = scratch.list(testBudget);
+                      const auto           frame = ms::render(labelScreen, list, bindOrThrow(font, text, records));
 
                       checks.expect(frame.has_value(), "the frame was recorded");
                       if (!frame.has_value()) {
@@ -586,10 +605,71 @@ const mdux::spec::Register labelInkLandsOnTheNodeCorner{
             .Execute();
     }};
 
-const mdux::spec::Register labelRefusals{
-    "A binding that cannot serve the screen is refused rather than drawn around", "evidence-unit", [] {
-        return speclab::Test("medui-screen-label-refusals")
+const mdux::spec::Register bindingRefusals{
+    "Three artifacts that do not describe each other are refused once, not per frame", "evidence-unit", [] {
+        return speclab::Test("medui-screen-binding-refusals")
             .Given("bindings that are wrong in one way each", [] {})
+            .When("each is offered to create()", [] {})
+            .Then("each reports its own error",
+                  [] {
+                      mdux::spec::Checks            checks;
+                      const mdux::font::FontPackage font = textFixtureFont();
+
+                      std::vector<std::byte> records;
+                      appendRecord(records, 1, 0, 0);
+
+                      const auto errorOf = [&](const mdux::text::TextPackage& text, std::span<const std::byte> runs) {
+                          auto made = ms::TextBinding::create(font, text, runs);
+                          return made.has_value() ? std::optional<ms::ScreenError>{} : std::optional{made.error()};
+                      };
+
+                      // A package baked against another font. Every glyph index would still be in
+                      // range here, so nothing downstream could detect it - the frame would draw a
+                      // plausible sentence made of the wrong letters.
+                      mdux::text::TextPackage otherAtlas = textFixturePackage("STR-A", records);
+                      otherAtlas.atlasId                 = "some-other-font";
+                      checks.expect(errorOf(otherAtlas, records) == ms::ScreenError::AtlasMismatch, "another font is AtlasMismatch");
+
+                      // The right length, the wrong bytes. This is the case a structural check
+                      // cannot reach and the digest exists for: it renders different words.
+                      std::vector<std::byte> impostor;
+                      appendRecord(impostor, 0, 0, 0);
+                      checks.expect(errorOf(textFixturePackage("STR-A", records), impostor) == ms::ScreenError::SidecarMismatch,
+                                    "a same-length wrong sidecar is SidecarMismatch");
+
+                      // A sidecar of the wrong length, which the cheap check catches first.
+                      checks.expect(errorOf(textFixturePackage("STR-A", records), std::span{records}.first(0))
+                                        == ms::ScreenError::SidecarMismatch,
+                                    "a short sidecar is SidecarMismatch");
+
+                      // The wraparound. `byteOffset + byteLength` sums to zero for these, so an
+                      // addition-form range check would accept them and hand `subspan()` an offset
+                      // past its size. Six bytes is one record, so the cap does not catch it either.
+                      mdux::text::TextPackage wrapped = textFixturePackage("STR-A", records);
+                      wrapped.runs[0].byteOffset      = std::numeric_limits<std::uint64_t>::max() - 5;
+                      wrapped.runs[0].byteLength      = 6;
+                      checks.expect(errorOf(wrapped, records) == ms::ScreenError::MalformedTextRun,
+                                    "a range that wraps is MalformedTextRun");
+
+                      // Past the cap. Built rather than described, so the constant and the refusal
+                      // cannot drift apart: one record more than the runtime will draw.
+                      std::vector<std::byte> tooMany;
+                      for (std::size_t i = 0; i <= ms::maxGlyphsPerRun; ++i) {
+                          appendRecord(tooMany, 1, static_cast<std::int16_t>(i), 0);
+                      }
+                      checks.expect(errorOf(textFixturePackage("STR-A", tooMany), tooMany) == ms::ScreenError::RunTooLong,
+                                    std::format("{} records is RunTooLong", ms::maxGlyphsPerRun + 1));
+
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register frameRefusals{
+    "A valid binding that does not serve this screen is refused, and the list is left as found",
+    "evidence-unit", [] {
+        return speclab::Test("medui-screen-frame-refusals")
+            .Given("bindings create() accepts but this screen cannot use", [] {})
             .When("the screen is rendered with each", [] {})
             .Then("each reports its own error and records nothing",
                   [] {
@@ -600,35 +680,33 @@ const mdux::spec::Register labelRefusals{
                       appendRecord(records, 1, 0, 0);
 
                       const auto renderWith = [&](const mdux::text::TextPackage& text, std::span<const std::byte> runs) {
-                          Scratch              scratch;
-                          mdux::draw::DrawList list = scratch.list(testBudget);
-                          const auto frame = ms::render(labelScreen, list, ms::TextBinding{.font = &font, .text = &text, .runs = runs});
-                          return std::pair{frame.has_value() ? ms::ScreenError::BudgetExhausted : frame.error(),
+                          const ms::TextBinding binding = bindOrThrow(font, text, runs);
+                          Scratch               scratch;
+                          mdux::draw::DrawList  list = scratch.list(testBudget);
+                          const auto            frame = ms::render(labelScreen, list, binding);
+                          return std::pair{frame.has_value() ? std::optional<ms::ScreenError>{} : std::optional{frame.error()},
                                            list.vertices().size()};
                       };
 
-                      // A package for another screen: it parses, it validates, and it does not carry
-                      // this node's key.
-                      const auto wrongKey = renderWith(textFixturePackage("STR-SOMETHING-ELSE", records.size()), records);
+                      // A package for another screen: it is internally consistent, it passes
+                      // `create()`, and it does not carry this node's key.
+                      const auto wrongKey = renderWith(textFixturePackage("STR-SOMETHING-ELSE", records), records);
                       checks.expect(wrongKey.first == ms::ScreenError::UnknownTextKey, "an absent key is UnknownTextKey");
                       checks.expect(wrongKey.second == 0, "and records nothing");
 
-                      // The package and the bytes handed with it do not belong together: the run's
-                      // range leaves the sidecar it was given.
-                      const auto shortSidecar = renderWith(textFixturePackage("STR-A", records.size()), std::span{records}.first(2));
-                      checks.expect(shortSidecar.first == ms::ScreenError::MalformedTextRun, "a range past the sidecar is MalformedTextRun");
-                      checks.expect(shortSidecar.second == 0, "and records nothing");
-
-                      // Past the cap. Built rather than described, so the constant and the refusal
-                      // cannot drift apart: one record more than the runtime will draw.
-                      std::vector<std::byte> tooMany;
-                      for (std::size_t i = 0; i <= ms::maxGlyphsPerRun; ++i) {
-                          appendRecord(tooMany, 1, static_cast<std::int16_t>(i), 0);
+                      // The finding this check exists for: a second valid package, same font, same
+                      // key, wider text. Nothing in the artifacts says which package the compiler
+                      // measured, so the runtime measures the one it was given - and refuses it
+                      // rather than drawing over the node's neighbours. The node is 100 wide; this
+                      // run is fifty glyphs at ten pixels of advance.
+                      std::vector<std::byte> wide;
+                      for (std::int16_t i = 0; i < 50; ++i) {
+                          appendRecord(wide, 1, static_cast<std::int16_t>(i * 10), 0);
                       }
-                      const auto overLong = renderWith(textFixturePackage("STR-A", tooMany.size()), tooMany);
-                      checks.expect(overLong.first == ms::ScreenError::RunTooLong,
-                                    std::format("{} records is RunTooLong", ms::maxGlyphsPerRun + 1));
-                      checks.expect(overLong.second == 0, "and records nothing");
+                      const auto overflowing = renderWith(textFixturePackage("STR-A", wide), wide);
+                      checks.expect(overflowing.first == ms::ScreenError::TextOverflowsNode,
+                                    "text wider than its node is TextOverflowsNode");
+                      checks.expect(overflowing.second == 0, "and the list is left as it was found");
 
                       checks.raise();
                   })
@@ -647,12 +725,11 @@ const mdux::spec::Register aRunOfBlanksDrawsNothing{
                       const mdux::font::FontPackage font = textFixtureFont();
                       std::vector<std::byte>        records;
                       appendRecord(records, 0, 0, 0);  // the space
-                      const mdux::text::TextPackage text = textFixturePackage("STR-A", records.size());
+                      const mdux::text::TextPackage text = textFixturePackage("STR-A", records);
 
                       Scratch              scratch;
-                      mdux::draw::DrawList list = scratch.list(testBudget);
-                      const auto           frame =
-                          ms::render(labelScreen, list, ms::TextBinding{.font = &font, .text = &text, .runs = records});
+                      mdux::draw::DrawList list  = scratch.list(testBudget);
+                      const auto           frame = ms::render(labelScreen, list, bindOrThrow(font, text, records));
 
                       checks.expect(frame.has_value(), "the frame was recorded");
                       if (frame.has_value()) {

--- a/tests/render/ScreenPixelTests.cpp
+++ b/tests/render/ScreenPixelTests.cpp
@@ -13,17 +13,20 @@
  *
  * ## What is on screen, and why it is one rectangle
  *
- * The runtime draws a `Panel`. `EndoscopeMonitor`'s Row declares a background, so the solver
- * synthesised one, and that is what appears: a 1280x72 bar in `Theme.Colors.TopbarBackground`. Its
- * image, its label, its video surface, its numeric readout and its waveform are visited, counted as
- * deferred, and left undrawn - the label because a compiled screen carries a `textKey` rather than
- * glyphs, so drawing it means joining the screen to a text package for the locale the device is
- * running, which is #17's work; the live-data components because they have no geometry until a
- * sample exists.
+ * The runtime draws a `Panel` and a `Label`. `EndoscopeMonitor`'s Row declares a background, so the
+ * solver synthesised one, and that is what appears: a 1280x72 bar in `Theme.Colors.TopbarBackground`,
+ * with the screen's title drawn over it from the committed text package (#242). Its image, its video
+ * surface, its numeric readout and its waveform are visited, counted as deferred, and left undrawn,
+ * because they have no geometry until a sample exists or a package this repository does not yet bake.
+ *
+ * Two scenarios below, deliberately not one. The first renders without a binding and is the older
+ * claim unchanged - the panel lands where the compiler put it, every text node deferred. The second
+ * binds the committed font and text packages and checks the glyphs. Keeping them apart is what makes
+ * the unbound path a tested contract rather than a code path nobody exercises once a binding exists.
  *
  * That makes this test thin in content and complete in path, and the distinction is the point. What
- * it proves is not that MduX can draw a clinical screen; it is that a rectangle on this display came
- * from a file an author wrote, through every stage, with nothing hand-carried between them. The
+ * it proves is not that MduX can draw a clinical screen; it is that a bar and a title on this display
+ * came from files an author wrote, through every stage, with nothing hand-carried between them. The
  * content grows when the components learn their geometry; the path does not have to be built again.
  *
  * ## What the golden sidecar has here, and what it does not
@@ -67,7 +70,10 @@ import mdux.medui.schema;
 import mdux.medui.screen;
 import mdux.render.offscreen;
 import mdux.render.vulkan;
+import mdux.font.schema;
 import mdux.shader.schema;
+import mdux.text.draw;
+import mdux.text.schema;
 import mdux.shader.generated.mdux_ui;
 import mdux.test;
 
@@ -121,6 +127,143 @@ struct RecordContext {
 void recordFrame(VkCommandBuffer commandBuffer, void* context) {
     auto* recording = static_cast<RecordContext*>(context);
     static_cast<void>(recording->renderer->record(commandBuffer, *recording->list));
+}
+
+/// Reads a committed file, or fails the scenario naming it.
+[[nodiscard]] std::vector<std::byte> committed(std::string_view kind, std::string_view id, std::string_view name) {
+    const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "generated" / kind / id / name;
+    std::ifstream               file{path, std::ios::binary};
+    if (!file.is_open()) {
+        throw std::runtime_error(std::format("cannot open {}", path.generic_string()));
+    }
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    const std::string  text = buffer.str();
+    const auto*        data = reinterpret_cast<const std::byte*>(text.data());
+    return std::vector<std::byte>{data, data + text.size()};
+}
+
+[[nodiscard]] std::string_view asText(const std::vector<std::byte>& bytes) noexcept {
+    return std::string_view{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+/// The three committed artifacts a device joins a locale-free screen to, held together so a
+/// scenario cannot bind two of them and forget the third.
+struct BoundText {
+    std::vector<std::byte>  fontJson;
+    std::vector<std::byte>  textJson;
+    std::vector<std::byte>  runs;
+    std::vector<std::byte>  atlas;
+    mdux::font::FontPackage font;
+    mdux::text::TextPackage text;
+
+    [[nodiscard]] medui::TextBinding binding() const noexcept {
+        return medui::TextBinding{.font = &font, .text = &text, .runs = runs};
+    }
+};
+
+/// Loads them from `generated/`, which is the point: the pixels below come from the same bytes
+/// `ctest -L evidence` compares, not from a fixture written to make this scenario pass.
+[[nodiscard]] BoundText loadCommittedText() {
+    BoundText bound;
+    bound.fontJson = committed("font", "dejavu-ui", "package.json");
+    bound.textJson = committed("text", "endoscope-monitor-en-us", "package.json");
+    bound.runs     = committed("text", "endoscope-monitor-en-us", "runs.bin");
+    bound.atlas    = committed("font", "dejavu-ui", "atlas.bin");
+
+    auto font = mdux::font::FontPackage::parse(asText(bound.fontJson));
+    if (!font.has_value()) {
+        throw std::runtime_error("the committed font package did not parse");
+    }
+    auto text = mdux::text::TextPackage::parse(asText(bound.textJson));
+    if (!text.has_value()) {
+        throw std::runtime_error("the committed text package did not parse");
+    }
+    bound.font = std::move(*font);
+    bound.text = std::move(*text);
+    return bound;
+}
+
+/// A rectangle in pixels, or nothing.
+struct InkBox {
+    bool   found{false};
+    core::Px left{0};
+    core::Px top{0};
+    core::Px right{0};   ///< exclusive
+    core::Px bottom{0};  ///< exclusive
+};
+
+/**
+ * @brief The ink one committed run paints, measured from the packages rather than from the frame.
+ *
+ * This is the *independent* half of the scenario below. The runtime derives the same quantity to
+ * decide where to put the run; deriving it here from the committed bytes - and then finding the same
+ * box in the rendered pixels - is what makes the assertion about the placement rule rather than a
+ * restatement of the code that implements it.
+ */
+[[nodiscard]] InkBox inkOfRun(const BoundText& bound, std::string_view key) {
+    const mdux::text::TextRun* run = nullptr;
+    for (const mdux::text::TextRun& candidate : bound.text.runs) {
+        if (candidate.id == key) {
+            run = &candidate;
+        }
+    }
+    if (run == nullptr) {
+        return InkBox{};
+    }
+    const std::span<const std::byte> records{bound.runs.data() + run->byteOffset, static_cast<std::size_t>(run->byteLength)};
+
+    InkBox box;
+    for (std::size_t offset = 0; offset < records.size(); offset += mdux::text::draw::recordSize) {
+        const auto placement = mdux::text::draw::decodeRecord(records.subspan(offset, mdux::text::draw::recordSize));
+        if (!placement.has_value()) {
+            return InkBox{};
+        }
+        const mdux::font::GlyphRecord& glyph = bound.font.glyphs[placement->packageIndex];
+        if (glyph.isBlank()) {
+            continue;
+        }
+        const auto left   = static_cast<core::Px>(placement->x + glyph.bitmapOriginX);
+        const auto top    = static_cast<core::Px>(placement->y - glyph.bitmapOriginY);
+        const auto right  = static_cast<core::Px>(left + static_cast<core::Px>(glyph.width));
+        const auto bottom = static_cast<core::Px>(top + static_cast<core::Px>(glyph.height));
+        if (!box.found) {
+            box = InkBox{.found = true, .left = left, .top = top, .right = right, .bottom = bottom};
+            continue;
+        }
+        box.left   = std::min(box.left, left);
+        box.top    = std::min(box.top, top);
+        box.right  = std::max(box.right, right);
+        box.bottom = std::max(box.bottom, bottom);
+    }
+    return box;
+}
+
+/// The bounding box of every pixel inside `within` that is not `ground`.
+///
+/// The label is drawn over the topbar panel, so "painted" means "differs from the panel's colour" -
+/// which also makes the assertion insensitive to the anti-aliased coverage values themselves. What
+/// is under test is where the glyphs landed, not what shade each edge pixel came out.
+[[nodiscard]] InkBox paintedWithin(std::span<const core::ColorRgba8> pixels, core::Extent2D surface,
+                                   const medui::NodeRect& within, core::ColorRgba8 ground) {
+    InkBox box;
+    for (core::Px y = static_cast<core::Px>(within.y); y < static_cast<core::Px>(within.y + within.height); ++y) {
+        for (core::Px x = static_cast<core::Px>(within.x); x < static_cast<core::Px>(within.x + within.width); ++x) {
+            const auto index = static_cast<std::size_t>(y) * static_cast<std::size_t>(surface.width) + static_cast<std::size_t>(x);
+            if (pixels[index] == ground) {
+                continue;
+            }
+            if (!box.found) {
+                box = InkBox{.found = true, .left = x, .top = y, .right = static_cast<core::Px>(x + 1), .bottom = static_cast<core::Px>(y + 1)};
+                continue;
+            }
+            box.left   = std::min(box.left, x);
+            box.top    = std::min(box.top, y);
+            box.right  = std::max(box.right, static_cast<core::Px>(x + 1));
+            box.bottom = std::max(box.bottom, static_cast<core::Px>(y + 1));
+        }
+    }
+    return box;
 }
 
 }  // namespace
@@ -314,4 +457,78 @@ TEST_CASE("The safety-critical region is empty, which is what the golden cannot 
     const std::size_t index   = centreY * static_cast<std::size_t>(surface.width) + centreX;
     REQUIRE(index < pixels->size());
     CHECK((*pixels)[index] == background);
+}
+
+TEST_CASE("An authored screen's label reaches pixels where the compiler measured it", "pixel") {
+    // The last link the chain was missing. The screen, the font package and the text package are all
+    // committed artifacts; the runtime joins them; the glyphs land on the display. Nothing in this
+    // scenario is hand-carried - the bytes are the ones `ctest -L evidence` byte-compares.
+    const medui::ScreenPackage package = screen();
+    const core::Extent2D       surface = surfaceOf(package);
+    const BoundText            bound   = loadCommittedText();
+
+    const medui::CompiledNode* label = package.find("screen-title");
+    REQUIRE(label != nullptr);
+
+    const auto& gpu    = sharedDevice();
+    auto        target = OffscreenTarget::create(gpu.device(), gpu.physicalDevice(), surface, gpu.queueFamilyIndex());
+    REQUIRE(target.has_value());
+
+    VulkanRenderContext context;
+    context.device           = gpu.device();
+    context.physicalDevice   = gpu.physicalDevice();
+    context.renderPass       = target->renderPass();
+    context.queue            = gpu.queue();
+    context.queueFamilyIndex = gpu.queueFamilyIndex();
+    context.viewport         = surface;
+
+    // The coverage overload, with the committed atlas. A default renderer would sample a white
+    // 1x1 default and every glyph would come out a filled rectangle - which would still "draw
+    // text" in the loosest sense and would prove nothing about the atlas.
+    auto renderer = UiRenderer::createWithCoverageAtlas(context, mdux::shader::generated::mdux_ui::package(), package.budget,
+                                                        bound.atlas, bound.font.atlas.width, bound.font.atlas.height);
+    REQUIRE(renderer.has_value());
+
+    Frame frame;
+    auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, package.budget);
+    REQUIRE(list.has_value());
+
+    const auto recorded = medui::render(package, *list, bound.binding());
+    REQUIRE(recorded.has_value());
+
+    // One fewer deferred node than the unbound frame, and the difference is the label. Asserted as
+    // the count rather than as "the label was drawn" so that a future component learning to draw
+    // cannot make this scenario pass for a reason it does not name.
+    CHECK(recorded->deferred == 4);
+    // The panel, plus one rectangle per inked glyph. "Endoscope Monitor" is 17 characters of which
+    // the space paints nothing, so 16 glyphs and the panel.
+    CHECK(recorded->rects == 17);
+
+    RecordContext recording{.renderer = &*renderer, .list = &*list};
+    auto          pixels = target->renderAndRead(gpu.queue(), background, recordFrame, &recording);
+    REQUIRE(pixels.has_value());
+
+    // The panel's colour, which is what the label is drawn over and therefore what "not painted"
+    // means inside the topbar.
+    constexpr core::ColorRgba8 topbar{.r = 209, .g = 214, .b = 219, .a = 255};
+
+    const InkBox derived = inkOfRun(bound, "STR-EM-TITLE");
+    REQUIRE(derived.found);
+    const InkBox painted = paintedWithin(*pixels, surface, label->bounds, topbar);
+    REQUIRE(painted.found);
+
+    // The placement rule, stated as an assertion: the ink box's top-left corner is the node's
+    // top-left corner. This is the whole of what Screen.cppm decides, and the reason it decides it -
+    // that #195 measured this box against this rectangle - is only true if these two agree.
+    CHECK(painted.left == label->bounds.x);
+    CHECK(painted.top == label->bounds.y);
+
+    // ...and the extent is the one measured from the committed packages, so the glyphs are the run's
+    // rather than some subset that happened to land in the right corner.
+    CHECK(painted.right - painted.left == derived.right - derived.left);
+    CHECK(painted.bottom - painted.top == derived.bottom - derived.top);
+
+    // The build-time promise, now observable: the text fits the box it was measured against.
+    CHECK(painted.right <= label->bounds.x + label->bounds.width);
+    CHECK(painted.bottom <= label->bounds.y + label->bounds.height);
 }

--- a/tests/render/ScreenPixelTests.cpp
+++ b/tests/render/ScreenPixelTests.cpp
@@ -157,8 +157,14 @@ struct BoundText {
     mdux::font::FontPackage font;
     mdux::text::TextPackage text;
 
-    [[nodiscard]] medui::TextBinding binding() const noexcept {
-        return medui::TextBinding{.font = &font, .text = &text, .runs = runs};
+    /// Through `create()`, which is the only way to obtain one - and which proves the three
+    /// committed artifacts describe each other before a frame reads any of them.
+    [[nodiscard]] medui::TextBinding binding() const {
+        auto made = medui::TextBinding::create(font, text, runs);
+        if (!made.has_value()) {
+            throw std::runtime_error(std::format("the committed artifacts were refused: {}", medui::describe(made.error())));
+        }
+        return *made;
     }
 };
 
@@ -211,12 +217,23 @@ struct InkBox {
     if (run == nullptr) {
         return InkBox{};
     }
+    // Bounds and alignment before the span exists, not after. This helper reads committed bytes,
+    // and a corrupt artifact should make it return "no ink" - which fails the REQUIRE below with the
+    // run named - rather than form an out-of-range span and take the process with it. Subtraction
+    // rather than `byteOffset + byteLength`, which wraps.
+    if (run->byteOffset > bound.runs.size() || run->byteLength > bound.runs.size() - run->byteOffset
+        || run->byteLength % mdux::text::draw::recordSize != 0) {
+        return InkBox{};
+    }
     const std::span<const std::byte> records{bound.runs.data() + run->byteOffset, static_cast<std::size_t>(run->byteLength)};
 
     InkBox box;
     for (std::size_t offset = 0; offset < records.size(); offset += mdux::text::draw::recordSize) {
         const auto placement = mdux::text::draw::decodeRecord(records.subspan(offset, mdux::text::draw::recordSize));
         if (!placement.has_value()) {
+            return InkBox{};
+        }
+        if (placement->packageIndex >= bound.font.glyphs.size()) {
             return InkBox{};
         }
         const mdux::font::GlyphRecord& glyph = bound.font.glyphs[placement->packageIndex];


### PR DESCRIPTION
Closes #242. The last link the chain was missing.

## What was missing

`recordRun()` has drawn a baked run since #162, a compiled screen has carried a `textKey` since #197, and both a font and a text package have been committed since #235. Nothing joined them. `render()` drew only a `Panel`, and `Screen.cppm` still justified that with "no text package is baked in this repository yet" — which stopped being true two PRs ago.

`render()` now takes a `TextBinding`: the font package, the text package for the locale the device is running, and the sidecar bytes. Defaulted, so every existing caller is unchanged and an unbound screen defers its labels exactly as before.

## Two decisions, made rather than stumbled into

**Where the glyphs go.** The shared component model says nothing about where text sits inside its box — I read the pinned contract rather than assume — and the font package carries no ascent, so there is no metric to derive a baseline from. Something has to be decided, so I picked the rule that is *already validated*: the run's **ink** box goes at the node's top-left corner, because that is exactly the box #195 measures against exactly that rectangle. Centring, or a baseline offset, would leave the build-time guarantee true of a rectangle nobody draws.

**The cap.** `Screen.cppm` has promised since #199 that making per-node work a fact rather than a measurement needs a type-level cap, "belonging with the first component whose geometry is variable". A `Label` is that component — its work scales with its run length. `maxGlyphsPerRun` is the cap, and a longer run is `RunTooLong` rather than truncated.

## Refusals

A key the bound package does not carry; a run whose range leaves the sidecar handed with it; a run past the cap. All three mean the caller bound the wrong thing for this screen, none can be true of packages this repository baked, and each rolls the frame back whole.

A run of blanks draws nothing and is **not** deferred: joined and found to paint nothing is a different fact from having nothing to join to.

## Evidence

The pixel scenario binds the **committed** artifacts — the same bytes `ctest -L evidence` compares — measures the ink box independently from them, then finds that box in the rendered frame and asserts its corner is the node's corner. I verified it can fail: shifting the origin by one pixel fails on `painted.left == label->bounds.x`.

The no-heap suite gains a case that renders *with* a binding, so "the join allocates nothing" is measured rather than asserted. That case caught a real allocation on its first run — my own `std::format` inside the measured loop, not the runtime. The scenario now keeps formatting out of it and says why.

## Verified locally

607/607 on `ninja-macos-clang`, the toolchain #241 made verified — `pixel`, `noheap`, `governed` and `evidence` included. The first PR in a while I could check before pushing rather than after.

## Out of scope

A `constexpr` emitter for font and text packages, so a device build stops parsing their JSON at startup — the shape #121 gave shaders and #153 asks for models. It deserves its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Labels can now render localized text using validated font and text packages.
  * Text is positioned at the label’s top-left corner and recorded as glyph runs.
  * Added clear errors for package mismatches, malformed runs, unknown text keys, and text that exceeds its label.

* **Bug Fixes**
  * Unbound labels are safely deferred.
  * Blank glyph runs no longer produce unnecessary drawing.

* **Documentation**
  * Updated runtime, architecture, roadmap, and README documentation to reflect current rendering capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->