### PR TITLE
Bind a screen to the text packages it was compiled against [#244]

### DIFF
--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -88,7 +88,8 @@ device runtime performs none of them, and turns that layout into vertices.**
 | Record each approved locale package id and canonical package digest | build machine | host tools |
 | Compute the `DrawBudget` | build machine | host tools |
 | Emit golden references (see rule below) | build machine | host tools |
-| Authenticate the selected text package against the compiled screen | device startup | governed |
+| Hash the selected package bytes and authenticate them against the compiled screen | device startup | governed |
+| Re-check the retained approval identity against the render target | each frame | governed |
 | **Build a `DrawList` from a compiled screen** | **device** | **governed** |
 
 *Layout*, not *geometry*: the compiler produces rectangles, budgets and the validated token and key
@@ -118,9 +119,12 @@ an approval record per locale: the text package id and SHA-256 of its canonical 
 
 That manifest closes a gap the name-only boundary left open. A second text package could be valid,
 use the same font and key, and still carry wording the compiler never measured or a reviewer never
-approved. `TextBinding::create()` therefore authenticates the running locale's package id and digest
-against the screen before rendering. The existing ink measurement remains a separate refusal for a
-run that exceeds its node; it is not evidence that the wording was approved.
+approved. The compiler refuses parseable but noncanonical text-package JSON, so the file bytes it
+records are the one canonical identity. `TextBinding::create()` hashes those caller-supplied bytes
+without allocating, authenticates the running locale's package id and digest, and retains that
+identity. `render()` checks it against its target screen before recording anything, so a binding
+approved for screen A cannot be reused for screen B. The existing ink measurement remains a
+separate refusal for a run that exceeds its node; it is not evidence that the wording was approved.
 
 **The changed cost is deliberate.** Adding a locale or changing an approved translation now rewrites
 the small approval manifest and the screen package digest, even though the rectangles remain shared.

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -85,8 +85,10 @@ device runtime performs none of them, and turns that layout into vertices.**
 | Validate theme tokens and text keys against every approved locale | build machine | host tools |
 | Solve layout, flatten `Row`, compute absolute rectangles | build machine | host tools |
 | Validate text budgets against every approved locale | build machine | host tools |
+| Record each approved locale package id and canonical package digest | build machine | host tools |
 | Compute the `DrawBudget` | build machine | host tools |
 | Emit golden references (see rule below) | build machine | host tools |
+| Authenticate the selected text package against the compiled screen | device startup | governed |
 | **Build a `DrawList` from a compiled screen** | **device** | **governed** |
 
 *Layout*, not *geometry*: the compiler produces rectangles, budgets and the validated token and key
@@ -109,23 +111,26 @@ this conclusion first — `resolve_color_token()` and `THEME_COLORS` are in Trus
 `trustsc-ui` crate, and its `CompiledScreenPackage` carries `text_key` and `color_token` — and the
 parity programme's direction is MduX moving toward it.
 
-**A compiled screen is locale-free.** It carries no locale field and no glyph runs. Per-locale
-glyph runs stay in the text package where ADR-010 already put them, and the two are joined on device
-by looking each node's `textKey` up for the running locale. TrustSC does exactly this in
-`ScreenTextLayout::from_screen(screen, package, locale)`.
+**A compiled screen's layout is locale-free, but its approvals are not.** It carries no selected
+locale and no glyph runs. Per-locale glyph runs stay in the text package where ADR-010 put them, and
+one rectangle and one `DrawBudget` still serve every approved locale. The package now also carries
+an approval record per locale: the text package id and SHA-256 of its canonical `package.json`.
 
-The consequence that decides it: **adding an approved locale touches no screen artifact at all.**
-The alternative — one screen package per locale, carrying baked runs — would add a file and an
-`evidence.screen.<id>` per locale, and would rebake every screen when a translation changed.
-Translations change far more often than layouts, and coupling the two makes the frequent change
-rewrite the stable artifact.
+That manifest closes a gap the name-only boundary left open. A second text package could be valid,
+use the same font and key, and still carry wording the compiler never measured or a reviewer never
+approved. `TextBinding::create()` therefore authenticates the running locale's package id and digest
+against the screen before rendering. The existing ink measurement remains a separate refusal for a
+run that exceeds its node; it is not evidence that the wording was approved.
 
-**The cost of choosing this way, stated as a cost.** A locale-free screen does not know which locale
-it will be paired with, so its `DrawBudget` has to cover the widest approved translation — and a
-device shipping only `en-US` carries the German or Finnish ceiling in its buffers. Per-locale
-packages would size each budget to its own locale, and that is their one real advantage; it is
-given up deliberately. Buffer headroom is cheap and recoverable, while a translation update that
-rewrites every screen's digest is neither.
+**The changed cost is deliberate.** Adding a locale or changing an approved translation now rewrites
+the small approval manifest and the screen package digest, even though the rectangles remain shared.
+That increases review churn, but makes the exact text inputs part of the reviewed screen identity.
+It still avoids one screen package and one `evidence.screen.<id>` per locale, and it keeps all glyph
+runs outside the screen.
+
+The shared `DrawBudget` still has to cover the widest approved translation, so a device shipping
+only `en-US` may carry another locale's ceiling in its buffers. Per-locale screen packages would
+size each budget independently, but would duplicate layout artifacts; that trade remains rejected.
 
 Two things this does *not* relax. The compiler still validates every key against every approved
 locale, and still validates text budgets against the widest approved translation (#195) — that work

--- a/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
+++ b/docs/adr/ADR-011-deterministic-medui-compile-boundary.md
@@ -121,9 +121,11 @@ That manifest closes a gap the name-only boundary left open. A second text packa
 use the same font and key, and still carry wording the compiler never measured or a reviewer never
 approved. The compiler refuses parseable but noncanonical text-package JSON, so the file bytes it
 records are the one canonical identity. `TextBinding::create()` hashes those caller-supplied bytes
-without allocating, authenticates the running locale's package id and digest, and retains that
-identity. `render()` checks it against its target screen before recording anything, so a binding
-approved for screen A cannot be reused for screen B. The existing ink measurement remains a
+without allocating, independently streams the parsed package back through the same canonical form,
+and requires the two digests to agree before authenticating and retaining the running locale's
+package id and digest. Approved bytes therefore cannot be paired with different parsed wording.
+`render()` checks the retained identity against its target screen before recording anything, so a
+binding approved for screen A cannot be reused for screen B. The existing ink measurement remains a
 separate refusal for a run that exceeds its node; it is not evidence that the wording was approved.
 
 **The changed cost is deliberate.** Adding a locale or changing an approved translation now rewrites

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -71,7 +71,7 @@ safety-critical nodes live.
 
 | File | Committed | Contents |
 |---|---|---|
-| `package.json` | yes | the compiled screen: compiled nodes, absolute rectangles, `DrawBudget`, requirement ids, and the validated `Theme.Colors.<Token>` and `t("STR-KEY")` names each node draws with. **No locale field, no glyph runs, no RGBA8** |
+| `package.json` | yes | the compiled screen: compiled nodes, absolute rectangles, `DrawBudget`, requirement ids, validated token/key names, and `approvedTextPackages` entries carrying each locale's package id and canonical-package digest. **No selected locale, no glyph runs, no RGBA8** |
 | `goldens.json` | yes | one golden reference per node matching ADR-011's predicate: `@safety_critical`, or an explicit `position:`, or both merged into one entry (#196). Always written, as `[]` when a screen matches no node |
 | `report.json` | yes | the ADR-007 bake report: inputs, digests, tool version |
 
@@ -101,17 +101,16 @@ that way, both binding on #198:
   slug from the screen name rather than using it, and the mapping has to be injective and recorded
   in the recipe, since two screens differing only in case would otherwise collide.
 
-**Locales do not multiply this layout.** One screen, one directory, whatever the approved locale
-count — because ADR-011 keeps the package locale-free and leaves the per-locale glyph runs in the
-text package. `mdux.text.schema`'s `TextPackage` already carries a single `locale` field and "the
-runtime reads no others" (`include/mdux/text/Schema.cppm:145`), so a device pairs one screen package
-with the text package for the locale it is running.
+**Locales do not multiply this layout.** One screen and one directory serve every approved locale,
+because per-locale glyph runs remain in text packages. The screen does carry a compact approval
+manifest, however: `TextPackageApproval { locale, packageId, packageSha256 }` for every package the
+compiler measured. `TextBinding::create()` hashes the selected package's canonical form and requires
+an exact manifest match before the runtime can use its runs.
 
-This question was recorded as open in an earlier revision, on the assumption that the screen carried
-baked glyph runs. It closes with that assumption. The reason to prefer it, stated as a consequence
-rather than a preference: **adding an approved locale rewrites no screen artifact**, so a translation
-update cannot change the digest of a screen whose layout nobody touched. In a byte-compared evidence
-pipeline that is the difference between re-verifying one artifact and re-verifying all of them.
+This amends the earlier consequence that adding a locale or changing a translation rewrote no screen
+artifact. It now rewrites `approvedTextPackages` and the screen's digest intentionally. The layout is
+still not duplicated and no glyph bytes move into the screen; the changed digest records that the
+reviewed words available to that screen changed.
 
 ### 2. The payload is **layout, not geometry**
 
@@ -237,12 +236,17 @@ human should read.
 - A device build links no host-tools module and parses nothing at startup, because the generated
   C++ is `constexpr` and lands in `.rodata`.
 - `static_assert` moves malformed-screen detection from startup to compile.
+- A valid but unreviewed text package cannot be substituted for one the compiler measured; package
+  id and canonical digest are authenticated once when the binding is created.
 
 ### Negative
 - **A fourth artifact kind to maintain**, with its own recipe schema, baker and update target.
 - **Layout diffs are verbose.** Moving a container by eight pixels rewrites every descendant's
   absolute rectangle in `package.json`. The alternative — storing relative offsets and resolving on
   device — is the layout solving ADR-011 forbids, so this is accepted rather than solved.
+- **Translation changes rewrite the screen package digest.** The layout may be unchanged, but its
+  approval manifest is not. This is accepted because the digest now answers which exact wording was
+  approved for the screen; the glyph runs themselves remain in their per-locale packages.
 - **Two files must stay consistent.** A node in `goldens.json` names a node in `package.json`;
   nothing in the format prevents them diverging. The check cannot live in the governed
   `validate()`: decision 4 puts the goldens outside the schema precisely because the runtime never

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -104,8 +104,10 @@ that way, both binding on #198:
 **Locales do not multiply this layout.** One screen and one directory serve every approved locale,
 because per-locale glyph runs remain in text packages. The screen does carry a compact approval
 manifest, however: `TextPackageApproval { locale, packageId, packageSha256 }` for every package the
-compiler measured. `TextBinding::create()` hashes the selected package's canonical form and requires
-an exact manifest match before the runtime can use its runs.
+compiler measured. The compiler first proves the input file is the canonical serialization, then
+`TextBinding::create()` hashes those already-loaded bytes without allocation and requires an exact
+manifest match. The binding retains that identity, and `render()` refuses it against a screen whose
+manifest does not contain the same record.
 
 This amends the earlier consequence that adding a locale or changing a translation rewrote no screen
 artifact. It now rewrites `approvedTextPackages` and the screen's digest intentionally. The layout is
@@ -237,7 +239,8 @@ human should read.
   C++ is `constexpr` and lands in `.rodata`.
 - `static_assert` moves malformed-screen detection from startup to compile.
 - A valid but unreviewed text package cannot be substituted for one the compiler measured; package
-  id and canonical digest are authenticated once when the binding is created.
+  id and canonical digest are authenticated when the binding is created and the retained identity
+  is checked against each render target.
 
 ### Negative
 - **A fourth artifact kind to maintain**, with its own recipe schema, baker and update target.

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -105,9 +105,10 @@ that way, both binding on #198:
 because per-locale glyph runs remain in text packages. The screen does carry a compact approval
 manifest, however: `TextPackageApproval { locale, packageId, packageSha256 }` for every package the
 compiler measured. The compiler first proves the input file is the canonical serialization, then
-`TextBinding::create()` hashes those already-loaded bytes without allocation and requires an exact
-manifest match. The binding retains that identity, and `render()` refuses it against a screen whose
-manifest does not contain the same record.
+`TextBinding::create()` hashes those already-loaded bytes and the supplied parsed package's canonical
+form without allocation, requires both digests to agree, and then requires an exact manifest match.
+The binding retains that identity, and `render()` refuses it against a screen whose manifest does not
+contain the same record.
 
 This amends the earlier consequence that adding a locale or changing a translation rewrote no screen
 artifact. It now rewrites `approvedTextPackages` and the screen's digest intentionally. The layout is

--- a/generated/screen/endoscope-monitor/package.json
+++ b/generated/screen/endoscope-monitor/package.json
@@ -1,4 +1,11 @@
 {
+  "approvedTextPackages": [
+    {
+      "locale": "en-US",
+      "packageId": "endoscope-monitor-en-us",
+      "packageSha256": "f8ed5dda0711eaa721fb63f2fc2054b8563849f2bbe38df43913d733cdeeb87b"
+    }
+  ],
   "budget": {
     "maxCommands": 64,
     "maxIndices": 6144,

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -40,7 +40,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "3bb40b1e7abf842ed7ec58dac8509b67f1bdd06809e5c36ad65360c2f5d7401e"
+      "sha256": "79bb460bbf10e51b69eeddde9782e3ef99c464a2c8d9e71cc0601623703fde07"
     }
   ],
   "recipe": {

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -31,16 +31,18 @@
  * That is the same split `mdux.ml.schema` makes with `mdux-mlbake`, and it is the price of a type a
  * device can hold in `.rodata`.
  *
- * ## The package is locale-free, and that is load-bearing
+ * ## The layout is locale-free; the approved package identities are not
  *
  * ADR-011, as amended by #203, carries `textKey` and `colorToken` as **validated names** rather than
  * as glyph runs and RGBA8. The device resolves each against a governed table for the locale it is
  * running - a bounded lookup, not a parse - and the per-locale glyph runs stay in the text package
  * where ADR-010 put them.
  *
- * The consequence that decides the file layout: **adding an approved locale rewrites no screen
- * artifact.** Translations change far more often than layouts, and a package carrying runs would
- * make the frequent change rewrite the stable artifact - and its digest, and its review.
+ * The screen still carries no locale-selected glyph run, so one layout serves every approved
+ * locale. It does carry the identity of every text package the compiler measured: locale, package
+ * id and canonical `package.json` digest. A changed translation therefore rewrites this small
+ * approval manifest, deliberately - otherwise a different, individually valid package could be
+ * substituted after review while every local consistency check still passed.
  *
  * The cost, stated as a cost: one rectangle serves every locale, so it must be the one that
  * survives the widest approved translation. That is what #195 measures, and why the budget below
@@ -83,6 +85,7 @@ export module mdux.medui.schema;
 import std;
 import mdux.core.result;
 import mdux.draw;
+import mdux.evidence.digest;
 import mdux.evidence.report;
 
 export namespace mdux::medui {
@@ -111,6 +114,9 @@ enum class SchemaError : std::uint8_t {
     NonPositiveMaxLength,      ///< a text input that can hold no character
     EmptyBudget,               ///< a screen with nodes whose budget can hold no primitive
     BudgetExceedsIndexWidth,   ///< more vertices than a 16-bit index can address
+    EmptyApprovedLocale,       ///< a text-package approval does not name its locale
+    EmptyApprovedPackageId,    ///< a text-package approval does not name its package
+    DuplicateApprovedLocale,   ///< two text-package approvals claim the same locale
 };
 
 [[nodiscard]] constexpr std::string_view describe(SchemaError error) noexcept {
@@ -147,6 +153,12 @@ enum class SchemaError : std::uint8_t {
             return "the screen has nodes and a budget that can hold no primitive";
         case SchemaError::BudgetExceedsIndexWidth:
             return "the vertex budget exceeds what a 16-bit index can address";
+        case SchemaError::EmptyApprovedLocale:
+            return "an approved text package does not name its locale";
+        case SchemaError::EmptyApprovedPackageId:
+            return "an approved text package does not name its package id";
+        case SchemaError::DuplicateApprovedLocale:
+            return "two approved text packages claim the same locale";
     }
     return "unknown schema error";
 }
@@ -547,18 +559,34 @@ static_assert(std::variant_size_v<NodePayload> == 11, "an alternative was added 
 }
 
 /**
+ * @brief One text package this screen was compiled and reviewed against.
+ *
+ * The package remains outside the screen: it owns the locale's glyph runs and sidecar. This record
+ * is only its identity, sufficient for `TextBinding::create()` to refuse a different package even
+ * when that package is internally valid, uses the same font and carries the same keys.
+ */
+struct TextPackageApproval {
+    std::string_view locale;           ///< the package's BCP 47 locale
+    std::string_view packageId;        ///< the package header id
+    evidence::Digest packageSha256{};  ///< SHA-256 of its canonical `package.json`
+
+    [[nodiscard]] constexpr bool operator==(const TextPackageApproval&) const noexcept = default;
+};
+
+/**
  * @brief A whole compiled screen as generated code exposes it and the runtime consumes it.
  *
  * Non-owning and `constexpr`-constructible throughout, so a generated translation unit can place one
  * in read-only memory and `static_assert` that it validates.
  */
 struct ScreenPackage {
-    std::string_view              id;
-    std::uint64_t                 schemaVersion{evidence::kSchemaVersion};
-    std::int32_t                  surfaceWidth{0};
-    std::int32_t                  surfaceHeight{0};
-    std::span<const CompiledNode> nodes;
-    mdux::draw::DrawBudget        budget{};
+    std::string_view                     id;
+    std::uint64_t                        schemaVersion{evidence::kSchemaVersion};
+    std::int32_t                         surfaceWidth{0};
+    std::int32_t                         surfaceHeight{0};
+    std::span<const TextPackageApproval> approvedTextPackages;
+    std::span<const CompiledNode>        nodes;
+    mdux::draw::DrawBudget               budget{};
 
     /// Checks every invariant a consumer is entitled to assume. See the module comment for the one
     /// invariant it deliberately leaves to the compiler: whether the budget is *large enough*.
@@ -764,6 +792,21 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
     }
     if (surfaceWidth <= 0 || surfaceHeight <= 0) {
         return err(SchemaError::NonPositiveSurface);
+    }
+
+    for (std::size_t index = 0; index < approvedTextPackages.size(); ++index) {
+        const TextPackageApproval& approval = approvedTextPackages[index];
+        if (approval.locale.empty()) {
+            return err(SchemaError::EmptyApprovedLocale);
+        }
+        if (approval.packageId.empty()) {
+            return err(SchemaError::EmptyApprovedPackageId);
+        }
+        for (std::size_t earlier = 0; earlier < index; ++earlier) {
+            if (approvedTextPackages[earlier].locale == approval.locale) {
+                return err(SchemaError::DuplicateApprovedLocale);
+            }
+        }
     }
 
     for (std::size_t index = 0; index < nodes.size(); ++index) {

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -98,25 +98,27 @@ inline constexpr std::string_view packageKind = "screen";
 inline constexpr std::string_view colorTokenPrefix = "Theme.Colors.";
 
 enum class SchemaError : std::uint8_t {
-    UnsupportedSchemaVersion,  ///< the package declares a version this module does not read
-    EmptyId,                   ///< the screen has no id, so no directory and no evidence entry
-    NonPositiveSurface,        ///< a surface with no extent cannot contain a rectangle
-    EmptyNodeId,               ///< a node with no id cannot be named by a golden or a requirement
-    DuplicateNodeId,           ///< two nodes share an id, so a golden could name either
-    DegenerateBounds,          ///< a rectangle with no extent, which `DrawList` refuses to record
-    BoundsOutsideSurface,      ///< a rectangle the declared surface does not contain
-    MalformedColorToken,       ///< a colour that is not a `Theme.Colors.<Token>` name
-    UnknownColorToken,         ///< a well-formed name the governed table does not define
-    UnknownPayload,            ///< a payload this module cannot name, or one left valueless
-    EmptyRequiredName,         ///< a spec field the component dictionary requires is empty
-    NoStates,                  ///< a status indicator that can show nothing
-    StateColorCountMismatch,   ///< per-state tints that do not pair one-to-one with the states
-    NonPositiveMaxLength,      ///< a text input that can hold no character
-    EmptyBudget,               ///< a screen with nodes whose budget can hold no primitive
-    BudgetExceedsIndexWidth,   ///< more vertices than a 16-bit index can address
-    EmptyApprovedLocale,       ///< a text-package approval does not name its locale
-    EmptyApprovedPackageId,    ///< a text-package approval does not name its package
-    DuplicateApprovedLocale,   ///< two text-package approvals claim the same locale
+    UnsupportedSchemaVersion,    ///< the package declares a version this module does not read
+    EmptyId,                     ///< the screen has no id, so no directory and no evidence entry
+    NonPositiveSurface,          ///< a surface with no extent cannot contain a rectangle
+    EmptyNodeId,                 ///< a node with no id cannot be named by a golden or a requirement
+    DuplicateNodeId,             ///< two nodes share an id, so a golden could name either
+    DegenerateBounds,            ///< a rectangle with no extent, which `DrawList` refuses to record
+    BoundsOutsideSurface,        ///< a rectangle the declared surface does not contain
+    MalformedColorToken,         ///< a colour that is not a `Theme.Colors.<Token>` name
+    UnknownColorToken,           ///< a well-formed name the governed table does not define
+    UnknownPayload,              ///< a payload this module cannot name, or one left valueless
+    EmptyRequiredName,           ///< a spec field the component dictionary requires is empty
+    NoStates,                    ///< a status indicator that can show nothing
+    StateColorCountMismatch,     ///< per-state tints that do not pair one-to-one with the states
+    NonPositiveMaxLength,        ///< a text input that can hold no character
+    EmptyBudget,                 ///< a screen with nodes whose budget can hold no primitive
+    BudgetExceedsIndexWidth,     ///< more vertices than a 16-bit index can address
+    EmptyApprovedLocale,         ///< a text-package approval does not name its locale
+    EmptyApprovedPackageId,      ///< a text-package approval does not name its package
+    EmptyApprovedPackageDigest,  ///< a text-package approval carries no package identity
+    DuplicateApprovedLocale,     ///< two text-package approvals claim the same locale
+    MissingTextPackageApproval,  ///< a text-bearing screen approves no text package
 };
 
 [[nodiscard]] constexpr std::string_view describe(SchemaError error) noexcept {
@@ -157,8 +159,12 @@ enum class SchemaError : std::uint8_t {
             return "an approved text package does not name its locale";
         case SchemaError::EmptyApprovedPackageId:
             return "an approved text package does not name its package id";
+        case SchemaError::EmptyApprovedPackageDigest:
+            return "an approved text package does not carry its package digest";
         case SchemaError::DuplicateApprovedLocale:
             return "two approved text packages claim the same locale";
+        case SchemaError::MissingTextPackageApproval:
+            return "a text-bearing screen approves no text package";
     }
     return "unknown schema error";
 }
@@ -781,6 +787,16 @@ struct ScreenPackage {
     return requireColor(spec->colorToken);
 }
 
+/// Whether this payload needs the font/locale inputs the text-budget stage approves.
+///
+/// Kept beside `validatePayload()` so a component added to the closed payload set cannot acquire
+/// text-bearing fields without the schema's approval-manifest rule being visible in the same edit.
+[[nodiscard]] constexpr bool needsTextPackageApproval(NodePayload payload) noexcept {
+    return std::holds_alternative<LabelSpec>(payload) || std::holds_alternative<ClockSpec>(payload) || std::holds_alternative<ButtonSpec>(payload)
+           || std::holds_alternative<CriticalButtonSpec>(payload) || std::holds_alternative<NumericDisplaySpec>(payload)
+           || std::holds_alternative<StatusIndicatorSpec>(payload) || std::holds_alternative<TextInputSpec>(payload);
+}
+
 constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const noexcept {
     using mdux::core::err;
 
@@ -802,6 +818,9 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
         if (approval.packageId.empty()) {
             return err(SchemaError::EmptyApprovedPackageId);
         }
+        if (approval.packageSha256 == evidence::Digest{}) {
+            return err(SchemaError::EmptyApprovedPackageDigest);
+        }
         for (std::size_t earlier = 0; earlier < index; ++earlier) {
             if (approvedTextPackages[earlier].locale == approval.locale) {
                 return err(SchemaError::DuplicateApprovedLocale);
@@ -811,6 +830,10 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
 
     for (std::size_t index = 0; index < nodes.size(); ++index) {
         const CompiledNode& node = nodes[index];
+
+        if (approvedTextPackages.empty() && needsTextPackageApproval(node.payload)) {
+            return err(SchemaError::MissingTextPackageApproval);
+        }
 
         if (node.id.empty()) {
             return err(SchemaError::EmptyNodeId);

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -114,6 +114,7 @@ import std;
 import mdux.core.result;
 import mdux.core.units;
 import mdux.draw;
+import mdux.evidence.digest;
 import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.text.draw;
@@ -141,9 +142,10 @@ enum class ScreenError : std::uint8_t {
 
 [[nodiscard]] std::string_view describe(ScreenError error) noexcept;
 
-// `AtlasMismatch`, `SidecarMismatch` and `PackageNotApproved` are `create()`'s, not a frame's: they
-// are properties of the four artifacts a caller bound together, decided once. `TextOverflowsNode`
-// is a frame's, and remains defense in depth after the package identity is authenticated.
+// `AtlasMismatch` and `SidecarMismatch` are `create()`'s, not a frame's: they are properties of the
+// artifacts a caller bound together, decided once. `PackageNotApproved` can also be a frame's when
+// a valid binding is offered to a different screen, and `TextOverflowsNode` remains defense in depth
+// after package identity is authenticated.
 
 /**
  * @brief The largest run this runtime will draw, in records.
@@ -183,9 +185,10 @@ inline constexpr std::size_t maxGlyphsPerRun = 256;
  * - every run's range must lie inside it, be a whole number of records, and hash to what the
  *   package recorded.
  *
- * So `create()` proves all of that once and is the only way to obtain a bound `TextBinding`. What
- * `render()` does per frame is a key lookup and a bounds comparison, which is what keeps the
- * bounded-work claim intact. A default-constructed binding is *unbound* and means "this caller has
+ * So `create()` proves all of that once and is the only way to obtain a bound `TextBinding`. The
+ * binding retains the approved locale/id/digest, and `render()` checks that fixed identity against
+ * its target screen before recording anything; this prevents a binding approved by screen A from
+ * being reused for screen B. A default-constructed binding is *unbound* and means "this caller has
  * no text": every text node is deferred, exactly as before #242, which is not an error.
  *
  * Nothing here is owned. The packages outlive the frame - on a device they are static - and the span
@@ -200,15 +203,20 @@ public:
     /**
      * @brief Proves the screen approved `text`, and that `font`, `text` and `runs` agree.
      *
-     * Hashes the sidecar, so it is linear in its size - once, at start-up, never in a frame.
+     * Hashes the canonical package bytes and sidecar, so it is linear in their combined size -
+     * once, at start-up, never in a frame. Both hashes are allocation-free.
      *
      * @param screen the compiled screen whose approval manifest authorizes the text package
      * @param font the font package the runs were positioned against
      * @param text the text package for the locale being run
+     * @param packageJson the canonical package bytes from which `text` was loaded
      * @param runs the sidecar bytes `text` addresses ranges of
      */
-    [[nodiscard]] static mdux::core::Result<TextBinding, ScreenError>
-    create(const ScreenPackage& screen, const mdux::font::FontPackage& font, const mdux::text::TextPackage& text, std::span<const std::byte> runs) noexcept;
+    [[nodiscard]] static mdux::core::Result<TextBinding, ScreenError> create(const ScreenPackage&           screen,
+                                                                             const mdux::font::FontPackage& font,
+                                                                             const mdux::text::TextPackage& text,
+                                                                             std::span<const std::byte>     packageJson,
+                                                                             std::span<const std::byte>     runs) noexcept;
 
     /// Whether this binding carries packages. False for a default-constructed one.
     [[nodiscard]] constexpr bool bound() const noexcept {
@@ -225,13 +233,32 @@ public:
         return runs_;
     }
 
+    /// Whether `screen` carries the exact locale/id/digest retained by this binding.
+    [[nodiscard]] constexpr bool approvedBy(const ScreenPackage& screen) const noexcept {
+        if (!bound()) {
+            return true;
+        }
+        for (const TextPackageApproval& candidate : screen.approvedTextPackages) {
+            if (candidate.locale == locale_ && candidate.packageId == packageId_ && candidate.packageSha256 == packageSha256_) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 private:
-    constexpr TextBinding(const mdux::font::FontPackage* font, const mdux::text::TextPackage* text, std::span<const std::byte> runs) noexcept
-        : font_{font}, text_{text}, runs_{runs} {}
+    constexpr TextBinding(const mdux::font::FontPackage* font,
+                          const mdux::text::TextPackage* text,
+                          std::span<const std::byte>     runs,
+                          mdux::evidence::Digest         packageSha256) noexcept
+        : font_{font}, text_{text}, runs_{runs}, locale_{text->locale}, packageId_{text->header.id}, packageSha256_{packageSha256} {}
 
     const mdux::font::FontPackage* font_{nullptr};
     const mdux::text::TextPackage* text_{nullptr};
     std::span<const std::byte>     runs_{};
+    std::string_view               locale_{};
+    std::string_view               packageId_{};
+    mdux::evidence::Digest         packageSha256_{};
 };
 
 // The guarantee `create()` is documented to give, held by the language rather than by discipline.

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -203,8 +203,10 @@ public:
     /**
      * @brief Proves the screen approved `text`, and that `font`, `text` and `runs` agree.
      *
-     * Hashes the canonical package bytes and sidecar, so it is linear in their combined size -
-     * once, at start-up, never in a frame. Both hashes are allocation-free.
+     * Hashes the canonical package bytes, independently hashes the canonical form represented by
+     * `text`, and hashes the sidecar, so approved bytes cannot be paired with different parsed
+     * wording. This is linear in their combined size - once, at start-up, never in a frame - and
+     * all three hashes are allocation-free.
      *
      * @param screen the compiled screen whose approval manifest authorizes the text package
      * @param font the font package the runs were positioned against

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -131,6 +131,7 @@ enum class ScreenError : std::uint8_t {
     RunTooLong,           ///< a run holds more than `maxGlyphsPerRun` records
     AtlasMismatch,        ///< the text package was baked against a different font package
     SidecarMismatch,      ///< the sidecar is not the one the text package describes
+    PackageNotApproved,   ///< the screen was not compiled against this locale/package/digest
     TextOverflowsNode,    ///< a run's ink is wider or taller than the node that names it
 };
 
@@ -140,10 +141,9 @@ enum class ScreenError : std::uint8_t {
 
 [[nodiscard]] std::string_view describe(ScreenError error) noexcept;
 
-// `AtlasMismatch` and `SidecarMismatch` are `create()`'s, not a frame's: both are properties of the
-// three artifacts a caller bound together, decided once. `TextOverflowsNode` is a frame's, and is
-// the check that makes the placement rule below safe against a binding this module cannot
-// authenticate - see `TextBinding` for what that means and what it does not.
+// `AtlasMismatch`, `SidecarMismatch` and `PackageNotApproved` are `create()`'s, not a frame's: they
+// are properties of the four artifacts a caller bound together, decided once. `TextOverflowsNode`
+// is a frame's, and remains defense in depth after the package identity is authenticated.
 
 /**
  * @brief The largest run this runtime will draw, in records.
@@ -160,7 +160,7 @@ enum class ScreenError : std::uint8_t {
 inline constexpr std::size_t maxGlyphsPerRun = 256;
 
 /**
- * @brief The packages a locale-free compiled screen is joined to, once its consistency is proved.
+ * @brief The packages a locale-independent screen layout is joined to, once consistency is proved.
  *
  * A compiled screen carries `textKey` rather than glyphs (ADR-011 as amended by #203), which is what
  * lets one screen serve every approved locale. The join is the device's, once, for the locale it is
@@ -169,9 +169,11 @@ inline constexpr std::size_t maxGlyphsPerRun = 256;
  *
  * ## Why this is not an aggregate
  *
- * Three artifacts have to agree before any of them can be trusted, and none of the agreements can be
+ * Four artifacts have to agree before any of them can be trusted, and none of the agreements can be
  * checked cheaply enough to repeat per frame:
  *
+ * - the screen must list this text package's locale, id and canonical-package digest, or a second,
+ *   individually valid package could display wording the screen's review never approved;
  * - the text package must be the one baked against *this* font, or the run records index a glyph
  *   table that assigns different shapes to the same numbers, and the frame draws a plausible
  *   sentence made of the wrong letters;
@@ -186,15 +188,6 @@ inline constexpr std::size_t maxGlyphsPerRun = 256;
  * bounded-work claim intact. A default-constructed binding is *unbound* and means "this caller has
  * no text": every text node is deferred, exactly as before #242, which is not an error.
  *
- * ## What it still does not prove
- *
- * That this is the package the compiler measured. A second, individually valid package can carry the
- * same key against the same font with different wording, and nothing in the artifacts links a
- * compiled screen to the packages #195 checked it against. `render()` closes the *consequence* -
- * text wider than its node is refused rather than drawn over its neighbours - but the identity
- * itself needs the compiled screen to carry it, which is a change to what a screen emits (ADR-012)
- * and is tracked separately.
- *
  * Nothing here is owned. The packages outlive the frame - on a device they are static - and the span
  * is the caller's storage, so `render()` allocates nothing by construction rather than by
  * discipline.
@@ -205,28 +198,35 @@ public:
     constexpr TextBinding() noexcept = default;
 
     /**
-     * @brief Proves `font`, `text` and `runs` describe each other, or says which one does not.
+     * @brief Proves the screen approved `text`, and that `font`, `text` and `runs` agree.
      *
      * Hashes the sidecar, so it is linear in its size - once, at start-up, never in a frame.
      *
+     * @param screen the compiled screen whose approval manifest authorizes the text package
      * @param font the font package the runs were positioned against
      * @param text the text package for the locale being run
      * @param runs the sidecar bytes `text` addresses ranges of
      */
-    [[nodiscard]] static mdux::core::Result<TextBinding, ScreenError> create(const mdux::font::FontPackage& font,
-                                                                             const mdux::text::TextPackage& text,
-                                                                             std::span<const std::byte>     runs) noexcept;
+    [[nodiscard]] static mdux::core::Result<TextBinding, ScreenError>
+    create(const ScreenPackage& screen, const mdux::font::FontPackage& font, const mdux::text::TextPackage& text, std::span<const std::byte> runs) noexcept;
 
     /// Whether this binding carries packages. False for a default-constructed one.
-    [[nodiscard]] constexpr bool bound() const noexcept { return font_ != nullptr && text_ != nullptr; }
+    [[nodiscard]] constexpr bool bound() const noexcept {
+        return font_ != nullptr && text_ != nullptr;
+    }
 
-    [[nodiscard]] constexpr const mdux::font::FontPackage* font() const noexcept { return font_; }
-    [[nodiscard]] constexpr const mdux::text::TextPackage* text() const noexcept { return text_; }
-    [[nodiscard]] constexpr std::span<const std::byte> runs() const noexcept { return runs_; }
+    [[nodiscard]] constexpr const mdux::font::FontPackage* font() const noexcept {
+        return font_;
+    }
+    [[nodiscard]] constexpr const mdux::text::TextPackage* text() const noexcept {
+        return text_;
+    }
+    [[nodiscard]] constexpr std::span<const std::byte> runs() const noexcept {
+        return runs_;
+    }
 
 private:
-    constexpr TextBinding(const mdux::font::FontPackage* font, const mdux::text::TextPackage* text,
-                          std::span<const std::byte> runs) noexcept
+    constexpr TextBinding(const mdux::font::FontPackage* font, const mdux::text::TextPackage* text, std::span<const std::byte> runs) noexcept
         : font_{font}, text_{text}, runs_{runs} {}
 
     const mdux::font::FontPackage* font_{nullptr};
@@ -274,7 +274,7 @@ struct FrameStats {
  * list can carry several screens; without the second check the screen's declared budget would be
  * decorative, and a mistake in a baked budget would be bypassed rather than observed.
  */
-[[nodiscard]] mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list,
-                                                                 const TextBinding& text = {}) noexcept;
+[[nodiscard]] mdux::core::Result<FrameStats, ScreenError>
+render(const ScreenPackage& screen, mdux::draw::DrawList& list, const TextBinding& text = {}) noexcept;
 
 }  // namespace mdux::medui

--- a/include/mdux/text/Schema.cppm
+++ b/include/mdux/text/Schema.cppm
@@ -157,6 +157,14 @@ struct TextPackage {
     /// Serializes to canonical JSON text, trailing newline included. Validates first.
     [[nodiscard]] mdux::core::Result<std::string, SchemaError> write() const noexcept;
 
+    /**
+     * @brief Hashes the exact canonical JSON bytes `write()` would produce, without allocating.
+     *
+     * This lets governed consumers prove that an already parsed package still represents the
+     * approved artifact bytes without serializing JSON on the device path.
+     */
+    [[nodiscard]] mdux::core::Result<evidence::Digest, SchemaError> canonicalSha256() const noexcept;
+
     /// Parses canonical `package.json` text. Strict: rejects a malformed shape, an unsupported
     /// `schemaVersion` and validates the result.
     [[nodiscard]] static mdux::core::Result<TextPackage, SchemaError> parse(

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -177,10 +177,14 @@ mdux::core::Result<TextBinding, ScreenError> TextBinding::create(const ScreenPac
     }
 
     // The compiler admits only canonical package bytes, so hashing the caller's already-loaded
-    // artifact is the exact identity it recorded. This is deliberately not `text.write()`: JSON
-    // serialization allocates, and an allocation failure inside this noexcept governed path would
-    // terminate rather than fail closed.
+    // artifact is the exact identity it recorded. The allocation-free canonical hash additionally
+    // proves those bytes describe the `text` object that will drive rendering; otherwise approved
+    // bytes for package A could be paired with parsed content from package B.
     const mdux::evidence::Digest packageSha256 = mdux::evidence::sha256(packageJson);
+    const auto                   textSha256    = text.canonicalSha256();
+    if (!textSha256.has_value() || *textSha256 != packageSha256) {
+        return mdux::core::err(ScreenError::PackageNotApproved);
+    }
 
     const auto approved = std::ranges::find_if(screen.approvedTextPackages, [&](const TextPackageApproval& candidate) {
         return candidate.locale == text.locale && candidate.packageId == text.header.id && candidate.packageSha256 == packageSha256;

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -133,6 +133,7 @@ struct InkBox {
 mdux::core::Result<TextBinding, ScreenError> TextBinding::create(const ScreenPackage&           screen,
                                                                  const mdux::font::FontPackage& font,
                                                                  const mdux::text::TextPackage& text,
+                                                                 std::span<const std::byte>     packageJson,
                                                                  std::span<const std::byte>     runs) noexcept {
     // The runs index `font.glyphs` by position, so a package baked against another font names the
     // same numbers for different shapes. Nothing downstream can detect that: every index would still
@@ -175,14 +176,11 @@ mdux::core::Result<TextBinding, ScreenError> TextBinding::create(const ScreenPac
         }
     }
 
-    // Package identity is the canonical package.json, not only the fields the runtime happens to
-    // read. Re-serializing the validated owning package gives the same bytes the baker committed and
-    // prevents a caller from supplying an approved digest beside a different in-memory package.
-    const auto canonical = text.write();
-    if (!canonical.has_value()) {
-        return mdux::core::err(ScreenError::PackageNotApproved);
-    }
-    const mdux::evidence::Digest packageSha256 = mdux::evidence::sha256(std::as_bytes(std::span{canonical->data(), canonical->size()}));
+    // The compiler admits only canonical package bytes, so hashing the caller's already-loaded
+    // artifact is the exact identity it recorded. This is deliberately not `text.write()`: JSON
+    // serialization allocates, and an allocation failure inside this noexcept governed path would
+    // terminate rather than fail closed.
+    const mdux::evidence::Digest packageSha256 = mdux::evidence::sha256(packageJson);
 
     const auto approved = std::ranges::find_if(screen.approvedTextPackages, [&](const TextPackageApproval& candidate) {
         return candidate.locale == text.locale && candidate.packageId == text.header.id && candidate.packageSha256 == packageSha256;
@@ -191,7 +189,7 @@ mdux::core::Result<TextBinding, ScreenError> TextBinding::create(const ScreenPac
         return mdux::core::err(ScreenError::PackageNotApproved);
     }
 
-    return TextBinding{&font, &text, runs};
+    return TextBinding{&font, &text, runs, packageSha256};
 }
 
 std::string_view describe(ScreenError error) noexcept {
@@ -235,6 +233,12 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
         static_cast<void>(list.rollback(start));
         return mdux::core::err(error);
     };
+
+    // A binding retains the identity create() authenticated. Re-checking it against the target
+    // screen closes the cross-screen substitution path without rehashing or allocating.
+    if (!text.approvedBy(screen)) {
+        return refuse(ScreenError::PackageNotApproved);
+    }
 
     // Where the list stood before this frame. The screen's own budget bounds what *this screen*
     // draws, and `DrawList` can only enforce the budget it was created with - which may be larger,

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -61,8 +61,12 @@ struct InkBox {
     mdux::core::Px right{0};   ///< exclusive
     mdux::core::Px bottom{0};  ///< exclusive
 
-    [[nodiscard]] constexpr mdux::core::Px width() const noexcept { return right - left; }
-    [[nodiscard]] constexpr mdux::core::Px height() const noexcept { return bottom - top; }
+    [[nodiscard]] constexpr mdux::core::Px width() const noexcept {
+        return right - left;
+    }
+    [[nodiscard]] constexpr mdux::core::Px height() const noexcept {
+        return bottom - top;
+    }
 };
 
 /**
@@ -76,8 +80,7 @@ struct InkBox {
  * Placement arithmetic is `addGlyphRect()`'s and is not restated: `bitmapOriginX` from the pen, and
  * `bitmapOriginY` measured *up* from the baseline, hence subtracted on a downward y axis.
  */
-[[nodiscard]] mdux::core::Result<InkBox, ScreenError> measureInk(const mdux::font::FontPackage& font,
-                                                                 std::span<const std::byte>     records) noexcept {
+[[nodiscard]] mdux::core::Result<InkBox, ScreenError> measureInk(const mdux::font::FontPackage& font, std::span<const std::byte> records) noexcept {
     InkBox box;
     for (std::size_t offset = 0; offset < records.size(); offset += mdux::text::draw::recordSize) {
         const auto placement = mdux::text::draw::decodeRecord(records.subspan(offset, mdux::text::draw::recordSize));
@@ -117,8 +120,7 @@ struct InkBox {
 ///
 /// The one failure left is the screen's rather than the binding's: a key this package does not
 /// carry means the wrong locale, or the wrong package, was bound for this screen.
-[[nodiscard]] mdux::core::Result<std::span<const std::byte>, ScreenError> runFor(const TextBinding& binding,
-                                                                                  std::string_view   textKey) noexcept {
+[[nodiscard]] mdux::core::Result<std::span<const std::byte>, ScreenError> runFor(const TextBinding& binding, std::string_view textKey) noexcept {
     const mdux::text::TextRun* run = binding.text()->find(textKey);
     if (run == nullptr) {
         return mdux::core::err(ScreenError::UnknownTextKey);
@@ -128,7 +130,8 @@ struct InkBox {
 
 }  // namespace
 
-mdux::core::Result<TextBinding, ScreenError> TextBinding::create(const mdux::font::FontPackage& font,
+mdux::core::Result<TextBinding, ScreenError> TextBinding::create(const ScreenPackage&           screen,
+                                                                 const mdux::font::FontPackage& font,
                                                                  const mdux::text::TextPackage& text,
                                                                  std::span<const std::byte>     runs) noexcept {
     // The runs index `font.glyphs` by position, so a package baked against another font names the
@@ -172,6 +175,22 @@ mdux::core::Result<TextBinding, ScreenError> TextBinding::create(const mdux::fon
         }
     }
 
+    // Package identity is the canonical package.json, not only the fields the runtime happens to
+    // read. Re-serializing the validated owning package gives the same bytes the baker committed and
+    // prevents a caller from supplying an approved digest beside a different in-memory package.
+    const auto canonical = text.write();
+    if (!canonical.has_value()) {
+        return mdux::core::err(ScreenError::PackageNotApproved);
+    }
+    const mdux::evidence::Digest packageSha256 = mdux::evidence::sha256(std::as_bytes(std::span{canonical->data(), canonical->size()}));
+
+    const auto approved = std::ranges::find_if(screen.approvedTextPackages, [&](const TextPackageApproval& candidate) {
+        return candidate.locale == text.locale && candidate.packageId == text.header.id && candidate.packageSha256 == packageSha256;
+    });
+    if (approved == screen.approvedTextPackages.end()) {
+        return mdux::core::err(ScreenError::PackageNotApproved);
+    }
+
     return TextBinding{&font, &text, runs};
 }
 
@@ -193,6 +212,8 @@ std::string_view describe(ScreenError error) noexcept {
             return "the text package was baked against a different font package";
         case ScreenError::SidecarMismatch:
             return "the sidecar is not the one the text package describes";
+        case ScreenError::PackageNotApproved:
+            return "the screen was not compiled against this text package";
         case ScreenError::TextOverflowsNode:
             return "a run's ink is larger than the node that names it";
     }
@@ -201,8 +222,7 @@ std::string_view describe(ScreenError error) noexcept {
     return "unknown screen error";
 }
 
-mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list,
-                                                   const TextBinding& text) noexcept {
+mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, mdux::draw::DrawList& list, const TextBinding& text) noexcept {
     // Taken before anything is recorded: every refusal below rolls back to here, so a frame is
     // whole or absent. A half-drawn frame on a medical display is the worst outcome available,
     // because it looks like a reading.
@@ -246,8 +266,7 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
 
             const auto labelColour = resolveColorToken(label->colorToken);
             if (!labelColour.has_value()) {
-                return refuse(labelColour.error() == ThemeError::MalformedToken ? ScreenError::MalformedColorToken
-                                                                                : ScreenError::UnknownColorToken);
+                return refuse(labelColour.error() == ThemeError::MalformedToken ? ScreenError::MalformedColorToken : ScreenError::UnknownColorToken);
             }
 
             const auto records = runFor(text, label->textKey);
@@ -276,8 +295,7 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
             // authenticate. #195 proved this box fits this rectangle for the package it measured;
             // this proves it for the package actually bound, at the cost of one comparison over a
             // walk the placement needs anyway. See Screen.cppm for why the two are not redundant.
-            if (ink->width() > static_cast<mdux::core::Px>(node.bounds.width)
-                || ink->height() > static_cast<mdux::core::Px>(node.bounds.height)) {
+            if (ink->width() > static_cast<mdux::core::Px>(node.bounds.width) || ink->height() > static_cast<mdux::core::Px>(node.bounds.height)) {
                 return refuse(ScreenError::TextOverflowsNode);
             }
 
@@ -287,8 +305,7 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
             const auto originY = static_cast<mdux::core::Px>(node.bounds.y) - ink->top;
 
             const std::size_t verticesBefore = list.vertices().size();
-            if (const auto recorded =
-                    mdux::text::draw::recordRun(list, *text.font(), *records, originX, originY, toColor(*labelColour));
+            if (const auto recorded = mdux::text::draw::recordRun(list, *text.font(), *records, originX, originY, toColor(*labelColour));
                 !recorded.has_value()) {
                 // `recordRun()` rolls its own run back and this rolls the whole frame back. Its error
                 // is not forwarded: every way it can fail here is either something `runFor()` and

--- a/src/text/Schema.cpp
+++ b/src/text/Schema.cpp
@@ -89,6 +89,89 @@ namespace {
     return {};
 }
 
+/// Allocation-free mirror of the canonical JSON writer for TextPackage's fixed schema.
+class PackageDigestWriter {
+public:
+    void text(std::string_view value) noexcept {
+        hasher_.update(std::as_bytes(std::span{value.data(), value.size()}));
+    }
+
+    template <std::size_t Size>
+    void text(const std::array<char, Size>& value) noexcept {
+        hasher_.update(std::as_bytes(std::span{value}));
+    }
+
+    void escaped(std::string_view value) noexcept {
+        text("\"");
+        for (const char character : value) {
+            switch (character) {
+                case '"':
+                    text("\\\"");
+                    break;
+                case '\\':
+                    text("\\\\");
+                    break;
+                case '\b':
+                    text("\\b");
+                    break;
+                case '\f':
+                    text("\\f");
+                    break;
+                case '\n':
+                    text("\\n");
+                    break;
+                case '\r':
+                    text("\\r");
+                    break;
+                case '\t':
+                    text("\\t");
+                    break;
+                default:
+                    if (static_cast<unsigned char>(character) < 0x20) {
+                        constexpr std::string_view digits = "0123456789abcdef";
+                        const auto byte = static_cast<unsigned char>(character);
+                        const std::array<char, 6> escapedCharacter{
+                            '\\', 'u', '0', '0', digits[(byte >> 4) & 0x0fu], digits[byte & 0x0fu]
+                        };
+                        text(escapedCharacter);
+                    } else {
+                        const std::array<char, 1> raw{character};
+                        text(raw);
+                    }
+                    break;
+            }
+        }
+        text("\"");
+    }
+
+    void unsignedInteger(std::uint64_t value) noexcept {
+        std::array<char, 20> digits{};
+        std::size_t length = 0;
+        do {
+            digits[length++] = static_cast<char>('0' + value % 10);
+            value /= 10;
+        } while (value != 0);
+        for (std::size_t index = length; index > 0; --index) {
+            const std::array<char, 1> digit{digits[index - 1]};
+            text(digit);
+        }
+    }
+
+    void digest(const evidence::Digest& value) noexcept {
+        const std::array<char, 64> hex = evidence::toHex(value);
+        text("\"");
+        text(hex);
+        text("\"");
+    }
+
+    [[nodiscard]] evidence::Digest finish() const noexcept {
+        return hasher_.finish();
+    }
+
+private:
+    evidence::Sha256 hasher_{};
+};
+
 [[nodiscard]] ResultVoid<SchemaError> pushElement(json::Value& array, json::Value value) noexcept {
     if (auto done = array.push(std::move(value)); !done.has_value()) {
         return err(SchemaError::MalformedPackage);
@@ -279,6 +362,51 @@ Result<std::string, SchemaError> TextPackage::write() const noexcept {
         return err(SchemaError::MalformedPackage);
     }
     return *text;
+}
+
+Result<evidence::Digest, SchemaError> TextPackage::canonicalSha256() const noexcept {
+    if (auto valid = validate(); !valid.has_value()) {
+        return err(valid.error());
+    }
+
+    PackageDigestWriter writer;
+    writer.text("{\n  \"atlas\": ");
+    writer.escaped(atlasId);
+    writer.text(",\n  \"id\": ");
+    writer.escaped(header.id);
+    writer.text(",\n  \"kind\": ");
+    writer.escaped(header.kind);
+    writer.text(",\n  \"locale\": ");
+    writer.escaped(locale);
+    writer.text(",\n  \"runs\": ");
+    if (runs.empty()) {
+        writer.text("[]");
+    } else {
+        writer.text("[\n");
+        for (std::size_t index = 0; index < runs.size(); ++index) {
+            const TextRun& run = runs[index];
+            writer.text("    {\n      \"byteLength\": ");
+            writer.unsignedInteger(run.byteLength);
+            writer.text(",\n      \"byteOffset\": ");
+            writer.unsignedInteger(run.byteOffset);
+            writer.text(",\n      \"id\": ");
+            writer.escaped(run.id);
+            writer.text(",\n      \"sha256\": ");
+            writer.digest(run.sha256);
+            writer.text(index + 1 < runs.size() ? "\n    },\n" : "\n    }\n");
+        }
+        writer.text("  ]");
+    }
+    writer.text(",\n  \"schemaVersion\": ");
+    writer.unsignedInteger(header.schemaVersion);
+    writer.text(",\n  \"sidecar\": {\n    \"byteLength\": ");
+    writer.unsignedInteger(sidecarByteLength);
+    writer.text(",\n    \"path\": ");
+    writer.escaped(sidecarPath);
+    writer.text(",\n    \"sha256\": ");
+    writer.digest(sidecarSha256);
+    writer.text("\n  }\n}\n");
+    return writer.finish();
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -19,6 +19,7 @@
 import std;
 import speclab;
 import mdux.draw;
+import mdux.evidence.digest;
 import mdux.evidence.report;
 import mdux.medui.schema;
 import mdux.tools.cli;
@@ -199,6 +200,53 @@ const mdux::spec::Register aCompileProducesThreeArtifacts{
                           checks.expect(report->outputs.size() == 2, std::format("package.json and goldens.json are recorded, got {}", report->outputs.size()));
                           checks.expect(report->inputs.size() == 1, std::format("the .medui source is the only input, got {}", report->inputs.size()));
                           checks.expect(report->validate().has_value(), "the report satisfies its own schema");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register compileCarriesApprovedPackageIdentity{
+    "A compiled screen carries the exact text package identity it was measured against",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-text-package-approval")
+            .Given("the committed endoscope screen recipe and its approved en-US text package", [] {})
+            .When("the compiler produces package.json", [] {})
+            .Then("the screen records that package's locale, id and exact input digest",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const std::string            recipeText = contentsOf(repoRoot() / "recipes/screen/endoscope-monitor.toml");
+                      const auto                   recipe     = md::parseRecipe(recipeText, "recipes/screen/endoscope-monitor.toml", diagnostics);
+                      if (!recipe.has_value()) {
+                          checks.expect(false, std::format("the committed recipe parses, first diagnostic '{}'", firstCode(diagnostics)));
+                          checks.raise();
+                          return;
+                      }
+
+                      const auto outputs = md::run(*recipe, "recipes/screen/endoscope-monitor.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, std::format("the committed screen compiles, first diagnostic '{}'", firstCode(diagnostics)));
+                          checks.raise();
+                          return;
+                      }
+
+                      const md::PackageReadResult read = md::readPackage(outputs->packageJson, "package.json");
+                      checks.expect(read.ok(), std::format("the compiled package reads back, first diagnostic '{}'", firstCode(read.diagnostics)));
+                      if (read.ok()) {
+                          const ms::ScreenPackage package = read.document.package();
+                          checks.expect(package.approvedTextPackages.size() == 1,
+                                        std::format("one locale is approved, got {}", package.approvedTextPackages.size()));
+                          if (package.approvedTextPackages.size() == 1) {
+                              const ms::TextPackageApproval& approval = package.approvedTextPackages.front();
+                              const std::string              textJson = contentsOf(repoRoot() / "generated/text/endoscope-monitor-en-us/package.json");
+                              checks.expect(approval.locale == "en-US", std::format("the locale is en-US, got '{}'", approval.locale));
+                              checks.expect(approval.packageId == "endoscope-monitor-en-us",
+                                            std::format("the package id is retained, got '{}'", approval.packageId));
+                              checks.expect(approval.packageSha256 == mdux::evidence::sha256(asBytes(textJson)),
+                                            "the approval digest is the exact package.json input digest");
+                          }
                       }
                       checks.raise();
                   })

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -21,7 +21,10 @@ import speclab;
 import mdux.draw;
 import mdux.evidence.digest;
 import mdux.evidence.report;
+import mdux.font.schema;
 import mdux.medui.schema;
+import mdux.medui.screen;
+import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.compile;
 import mdux.tools.medui.package;
@@ -246,8 +249,85 @@ const mdux::spec::Register compileCarriesApprovedPackageIdentity{
                                             std::format("the package id is retained, got '{}'", approval.packageId));
                               checks.expect(approval.packageSha256 == mdux::evidence::sha256(asBytes(textJson)),
                                             "the approval digest is the exact package.json input digest");
+
+                              const std::string fontJson = contentsOf(repoRoot() / "generated/font/dejavu-ui/package.json");
+                              const std::string runs     = contentsOf(repoRoot() / "generated/text/endoscope-monitor-en-us/runs.bin");
+                              const auto        font     = mdux::font::FontPackage::parse(fontJson);
+                              const auto        text     = mdux::text::TextPackage::parse(textJson);
+                              checks.expect(font.has_value() && text.has_value(), "the committed font and text packages parse without Vulkan");
+                              if (font.has_value() && text.has_value()) {
+                                  const auto binding = ms::TextBinding::create(package, *font, *text, asBytes(textJson), asBytes(runs));
+                                  checks.expect(binding.has_value(), "the compiler digest and runtime digest agree on the committed package");
+                              }
                           }
                       }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register noncanonicalTextPackageIsRefused{
+    "A valid but noncanonical text package is refused where an author can rebake it",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-canonical-text-package")
+            .Given("the committed screen inputs with whitespace added to the text package JSON", [] {})
+            .When("the compiler loads the locale package", [] {})
+            .Then("it reports MEDUI-E002 instead of emitting an identity the runtime cannot reproduce",
+                  [] {
+                      mdux::spec::Checks             checks;
+                      std::vector<cli::Diagnostic>   diagnostics;
+                      mdux::test::TemporaryDirectory root{"mdux-meduic-canonical-text"};
+
+                      const auto copy = [&](std::string_view relative) {
+                          const std::filesystem::path destination = root.path() / relative;
+                          std::filesystem::create_directories(destination.parent_path());
+                          std::filesystem::copy_file(repoRoot() / relative, destination, std::filesystem::copy_options::overwrite_existing);
+                      };
+                      copy("recipes/screen/endoscope-monitor/EndoscopeMonitor.medui");
+                      copy("generated/font/dejavu-ui/package.json");
+                      copy("generated/text/endoscope-monitor-en-us/runs.bin");
+
+                      const std::filesystem::path textPath = root.path() / "generated/text/endoscope-monitor-en-us/package.json";
+                      std::filesystem::create_directories(textPath.parent_path());
+                      std::ofstream textFile{textPath, std::ios::binary};
+                      textFile << ' ' << contentsOf(repoRoot() / "generated/text/endoscope-monitor-en-us/package.json");
+                      textFile.close();
+
+                      const std::string recipeText = contentsOf(repoRoot() / "recipes/screen/endoscope-monitor.toml");
+                      const auto        recipe     = md::parseRecipe(recipeText, "recipes/screen/endoscope-monitor.toml", diagnostics);
+                      checks.expect(recipe.has_value(), "the committed recipe parses");
+                      if (recipe.has_value()) {
+                          const auto outputs = md::run(*recipe, "recipes/screen/endoscope-monitor.toml", asBytes(recipeText), root.path(), diagnostics);
+                          checks.expect(!outputs.has_value(), "the noncanonical text package is refused");
+                          checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
+                          checks.expect(!diagnostics.empty() && diagnostics.front().message.find("not canonical") != std::string::npos,
+                                        "the diagnostic tells the author which invariant failed");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register unusedTextRecipeIsRefused{
+    "A text-free screen cannot silently ignore a recipe's text packages",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-unused-text-table")
+            .Given("a text-free screen recipe that nevertheless names font and locale packages", [] {})
+            .When("the compiler checks whether the screen needs a text budget", [] {})
+            .Then("it reports MEDUI-E002 before producing an empty approval manifest",
+                  [] {
+                      mdux::spec::Checks           checks;
+                      std::vector<cli::Diagnostic> diagnostics;
+                      md::Recipe                   recipe = textlessRecipe(diagnostics);
+                      recipe.fontPackage                  = "unused-font.json";
+                      recipe.textPackages                 = {"unused-text.json"};
+
+                      const std::string recipeText = fixture("textless-screen.toml");
+                      const auto        outputs    = md::run(recipe, "recipe.toml", asBytes(recipeText), repoRoot(), diagnostics);
+                      checks.expect(!outputs.has_value(), "unused text inputs are refused rather than ignored");
+                      checks.expect(firstCode(diagnostics) == "MEDUI-E002", std::format("reported as MEDUI-E002, got '{}'", firstCode(diagnostics)));
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -90,7 +90,8 @@ const mdux::spec::Register theEmittedFixtureIsWhatTheCompilerProduces{
                           return;
                       }
 
-                      const std::string produced = md::writePackage(md::buildPackage(layout, {.id = "every-component", .budget = fixtureBudget}).package());
+                      const std::string produced = md::writePackage(
+                          md::buildPackage(layout, {.id = "every-component", .budget = fixtureBudget, .approvedTextPackages = {}}).package());
                       checks.expect(produced == fixture("every-component-package.json"), std::format("the committed package is current, got:\n{}", produced));
                       checks.raise();
                   })
@@ -338,7 +339,8 @@ const mdux::spec::Register aDecodedControlCharacterCannotEndTheLiteral{
                           return;
                       }
 
-                      const std::string           json = md::writePackage(md::buildPackage(layout, {.id = "escapes", .budget = fixtureBudget}).package());
+                      const std::string json = md::writePackage(
+                          md::buildPackage(layout, {.id = "escapes", .budget = fixtureBudget, .approvedTextPackages = {}}).package());
                       const std::filesystem::path path = scratch.path() / "package.json";
                       std::ofstream               out{path, std::ios::binary | std::ios::trunc};
                       out.write(json.data(), static_cast<std::streamsize>(json.size()));

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -30,7 +30,12 @@ import mdux.tools.medui.parser;
 namespace {
 
 namespace md  = mdux::tools::medui;
+namespace ms  = mdux::medui;
 namespace cli = mdux::tools::cli;
+
+constexpr std::array fixtureApprovals{
+    ms::TextPackageApproval{.locale = "en-US", .packageId = "every-component-en-us", .packageSha256 = {1}}
+};
 
 /// The budget the fixture package declares, and therefore the one a rebuild must reproduce.
 constexpr mdux::draw::DrawBudget fixtureBudget{.maxVertices = 4096, .maxIndices = 6144, .maxCommands = 256};
@@ -91,7 +96,7 @@ const mdux::spec::Register theEmittedFixtureIsWhatTheCompilerProduces{
                       }
 
                       const std::string produced = md::writePackage(
-                          md::buildPackage(layout, {.id = "every-component", .budget = fixtureBudget, .approvedTextPackages = {}}).package());
+                          md::buildPackage(layout, {.id = "every-component", .budget = fixtureBudget, .approvedTextPackages = fixtureApprovals}).package());
                       checks.expect(produced == fixture("every-component-package.json"), std::format("the committed package is current, got:\n{}", produced));
                       checks.raise();
                   })
@@ -340,7 +345,7 @@ const mdux::spec::Register aDecodedControlCharacterCannotEndTheLiteral{
                       }
 
                       const std::string json = md::writePackage(
-                          md::buildPackage(layout, {.id = "escapes", .budget = fixtureBudget, .approvedTextPackages = {}}).package());
+                          md::buildPackage(layout, {.id = "escapes", .budget = fixtureBudget, .approvedTextPackages = fixtureApprovals}).package());
                       const std::filesystem::path path = scratch.path() / "package.json";
                       std::ofstream               out{path, std::ios::binary | std::ios::trunc};
                       out.write(json.data(), static_cast<std::streamsize>(json.size()));

--- a/tests/medui/GeneratedScreenTests.cpp
+++ b/tests/medui/GeneratedScreenTests.cpp
@@ -49,6 +49,14 @@ const mdux::spec::Register bothFormsDescribeOneScreen{
                       checks.expect(fromModule.surfaceWidth == fromHeader.surfaceWidth && fromModule.surfaceHeight == fromHeader.surfaceHeight,
                                     "both forms declare one surface");
                       checks.expect(fromModule.budget == fromHeader.budget, "both forms declare one draw budget");
+                      checks.expect(fromModule.approvedTextPackages.size() == fromHeader.approvedTextPackages.size(),
+                                    std::format("both forms hold {} text approvals, header holds {}",
+                                                fromModule.approvedTextPackages.size(),
+                                                fromHeader.approvedTextPackages.size()));
+                      for (std::size_t index = 0; index < std::min(fromModule.approvedTextPackages.size(), fromHeader.approvedTextPackages.size()); ++index) {
+                          checks.expect(fromModule.approvedTextPackages[index] == fromHeader.approvedTextPackages[index],
+                                        std::format("text approval {} is identical in both forms", index));
+                      }
                       checks.expect(fromModule.nodes.size() == fromHeader.nodes.size(),
                                     std::format("both forms hold {} nodes, header holds {}", fromModule.nodes.size(), fromHeader.nodes.size()));
 

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -37,6 +37,10 @@ namespace cli = mdux::tools::cli;
 /// The budget every scenario compiles with. Declared rather than computed, as `PackageInputs` says.
 constexpr mdux::draw::DrawBudget testBudget{.maxVertices = 4096, .maxIndices = 6144, .maxCommands = 256};
 
+constexpr std::array fixtureApprovals{
+    ms::TextPackageApproval{.locale = "en-US", .packageId = "every-component-en-us", .packageSha256 = {1}}
+};
+
 [[nodiscard]] std::string fixture(std::string_view name) {
     const std::filesystem::path path = std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
     std::ifstream               in{path, std::ios::binary};
@@ -65,7 +69,7 @@ constexpr mdux::draw::DrawBudget testBudget{.maxVertices = 4096, .maxIndices = 6
 /// The screen carrying all eleven payloads, compiled.
 [[nodiscard]] md::ScreenDocument everyComponent() {
     return md::buildPackage(layoutOf(fixture("accepted-every-component.medui"), 800, 700),
-                            {.id = "every-component", .budget = testBudget, .approvedTextPackages = {}});
+                            {.id = "every-component", .budget = testBudget, .approvedTextPackages = fixtureApprovals});
 }
 
 /// One Label on a small surface: the screen the byte-exact scenario spells out.
@@ -85,16 +89,16 @@ constexpr mdux::draw::DrawBudget testBudget{.maxVertices = 4096, .maxIndices = 6
 }
 
 [[nodiscard]] md::ScreenDocument tinyDocument() {
-    return md::buildPackage(layoutOf(tinyScreen(), 200, 100), {.id = "tiny", .budget = testBudget, .approvedTextPackages = {}});
-}
-
-[[nodiscard]] md::ScreenDocument tinyApprovedDocument() {
     const std::string_view       bytes  = "approved-package";
     const mdux::evidence::Digest digest = mdux::evidence::sha256(std::as_bytes(std::span{bytes.data(), bytes.size()}));
     const std::array             approvals{
         ms::TextPackageApproval{.locale = "en-US", .packageId = "tiny-en-us", .packageSha256 = digest}
     };
     return md::buildPackage(layoutOf(tinyScreen(), 200, 100), {.id = "tiny", .budget = testBudget, .approvedTextPackages = approvals});
+}
+
+[[nodiscard]] md::ScreenDocument tinyApprovedDocument() {
+    return tinyDocument();
 }
 
 [[nodiscard]] const ms::CompiledNode& node(const ms::ScreenPackage& package, std::string_view id) {
@@ -277,6 +281,19 @@ const mdux::spec::Register textPackageApprovalsRoundTripStrictly{
                           checks.expect(after.size() == 1 && after[0] == before[0], "locale, package id and package digest survive");
                       }
 
+                      md::ScreenDocument replaced = tinyApprovedDocument();
+                      const std::array   replacement{
+                          ms::TextPackageApproval{.locale = "fr-FR", .packageId = "tiny-fr-fr", .packageSha256 = {3}}
+                      };
+                      replaced.setHeader("tiny", 200, 100, testBudget, replacement);
+                      checks.expect(replaced.package().approvedTextPackages.size() == 1 && replaced.package().approvedTextPackages[0] == replacement[0],
+                                    "setting the header again replaces rather than appends approvals");
+
+                      const auto aliased = replaced.package().approvedTextPackages;
+                      replaced.setHeader("tiny", 200, 100, testBudget, aliased);
+                      checks.expect(replaced.package().approvedTextPackages.size() == 1 && replaced.package().approvedTextPackages[0] == replacement[0],
+                                    "replacement remains safe when the input aliases document storage");
+
                       const std::size_t marker = written.find("\"packageSha256\": \"");
                       checks.expect(marker != std::string::npos, "the canonical bytes carry the package digest");
                       if (marker != std::string::npos) {
@@ -286,6 +303,12 @@ const mdux::spec::Register textPackageApprovalsRoundTripStrictly{
                           const md::PackageReadResult refused = md::readPackage(malformed, "package.json");
                           checks.expect(!refused.ok() && firstCode(refused) == "SCP002",
                                         std::format("a malformed digest is SCP002, got '{}'", firstCode(refused)));
+
+                          const std::string           nonString = editing(written, std::format("\"{}\"", std::string_view{written}.substr(digest, 64)), "42");
+                          const md::PackageReadResult wrongType = md::readPackage(nonString, "package.json");
+                          checks.expect(!wrongType.ok() && !wrongType.diagnostics.empty()
+                                            && wrongType.diagnostics.front().message.find("is not a string") != std::string::npos,
+                                        "a digest of the wrong JSON type is diagnosed as a type error");
                       }
                       checks.raise();
                   })
@@ -305,7 +328,13 @@ const mdux::spec::Register theBytesAreExactlyDetermined{
                       const std::string  written = md::writePackage(tinyDocument().package());
 
                       const std::string expected = R"({
-  "approvedTextPackages": [],
+  "approvedTextPackages": [
+    {
+      "locale": "en-US",
+      "packageId": "tiny-en-us",
+      "packageSha256": "8a0efead27dcc041c99a973e4f9881b58d8ace2eda79c45cde82e67a369a8d12"
+    }
+  ],
   "budget": {
     "maxCommands": 256,
     "maxIndices": 6144,

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -17,6 +17,7 @@
 import std;
 import speclab;
 import mdux.draw;
+import mdux.evidence.digest;
 import mdux.medui.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.ast;
@@ -63,7 +64,8 @@ constexpr mdux::draw::DrawBudget testBudget{.maxVertices = 4096, .maxIndices = 6
 
 /// The screen carrying all eleven payloads, compiled.
 [[nodiscard]] md::ScreenDocument everyComponent() {
-    return md::buildPackage(layoutOf(fixture("accepted-every-component.medui"), 800, 700), {.id = "every-component", .budget = testBudget});
+    return md::buildPackage(layoutOf(fixture("accepted-every-component.medui"), 800, 700),
+                            {.id = "every-component", .budget = testBudget, .approvedTextPackages = {}});
 }
 
 /// One Label on a small surface: the screen the byte-exact scenario spells out.
@@ -83,7 +85,16 @@ constexpr mdux::draw::DrawBudget testBudget{.maxVertices = 4096, .maxIndices = 6
 }
 
 [[nodiscard]] md::ScreenDocument tinyDocument() {
-    return md::buildPackage(layoutOf(tinyScreen(), 200, 100), {.id = "tiny", .budget = testBudget});
+    return md::buildPackage(layoutOf(tinyScreen(), 200, 100), {.id = "tiny", .budget = testBudget, .approvedTextPackages = {}});
+}
+
+[[nodiscard]] md::ScreenDocument tinyApprovedDocument() {
+    const std::string_view       bytes  = "approved-package";
+    const mdux::evidence::Digest digest = mdux::evidence::sha256(std::as_bytes(std::span{bytes.data(), bytes.size()}));
+    const std::array             approvals{
+        ms::TextPackageApproval{.locale = "en-US", .packageId = "tiny-en-us", .packageSha256 = digest}
+    };
+    return md::buildPackage(layoutOf(tinyScreen(), 200, 100), {.id = "tiny", .budget = testBudget, .approvedTextPackages = approvals});
 }
 
 [[nodiscard]] const ms::CompiledNode& node(const ms::ScreenPackage& package, std::string_view id) {
@@ -246,6 +257,41 @@ const mdux::spec::Register writingAndReadingAgree{
             .Execute();
     }};
 
+const mdux::spec::Register textPackageApprovalsRoundTripStrictly{
+    "Approved text package identities round-trip, and malformed digests are refused",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-text-approvals")
+            .Given("a screen approving one locale package", [] {})
+            .When("it is written, read back, and its digest is then malformed", [] {})
+            .Then("the identity survives exactly and the malformed form is SCP002",
+                  [] {
+                      mdux::spec::Checks          checks;
+                      const md::ScreenDocument    original = tinyApprovedDocument();
+                      const std::string           written  = md::writePackage(original.package());
+                      const md::PackageReadResult reread   = md::readPackage(written, "package.json");
+                      checks.expect(reread.ok(), std::format("the approved package reads back, first diagnostic '{}'", firstCode(reread)));
+                      if (reread.ok()) {
+                          const auto before = original.package().approvedTextPackages;
+                          const auto after  = reread.document.package().approvedTextPackages;
+                          checks.expect(after.size() == 1 && after[0] == before[0], "locale, package id and package digest survive");
+                      }
+
+                      const std::size_t marker = written.find("\"packageSha256\": \"");
+                      checks.expect(marker != std::string::npos, "the canonical bytes carry the package digest");
+                      if (marker != std::string::npos) {
+                          std::string       malformed = written;
+                          const std::size_t digest    = marker + std::string_view{"\"packageSha256\": \""}.size();
+                          malformed.replace(digest, 64, "not-a-digest");
+                          const md::PackageReadResult refused = md::readPackage(malformed, "package.json");
+                          checks.expect(!refused.ok() && firstCode(refused) == "SCP002",
+                                        std::format("a malformed digest is SCP002, got '{}'", firstCode(refused)));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register theBytesAreExactlyDetermined{
     "A small screen has exactly these bytes",
     "evidence-unit",
@@ -259,6 +305,7 @@ const mdux::spec::Register theBytesAreExactlyDetermined{
                       const std::string  written = md::writePackage(tinyDocument().package());
 
                       const std::string expected = R"({
+  "approvedTextPackages": [],
   "budget": {
     "maxCommands": 256,
     "maxIndices": 6144,
@@ -424,7 +471,7 @@ const mdux::spec::Register aBypassedGateIsARefusalNotADiagnostic{
 
                       bool threw = false;
                       try {
-                          const md::ScreenDocument document = md::buildPackage(unresolved, {.id = "tiny", .budget = testBudget});
+                          const md::ScreenDocument document = md::buildPackage(unresolved, {.id = "tiny", .budget = testBudget, .approvedTextPackages = {}});
                           checks.expect(document.package().nodes.empty(), "unreachable: the stage compiled a screen that did not resolve");
                       } catch (const std::logic_error&) {
                           threw = true;

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -47,13 +47,18 @@ constexpr std::array<ms::CompiledNode, 3> constNodes{
     ms::CompiledNode{            .id = "score", .bounds = {250, 60, 120, 60}, .payload = scoreDisplay}
 };
 
+constexpr std::array<ms::TextPackageApproval, 1> constApprovals{
+    ms::TextPackageApproval{.locale = "en-US", .packageId = "neurosense-en-us", .packageSha256 = {}}
+};
+
 constexpr ms::ScreenPackage constPackage{
-    .id            = "neurosense",
-    .schemaVersion = mdux::evidence::kSchemaVersion,
-    .surfaceWidth  = 400,
-    .surfaceHeight = 300,
-    .nodes         = constNodes,
-    .budget        = mdux::draw::DrawBudget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16}
+    .id                   = "neurosense",
+    .schemaVersion        = mdux::evidence::kSchemaVersion,
+    .surfaceWidth         = 400,
+    .surfaceHeight        = 300,
+    .approvedTextPackages = constApprovals,
+    .nodes                = constNodes,
+    .budget               = mdux::draw::DrawBudget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16}
 };
 
 // The module promises a generated screen can be validated at compile time and placed in read-only
@@ -95,12 +100,13 @@ inline constexpr std::array<ms::CompiledNode, 1> inlineNodes{
 };
 
 inline constexpr ms::ScreenPackage inlinePackage{
-    .id            = "inline-screen",
-    .schemaVersion = mdux::evidence::kSchemaVersion,
-    .surfaceWidth  = 200,
-    .surfaceHeight = 100,
-    .nodes         = inlineNodes,
-    .budget        = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+    .id                   = "inline-screen",
+    .schemaVersion        = mdux::evidence::kSchemaVersion,
+    .surfaceWidth         = 200,
+    .surfaceHeight        = 100,
+    .approvedTextPackages = {},
+    .nodes                = inlineNodes,
+    .budget               = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
 };
 
 static_assert(inlinePackage.validate().has_value(), "an inline constexpr screen validates at compile time, as generated code is");
@@ -142,20 +148,22 @@ static_assert(ms::resolveColorToken("Theme.Colors.ScoreDigits").value() == std::
 
 /// Owns what the package's spans point at, so a mutated fixture stays self-consistent.
 struct Fixture {
-    std::vector<ms::CompiledNode> nodes{constNodes.begin(), constNodes.end()};
-    std::string                   id{"neurosense"};
-    std::uint64_t                 schemaVersion{mdux::evidence::kSchemaVersion};
-    std::int32_t                  surfaceWidth{400};
-    std::int32_t                  surfaceHeight{300};
-    mdux::draw::DrawBudget        budget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
+    std::vector<ms::TextPackageApproval> approvedTextPackages{constApprovals.begin(), constApprovals.end()};
+    std::vector<ms::CompiledNode>        nodes{constNodes.begin(), constNodes.end()};
+    std::string                          id{"neurosense"};
+    std::uint64_t                        schemaVersion{mdux::evidence::kSchemaVersion};
+    std::int32_t                         surfaceWidth{400};
+    std::int32_t                         surfaceHeight{300};
+    mdux::draw::DrawBudget               budget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
 
     [[nodiscard]] ms::ScreenPackage package() const noexcept {
-        return ms::ScreenPackage{.id            = id,
-                                 .schemaVersion = schemaVersion,
-                                 .surfaceWidth  = surfaceWidth,
-                                 .surfaceHeight = surfaceHeight,
-                                 .nodes         = nodes,
-                                 .budget        = budget};
+        return ms::ScreenPackage{.id                   = id,
+                                 .schemaVersion        = schemaVersion,
+                                 .surfaceWidth         = surfaceWidth,
+                                 .surfaceHeight        = surfaceHeight,
+                                 .approvedTextPackages = approvedTextPackages,
+                                 .nodes                = nodes,
+                                 .budget               = budget};
     }
 };
 
@@ -208,6 +216,42 @@ const mdux::spec::Register identityIsRequired{"A screen with no id and one with 
                                                             })
                                                       .Execute();
                                               }};
+
+const mdux::spec::Register textPackageApprovalsAreIdentified{
+    "Every approved text package names one unique locale and a package id",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-text-package-approvals")
+            .Given("the reference screen with one approved locale", [] {})
+            .When("an approval loses either name, and two approvals claim one locale", [] {})
+            .Then("each malformed manifest is refused with its own schema error",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Fixture noLocale;
+                      noLocale.approvedTextPackages[0].locale = {};
+                      checks.expect(errorOf(noLocale) == ms::SchemaError::EmptyApprovedLocale,
+                                    std::format("an unnamed locale is refused, got {}", describe(errorOf(noLocale))));
+
+                      Fixture noPackage;
+                      noPackage.approvedTextPackages[0].packageId = {};
+                      checks.expect(errorOf(noPackage) == ms::SchemaError::EmptyApprovedPackageId,
+                                    std::format("an unnamed package is refused, got {}", describe(errorOf(noPackage))));
+
+                      Fixture duplicate;
+                      duplicate.approvedTextPackages.push_back(
+                          ms::TextPackageApproval{.locale = duplicate.approvedTextPackages[0].locale, .packageId = "another-package", .packageSha256 = {}});
+                      checks.expect(errorOf(duplicate) == ms::SchemaError::DuplicateApprovedLocale,
+                                    std::format("a duplicated locale is refused, got {}", describe(errorOf(duplicate))));
+
+                      Fixture textFree;
+                      textFree.approvedTextPackages.clear();
+                      textFree.nodes.erase(textFree.nodes.begin() + 1, textFree.nodes.end());
+                      checks.expect(!errorOf(textFree).has_value(), "an empty approval manifest remains valid");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
 
 const mdux::spec::Register nodesAreAddressable{"Every node must be addressable, and addressable by exactly one id", "evidence-unit", [] {
                                                    return speclab::Test("medui-schema-node-ids")
@@ -554,12 +598,13 @@ const mdux::spec::Register statesAndTheirTintsPairUp{
 
                       const auto packageWith = [](std::span<const ms::CompiledNode> storage) {
                           return ms::ScreenPackage{
-                              .id            = "screen",
-                              .schemaVersion = mdux::evidence::kSchemaVersion,
-                              .surfaceWidth  = 400,
-                              .surfaceHeight = 300,
-                              .nodes         = storage,
-                              .budget        = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+                              .id                   = "screen",
+                              .schemaVersion        = mdux::evidence::kSchemaVersion,
+                              .surfaceWidth         = 400,
+                              .surfaceHeight        = 300,
+                              .approvedTextPackages = {},
+                              .nodes                = storage,
+                              .budget               = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
                           };
                       };
 
@@ -623,12 +668,13 @@ const mdux::spec::Register unknownPayloadsAreRefused{
                       };
                       const std::array<ms::CompiledNode, 1> nodes{noSource};
                       const ms::ScreenPackage               package{
-                                        .id            = "screen",
-                                        .schemaVersion = mdux::evidence::kSchemaVersion,
-                                        .surfaceWidth  = 400,
-                                        .surfaceHeight = 300,
-                                        .nodes         = nodes,
-                                        .budget        = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+                                        .id                   = "screen",
+                                        .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth         = 400,
+                                        .surfaceHeight        = 300,
+                                        .approvedTextPackages = {},
+                                        .nodes                = nodes,
+                                        .budget               = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
                       };
                       const auto result = package.validate();
                       checks.expect(!result.has_value() && result.error() == ms::SchemaError::EmptyRequiredName,

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -48,7 +48,7 @@ constexpr std::array<ms::CompiledNode, 3> constNodes{
 };
 
 constexpr std::array<ms::TextPackageApproval, 1> constApprovals{
-    ms::TextPackageApproval{.locale = "en-US", .packageId = "neurosense-en-us", .packageSha256 = {}}
+    ms::TextPackageApproval{.locale = "en-US", .packageId = "neurosense-en-us", .packageSha256 = {1}}
 };
 
 constexpr ms::ScreenPackage constPackage{
@@ -104,7 +104,7 @@ inline constexpr ms::ScreenPackage inlinePackage{
     .schemaVersion        = mdux::evidence::kSchemaVersion,
     .surfaceWidth         = 200,
     .surfaceHeight        = 100,
-    .approvedTextPackages = {},
+    .approvedTextPackages = constApprovals,
     .nodes                = inlineNodes,
     .budget               = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
 };
@@ -238,9 +238,14 @@ const mdux::spec::Register textPackageApprovalsAreIdentified{
                       checks.expect(errorOf(noPackage) == ms::SchemaError::EmptyApprovedPackageId,
                                     std::format("an unnamed package is refused, got {}", describe(errorOf(noPackage))));
 
+                      Fixture noDigest;
+                      noDigest.approvedTextPackages[0].packageSha256 = {};
+                      checks.expect(errorOf(noDigest) == ms::SchemaError::EmptyApprovedPackageDigest,
+                                    std::format("an unset package digest is refused, got {}", describe(errorOf(noDigest))));
+
                       Fixture duplicate;
                       duplicate.approvedTextPackages.push_back(
-                          ms::TextPackageApproval{.locale = duplicate.approvedTextPackages[0].locale, .packageId = "another-package", .packageSha256 = {}});
+                          ms::TextPackageApproval{.locale = duplicate.approvedTextPackages[0].locale, .packageId = "another-package", .packageSha256 = {2}});
                       checks.expect(errorOf(duplicate) == ms::SchemaError::DuplicateApprovedLocale,
                                     std::format("a duplicated locale is refused, got {}", describe(errorOf(duplicate))));
 
@@ -248,6 +253,11 @@ const mdux::spec::Register textPackageApprovalsAreIdentified{
                       textFree.approvedTextPackages.clear();
                       textFree.nodes.erase(textFree.nodes.begin() + 1, textFree.nodes.end());
                       checks.expect(!errorOf(textFree).has_value(), "an empty approval manifest remains valid");
+
+                      Fixture textBearing;
+                      textBearing.approvedTextPackages.clear();
+                      checks.expect(errorOf(textBearing) == ms::SchemaError::MissingTextPackageApproval,
+                                    std::format("a text-bearing screen without approvals is refused, got {}", describe(errorOf(textBearing))));
                       checks.raise();
                   })
             .Execute();
@@ -602,7 +612,7 @@ const mdux::spec::Register statesAndTheirTintsPairUp{
                               .schemaVersion        = mdux::evidence::kSchemaVersion,
                               .surfaceWidth         = 400,
                               .surfaceHeight        = 300,
-                              .approvedTextPackages = {},
+                              .approvedTextPackages = constApprovals,
                               .nodes                = storage,
                               .budget               = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
                           };
@@ -672,7 +682,7 @@ const mdux::spec::Register unknownPayloadsAreRefused{
                                         .schemaVersion        = mdux::evidence::kSchemaVersion,
                                         .surfaceWidth         = 400,
                                         .surfaceHeight        = 300,
-                                        .approvedTextPackages = {},
+                                        .approvedTextPackages = constApprovals,
                                         .nodes                = nodes,
                                         .budget               = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
                       };

--- a/tests/medui/ScreenNoHeapTests.cpp
+++ b/tests/medui/ScreenNoHeapTests.cpp
@@ -47,12 +47,13 @@ constexpr std::array<ms::CompiledNode, 3> nodes{
     ms::CompiledNode{.id = "clock", .bounds = {8, 40, 120, 24}, .payload = clock}
 };
 
-constexpr ms::ScreenPackage screen{.id            = "noheap",
-                                   .schemaVersion = mdux::evidence::kSchemaVersion,
-                                   .surfaceWidth  = 400,
-                                   .surfaceHeight = 300,
-                                   .nodes         = nodes,
-                                   .budget        = budget};
+constexpr ms::ScreenPackage screen{.id                   = "noheap",
+                                   .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                   .surfaceWidth         = 400,
+                                   .surfaceHeight        = 300,
+                                   .approvedTextPackages = {},
+                                   .nodes                = nodes,
+                                   .budget               = budget};
 
 static_assert(screen.validate().has_value(), "the screen under measurement must be one a device could hold");
 
@@ -153,12 +154,13 @@ const mdux::spec::Register refusingAFrameAllocatesNothing{
                       constexpr std::array<ms::CompiledNode, 1> refusedNodes{
                           ms::CompiledNode{.id = "wrong", .bounds = {0, 0, 400, 40}, .payload = unknown}
                       };
-                      const ms::ScreenPackage refused{.id            = "refused",
-                                                      .schemaVersion = mdux::evidence::kSchemaVersion,
-                                                      .surfaceWidth  = 400,
-                                                      .surfaceHeight = 300,
-                                                      .nodes         = refusedNodes,
-                                                      .budget        = budget};
+                      const ms::ScreenPackage refused{.id                   = "refused",
+                                                      .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                      .surfaceWidth         = 400,
+                                                      .surfaceHeight        = 300,
+                                                      .approvedTextPackages = {},
+                                                      .nodes                = refusedNodes,
+                                                      .budget               = budget};
 
                       const std::size_t before = allocations();
                       const auto        frame  = ms::render(refused, list);
@@ -193,50 +195,73 @@ const mdux::spec::Register drawingTextAllocatesNothing{
                       // is the join: `render()` reading them per frame.
                       static const mdux::font::FontPackage font = [] {
                           mdux::font::FontPackage built;
-                          built.id         = "noheap-ui";
-                          built.unitsPerEm = 1000;
-                          built.pixelSize  = 10;
-                          built.locales    = {"en-US"};
+                          built.id                     = "noheap-ui";
+                          built.unitsPerEm             = 1000;
+                          built.pixelSize              = 10;
+                          built.locales                = {"en-US"};
                           built.atlas.path             = "atlas.bin";
                           built.atlas.width            = 8;
                           built.atlas.height           = 8;
                           built.atlas.byteLength       = 64;
                           built.atlas.sha256           = std::string(64, 'a');
                           built.atlas.occupancyPercent = 25;
-                          built.glyphs = {{.codePoint = U'A', .glyphIndex = 4, .advanceWidth = 700, .leftSideBearing = 0,
-                                           .x = 0, .y = 0, .width = 4, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6}};
-                          built.restrictedCharset = {{.first = U'A', .last = U'A'}};
+                          built.glyphs                 = {
+                              {.codePoint       = U'A',
+                               .glyphIndex      = 4,
+                               .advanceWidth    = 700,
+                               .leftSideBearing = 0,
+                               .x               = 0,
+                               .y               = 0,
+                               .width           = 4,
+                               .height          = 6,
+                               .bitmapOriginX   = 0,
+                               .bitmapOriginY   = 6}
+                          };
+                          built.restrictedCharset = {
+                              {.first = U'A', .last = U'A'}
+                          };
                           return built;
                       }();
 
                       // One record: glyph 0 at the run's own origin, little-endian, as
                       // `mdux::text::draw::decodeRecord()` reads it.
-                      static const std::array<std::byte, 6> records{std::byte{0}, std::byte{0}, std::byte{0},
-                                                                    std::byte{0}, std::byte{0}, std::byte{0}};
+                      static const std::array<std::byte, 6> records{std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}};
 
                       static const mdux::text::TextPackage text = [] {
                           mdux::text::TextPackage built;
-                          built.header.id        = "noheap-text";
-                          built.header.kind      = std::string{mdux::text::packageKind};
-                          built.atlasId          = "noheap-ui";
-                          built.locale           = "en-US";
-                          built.sidecarPath      = "runs.bin";
+                          built.header.id         = "noheap-text";
+                          built.header.kind       = std::string{mdux::text::packageKind};
+                          built.atlasId           = "noheap-ui";
+                          built.locale            = "en-US";
+                          built.sidecarPath       = "runs.bin";
                           built.sidecarByteLength = records.size();
                           // The digests `create()` checks. Computed rather than written out, so the
                           // fixture cannot drift from the bytes above and start exercising the
                           // rejection path while claiming to measure the accepted one.
-                          built.sidecarSha256     = mdux::evidence::sha256(records);
-                          built.runs.push_back(mdux::text::TextRun{.id         = "STR-TITLE",
-                                                                   .byteOffset = 0,
-                                                                   .byteLength = records.size(),
-                                                                   .sha256     = mdux::evidence::sha256(records)});
+                          built.sidecarSha256 = mdux::evidence::sha256(records);
+                          built.runs.push_back(
+                              mdux::text::TextRun{.id = "STR-TITLE", .byteOffset = 0, .byteLength = records.size(), .sha256 = mdux::evidence::sha256(records)});
                           return built;
                       }();
 
                       // Through `create()`, which is the only way to obtain one - and which hashes
                       // the sidecar. That cost is the caller's, once, and sits outside the counter
                       // below on purpose: what this scenario measures is the frame, not the setup.
-                      const auto made = ms::TextBinding::create(font, text, records);
+                      const auto canonical = text.write();
+                      if (!canonical.has_value()) {
+                          checks.expect(false, "the fixture package serializes");
+                          checks.raise();
+                          return;
+                      }
+                      const std::array approvals{
+                          ms::TextPackageApproval{.locale        = text.locale,
+                                                  .packageId     = text.header.id,
+                                                  .packageSha256 = mdux::evidence::sha256(std::as_bytes(std::span{canonical->data(), canonical->size()}))}
+                      };
+                      ms::ScreenPackage boundScreen    = screen;
+                      boundScreen.approvedTextPackages = approvals;
+
+                      const auto made = ms::TextBinding::create(boundScreen, font, text, records);
                       if (!made.has_value()) {
                           checks.expect(false, "the fixture binding is valid");
                           checks.raise();
@@ -260,13 +285,13 @@ const mdux::spec::Register drawingTextAllocatesNothing{
                       // scenario learned by breaking it: `std::format` allocates, so a per-frame
                       // assertion carrying one would report the test's own allocation as the
                       // runtime's. The outcome is captured and asserted after the counter is read.
-                      std::uint32_t lastRects = 0;
+                      std::uint32_t lastRects   = 0;
                       bool          allRecorded = true;
 
                       const std::size_t before = allocations();
                       for (int frame = 0; frame < 8; ++frame) {
                           list.reset();
-                          const auto recorded = ms::render(screen, list, binding);
+                          const auto recorded = ms::render(boundScreen, list, binding);
                           if (!recorded.has_value()) {
                               allRecorded = false;
                               continue;

--- a/tests/medui/ScreenNoHeapTests.cpp
+++ b/tests/medui/ScreenNoHeapTests.cpp
@@ -47,11 +47,15 @@ constexpr std::array<ms::CompiledNode, 3> nodes{
     ms::CompiledNode{.id = "clock", .bounds = {8, 40, 120, 24}, .payload = clock}
 };
 
+constexpr std::array defaultApprovals{
+    ms::TextPackageApproval{.locale = "en-US", .packageId = "noheap-text", .packageSha256 = {1}}
+};
+
 constexpr ms::ScreenPackage screen{.id                   = "noheap",
                                    .schemaVersion        = mdux::evidence::kSchemaVersion,
                                    .surfaceWidth         = 400,
                                    .surfaceHeight        = 300,
-                                   .approvedTextPackages = {},
+                                   .approvedTextPackages = defaultApprovals,
                                    .nodes                = nodes,
                                    .budget               = budget};
 
@@ -185,127 +189,128 @@ const mdux::spec::Register drawingTextAllocatesNothing{
         return speclab::Test("medui-screen-noheap-render-text")
             .Given("a screen whose label is joined to a font and text package", [] {})
             .When("frames are recorded", [] {})
-            .Then("the allocation counter does not move",
-                  [] {
-                      mdux::spec::Checks checks;
+            .Then(
+                "the allocation counter does not move",
+                [] {
+                    mdux::spec::Checks checks;
 
-                      // The packages are built before the measurement, and they *do* allocate - a
-                      // FontPackage owns vectors. That is the caller's cost, paid once on a device
-                      // at start-up or not at all if the packages are `constexpr`. What is measured
-                      // is the join: `render()` reading them per frame.
-                      static const mdux::font::FontPackage font = [] {
-                          mdux::font::FontPackage built;
-                          built.id                     = "noheap-ui";
-                          built.unitsPerEm             = 1000;
-                          built.pixelSize              = 10;
-                          built.locales                = {"en-US"};
-                          built.atlas.path             = "atlas.bin";
-                          built.atlas.width            = 8;
-                          built.atlas.height           = 8;
-                          built.atlas.byteLength       = 64;
-                          built.atlas.sha256           = std::string(64, 'a');
-                          built.atlas.occupancyPercent = 25;
-                          built.glyphs                 = {
-                              {.codePoint       = U'A',
-                               .glyphIndex      = 4,
-                               .advanceWidth    = 700,
-                               .leftSideBearing = 0,
-                               .x               = 0,
-                               .y               = 0,
-                               .width           = 4,
-                               .height          = 6,
-                               .bitmapOriginX   = 0,
-                               .bitmapOriginY   = 6}
-                          };
-                          built.restrictedCharset = {
-                              {.first = U'A', .last = U'A'}
-                          };
-                          return built;
-                      }();
+                    // The packages are built before the measurement, and they *do* allocate - a
+                    // FontPackage owns vectors. That is the caller's cost, paid once on a device
+                    // at start-up or not at all if the packages are `constexpr`. What is measured
+                    // is the join: `render()` reading them per frame.
+                    static const mdux::font::FontPackage font = [] {
+                        mdux::font::FontPackage built;
+                        built.id                     = "noheap-ui";
+                        built.unitsPerEm             = 1000;
+                        built.pixelSize              = 10;
+                        built.locales                = {"en-US"};
+                        built.atlas.path             = "atlas.bin";
+                        built.atlas.width            = 8;
+                        built.atlas.height           = 8;
+                        built.atlas.byteLength       = 64;
+                        built.atlas.sha256           = std::string(64, 'a');
+                        built.atlas.occupancyPercent = 25;
+                        built.glyphs                 = {
+                            {.codePoint       = U'A',
+                             .glyphIndex      = 4,
+                             .advanceWidth    = 700,
+                             .leftSideBearing = 0,
+                             .x               = 0,
+                             .y               = 0,
+                             .width           = 4,
+                             .height          = 6,
+                             .bitmapOriginX   = 0,
+                             .bitmapOriginY   = 6}
+                        };
+                        built.restrictedCharset = {
+                            {.first = U'A', .last = U'A'}
+                        };
+                        return built;
+                    }();
 
-                      // One record: glyph 0 at the run's own origin, little-endian, as
-                      // `mdux::text::draw::decodeRecord()` reads it.
-                      static const std::array<std::byte, 6> records{std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}};
+                    // One record: glyph 0 at the run's own origin, little-endian, as
+                    // `mdux::text::draw::decodeRecord()` reads it.
+                    static const std::array<std::byte, 6> records{std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}};
 
-                      static const mdux::text::TextPackage text = [] {
-                          mdux::text::TextPackage built;
-                          built.header.id         = "noheap-text";
-                          built.header.kind       = std::string{mdux::text::packageKind};
-                          built.atlasId           = "noheap-ui";
-                          built.locale            = "en-US";
-                          built.sidecarPath       = "runs.bin";
-                          built.sidecarByteLength = records.size();
-                          // The digests `create()` checks. Computed rather than written out, so the
-                          // fixture cannot drift from the bytes above and start exercising the
-                          // rejection path while claiming to measure the accepted one.
-                          built.sidecarSha256 = mdux::evidence::sha256(records);
-                          built.runs.push_back(
-                              mdux::text::TextRun{.id = "STR-TITLE", .byteOffset = 0, .byteLength = records.size(), .sha256 = mdux::evidence::sha256(records)});
-                          return built;
-                      }();
+                    static const mdux::text::TextPackage text = [] {
+                        mdux::text::TextPackage built;
+                        built.header.id         = "noheap-text";
+                        built.header.kind       = std::string{mdux::text::packageKind};
+                        built.atlasId           = "noheap-ui";
+                        built.locale            = "en-US";
+                        built.sidecarPath       = "runs.bin";
+                        built.sidecarByteLength = records.size();
+                        // The digests `create()` checks. Computed rather than written out, so the
+                        // fixture cannot drift from the bytes above and start exercising the
+                        // rejection path while claiming to measure the accepted one.
+                        built.sidecarSha256 = mdux::evidence::sha256(records);
+                        built.runs.push_back(
+                            mdux::text::TextRun{.id = "STR-TITLE", .byteOffset = 0, .byteLength = records.size(), .sha256 = mdux::evidence::sha256(records)});
+                        return built;
+                    }();
 
-                      // Through `create()`, which is the only way to obtain one - and which hashes
-                      // the sidecar. That cost is the caller's, once, and sits outside the counter
-                      // below on purpose: what this scenario measures is the frame, not the setup.
-                      const auto canonical = text.write();
-                      if (!canonical.has_value()) {
-                          checks.expect(false, "the fixture package serializes");
-                          checks.raise();
-                          return;
-                      }
-                      const std::array approvals{
-                          ms::TextPackageApproval{.locale        = text.locale,
-                                                  .packageId     = text.header.id,
-                                                  .packageSha256 = mdux::evidence::sha256(std::as_bytes(std::span{canonical->data(), canonical->size()}))}
-                      };
-                      ms::ScreenPackage boundScreen    = screen;
-                      boundScreen.approvedTextPackages = approvals;
+                    // Through `create()`, which is the only way to obtain one - and which hashes
+                    // the sidecar. That cost is the caller's, once, and sits outside the counter
+                    // below on purpose: what this scenario measures is the frame, not the setup.
+                    const auto canonical = text.write();
+                    if (!canonical.has_value()) {
+                        checks.expect(false, "the fixture package serializes");
+                        checks.raise();
+                        return;
+                    }
+                    const std::array approvals{
+                        ms::TextPackageApproval{.locale        = text.locale,
+                                                .packageId     = text.header.id,
+                                                .packageSha256 = mdux::evidence::sha256(std::as_bytes(std::span{canonical->data(), canonical->size()}))}
+                    };
+                    ms::ScreenPackage boundScreen    = screen;
+                    boundScreen.approvedTextPackages = approvals;
 
-                      const auto made = ms::TextBinding::create(boundScreen, font, text, records);
-                      if (!made.has_value()) {
-                          checks.expect(false, "the fixture binding is valid");
-                          checks.raise();
-                          return;
-                      }
-                      const ms::TextBinding binding = *made;
+                    const auto made = ms::TextBinding::create(boundScreen, font, text, std::as_bytes(std::span{canonical->data(), canonical->size()}), records);
+                    if (!made.has_value()) {
+                        checks.expect(false, "the fixture binding is valid");
+                        checks.raise();
+                        return;
+                    }
+                    const ms::TextBinding binding = *made;
 
-                      static std::array<mdux::draw::UiVertex, 512>   vertices{};
-                      static std::array<mdux::draw::Index, 768>      indices{};
-                      static std::array<mdux::draw::DrawCommand, 16> commands{};
+                    static std::array<mdux::draw::UiVertex, 512>   vertices{};
+                    static std::array<mdux::draw::Index, 768>      indices{};
+                    static std::array<mdux::draw::DrawCommand, 16> commands{};
 
-                      auto created = mdux::draw::DrawList::create(vertices, indices, commands, budget);
-                      if (!created.has_value()) {
-                          checks.expect(false, "the storage satisfies the budget");
-                          checks.raise();
-                          return;
-                      }
-                      mdux::draw::DrawList list = std::move(*created);
+                    auto created = mdux::draw::DrawList::create(vertices, indices, commands, budget);
+                    if (!created.has_value()) {
+                        checks.expect(false, "the storage satisfies the budget");
+                        checks.raise();
+                        return;
+                    }
+                    mdux::draw::DrawList list = std::move(*created);
 
-                      // Nothing inside the measured loop may format a message, which is a rule this
-                      // scenario learned by breaking it: `std::format` allocates, so a per-frame
-                      // assertion carrying one would report the test's own allocation as the
-                      // runtime's. The outcome is captured and asserted after the counter is read.
-                      std::uint32_t lastRects   = 0;
-                      bool          allRecorded = true;
+                    // Nothing inside the measured loop may format a message, which is a rule this
+                    // scenario learned by breaking it: `std::format` allocates, so a per-frame
+                    // assertion carrying one would report the test's own allocation as the
+                    // runtime's. The outcome is captured and asserted after the counter is read.
+                    std::uint32_t lastRects   = 0;
+                    bool          allRecorded = true;
 
-                      const std::size_t before = allocations();
-                      for (int frame = 0; frame < 8; ++frame) {
-                          list.reset();
-                          const auto recorded = ms::render(boundScreen, list, binding);
-                          if (!recorded.has_value()) {
-                              allRecorded = false;
-                              continue;
-                          }
-                          lastRects = recorded->rects;
-                      }
-                      const std::size_t after = allocations();
+                    const std::size_t before = allocations();
+                    for (int frame = 0; frame < 8; ++frame) {
+                        list.reset();
+                        const auto recorded = ms::render(boundScreen, list, binding);
+                        if (!recorded.has_value()) {
+                            allRecorded = false;
+                            continue;
+                        }
+                        lastRects = recorded->rects;
+                    }
+                    const std::size_t after = allocations();
 
-                      checks.expect(allRecorded, "each frame is recorded");
-                      // The label is drawn rather than deferred, so this scenario measures the text
-                      // path rather than the same deferred walk the case above measures.
-                      checks.expect(lastRects == 2, std::format("the panel and the glyph, got {}", lastRects));
-                      checks.expect(after == before, std::format("no allocation across eight frames, counter went {} to {}", before, after));
-                      checks.raise();
-                  })
+                    checks.expect(allRecorded, "each frame is recorded");
+                    // The label is drawn rather than deferred, so this scenario measures the text
+                    // path rather than the same deferred walk the case above measures.
+                    checks.expect(lastRects == 2, std::format("the panel and the glyph, got {}", lastRects));
+                    checks.expect(after == before, std::format("no allocation across eight frames, counter went {} to {}", before, after));
+                    checks.raise();
+                })
             .Execute();
     }};

--- a/tests/medui/ScreenRuntimeTests.cpp
+++ b/tests/medui/ScreenRuntimeTests.cpp
@@ -60,11 +60,15 @@ constexpr std::array<ms::CompiledNode, 3> mixedNodes{
     ms::CompiledNode{.id = "footer", .bounds = {0, 260, 400, 40}, .payload = footer}
 };
 
+constexpr std::array defaultApprovals{
+    ms::TextPackageApproval{.locale = "en-US", .packageId = "runtime-text", .packageSha256 = {1}}
+};
+
 constexpr ms::ScreenPackage mixedScreen{.id                   = "mixed",
                                         .schemaVersion        = mdux::evidence::kSchemaVersion,
                                         .surfaceWidth         = 400,
                                         .surfaceHeight        = 300,
-                                        .approvedTextPackages = {},
+                                        .approvedTextPackages = defaultApprovals,
                                         .nodes                = mixedNodes,
                                         .budget               = testBudget};
 
@@ -82,7 +86,7 @@ constexpr ms::ScreenPackage doubledScreen{.id                   = "doubled",
                                           .schemaVersion        = mdux::evidence::kSchemaVersion,
                                           .surfaceWidth         = 400,
                                           .surfaceHeight        = 300,
-                                          .approvedTextPackages = {},
+                                          .approvedTextPackages = defaultApprovals,
                                           .nodes                = doubledNodes,
                                           .budget               = testBudget};
 
@@ -589,6 +593,18 @@ constexpr ms::ScreenPackage labelScreen{.id                   = "label",
                                    .packageSha256 = mdux::evidence::sha256(std::as_bytes(std::span{canonical->data(), canonical->size()}))};
 }
 
+[[nodiscard]] std::string packageJsonFor(const mdux::text::TextPackage& text) {
+    const auto canonical = text.write();
+    if (!canonical.has_value()) {
+        throw speclab::core::AssertionFailure("the fixture text package did not serialize", std::source_location::current());
+    }
+    return *canonical;
+}
+
+[[nodiscard]] std::span<const std::byte> bytesOf(std::string_view text) noexcept {
+    return std::as_bytes(std::span{text.data(), text.size()});
+}
+
 [[nodiscard]] ms::ScreenPackage screenWith(std::span<const ms::TextPackageApproval> approvals) noexcept {
     ms::ScreenPackage screen    = labelScreen;
     screen.approvedTextPackages = approvals;
@@ -598,7 +614,8 @@ constexpr ms::ScreenPackage labelScreen{.id                   = "label",
 /// A binding built from a fixture, or a scenario failure naming what `create()` refused.
 [[nodiscard]] ms::TextBinding
 bindOrThrow(const ms::ScreenPackage& screen, const mdux::font::FontPackage& font, const mdux::text::TextPackage& text, std::span<const std::byte> records) {
-    auto made = ms::TextBinding::create(screen, font, text, records);
+    const std::string packageJson = packageJsonFor(text);
+    auto              made        = ms::TextBinding::create(screen, font, text, bytesOf(packageJson), records);
     if (!made.has_value()) {
         throw speclab::core::AssertionFailure(std::format("the fixture binding was refused: {}", ms::describe(made.error())), std::source_location::current());
     }
@@ -668,10 +685,11 @@ const mdux::spec::Register bindingRefusals{
                       appendRecord(records, 1, 0, 0);
                       const mdux::text::TextPackage approvedText = textFixturePackage("STR-A", records);
                       const std::array              approvals{approvalFor(approvedText)};
-                      const ms::ScreenPackage       screen = screenWith(approvals);
+                      const ms::ScreenPackage       screen       = screenWith(approvals);
+                      const std::string             approvedJson = packageJsonFor(approvedText);
 
                       const auto errorOf = [&](const mdux::text::TextPackage& text, std::span<const std::byte> runs) {
-                          auto made = ms::TextBinding::create(screen, font, text, runs);
+                          auto made = ms::TextBinding::create(screen, font, text, bytesOf(approvedJson), runs);
                           return made.has_value() ? std::optional<ms::ScreenError>{} : std::optional{made.error()};
                       };
 
@@ -735,7 +753,8 @@ const mdux::spec::Register unapprovedPackageIsRefused{
 
                       mdux::text::TextPackage otherId = approvedText;
                       otherId.header.id               = "other-runtime-text";
-                      const auto idResult             = ms::TextBinding::create(screen, font, otherId, approvedRuns);
+                      const std::string otherIdJson   = packageJsonFor(otherId);
+                      const auto        idResult      = ms::TextBinding::create(screen, font, otherId, bytesOf(otherIdJson), approvedRuns);
                       checks.expect(!idResult.has_value() && idResult.error() == ms::ScreenError::PackageNotApproved,
                                     "a different package id is PackageNotApproved");
 
@@ -745,13 +764,49 @@ const mdux::spec::Register unapprovedPackageIsRefused{
                       std::vector<std::byte> changedRuns;
                       appendRecord(changedRuns, 0, 0, 0);
                       const mdux::text::TextPackage changedText  = textFixturePackage("STR-A", changedRuns);
-                      const auto                    digestResult = ms::TextBinding::create(screen, font, changedText, changedRuns);
+                      const std::string             changedJson  = packageJsonFor(changedText);
+                      const auto                    digestResult = ms::TextBinding::create(screen, font, changedText, bytesOf(changedJson), changedRuns);
                       checks.expect(!digestResult.has_value() && digestResult.error() == ms::ScreenError::PackageNotApproved,
                                     "same id and locale with different reviewed bytes is PackageNotApproved");
                       checks.raise();
                   })
             .Execute();
     }};
+
+const mdux::spec::Register bindingCannotCrossScreens{"A binding approved for one screen cannot render another screen", "evidence-unit", [] {
+                                                         return speclab::Test("medui-screen-binding-target")
+                                                             .Given("two screens approving different fitting packages with the same font and key", [] {})
+                                                             .When("the first screen's binding is offered to the second screen", [] {})
+                                                             .Then("the frame is PackageNotApproved and records nothing",
+                                                                   [] {
+                                                                       mdux::spec::Checks            checks;
+                                                                       const mdux::font::FontPackage font = textFixtureFont();
+
+                                                                       std::vector<std::byte> firstRuns;
+                                                                       appendRecord(firstRuns, 1, 0, 0);
+                                                                       const mdux::text::TextPackage firstText = textFixturePackage("STR-A", firstRuns);
+                                                                       const std::array              firstApprovals{approvalFor(firstText)};
+                                                                       const ms::ScreenPackage       firstScreen = screenWith(firstApprovals);
+                                                                       const ms::TextBinding binding = bindOrThrow(firstScreen, font, firstText, firstRuns);
+
+                                                                       std::vector<std::byte> secondRuns;
+                                                                       appendRecord(secondRuns, 0, 0, 0);
+                                                                       const mdux::text::TextPackage secondText = textFixturePackage("STR-A", secondRuns);
+                                                                       const std::array              secondApprovals{approvalFor(secondText)};
+                                                                       const ms::ScreenPackage       secondScreen = screenWith(secondApprovals);
+
+                                                                       Scratch              scratch;
+                                                                       mdux::draw::DrawList list  = scratch.list(testBudget);
+                                                                       const auto           frame = ms::render(secondScreen, list, binding);
+                                                                       checks.expect(!frame.has_value() && frame.error() == ms::ScreenError::PackageNotApproved,
+                                                                                     "the second screen refuses the first screen's binding by identity");
+                                                                       checks.expect(list.vertices().empty() && list.indices().empty()
+                                                                                         && list.commands().empty(),
+                                                                                     "the refused frame records nothing");
+                                                                       checks.raise();
+                                                                   })
+                                                             .Execute();
+                                                     }};
 
 const mdux::spec::Register frameRefusals{"A valid binding that does not serve this screen is refused, and the list is left as found", "evidence-unit", [] {
                                              return speclab::Test("medui-screen-frame-refusals")

--- a/tests/medui/ScreenRuntimeTests.cpp
+++ b/tests/medui/ScreenRuntimeTests.cpp
@@ -60,12 +60,13 @@ constexpr std::array<ms::CompiledNode, 3> mixedNodes{
     ms::CompiledNode{.id = "footer", .bounds = {0, 260, 400, 40}, .payload = footer}
 };
 
-constexpr ms::ScreenPackage mixedScreen{.id            = "mixed",
-                                        .schemaVersion = mdux::evidence::kSchemaVersion,
-                                        .surfaceWidth  = 400,
-                                        .surfaceHeight = 300,
-                                        .nodes         = mixedNodes,
-                                        .budget        = testBudget};
+constexpr ms::ScreenPackage mixedScreen{.id                   = "mixed",
+                                        .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth         = 400,
+                                        .surfaceHeight        = 300,
+                                        .approvedTextPackages = {},
+                                        .nodes                = mixedNodes,
+                                        .budget               = testBudget};
 
 /// The same screen with twice the nodes, for the scaling half of the bounded-work acceptance.
 constexpr std::array<ms::CompiledNode, 6> doubledNodes{
@@ -77,12 +78,13 @@ constexpr std::array<ms::CompiledNode, 6> doubledNodes{
     ms::CompiledNode{.id = "footer2", .bounds = {0, 200, 400, 40}, .payload = footer}
 };
 
-constexpr ms::ScreenPackage doubledScreen{.id            = "doubled",
-                                          .schemaVersion = mdux::evidence::kSchemaVersion,
-                                          .surfaceWidth  = 400,
-                                          .surfaceHeight = 300,
-                                          .nodes         = doubledNodes,
-                                          .budget        = testBudget};
+constexpr ms::ScreenPackage doubledScreen{.id                   = "doubled",
+                                          .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                          .surfaceWidth         = 400,
+                                          .surfaceHeight        = 300,
+                                          .approvedTextPackages = {},
+                                          .nodes                = doubledNodes,
+                                          .budget               = testBudget};
 
 static_assert(mixedScreen.validate().has_value(), "the reference screen must be one a device could hold");
 static_assert(doubledScreen.validate().has_value(), "and so must the doubled one");
@@ -221,12 +223,13 @@ const mdux::spec::Register aRefusedFrameLeavesNothingBehind{
                           ms::CompiledNode{ .id = "good",  .bounds = {0, 0, 400, 40},  .payload = topbar},
                           ms::CompiledNode{.id = "wrong", .bounds = {0, 60, 400, 40}, .payload = unknown}
                       };
-                      const ms::ScreenPackage screen{.id            = "unknown-token",
-                                                     .schemaVersion = mdux::evidence::kSchemaVersion,
-                                                     .surfaceWidth  = 400,
-                                                     .surfaceHeight = 300,
-                                                     .nodes         = nodes,
-                                                     .budget        = testBudget};
+                      const ms::ScreenPackage screen{.id                   = "unknown-token",
+                                                     .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                     .surfaceWidth         = 400,
+                                                     .surfaceHeight        = 300,
+                                                     .approvedTextPackages = {},
+                                                     .nodes                = nodes,
+                                                     .budget               = testBudget};
 
                       const auto frame = ms::render(screen, list);
                       checks.expect(!frame.has_value(), "a screen naming an unknown colour is refused");
@@ -242,12 +245,13 @@ const mdux::spec::Register aRefusedFrameLeavesNothingBehind{
                       constexpr std::array<ms::CompiledNode, 1> malformedNodes{
                           ms::CompiledNode{.id = "bad", .bounds = {0, 0, 40, 40}, .payload = malformed}
                       };
-                      const ms::ScreenPackage malformedScreen{.id            = "malformed-token",
-                                                              .schemaVersion = mdux::evidence::kSchemaVersion,
-                                                              .surfaceWidth  = 400,
-                                                              .surfaceHeight = 300,
-                                                              .nodes         = malformedNodes,
-                                                              .budget        = testBudget};
+                      const ms::ScreenPackage malformedScreen{.id                   = "malformed-token",
+                                                              .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                              .surfaceWidth         = 400,
+                                                              .surfaceHeight        = 300,
+                                                              .approvedTextPackages = {},
+                                                              .nodes                = malformedNodes,
+                                                              .budget               = testBudget};
                       const auto              malformedFrame = ms::render(malformedScreen, list);
                       checks.expect(!malformedFrame.has_value(), "a malformed colour is refused too");
                       if (!malformedFrame.has_value()) {
@@ -282,12 +286,13 @@ const mdux::spec::Register aBudgetTooSmallIsRefusedNotTruncated{
                           ms::CompiledNode{.id = "one",  .bounds = {0, 0, 400, 40}, .payload = topbar},
                           ms::CompiledNode{.id = "two", .bounds = {0, 60, 400, 40}, .payload = footer}
                       };
-                      const ms::ScreenPackage screen{.id            = "too-tight",
-                                                     .schemaVersion = mdux::evidence::kSchemaVersion,
-                                                     .surfaceWidth  = 400,
-                                                     .surfaceHeight = 300,
-                                                     .nodes         = nodes,
-                                                     .budget        = tight};
+                      const ms::ScreenPackage screen{.id                   = "too-tight",
+                                                     .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                     .surfaceWidth         = 400,
+                                                     .surfaceHeight        = 300,
+                                                     .approvedTextPackages = {},
+                                                     .nodes                = nodes,
+                                                     .budget               = tight};
 
                       const auto frame = ms::render(screen, list);
                       checks.expect(!frame.has_value(), "the frame is refused");
@@ -331,18 +336,20 @@ const mdux::spec::Register theWorkDoesNotVaryWithTheData{
                           ms::CompiledNode{.id = "c",  .bounds = {0, 250, 400, 50}, .payload = alert}
                       };
 
-                      const ms::ScreenPackage tiny{.id            = "tiny",
-                                                   .schemaVersion = mdux::evidence::kSchemaVersion,
-                                                   .surfaceWidth  = 400,
-                                                   .surfaceHeight = 300,
-                                                   .nodes         = tinyNodes,
-                                                   .budget        = testBudget};
-                      const ms::ScreenPackage huge{.id            = "huge",
-                                                   .schemaVersion = mdux::evidence::kSchemaVersion,
-                                                   .surfaceWidth  = 400,
-                                                   .surfaceHeight = 300,
-                                                   .nodes         = hugeNodes,
-                                                   .budget        = testBudget};
+                      const ms::ScreenPackage tiny{.id                   = "tiny",
+                                                   .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                   .surfaceWidth         = 400,
+                                                   .surfaceHeight        = 300,
+                                                   .approvedTextPackages = {},
+                                                   .nodes                = tinyNodes,
+                                                   .budget               = testBudget};
+                      const ms::ScreenPackage huge{.id                   = "huge",
+                                                   .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                   .surfaceWidth         = 400,
+                                                   .surfaceHeight        = 300,
+                                                   .approvedTextPackages = {},
+                                                   .nodes                = hugeNodes,
+                                                   .budget               = testBudget};
 
                       Scratch small;
                       Scratch large;
@@ -383,12 +390,13 @@ const mdux::spec::Register theEmittedBytesArePinned{
                       constexpr std::array<ms::CompiledNode, 1> pinned{
                           ms::CompiledNode{.id = "topbar", .bounds = {0, 0, 400, 40}, .payload = topbar}
                       };
-                      const ms::ScreenPackage screen{.id            = "pinned",
-                                                     .schemaVersion = mdux::evidence::kSchemaVersion,
-                                                     .surfaceWidth  = 400,
-                                                     .surfaceHeight = 300,
-                                                     .nodes         = pinned,
-                                                     .budget        = testBudget};
+                      const ms::ScreenPackage screen{.id                   = "pinned",
+                                                     .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                     .surfaceWidth         = 400,
+                                                     .surfaceHeight        = 300,
+                                                     .approvedTextPackages = {},
+                                                     .nodes                = pinned,
+                                                     .budget               = testBudget};
 
                       const auto frame = ms::render(screen, list);
                       if (!frame.has_value()) {
@@ -459,12 +467,13 @@ const mdux::spec::Register theScreensOwnBudgetBoundsTheFrame{
                           ms::CompiledNode{.id = "one",  .bounds = {0, 0, 400, 40}, .payload = topbar},
                           ms::CompiledNode{.id = "two", .bounds = {0, 60, 400, 40}, .payload = footer}
                       };
-                      const ms::ScreenPackage screen{.id            = "declares-one-rect",
-                                                     .schemaVersion = mdux::evidence::kSchemaVersion,
-                                                     .surfaceWidth  = 400,
-                                                     .surfaceHeight = 300,
-                                                     .nodes         = nodes,
-                                                     .budget        = oneRect};
+                      const ms::ScreenPackage screen{.id                   = "declares-one-rect",
+                                                     .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                     .surfaceWidth         = 400,
+                                                     .surfaceHeight        = 300,
+                                                     .approvedTextPackages = {},
+                                                     .nodes                = nodes,
+                                                     .budget               = oneRect};
 
                       const auto frame = ms::render(screen, list);
                       checks.expect(!frame.has_value(), "the screen's own budget refuses the second rectangle");
@@ -488,24 +497,43 @@ namespace {
 /// baseline, so an ink box computed from it is checkable by hand.
 [[nodiscard]] mdux::font::FontPackage textFixtureFont() {
     mdux::font::FontPackage font;
-    font.id         = "runtime-ui";
-    font.unitsPerEm = 1000;
-    font.pixelSize  = 10;
-    font.locales    = {"en-US"};
+    font.id                     = "runtime-ui";
+    font.unitsPerEm             = 1000;
+    font.pixelSize              = 10;
+    font.locales                = {"en-US"};
     font.atlas.path             = "atlas.bin";
     font.atlas.width            = 8;
     font.atlas.height           = 8;
     font.atlas.byteLength       = 64;
     font.atlas.sha256           = std::string(64, 'a');
     font.atlas.occupancyPercent = 25;
-    font.glyphs = {
+    font.glyphs                 = {
         // A blank, so a run made only of these can be measured as painting nothing.
-        {.codePoint = U' ', .glyphIndex = 3, .advanceWidth = 250, .leftSideBearing = 0,
-         .x = 0, .y = 0, .width = 0, .height = 0, .bitmapOriginX = 0, .bitmapOriginY = 0},
-        {.codePoint = U'A', .glyphIndex = 4, .advanceWidth = 700, .leftSideBearing = 0,
-         .x = 0, .y = 0, .width = 4, .height = 6, .bitmapOriginX = 0, .bitmapOriginY = 6},
+        {.codePoint       = U' ',
+         .glyphIndex      = 3,
+         .advanceWidth    = 250,
+         .leftSideBearing = 0,
+         .x               = 0,
+         .y               = 0,
+         .width           = 0,
+         .height          = 0,
+         .bitmapOriginX   = 0,
+         .bitmapOriginY   = 0},
+        {.codePoint       = U'A',
+         .glyphIndex      = 4,
+         .advanceWidth    = 700,
+         .leftSideBearing = 0,
+         .x               = 0,
+         .y               = 0,
+         .width           = 4,
+         .height          = 6,
+         .bitmapOriginX   = 0,
+         .bitmapOriginY   = 6},
     };
-    font.restrictedCharset = {{.first = U' ', .last = U' '}, {.first = U'A', .last = U'A'}};
+    font.restrictedCharset = {
+        {.first = U' ', .last = U' '},
+        {.first = U'A', .last = U'A'}
+    };
     return font;
 }
 
@@ -534,38 +562,55 @@ void appendRecord(std::vector<std::byte>& out, std::uint16_t index, std::int16_t
     package.sidecarPath       = "runs.bin";
     package.sidecarByteLength = records.size();
     package.sidecarSha256     = mdux::evidence::sha256(records);
-    package.runs.push_back(mdux::text::TextRun{.id         = std::string{key},
-                                               .byteOffset = 0,
-                                               .byteLength = records.size(),
-                                               .sha256     = mdux::evidence::sha256(records)});
+    package.runs.push_back(
+        mdux::text::TextRun{.id = std::string{key}, .byteOffset = 0, .byteLength = records.size(), .sha256 = mdux::evidence::sha256(records)});
     return package;
 }
 
+constexpr ms::LabelSpec                   fixtureLabel{.textKey = "STR-A", .colorToken = "Theme.Colors.Title"};
+constexpr std::array<ms::CompiledNode, 1> labelOnly{
+    ms::CompiledNode{.id = "title", .bounds = {20, 30, 100, 40}, .payload = fixtureLabel}
+};
+constexpr ms::ScreenPackage labelScreen{.id                   = "label",
+                                        .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth         = 200,
+                                        .surfaceHeight        = 100,
+                                        .approvedTextPackages = {},
+                                        .nodes                = labelOnly,
+                                        .budget               = testBudget};
+
+[[nodiscard]] ms::TextPackageApproval approvalFor(const mdux::text::TextPackage& text) {
+    const auto canonical = text.write();
+    if (!canonical.has_value()) {
+        throw speclab::core::AssertionFailure("the fixture text package did not serialize", std::source_location::current());
+    }
+    return ms::TextPackageApproval{.locale        = text.locale,
+                                   .packageId     = text.header.id,
+                                   .packageSha256 = mdux::evidence::sha256(std::as_bytes(std::span{canonical->data(), canonical->size()}))};
+}
+
+[[nodiscard]] ms::ScreenPackage screenWith(std::span<const ms::TextPackageApproval> approvals) noexcept {
+    ms::ScreenPackage screen    = labelScreen;
+    screen.approvedTextPackages = approvals;
+    return screen;
+}
+
 /// A binding built from a fixture, or a scenario failure naming what `create()` refused.
-[[nodiscard]] ms::TextBinding bindOrThrow(const mdux::font::FontPackage& font, const mdux::text::TextPackage& text,
-                                          std::span<const std::byte> records) {
-    auto made = ms::TextBinding::create(font, text, records);
+[[nodiscard]] ms::TextBinding
+bindOrThrow(const ms::ScreenPackage& screen, const mdux::font::FontPackage& font, const mdux::text::TextPackage& text, std::span<const std::byte> records) {
+    auto made = ms::TextBinding::create(screen, font, text, records);
     if (!made.has_value()) {
-        throw speclab::core::AssertionFailure(std::format("the fixture binding was refused: {}", ms::describe(made.error())),
-                                              std::source_location::current());
+        throw speclab::core::AssertionFailure(std::format("the fixture binding was refused: {}", ms::describe(made.error())), std::source_location::current());
     }
     return *made;
 }
 
-constexpr ms::LabelSpec fixtureLabel{.textKey = "STR-A", .colorToken = "Theme.Colors.Title"};
-constexpr std::array<ms::CompiledNode, 1> labelOnly{
-    ms::CompiledNode{.id = "title", .bounds = {20, 30, 100, 40}, .payload = fixtureLabel}};
-constexpr ms::ScreenPackage labelScreen{.id            = "label",
-                                        .schemaVersion = mdux::evidence::kSchemaVersion,
-                                        .surfaceWidth  = 200,
-                                        .surfaceHeight = 100,
-                                        .nodes         = labelOnly,
-                                        .budget        = testBudget};
-
 }  // namespace
 
 const mdux::spec::Register labelInkLandsOnTheNodeCorner{
-    "A label's ink box is placed at the node's corner, which is what #195 measured", "evidence-unit", [] {
+    "A label's ink box is placed at the node's corner, which is what #195 measured",
+    "evidence-unit",
+    [] {
         return speclab::Test("medui-screen-label-placement")
             .Given("a run whose single glyph sits six pixels above its baseline", [] {})
             .When("the screen is rendered with the run bound", [] {})
@@ -577,10 +622,12 @@ const mdux::spec::Register labelInkLandsOnTheNodeCorner{
                       std::vector<std::byte>        records;
                       appendRecord(records, 1, 0, 0);  // the 'A', at the run's own origin
                       const mdux::text::TextPackage text = textFixturePackage("STR-A", records);
+                      const std::array              approvals{approvalFor(text)};
+                      const ms::ScreenPackage       screen = screenWith(approvals);
 
                       Scratch              scratch;
                       mdux::draw::DrawList list  = scratch.list(testBudget);
-                      const auto           frame = ms::render(labelScreen, list, bindOrThrow(font, text, records));
+                      const auto           frame = ms::render(screen, list, bindOrThrow(screen, font, text, records));
 
                       checks.expect(frame.has_value(), "the frame was recorded");
                       if (!frame.has_value()) {
@@ -606,7 +653,9 @@ const mdux::spec::Register labelInkLandsOnTheNodeCorner{
     }};
 
 const mdux::spec::Register bindingRefusals{
-    "Three artifacts that do not describe each other are refused once, not per frame", "evidence-unit", [] {
+    "Three artifacts that do not describe each other are refused once, not per frame",
+    "evidence-unit",
+    [] {
         return speclab::Test("medui-screen-binding-refusals")
             .Given("bindings that are wrong in one way each", [] {})
             .When("each is offered to create()", [] {})
@@ -617,9 +666,12 @@ const mdux::spec::Register bindingRefusals{
 
                       std::vector<std::byte> records;
                       appendRecord(records, 1, 0, 0);
+                      const mdux::text::TextPackage approvedText = textFixturePackage("STR-A", records);
+                      const std::array              approvals{approvalFor(approvedText)};
+                      const ms::ScreenPackage       screen = screenWith(approvals);
 
                       const auto errorOf = [&](const mdux::text::TextPackage& text, std::span<const std::byte> runs) {
-                          auto made = ms::TextBinding::create(font, text, runs);
+                          auto made = ms::TextBinding::create(screen, font, text, runs);
                           return made.has_value() ? std::optional<ms::ScreenError>{} : std::optional{made.error()};
                       };
 
@@ -638,8 +690,7 @@ const mdux::spec::Register bindingRefusals{
                                     "a same-length wrong sidecar is SidecarMismatch");
 
                       // A sidecar of the wrong length, which the cheap check catches first.
-                      checks.expect(errorOf(textFixturePackage("STR-A", records), std::span{records}.first(0))
-                                        == ms::ScreenError::SidecarMismatch,
+                      checks.expect(errorOf(textFixturePackage("STR-A", records), std::span{records}.first(0)) == ms::ScreenError::SidecarMismatch,
                                     "a short sidecar is SidecarMismatch");
 
                       // The wraparound. `byteOffset + byteLength` sums to zero for these, so an
@@ -648,8 +699,7 @@ const mdux::spec::Register bindingRefusals{
                       mdux::text::TextPackage wrapped = textFixturePackage("STR-A", records);
                       wrapped.runs[0].byteOffset      = std::numeric_limits<std::uint64_t>::max() - 5;
                       wrapped.runs[0].byteLength      = 6;
-                      checks.expect(errorOf(wrapped, records) == ms::ScreenError::MalformedTextRun,
-                                    "a range that wraps is MalformedTextRun");
+                      checks.expect(errorOf(wrapped, records) == ms::ScreenError::MalformedTextRun, "a range that wraps is MalformedTextRun");
 
                       // Past the cap. Built rather than described, so the constant and the refusal
                       // cannot drift apart: one record more than the runtime will draw.
@@ -665,102 +715,143 @@ const mdux::spec::Register bindingRefusals{
             .Execute();
     }};
 
-const mdux::spec::Register frameRefusals{
-    "A valid binding that does not serve this screen is refused, and the list is left as found",
-    "evidence-unit", [] {
-        return speclab::Test("medui-screen-frame-refusals")
-            .Given("bindings create() accepts but this screen cannot use", [] {})
-            .When("the screen is rendered with each", [] {})
-            .Then("each reports its own error and records nothing",
+const mdux::spec::Register unapprovedPackageIsRefused{
+    "A valid text package the screen was not compiled against is refused by identity",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-screen-package-not-approved")
+            .Given("a screen approving one fitting package, and two other valid packages for the same locale, font and key", [] {})
+            .When("each other package is offered to create()", [] {})
+            .Then("both are PackageNotApproved, including the package that reuses the approved id",
                   [] {
                       mdux::spec::Checks            checks;
                       const mdux::font::FontPackage font = textFixtureFont();
 
-                      std::vector<std::byte> records;
-                      appendRecord(records, 1, 0, 0);
+                      std::vector<std::byte> approvedRuns;
+                      appendRecord(approvedRuns, 1, 0, 0);
+                      const mdux::text::TextPackage approvedText = textFixturePackage("STR-A", approvedRuns);
+                      const std::array              approvals{approvalFor(approvedText)};
+                      const ms::ScreenPackage       screen = screenWith(approvals);
 
-                      const auto renderWith = [&](const mdux::text::TextPackage& text, std::span<const std::byte> runs) {
-                          const ms::TextBinding binding = bindOrThrow(font, text, runs);
-                          Scratch               scratch;
-                          mdux::draw::DrawList  list = scratch.list(testBudget);
-                          const auto            frame = ms::render(labelScreen, list, binding);
-                          return std::pair{frame.has_value() ? std::optional<ms::ScreenError>{} : std::optional{frame.error()},
-                                           list.vertices().size()};
-                      };
+                      mdux::text::TextPackage otherId = approvedText;
+                      otherId.header.id               = "other-runtime-text";
+                      const auto idResult             = ms::TextBinding::create(screen, font, otherId, approvedRuns);
+                      checks.expect(!idResult.has_value() && idResult.error() == ms::ScreenError::PackageNotApproved,
+                                    "a different package id is PackageNotApproved");
 
-                      // A package for another screen: it is internally consistent, it passes
-                      // `create()`, and it does not carry this node's key.
-                      const auto wrongKey = renderWith(textFixturePackage("STR-SOMETHING-ELSE", records), records);
-                      checks.expect(wrongKey.first == ms::ScreenError::UnknownTextKey, "an absent key is UnknownTextKey");
-                      checks.expect(wrongKey.second == 0, "and records nothing");
-
-                      // The finding this check exists for: a second valid package, same font, same
-                      // key, wider text. Nothing in the artifacts says which package the compiler
-                      // measured, so the runtime measures the one it was given - and refuses it
-                      // rather than drawing over the node's neighbours. The node is 100 wide; this
-                      // run is fifty glyphs at ten pixels of advance.
-                      std::vector<std::byte> wide;
-                      for (std::int16_t i = 0; i < 50; ++i) {
-                          appendRecord(wide, 1, static_cast<std::int16_t>(i * 10), 0);
-                      }
-                      const auto overflowing = renderWith(textFixturePackage("STR-A", wide), wide);
-                      checks.expect(overflowing.first == ms::ScreenError::TextOverflowsNode,
-                                    "text wider than its node is TextOverflowsNode");
-                      checks.expect(overflowing.second == 0, "and the list is left as it was found");
-
+                      // A blank glyph is still a fitting run, and the package keeps the approved id.
+                      // Only its canonical package digest distinguishes it from what the compiler
+                      // measured, so this assertion proves the digest participates in identity.
+                      std::vector<std::byte> changedRuns;
+                      appendRecord(changedRuns, 0, 0, 0);
+                      const mdux::text::TextPackage changedText  = textFixturePackage("STR-A", changedRuns);
+                      const auto                    digestResult = ms::TextBinding::create(screen, font, changedText, changedRuns);
+                      checks.expect(!digestResult.has_value() && digestResult.error() == ms::ScreenError::PackageNotApproved,
+                                    "same id and locale with different reviewed bytes is PackageNotApproved");
                       checks.raise();
                   })
             .Execute();
     }};
 
-const mdux::spec::Register aRunOfBlanksDrawsNothing{
-    "A run that paints nothing is drawn, not deferred", "evidence-unit", [] {
-        return speclab::Test("medui-screen-label-blank-run")
-            .Given("a run made only of blank glyphs", [] {})
-            .When("the screen is rendered with it bound", [] {})
-            .Then("no rectangle is recorded and the node is not counted as deferred",
-                  [] {
-                      mdux::spec::Checks checks;
+const mdux::spec::Register frameRefusals{"A valid binding that does not serve this screen is refused, and the list is left as found", "evidence-unit", [] {
+                                             return speclab::Test("medui-screen-frame-refusals")
+                                                 .Given("bindings create() accepts but this screen cannot use", [] {})
+                                                 .When("the screen is rendered with each", [] {})
+                                                 .Then("each reports its own error and records nothing",
+                                                       [] {
+                                                           mdux::spec::Checks            checks;
+                                                           const mdux::font::FontPackage font = textFixtureFont();
 
-                      const mdux::font::FontPackage font = textFixtureFont();
-                      std::vector<std::byte>        records;
-                      appendRecord(records, 0, 0, 0);  // the space
-                      const mdux::text::TextPackage text = textFixturePackage("STR-A", records);
+                                                           std::vector<std::byte> records;
+                                                           appendRecord(records, 1, 0, 0);
 
-                      Scratch              scratch;
-                      mdux::draw::DrawList list  = scratch.list(testBudget);
-                      const auto           frame = ms::render(labelScreen, list, bindOrThrow(font, text, records));
+                                                           const auto renderWith = [&](const mdux::text::TextPackage& text, std::span<const std::byte> runs) {
+                                                               const std::array        approvals{approvalFor(text)};
+                                                               const ms::ScreenPackage screen  = screenWith(approvals);
+                                                               const ms::TextBinding   binding = bindOrThrow(screen, font, text, runs);
+                                                               Scratch                 scratch;
+                                                               mdux::draw::DrawList    list  = scratch.list(testBudget);
+                                                               const auto              frame = ms::render(screen, list, binding);
+                                                               return std::pair{frame.has_value() ? std::optional<ms::ScreenError>{}
+                                                                                                  : std::optional{frame.error()},
+                                                                                list.vertices().size()};
+                                                           };
 
-                      checks.expect(frame.has_value(), "the frame was recorded");
-                      if (frame.has_value()) {
-                          checks.expect(frame->rects == 0, std::format("no rectangle, got {}", frame->rects));
-                          // The distinction the module documents: joined and found to paint nothing
-                          // is a different fact from having no package to join to.
-                          checks.expect(frame->deferred == 0, std::format("nothing deferred, got {}", frame->deferred));
-                      }
-                      checks.raise();
-                  })
-            .Execute();
-    }};
+                                                           // A package for another screen: it is internally consistent, it passes
+                                                           // `create()`, and it does not carry this node's key.
+                                                           const auto wrongKey = renderWith(textFixturePackage("STR-SOMETHING-ELSE", records), records);
+                                                           checks.expect(wrongKey.first == ms::ScreenError::UnknownTextKey, "an absent key is UnknownTextKey");
+                                                           checks.expect(wrongKey.second == 0, "and records nothing");
 
-const mdux::spec::Register anUnboundLabelIsDeferred{
-    "Without a binding a label is deferred exactly as it was before #242", "evidence-unit", [] {
-        return speclab::Test("medui-screen-label-unbound")
-            .Given("no text binding", [] {})
-            .When("the screen is rendered", [] {})
-            .Then("the label is deferred and the frame succeeds",
-                  [] {
-                      mdux::spec::Checks   checks;
-                      Scratch              scratch;
-                      mdux::draw::DrawList list  = scratch.list(testBudget);
-                      const auto           frame = ms::render(labelScreen, list);
+                                                           // The finding this check exists for: a second valid package, same font, same
+                                                           // key, wider text. Nothing in the artifacts says which package the compiler
+                                                           // measured, so the runtime measures the one it was given - and refuses it
+                                                           // rather than drawing over the node's neighbours. The node is 100 wide; this
+                                                           // run is fifty glyphs at ten pixels of advance.
+                                                           std::vector<std::byte> wide;
+                                                           for (std::int16_t i = 0; i < 50; ++i) {
+                                                               appendRecord(wide, 1, static_cast<std::int16_t>(i * 10), 0);
+                                                           }
+                                                           const auto overflowing = renderWith(textFixturePackage("STR-A", wide), wide);
+                                                           checks.expect(overflowing.first == ms::ScreenError::TextOverflowsNode,
+                                                                         "text wider than its node is TextOverflowsNode");
+                                                           checks.expect(overflowing.second == 0, "and the list is left as it was found");
 
-                      checks.expect(frame.has_value(), "the frame was recorded");
-                      if (frame.has_value()) {
-                          checks.expect(frame->deferred == 1, std::format("one deferred node, got {}", frame->deferred));
-                          checks.expect(frame->rects == 0, std::format("no rectangle, got {}", frame->rects));
-                      }
-                      checks.raise();
-                  })
-            .Execute();
-    }};
+                                                           checks.raise();
+                                                       })
+                                                 .Execute();
+                                         }};
+
+const mdux::spec::Register aRunOfBlanksDrawsNothing{"A run that paints nothing is drawn, not deferred", "evidence-unit", [] {
+                                                        return speclab::Test("medui-screen-label-blank-run")
+                                                            .Given("a run made only of blank glyphs", [] {})
+                                                            .When("the screen is rendered with it bound", [] {})
+                                                            .Then("no rectangle is recorded and the node is not counted as deferred",
+                                                                  [] {
+                                                                      mdux::spec::Checks checks;
+
+                                                                      const mdux::font::FontPackage font = textFixtureFont();
+                                                                      std::vector<std::byte>        records;
+                                                                      appendRecord(records, 0, 0, 0);  // the space
+                                                                      const mdux::text::TextPackage text = textFixturePackage("STR-A", records);
+                                                                      const std::array              approvals{approvalFor(text)};
+                                                                      const ms::ScreenPackage       screen = screenWith(approvals);
+
+                                                                      Scratch              scratch;
+                                                                      mdux::draw::DrawList list = scratch.list(testBudget);
+                                                                      const auto frame = ms::render(screen, list, bindOrThrow(screen, font, text, records));
+
+                                                                      checks.expect(frame.has_value(), "the frame was recorded");
+                                                                      if (frame.has_value()) {
+                                                                          checks.expect(frame->rects == 0, std::format("no rectangle, got {}", frame->rects));
+                                                                          // The distinction the module documents: joined and found to paint nothing
+                                                                          // is a different fact from having no package to join to.
+                                                                          checks.expect(frame->deferred == 0,
+                                                                                        std::format("nothing deferred, got {}", frame->deferred));
+                                                                      }
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};
+
+const mdux::spec::Register anUnboundLabelIsDeferred{"Without a binding a label is deferred exactly as it was before #242", "evidence-unit", [] {
+                                                        return speclab::Test("medui-screen-label-unbound")
+                                                            .Given("no text binding", [] {})
+                                                            .When("the screen is rendered", [] {})
+                                                            .Then("the label is deferred and the frame succeeds",
+                                                                  [] {
+                                                                      mdux::spec::Checks   checks;
+                                                                      Scratch              scratch;
+                                                                      mdux::draw::DrawList list  = scratch.list(testBudget);
+                                                                      const auto           frame = ms::render(labelScreen, list);
+
+                                                                      checks.expect(frame.has_value(), "the frame was recorded");
+                                                                      if (frame.has_value()) {
+                                                                          checks.expect(frame->deferred == 1,
+                                                                                        std::format("one deferred node, got {}", frame->deferred));
+                                                                          checks.expect(frame->rects == 0, std::format("no rectangle, got {}", frame->rects));
+                                                                      }
+                                                                      checks.raise();
+                                                                  })
+                                                            .Execute();
+                                                    }};

--- a/tests/medui/ScreenRuntimeTests.cpp
+++ b/tests/medui/ScreenRuntimeTests.cpp
@@ -768,6 +768,14 @@ const mdux::spec::Register unapprovedPackageIsRefused{
                       const auto                    digestResult = ms::TextBinding::create(screen, font, changedText, bytesOf(changedJson), changedRuns);
                       checks.expect(!digestResult.has_value() && digestResult.error() == ms::ScreenError::PackageNotApproved,
                                     "same id and locale with different reviewed bytes is PackageNotApproved");
+
+                      // The approved bytes and parsed package are one authenticated input. Supplying
+                      // A's approved JSON alongside B's internally valid text and sidecar must not
+                      // let B's unreviewed wording through merely because its id and locale match.
+                      const std::string approvedJson = packageJsonFor(approvedText);
+                      const auto        splitResult  = ms::TextBinding::create(screen, font, changedText, bytesOf(approvedJson), changedRuns);
+                      checks.expect(!splitResult.has_value() && splitResult.error() == ms::ScreenError::PackageNotApproved,
+                                    "approved JSON paired with different parsed text is PackageNotApproved");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/fixtures/empty-screen-package.json
+++ b/tests/medui/fixtures/empty-screen-package.json
@@ -1,4 +1,5 @@
 {
+  "approvedTextPackages": [],
   "budget": {
     "maxCommands": 0,
     "maxIndices": 0,

--- a/tests/medui/fixtures/every-component-package.json
+++ b/tests/medui/fixtures/every-component-package.json
@@ -1,4 +1,5 @@
 {
+  "approvedTextPackages": [],
   "budget": {
     "maxCommands": 256,
     "maxIndices": 6144,

--- a/tests/medui/fixtures/every-component-package.json
+++ b/tests/medui/fixtures/every-component-package.json
@@ -1,5 +1,11 @@
 {
-  "approvedTextPackages": [],
+  "approvedTextPackages": [
+    {
+      "locale": "en-US",
+      "packageId": "every-component-en-us",
+      "packageSha256": "0100000000000000000000000000000000000000000000000000000000000000"
+    }
+  ],
   "budget": {
     "maxCommands": 256,
     "maxIndices": 6144,

--- a/tests/render/ScreenPixelTests.cpp
+++ b/tests/render/ScreenPixelTests.cpp
@@ -109,6 +109,10 @@ constexpr core::ColorRgba8 background{.r = 0, .g = 0, .b = 0, .a = 255};
 /// The screen as a constant expression, so the storage below can be sized from the budget the
 /// artifact bakes rather than from three numbers copied out of it.
 constexpr medui::ScreenPackage compiled = medui::generated::screen_endoscope_monitor::package();
+static_assert(compiled.validate().has_value(), "the committed screen's generated form validates");
+static_assert(compiled.approvedTextPackages.size() == 1, "the committed screen approves one locale package");
+static_assert(compiled.approvedTextPackages[0].locale == "en-US", "the emitted approval keeps its locale");
+static_assert(compiled.approvedTextPackages[0].packageId == "endoscope-monitor-en-us", "the emitted approval keeps its package id");
 
 /// Storage sized once from the screen's own budget, as a device would size it - and sized *by* it,
 /// so the two cannot drift. Hard-coding the three numbers would have left this test claiming a
@@ -138,8 +142,8 @@ void recordFrame(VkCommandBuffer commandBuffer, void* context) {
     }
     std::ostringstream buffer;
     buffer << file.rdbuf();
-    const std::string  text = buffer.str();
-    const auto*        data = reinterpret_cast<const std::byte*>(text.data());
+    const std::string text = buffer.str();
+    const auto*       data = reinterpret_cast<const std::byte*>(text.data());
     return std::vector<std::byte>{data, data + text.size()};
 }
 
@@ -159,8 +163,8 @@ struct BoundText {
 
     /// Through `create()`, which is the only way to obtain one - and which proves the three
     /// committed artifacts describe each other before a frame reads any of them.
-    [[nodiscard]] medui::TextBinding binding() const {
-        auto made = medui::TextBinding::create(font, text, runs);
+    [[nodiscard]] medui::TextBinding binding(const medui::ScreenPackage& screen) const {
+        auto made = medui::TextBinding::create(screen, font, text, runs);
         if (!made.has_value()) {
             throw std::runtime_error(std::format("the committed artifacts were refused: {}", medui::describe(made.error())));
         }
@@ -192,7 +196,7 @@ struct BoundText {
 
 /// A rectangle in pixels, or nothing.
 struct InkBox {
-    bool   found{false};
+    bool     found{false};
     core::Px left{0};
     core::Px top{0};
     core::Px right{0};   ///< exclusive
@@ -221,8 +225,7 @@ struct InkBox {
     // and a corrupt artifact should make it return "no ink" - which fails the REQUIRE below with the
     // run named - rather than form an out-of-range span and take the process with it. Subtraction
     // rather than `byteOffset + byteLength`, which wraps.
-    if (run->byteOffset > bound.runs.size() || run->byteLength > bound.runs.size() - run->byteOffset
-        || run->byteLength % mdux::text::draw::recordSize != 0) {
+    if (run->byteOffset > bound.runs.size() || run->byteLength > bound.runs.size() - run->byteOffset || run->byteLength % mdux::text::draw::recordSize != 0) {
         return InkBox{};
     }
     const std::span<const std::byte> records{bound.runs.data() + run->byteOffset, static_cast<std::size_t>(run->byteLength)};
@@ -261,8 +264,7 @@ struct InkBox {
 /// The label is drawn over the topbar panel, so "painted" means "differs from the panel's colour" -
 /// which also makes the assertion insensitive to the anti-aliased coverage values themselves. What
 /// is under test is where the glyphs landed, not what shade each edge pixel came out.
-[[nodiscard]] InkBox paintedWithin(std::span<const core::ColorRgba8> pixels, core::Extent2D surface,
-                                   const medui::NodeRect& within, core::ColorRgba8 ground) {
+[[nodiscard]] InkBox paintedWithin(std::span<const core::ColorRgba8> pixels, core::Extent2D surface, const medui::NodeRect& within, core::ColorRgba8 ground) {
     InkBox box;
     for (core::Px y = static_cast<core::Px>(within.y); y < static_cast<core::Px>(within.y + within.height); ++y) {
         for (core::Px x = static_cast<core::Px>(within.x); x < static_cast<core::Px>(within.x + within.width); ++x) {
@@ -502,15 +504,19 @@ TEST_CASE("An authored screen's label reaches pixels where the compiler measured
     // The coverage overload, with the committed atlas. A default renderer would sample a white
     // 1x1 default and every glyph would come out a filled rectangle - which would still "draw
     // text" in the loosest sense and would prove nothing about the atlas.
-    auto renderer = UiRenderer::createWithCoverageAtlas(context, mdux::shader::generated::mdux_ui::package(), package.budget,
-                                                        bound.atlas, bound.font.atlas.width, bound.font.atlas.height);
+    auto renderer = UiRenderer::createWithCoverageAtlas(context,
+                                                        mdux::shader::generated::mdux_ui::package(),
+                                                        package.budget,
+                                                        bound.atlas,
+                                                        bound.font.atlas.width,
+                                                        bound.font.atlas.height);
     REQUIRE(renderer.has_value());
 
     Frame frame;
     auto  list = draw::DrawList::create(frame.vertices, frame.indices, frame.commands, package.budget);
     REQUIRE(list.has_value());
 
-    const auto recorded = medui::render(package, *list, bound.binding());
+    const auto recorded = medui::render(package, *list, bound.binding(package));
     REQUIRE(recorded.has_value());
 
     // One fewer deferred node than the unbound frame, and the difference is the label. Asserted as

--- a/tests/render/ScreenPixelTests.cpp
+++ b/tests/render/ScreenPixelTests.cpp
@@ -164,7 +164,7 @@ struct BoundText {
     /// Through `create()`, which is the only way to obtain one - and which proves the three
     /// committed artifacts describe each other before a frame reads any of them.
     [[nodiscard]] medui::TextBinding binding(const medui::ScreenPackage& screen) const {
-        auto made = medui::TextBinding::create(screen, font, text, runs);
+        auto made = medui::TextBinding::create(screen, font, text, textJson, runs);
         if (!made.has_value()) {
             throw std::runtime_error(std::format("the committed artifacts were refused: {}", medui::describe(made.error())));
         }

--- a/tests/text/SchemaTests.cpp
+++ b/tests/text/SchemaTests.cpp
@@ -488,6 +488,41 @@ const mdux::spec::Register packageRoundTrip{
             .Execute();
     }};
 
+const mdux::spec::Register allocationFreeCanonicalDigest{
+    "The allocation-free package digest is the digest of canonical write() bytes", "evidence-unit", [] {
+        return speclab::Test("text-package-canonical-digest")
+            .Given("packages with ordinary, escaped, and empty-run content", [] {})
+            .When("each is hashed both by write() and by canonicalSha256()", [] {})
+            .Then("the digests agree byte for byte",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto agrees = [&checks](const TextPackage& package, std::string_view description) {
+                          const auto written = package.write();
+                          const auto streamed = package.canonicalSha256();
+                          checks.expect(written.has_value(), std::format("{} writes", description));
+                          checks.expect(streamed.has_value(), std::format("{} hashes", description));
+                          if (written.has_value() && streamed.has_value()) {
+                              checks.expect(*streamed == digestOf(*written),
+                                            std::format("{} digest matches write()", description));
+                          }
+                      };
+
+                      agrees(validPackage(), "ordinary package");
+
+                      TextPackage escaped = validPackage();
+                      escaped.header.id = "label-\"welcome\"";
+                      escaped.runs[0].id = "title\\primary\nline";
+                      agrees(escaped, "escaped package");
+
+                      TextPackage empty = validPackage();
+                      empty.sidecarByteLength = 0;
+                      empty.runs.clear();
+                      agrees(empty, "empty-run package");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register malformedPackageRejected{
     "Parsing rejects malformed text", "evidence-unit", [] {
         struct State {

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -399,6 +399,7 @@ namespace {
 struct LoadedLocale {
     mdux::text::TextPackage package;
     std::vector<std::byte>  sidecar;
+    evidence::Digest        packageSha256{};
 };
 
 /// Reads the font package the recipe names, or reports why it could not.
@@ -433,7 +434,8 @@ loadLocales(const Recipe& recipe, const std::filesystem::path& root, std::vector
         if (!bytes.has_value()) {
             return std::nullopt;
         }
-        inputs.push_back(fileRecord(relative, *bytes));
+        const evidence::FileRecord packageRecord = fileRecord(relative, *bytes);
+        inputs.push_back(packageRecord);
 
         auto package = mdux::text::TextPackage::parse(textOf(*bytes));
         if (!package.has_value()) {
@@ -454,7 +456,7 @@ loadLocales(const Recipe& recipe, const std::filesystem::path& root, std::vector
         }
         inputs.push_back(fileRecord(sidecarRelative.generic_string(), *sidecar));
 
-        locales.push_back(LoadedLocale{.package = std::move(*package), .sidecar = *sidecar});
+        locales.push_back(LoadedLocale{.package = std::move(*package), .sidecar = *sidecar, .packageSha256 = packageRecord.sha256});
     }
     return locales;
 }
@@ -618,6 +620,13 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
         textPackages.push_back(locale.package);
     }
 
+    std::vector<ms::TextPackageApproval> approvals;
+    approvals.reserve(locales.size());
+    for (const LoadedLocale& locale : locales) {
+        approvals.push_back(
+            ms::TextPackageApproval{.locale = locale.package.locale, .packageId = locale.package.header.id, .packageSha256 = locale.packageSha256});
+    }
+
     // 2. Semantic analysis. The theme tokens are the governed table the schema publishes, not a
     //    second list: `resolveColorToken()` on a device and this check on the host then agree by
     //    construction rather than by review.
@@ -691,7 +700,7 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
     const std::vector<GoldenReference> goldens = collectGoldens(layout);
 
     // 7. The compiled screen and its bytes.
-    const ScreenDocument    document = buildPackage(layout, {.id = recipe.id, .budget = recipe.budget});
+    const ScreenDocument    document = buildPackage(layout, {.id = recipe.id, .budget = recipe.budget, .approvedTextPackages = approvals});
     const ms::ScreenPackage package  = document.package();
 
     CompileOutputs outputs;

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -447,6 +447,21 @@ loadLocales(const Recipe& recipe, const std::filesystem::path& root, std::vector
             return std::nullopt;
         }
 
+        // The device hashes these bytes directly. Accepting a parseable but noncanonical file here
+        // would record one digest while the in-memory package denotes the canonical form of another,
+        // leaving a package that compiles successfully and can never bind. Diagnose that authoring
+        // error on the host, where rebaking it is actionable.
+        const auto canonical = package->write();
+        if (!canonical.has_value() || *canonical != textOf(*bytes)) {
+            report(diagnostics,
+                   Code::RecipeMissingMember,
+                   relative,
+                   0,
+                   "the text package is valid but its package.json is not canonical",
+                   "re-bake the text package instead of editing package.json by hand");
+            return std::nullopt;
+        }
+
         // The sidecar sits beside the package, under the name the package itself records - the same
         // arrangement every other artifact kind uses, so a caller never guesses a filename.
         const std::filesystem::path                 sidecarRelative = std::filesystem::path{relative}.parent_path() / package->sidecarPath;
@@ -589,6 +604,15 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
                "this screen draws text, so the recipe needs a [text] table naming the font package and one text package per "
                "approved locale",
                "a screen that draws text and declares no approved locale would be certified against a set nobody approved");
+        return std::nullopt;
+    }
+    if (!measurable && (!recipe.fontPackage.empty() || !recipe.textPackages.empty())) {
+        report(diagnostics,
+               Code::RecipeMissingMember,
+               std::string{recipePath},
+               0,
+               "this screen carries no measurable text, so its recipe must not declare a [text] table",
+               "remove the unused font and locale packages; otherwise the report would name inputs the compiler never authenticated");
         return std::nullopt;
     }
 

--- a/tools/medui/Emit.cpp
+++ b/tools/medui/Emit.cpp
@@ -160,6 +160,28 @@ void appendSpan(std::string& out, bool& first, std::string_view member, std::str
     return out;
 }
 
+[[nodiscard]] std::string renderApprovals(const ms::ScreenPackage& package) {
+    if (package.approvedTextPackages.empty()) {
+        return "/// This screen was compiled without text packages.\n"
+               "inline constexpr std::span<const mdux::medui::TextPackageApproval> approvedTextPackages{};\n\n";
+    }
+
+    std::string out = "/// The exact per-locale text packages measured when this screen was compiled.\n"
+                      "inline constexpr mdux::medui::TextPackageApproval approvedTextPackages[] = {\n";
+    for (const ms::TextPackageApproval& approval : package.approvedTextPackages) {
+        out += std::format("    {{.locale = {}, .packageId = {}, .packageSha256 = {{", quoted(approval.locale), quoted(approval.packageId));
+        for (std::size_t index = 0; index < approval.packageSha256.size(); ++index) {
+            if (index != 0) {
+                out += ", ";
+            }
+            out += std::to_string(approval.packageSha256[index]);
+        }
+        out += "}},\n";
+    }
+    out += "};\n\n";
+    return out;
+}
+
 /**
  * @brief One node's payload as a spec initialiser.
  *
@@ -244,6 +266,7 @@ void appendSpan(std::string& out, bool& first, std::string_view member, std::str
     out += std::format("    .schemaVersion = {},\n", package.schemaVersion);
     out += std::format("    .surfaceWidth = {},\n", package.surfaceWidth);
     out += std::format("    .surfaceHeight = {},\n", package.surfaceHeight);
+    out += "    .approvedTextPackages = approvedTextPackages,\n";
     out += "    .nodes = nodes,\n";
     out += std::format("    .budget = {{.maxVertices = {}, .maxIndices = {}, .maxCommands = {}}},\n",
                        package.budget.maxVertices,
@@ -274,6 +297,7 @@ void appendSpan(std::string& out, bool& first, std::string_view member, std::str
     out += "/// The package id this screen was generated from.\n";
     out += std::format("inline constexpr std::string_view id = {};\n\n", quoted(package.id));
 
+    out += renderApprovals(package);
     out += renderStateArrays(package);
 
     // A screen with nothing to draw is valid - `ScreenPackage::validate()` permits it, with an empty

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -334,11 +334,15 @@ void ScreenDocument::setHeader(std::string_view                         id,
     surfaceWidth_  = surfaceWidth;
     surfaceHeight_ = surfaceHeight;
     budget_        = budget;
-    approvedTextPackages_.reserve(approvedTextPackages.size());
+    // Build before replacing: `approvedTextPackages` may be a span returned by this document's own
+    // `package()`, so clearing first would invalidate the input we are still reading.
+    std::vector<ms::TextPackageApproval> replacements;
+    replacements.reserve(approvedTextPackages.size());
     for (const ms::TextPackageApproval& approval : approvedTextPackages) {
-        approvedTextPackages_.push_back(
+        replacements.push_back(
             ms::TextPackageApproval{.locale = intern(approval.locale), .packageId = intern(approval.packageId), .packageSha256 = approval.packageSha256});
     }
+    approvedTextPackages_ = std::move(replacements);
 }
 
 void ScreenDocument::addNode(ms::CompiledNode node) {
@@ -531,7 +535,7 @@ private:
     }
     const auto text = member->asString();
     if (!text.has_value()) {
-        sink.fail(memberWrong, std::format("{} member '{}' is not a lowercase SHA-256 string", what, key));
+        sink.fail(memberWrong, std::format("{} member '{}' is not a string", what, key));
         return std::nullopt;
     }
     auto digest = mdux::evidence::digestFromHex(*text);

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -9,6 +9,7 @@ module mdux.tools.medui.package;
 
 import std;
 import mdux.draw;
+import mdux.evidence.digest;
 import mdux.evidence.json;
 import mdux.evidence.report;
 import mdux.medui.schema;
@@ -230,6 +231,24 @@ template <typename Rect>
     return json::Value::array(std::move(elements));
 }
 
+[[nodiscard]] std::string hexOf(const mdux::evidence::Digest& digest) {
+    const std::array<char, 64> hex = mdux::evidence::toHex(digest);
+    return {hex.data(), hex.size()};
+}
+
+[[nodiscard]] json::Value writeApprovals(std::span<const ms::TextPackageApproval> approvals) {
+    std::vector<json::Value> entries;
+    entries.reserve(approvals.size());
+    for (const ms::TextPackageApproval& approval : approvals) {
+        json::Value entry = json::Value::emptyObject();
+        put(entry, "locale", json::Value::string(std::string{approval.locale}));
+        put(entry, "packageId", json::Value::string(std::string{approval.packageId}));
+        put(entry, "packageSha256", json::Value::string(hexOf(approval.packageSha256)));
+        entries.push_back(std::move(entry));
+    }
+    return json::Value::array(std::move(entries));
+}
+
 /// The `spec` object for one payload: the component's own fields, and nothing shared.
 [[nodiscard]] json::Value writeSpec(const ms::NodePayload& payload) {
     json::Value spec = json::Value::emptyObject();
@@ -306,11 +325,20 @@ std::span<const std::string_view> ScreenDocument::internList(std::span<const std
     return views;
 }
 
-void ScreenDocument::setHeader(std::string_view id, std::int32_t surfaceWidth, std::int32_t surfaceHeight, mdux::draw::DrawBudget budget) {
+void ScreenDocument::setHeader(std::string_view                         id,
+                               std::int32_t                             surfaceWidth,
+                               std::int32_t                             surfaceHeight,
+                               mdux::draw::DrawBudget                   budget,
+                               std::span<const ms::TextPackageApproval> approvedTextPackages) {
     id_            = intern(id);
     surfaceWidth_  = surfaceWidth;
     surfaceHeight_ = surfaceHeight;
     budget_        = budget;
+    approvedTextPackages_.reserve(approvedTextPackages.size());
+    for (const ms::TextPackageApproval& approval : approvedTextPackages) {
+        approvedTextPackages_.push_back(
+            ms::TextPackageApproval{.locale = intern(approval.locale), .packageId = intern(approval.packageId), .packageSha256 = approval.packageSha256});
+    }
 }
 
 void ScreenDocument::addNode(ms::CompiledNode node) {
@@ -318,12 +346,13 @@ void ScreenDocument::addNode(ms::CompiledNode node) {
 }
 
 ms::ScreenPackage ScreenDocument::package() const noexcept {
-    return ms::ScreenPackage{.id            = id_,
-                             .schemaVersion = mdux::evidence::kSchemaVersion,
-                             .surfaceWidth  = surfaceWidth_,
-                             .surfaceHeight = surfaceHeight_,
-                             .nodes         = nodes_,
-                             .budget        = budget_};
+    return ms::ScreenPackage{.id                   = id_,
+                             .schemaVersion        = mdux::evidence::kSchemaVersion,
+                             .surfaceWidth         = surfaceWidth_,
+                             .surfaceHeight        = surfaceHeight_,
+                             .approvedTextPackages = approvedTextPackages_,
+                             .nodes                = nodes_,
+                             .budget               = budget_};
 }
 
 // ---------------------------------------------------------------------------
@@ -336,7 +365,11 @@ ScreenDocument buildPackage(const LayoutResult& layout, PackageInputs inputs) {
     }
 
     ScreenDocument document;
-    document.setHeader(inputs.id, narrow(layout.surfaceWidth, "surface width"), narrow(layout.surfaceHeight, "surface height"), inputs.budget);
+    document.setHeader(inputs.id,
+                       narrow(layout.surfaceWidth, "surface width"),
+                       narrow(layout.surfaceHeight, "surface height"),
+                       inputs.budget,
+                       inputs.approvedTextPackages);
 
     for (const ResolvedNode& resolved : layout.nodes) {
         document.addNode(ms::CompiledNode{
@@ -381,6 +414,7 @@ std::string writePackage(const ms::ScreenPackage& package) {
     put(budget, "maxVertices", json::Value::unsignedInteger(package.budget.maxVertices));
 
     json::Value root = json::Value::emptyObject();
+    put(root, "approvedTextPackages", writeApprovals(package.approvedTextPackages));
     put(root, "budget", std::move(budget));
     put(root, "id", json::Value::string(std::string{package.id}));
     put(root, "kind", json::Value::string(std::string{ms::packageKind}));
@@ -487,6 +521,25 @@ private:
         return std::nullopt;
     }
     return std::string{*text};
+}
+
+[[nodiscard]] std::optional<mdux::evidence::Digest> readDigest(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        sink.fail(memberWrong, std::format("{} is missing the member '{}'", what, key));
+        return std::nullopt;
+    }
+    const auto text = member->asString();
+    if (!text.has_value()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not a lowercase SHA-256 string", what, key));
+        return std::nullopt;
+    }
+    auto digest = mdux::evidence::digestFromHex(*text);
+    if (!digest.has_value()) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not 64 lowercase hexadecimal digits", what, key));
+        return std::nullopt;
+    }
+    return *digest;
 }
 
 [[nodiscard]] std::optional<std::int64_t> readInteger(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
@@ -772,9 +825,11 @@ PackageReadResult readPackage(std::string_view text, std::string file) {
         return result;
     }
 
-    static constexpr std::array<std::string_view, 7> rootMembers{"budget", "id", "kind", "nodes", "schemaVersion", "surfaceHeight", "surfaceWidth"};
+    static constexpr std::array<std::string_view, 8>
+        rootMembers{"approvedTextPackages", "budget", "id", "kind", "nodes", "schemaVersion", "surfaceHeight", "surfaceWidth"};
     static constexpr std::array<std::string_view, 3> budgetMembers{"maxCommands", "maxIndices", "maxVertices"};
     static constexpr std::array<std::string_view, 4> nodeMembers{"bounds", "id", "kind", "spec"};
+    static constexpr std::array<std::string_view, 3> approvalMembers{"locale", "packageId", "packageSha256"};
 
     const json::Value& root = *parsed;
     if (!expectObject(root, "the package", rootMembers, sink)) {
@@ -814,11 +869,40 @@ PackageReadResult readPackage(std::string_view text, std::string file) {
         return result;
     }
 
+    const json::Value* approvalsValue = root.find("approvedTextPackages");
+    if (approvalsValue == nullptr || approvalsValue->kind() != json::Value::Kind::Array) {
+        sink.fail(memberWrong, "the package member 'approvedTextPackages' is missing or is not an array");
+        return result;
+    }
+    std::vector<ms::TextPackageApproval> approvals;
+    std::vector<std::string>             approvalLocales;
+    std::vector<std::string>             approvalPackageIds;
+    approvals.reserve(approvalsValue->elements().size());
+    approvalLocales.reserve(approvalsValue->elements().size());
+    approvalPackageIds.reserve(approvalsValue->elements().size());
+    for (std::size_t index = 0; index < approvalsValue->elements().size(); ++index) {
+        const json::Value& entry = approvalsValue->elements()[index];
+        const std::string  what  = std::format("approved text package {}", index);
+        if (!expectObject(entry, what, approvalMembers, sink)) {
+            return result;
+        }
+        const auto locale        = readName(entry, "locale", what, sink);
+        const auto packageId     = readName(entry, "packageId", what, sink);
+        const auto packageSha256 = readDigest(entry, "packageSha256", what, sink);
+        if (!locale.has_value() || !packageId.has_value() || !packageSha256.has_value()) {
+            return result;
+        }
+        approvalLocales.push_back(*locale);
+        approvalPackageIds.push_back(*packageId);
+        approvals.push_back(ms::TextPackageApproval{.locale = approvalLocales.back(), .packageId = approvalPackageIds.back(), .packageSha256 = *packageSha256});
+    }
+
     ScreenDocument document;
     document.setHeader(*id,
                        *surfaceWidth,
                        *surfaceHeight,
-                       mdux::draw::DrawBudget{.maxVertices = *maxVertices, .maxIndices = *maxIndices, .maxCommands = *maxCommands});
+                       mdux::draw::DrawBudget{.maxVertices = *maxVertices, .maxIndices = *maxIndices, .maxCommands = *maxCommands},
+                       approvals);
 
     const json::Value* nodes = root.find("nodes");
     if (nodes == nullptr || nodes->kind() != json::Value::Kind::Array) {

--- a/tools/medui/Package.cppm
+++ b/tools/medui/Package.cppm
@@ -47,8 +47,9 @@
  * ## What the artifact contains, and what it deliberately does not
  *
  * `package.json` carries the compiled nodes, their absolute rectangles, the draw budget, and the
- * validated names each node draws with. It carries no resolved colour, no glyph run, no locale and
- * no vertex - ADR-011 fixes that boundary and ADR-012 explains it. One consequence is worth naming
+ * validated names each node draws with, plus the locale/package/digest approval records the runtime
+ * uses to authenticate a binding. It carries no selected locale, no resolved colour, no glyph run
+ * and no vertex - ADR-011 fixes that boundary and ADR-012 explains it. One consequence is worth naming
  * because it is unusual for this repository: **a screen package contains no floating-point number at
  * all**, so the `{"bits": N}` encoding that ADR-007 requires for a float never appears in one. Every
  * number here is an integer the layout solver computed in integer arithmetic.
@@ -115,8 +116,9 @@ export namespace mdux::tools::medui {
  * nodes, and `DrawList` fails closed against it at run time.
  */
 struct PackageInputs {
-    std::string_view       id;
-    mdux::draw::DrawBudget budget{};
+    std::string_view                                  id;
+    mdux::draw::DrawBudget                            budget{};
+    std::span<const mdux::medui::TextPackageApproval> approvedTextPackages;
 };
 
 /**
@@ -142,7 +144,11 @@ public:
     [[nodiscard]] mdux::medui::ScreenPackage package() const noexcept;
 
     /// Records the header. Interns `id`, so the caller's storage need not outlive the call.
-    void setHeader(std::string_view id, std::int32_t surfaceWidth, std::int32_t surfaceHeight, mdux::draw::DrawBudget budget);
+    void setHeader(std::string_view                                  id,
+                   std::int32_t                                      surfaceWidth,
+                   std::int32_t                                      surfaceHeight,
+                   mdux::draw::DrawBudget                            budget,
+                   std::span<const mdux::medui::TextPackageApproval> approvedTextPackages);
 
     /// Appends a node. Its views must already point into this document - `intern()` produces them.
     ///
@@ -161,13 +167,14 @@ public:
     [[nodiscard]] std::span<const std::string_view> internList(std::span<const std::string> items);
 
 private:
-    std::deque<std::string>                   text_;
-    std::deque<std::vector<std::string_view>> lists_;
-    std::vector<mdux::medui::CompiledNode>    nodes_;
-    std::string_view                          id_;
-    std::int32_t                              surfaceWidth_{0};
-    std::int32_t                              surfaceHeight_{0};
-    mdux::draw::DrawBudget                    budget_{};
+    std::deque<std::string>                       text_;
+    std::deque<std::vector<std::string_view>>     lists_;
+    std::vector<mdux::medui::TextPackageApproval> approvedTextPackages_;
+    std::vector<mdux::medui::CompiledNode>        nodes_;
+    std::string_view                              id_;
+    std::int32_t                                  surfaceWidth_{0};
+    std::int32_t                                  surfaceHeight_{0};
+    mdux::draw::DrawBudget                        budget_{};
 };
 
 /**


### PR DESCRIPTION
## Summary

Bind each compiled screen to the exact text packages reviewed during compilation. The screen artifact now carries an approved package ID and `package.json` SHA-256 per locale, and `TextBinding::create()` fails closed with `PackageNotApproved` when a different valid package is supplied.

The compiler, canonical JSON representation, both C++ emitters, runtime binding, committed endoscope screen artifact, tests, and ADR-011/ADR-012 are updated together.

Closes #244

## Invitation and contributor agreement

- [x] Maintainer-authored change; an invitation is not applicable.
- [x] Maintainer-authored change; contributor CLA acceptance is not applicable.

Invitation / CLA issue: none — maintainer-authored

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [x] Committed artifacts under `generated/`
- [ ] None of the above

## Rebase state

- **Rebased onto:** `b1750b606403e2c94fac0038482a9d45bf1c6579`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run locally; macOS verified tuple used
- [ ] `ctest --test-dir build-gcc` — not run locally; macOS verified tuple used
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — passed, together with docs-lint unit tests, file-header lint, AI-reference check, and schema drift check
- [x] Other: `cmake --build build-macos-clang -j 4` passed
- [x] Other: `ctest --test-dir build-macos-clang --output-on-failure -j 4` — 611 passed, 0 failed, 1 skipped
- [x] Other: `ctest --test-dir build-macos-clang -L evidence --output-on-failure -j 4` — 554 passed
- [x] Other: `cmake --build build-macos-clang --target mdux-bake-update -j 4` — committed artifact regenerated and byte-identity checks passed

The skipped test is `offscreen_tests`: the local host has no usable Vulkan loader/ICD. The target and generated-screen approval assertions compile; CI must execute the pixel leg.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green. *(No successor; nothing is gated.)*

## Regulatory impact

This is a safety-relevant, fail-closed approval-integrity change: a device can bind only a text package whose locale, package ID, and canonical package digest were recorded when the screen was compiled. It changes governed schema/runtime behavior and committed traceability evidence. ADR-011, ADR-012, runtime refusal tests, no-allocation tests, and the generated screen package/report were updated. Maintainer/domain review is required before merge. No certification or standards-compliance claim is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compiled screen packages now record approved locales, text package IDs, and SHA-256 digests.
  * Runtime rendering verifies that text packages match the screen’s approved content.
  * Package metadata supports reliable round-trip storage and validation of approved translations.

* **Bug Fixes**
  * Prevents unapproved, modified, or noncanonical text packages from being used.
  * Rejects text approvals that are missing required metadata or applied to text-free screens.

* **Documentation**
  * Updated architecture guidance for locale approvals and authenticated text binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->