### PR TITLE
Ask whether the Linux Clang leg can run the evidence tests [#246]

### DIFF
--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -1,25 +1,49 @@
-# Clang leg — manual-dispatch only, not part of the automatic CI set.
+# Clang leg on Linux — manual-dispatch while issue #246 runs.
 #
-# This job is NOT wired to push or pull_request on purpose: Clang 20's `std` module support is
-# not ready for this codebase (issue #48 added the GCC 16 leg but did not re-enable this one, so
-# the Clang half of that story remains open). It is kept as a live workflow rather than a
-# commented-out `.disabled` file so that:
+# This job is NOT wired to push or pull_request yet, and #246 has now established why — the reason
+# is not the one this comment used to give.
+#
+# The old rationale, kept so nobody restores it: "Clang 20's `std` module support is not ready for
+# this codebase", with the preset pinned to clang-20 to match. That is obsolete twice over. #222 made
+# Clang 21.1.8 with libc++ continuously verified on macOS, and run 32945833117 on this workflow
+# showed `import std` resolving fine on Linux too: libc++-21-dev ships its module manifest at
+# /usr/lib/llvm-21/lib/libc++.modules.json, the toolchain file finds it, and CMake configures
+# cleanly. The module story is no longer the blocker.
+#
+# **The actual blocker, measured rather than assumed.** The build fails on exactly one diagnostic:
+#
+#     src/shader/Schema.cpp:322: error: stack frame size (4120) exceeds limit (4096) in
+#     'mdux::shader::ShaderPackage@mdux.shader.schema::toJson() const' [-Werror,-Wframe-larger-than]
+#
+# 24 bytes over, in one function, and nothing else in the tree. That limit is not incidental: it is
+# the determinism guard from issue #63 (cmake/MduXDeterminism.cmake), and its comment states the
+# reason — "no heap" must not quietly become "enormous stack", which on a device is the same bug
+# wearing a different hat. So the two available fixes are not equivalent. Reducing `toJson()`'s frame
+# is real work; raising the number retires a device-safety guard to accommodate a CI leg, and this
+# comment exists to say that is not a trade this project makes silently.
+#
+# Note the target, because it explains why macOS is green and this is not: the macOS lane is arm64
+# and this runner is x86-64. Same compiler version, different register allocation and ABI. The
+# function is a long linear chain of `json::Value` temporaries in sibling scopes, and Clang reuses
+# those stack slots less aggressively than GCC does.
+#
+# Until that is settled, the leg stays manual-dispatch. Run it from the Actions tab; because it is
+# `workflow_dispatch` only, a red result never blocks a PR, which is what makes it usable as an
+# experiment. The evidence step below is live rather than deferred, so the moment the build passes,
+# this workflow answers the remaining half of #246 without further edits.
+#
+# It is kept as a live workflow rather than a commented-out `.disabled` file so that:
 #
 #   - the YAML stays syntax-checked by GitHub instead of rotting silently,
 #   - Dependabot can see and bump the action versions pinned below,
-#   - re-enabling it is adding a trigger, not a rename plus an un-comment pass.
+#   - enabling it is adding a trigger, not a rename plus an un-comment pass.
 #
-# Run it from the Actions tab when checking whether a newer Clang has caught up. Because it is
-# `workflow_dispatch` only, a red result here never blocks a PR.
-#
-# When it is turned back on for real, add an evidence step matching the MSVC and GCC legs in
-# windows-build.yml / linux-gcc16-build.yml:
-#
-#     - name: Verify evidence artifacts (Clang)
-#       run: ctest --preset ninja-clang -L evidence
-#
-# Clang's floating-point code generation differs from both MSVC's and GCC's, so a third
-# independent toolchain strengthens the byte-identity claim in ADR-007 further (decision 6).
+# On the third-toolchain claim in ADR-007 decision 6: an earlier version of this comment reserved it
+# for whenever this leg came back. It is no longer outstanding. Since #222 the macOS lane runs
+# `ctest --preset ninja-macos-clang -L evidence` on every push, so byte-identity already holds across
+# MSVC, GCC and Clang 21/libc++. What a Linux Clang leg would add is that third toolchain on the
+# same OS as the GCC leg — isolating the standard library and code generator from the platform —
+# which is a sharper claim, not the first one.
 
 name: Clang Build (manual)
 
@@ -74,7 +98,7 @@ jobs:
       with:
         cmake-version: '4.3.1'
 
-    - name: Install LLVM/Clang 20
+    - name: Install LLVM/Clang 21 and libc++
       run: |
         set -euo pipefail
         sudo apt-get update
@@ -91,15 +115,19 @@ jobs:
           | awk -F: '/^fpr:/ {print $10}' | grep -qx "$LLVM_KEY_FPR"
         gpg --dearmor < /tmp/llvm-snapshot.asc > /tmp/llvm.gpg
         sudo install -m 0644 /tmp/llvm.gpg /etc/apt/keyrings/llvm.gpg
-        echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" \
-          | sudo tee /etc/apt/sources.list.d/llvm-toolchain-20.list
+        # Derived, not hardcoded: this job runs on ubuntu-latest, whose codename moves. A pinned
+        # `jammy` line silently installs nothing on a noble runner, and the failure then surfaces as
+        # a missing compiler rather than as a wrong source list.
+        codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+        echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-21 main" \
+          | sudo tee /etc/apt/sources.list.d/llvm-toolchain-21.list
         sudo apt-get update
         sudo apt-get install -y \
           ninja-build \
           build-essential \
-          clang-20 \
-          libc++-20-dev \
-          libc++abi-20-dev \
+          clang-21 \
+          libc++-21-dev \
+          libc++abi-21-dev \
           vulkan-tools \
           libvulkan-dev \
           vulkan-utility-libraries-dev \
@@ -107,12 +135,26 @@ jobs:
           libglfw3-dev \
           xvfb
 
-    - name: Setup Clang 20
+    - name: Setup Clang 21
       run: |
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 60
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 60
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 60
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 60
         clang --version
         clang++ --version
+
+    # #246's first question, answered before the configure step so that a missing manifest is
+    # reported as itself rather than as an unresolved `import std` hundreds of lines later. The
+    # toolchain file searches the same locations; this step only makes the finding visible in the log.
+    - name: Report the libc++ std module manifest
+      run: |
+        set -euo pipefail
+        echo "Searching /usr/lib/llvm-21 for libc++.modules.json"
+        found="$(find /usr/lib/llvm-21 -name 'libc++.modules.json' 2>/dev/null || true)"
+        if [ -z "$found" ]; then
+          echo "::warning::No libc++.modules.json in this packaging; import std cannot resolve for libc++. Record on #246."
+        else
+          echo "$found"
+        fi
 
     - name: Verify Vulkan installation
       run: |
@@ -132,3 +174,13 @@ jobs:
         export DISPLAY=:99
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         ctest --preset ninja-clang --output-on-failure
+
+    # The step this workflow's header used to describe as future work. It matches the MSVC and GCC
+    # legs in windows-build.yml / linux-gcc16-build.yml: re-derive every committed artifact and
+    # byte-compare it, on a third standard library and code generator.
+    #
+    # `--no-tests=error` on purpose. Without it a preset that discovered no `evidence` test at all
+    # would pass this step, and the byte-identity claim in ADR-007 decision 6 would rest on a
+    # green tick for zero assertions.
+    - name: Verify evidence artifacts (Clang)
+      run: ctest --preset ninja-clang -L evidence --output-on-failure --no-tests=error

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -1,53 +1,36 @@
-# Clang leg on Linux — manual-dispatch while issue #246 runs.
+# Clang leg on Linux — part of the automatic CI set since #246.
 #
-# This job is NOT wired to push or pull_request yet, and #246 has now established why — the reason
-# is not the one this comment used to give.
+# What #246 found, kept because it corrects two things this file used to assert:
 #
-# The old rationale, kept so nobody restores it: "Clang 20's `std` module support is not ready for
-# this codebase", with the preset pinned to clang-20 to match. That is obsolete twice over. #222 made
-# Clang 21.1.8 with libc++ continuously verified on macOS, and run 32945833117 on this workflow
-# showed `import std` resolving fine on Linux too: libc++-21-dev ships its module manifest at
-# /usr/lib/llvm-21/lib/libc++.modules.json, the toolchain file finds it, and CMake configures
-# cleanly. The module story is no longer the blocker.
+#   1. The old rationale — "Clang 20's `std` module support is not ready for this codebase" — was
+#      obsolete. libc++-21-dev ships its module manifest at
+#      /usr/lib/llvm-21/lib/libc++.modules.json, the toolchain file finds it, and `import std`
+#      resolves. The module story was never the remaining blocker.
+#   2. Two real defects were, and both were invisible on every other leg:
+#      - `ShaderPackage::toJson()` measured a 4120-byte frame against the 4096-byte
+#        `-Wframe-larger-than` guard from #63. This is the only leg that compiles that function for
+#        x86-64 with Clang, and Clang reuses sibling-scope stack slots less than GCC does. The
+#        function was split into per-section helpers; the guard was left alone.
+#      - `InstallTreeConsumer` never forwarded the compiler flags to its nested configure, so the
+#        consumer built against the compiler's default standard library rather than the one MduX was
+#        built with. On macOS libc++ *is* the default, which hid it; here it is not.
 #
-# **The actual blocker, measured rather than assumed.** The build fails on exactly one diagnostic:
+# So this leg earns its place by having caught two things three green legs did not, which is the
+# argument for running it on every PR rather than on demand.
 #
-#     src/shader/Schema.cpp:322: error: stack frame size (4120) exceeds limit (4096) in
-#     'mdux::shader::ShaderPackage@mdux.shader.schema::toJson() const' [-Werror,-Wframe-larger-than]
-#
-# 24 bytes over, in one function, and nothing else in the tree. That limit is not incidental: it is
-# the determinism guard from issue #63 (cmake/MduXDeterminism.cmake), and its comment states the
-# reason — "no heap" must not quietly become "enormous stack", which on a device is the same bug
-# wearing a different hat. So the two available fixes are not equivalent. Reducing `toJson()`'s frame
-# is real work; raising the number retires a device-safety guard to accommodate a CI leg, and this
-# comment exists to say that is not a trade this project makes silently.
-#
-# Note the target, because it explains why macOS is green and this is not: the macOS lane is arm64
-# and this runner is x86-64. Same compiler version, different register allocation and ABI. The
-# function is a long linear chain of `json::Value` temporaries in sibling scopes, and Clang reuses
-# those stack slots less aggressively than GCC does.
-#
-# Until that is settled, the leg stays manual-dispatch. Run it from the Actions tab; because it is
-# `workflow_dispatch` only, a red result never blocks a PR, which is what makes it usable as an
-# experiment. The evidence step below is live rather than deferred, so the moment the build passes,
-# this workflow answers the remaining half of #246 without further edits.
-#
-# It is kept as a live workflow rather than a commented-out `.disabled` file so that:
-#
-#   - the YAML stays syntax-checked by GitHub instead of rotting silently,
-#   - Dependabot can see and bump the action versions pinned below,
-#   - enabling it is adding a trigger, not a rename plus an un-comment pass.
-#
-# On the third-toolchain claim in ADR-007 decision 6: an earlier version of this comment reserved it
-# for whenever this leg came back. It is no longer outstanding. Since #222 the macOS lane runs
-# `ctest --preset ninja-macos-clang -L evidence` on every push, so byte-identity already holds across
-# MSVC, GCC and Clang 21/libc++. What a Linux Clang leg would add is that third toolchain on the
-# same OS as the GCC leg — isolating the standard library and code generator from the platform —
-# which is a sharper claim, not the first one.
+# On ADR-007 decision 6: this is the toolchain that sharpens the claim. MSVC, GCC 16 and macOS/Clang
+# 21 already gave byte-identity across three toolchains, but the Clang leg there also changes the
+# platform. This one runs the same standard library and code generator as the macOS lane on the same
+# OS as the GCC lane, which separates "different toolchain" from "different platform" — the
+# comparison the doctrine actually wants.
 
-name: Clang Build (manual)
+name: Linux Clang Build
 
 on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
   workflow_dispatch:
 
 permissions:
@@ -55,7 +38,7 @@ permissions:
 
 jobs:
   clang-build:
-    name: Linux (Clang, Vulkan)
+    name: Linux (Clang 21, libc++, Vulkan)
     runs-on: ubuntu-latest
     env:
       MEDUI_CONFORMANCE_DIR: ${{ github.workspace }}/.medui-conformance

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -118,12 +118,26 @@ jobs:
           libglfw3-dev \
           xvfb
 
-    - name: Setup Clang 21
+    # Verifies the binaries this build actually uses, which are not the ones on PATH. An earlier
+    # version of this step ran `update-alternatives` and then printed `clang --version`; the
+    # alternative did not win over Ubuntu's own, so a step named "Setup Clang 21" printed
+    # "clang version 18.1.3" twice and passed. The build was genuinely Clang 21 - the toolchain file
+    # addresses /usr/lib/llvm-21/bin directly and never consults PATH - but a verification step that
+    # demonstrates the wrong compiler is worse than none, because it is evidence pointing at the
+    # wrong thing.
+    #
+    # The assertion is exact rather than a print, matching the macOS lane's version gate: a silently
+    # different Clang would otherwise change code generation under a byte-identity claim.
+    - name: Verify Clang 21 is the compiler this job uses
       run: |
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 60
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 60
-        clang --version
-        clang++ --version
+        set -euo pipefail
+        clangxx=/usr/lib/llvm-21/bin/clang++
+        "$clangxx" --version
+        major="$("$clangxx" --version | sed -n 's/.*clang version \([0-9]*\).*/\1/p' | head -1)"
+        if [ "$major" != "21" ]; then
+          echo "::error::${clangxx} reports major version ${major}, expected 21."
+          exit 1
+        fi
 
     # #246's first question, answered before the configure step so that a missing manifest is
     # reported as itself rather than as an unresolved `import std` hundreds of lines later. The

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,6 +614,11 @@ if(MDUX_BUILD_TESTS)
         -D "RANLIB=${CMAKE_RANLIB}"
         -D "STDLIB_MODULES_JSON=${CMAKE_CXX_STDLIB_MODULES_JSON}"
         -D "OSX_SYSROOT=${CMAKE_OSX_SYSROOT}"
+        # The consumer must select the same standard library as this build, not the compiler's
+        # default. Omitting this is invisible on macOS, where libc++ *is* Clang's default, and fatal
+        # on Linux, where it is not: the nested configure then scans libc++'s std.cppm with
+        # libstdc++'s include path and fails on a missing '__config'. Found by #246's Linux leg.
+        -D "CXX_FLAGS=${CMAKE_CXX_FLAGS}"
         -D "GENERATOR=${CMAKE_GENERATOR}"
         -D "EXPECTED_VERSION=${PROJECT_VERSION}"
         -P "${CMAKE_SOURCE_DIR}/cmake/TestInstallConsumer.cmake"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,9 +77,10 @@
         {
             "name": "ninja-clang",
             "displayName": "Ninja with Clang",
-            "description": "Ninja generator with Clang 20+ for C++23 modules and import std support. Mirrors the manual-dispatch-only clang-build job in .github/workflows/clang-build.yml, which no push or pull_request trigger runs (see issue #48 for re-enabling it).",
+            "description": "Ninja generator with upstream Clang 21 and libc++ for C++23 modules and import std. Mirrors the clang-build job in .github/workflows/clang-build.yml. The leg is manual-dispatch while #246 establishes whether it runs green; the toolchain file carries the import-std wiring that made the macOS lane work.",
             "generator": "Ninja",
             "binaryDir": "build-clang",
+            "toolchainFile": "${sourceDir}/cmake/toolchains/linux-clang21-libcxx.cmake",
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
@@ -87,8 +88,6 @@
             },
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_C_COMPILER": "clang-20",
-                "CMAKE_CXX_COMPILER": "clang++-20",
                 "MDUX_BUILD_EXAMPLES": "ON",
                 "MDUX_BUILD_TESTS": "ON",
                 "MDUX_BUILD_DOCS": "OFF"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,7 +77,7 @@
         {
             "name": "ninja-clang",
             "displayName": "Ninja with Clang",
-            "description": "Ninja generator with upstream Clang 21 and libc++ for C++23 modules and import std. Mirrors the clang-build job in .github/workflows/clang-build.yml. The leg is manual-dispatch while #246 establishes whether it runs green; the toolchain file carries the import-std wiring that made the macOS lane work.",
+            "description": "Ninja generator with upstream Clang 21 and libc++ for C++23 modules and import std. Mirrors the Linux Clang leg in .github/workflows/clang-build.yml, which runs on every push since #246. The toolchain file carries the import-std wiring that made the macOS lane work.",
             "generator": "Ninja",
             "binaryDir": "build-clang",
             "toolchainFile": "${sourceDir}/cmake/toolchains/linux-clang21-libcxx.cmake",

--- a/cmake/TestInstallConsumer.cmake
+++ b/cmake/TestInstallConsumer.cmake
@@ -98,6 +98,11 @@ endif()
 if(DEFINED OSX_SYSROOT AND NOT OSX_SYSROOT STREQUAL "")
     list(APPEND consumer_toolchain_arguments "-DCMAKE_OSX_SYSROOT=${OSX_SYSROOT}")
 endif()
+if(DEFINED CXX_FLAGS AND NOT CXX_FLAGS STREQUAL "")
+    # Carries -stdlib=libc++ where the toolchain sets it. Without this the consumer builds against
+    # the compiler's default standard library while linking a MduX built against another one.
+    list(APPEND consumer_toolchain_arguments "-DCMAKE_CXX_FLAGS=${CXX_FLAGS}")
+endif()
 execute_process(
     COMMAND "${CMAKE_COMMAND}" -B "${consumer_build}" -S "${consumer_src}"
             -G "${GENERATOR}"

--- a/cmake/toolchains/linux-clang21-libcxx.cmake
+++ b/cmake/toolchains/linux-clang21-libcxx.cmake
@@ -35,7 +35,20 @@ set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
 # Where Debian/Ubuntu put `libc++.modules.json` is not fixed across LLVM packagings, so search the
 # layouts that exist rather than asserting one. A wrong guess here would fail later and less
 # legibly, as a missing `std` module rather than a missing file.
-if(NOT DEFINED CMAKE_CXX_STDLIB_MODULES_JSON)
+#
+# The manifest is cached, and the compilers above are re-FORCED on every configure, so a bare
+# `if(NOT DEFINED ...)` guard would be wrong in a way that is hard to see: re-configuring an existing
+# build tree with a different MDUX_LLVM_ROOT would take the new root's clang++ and keep the old
+# root's libc++ metadata. Mixing two LLVM installations is not a build that should be allowed to
+# succeed quietly, least of all under a pipeline whose claim is byte-identical output.
+#
+# So record which root the cached manifest was discovered under, and re-discover when it moves. An
+# operator's explicit -DCMAKE_CXX_STDLIB_MODULES_JSON has no recorded root and is left alone, which
+# keeps the manual override the multi-candidate warning below points at.
+if(DEFINED CMAKE_CXX_STDLIB_MODULES_JSON AND NOT DEFINED MDUX_STDLIB_MODULES_JSON_ROOT)
+    # Pinned by the operator; this file does not second-guess it.
+elseif(NOT DEFINED CMAKE_CXX_STDLIB_MODULES_JSON
+       OR NOT MDUX_STDLIB_MODULES_JSON_ROOT STREQUAL "${_mdux_llvm_root}")
     file(GLOB_RECURSE _mdux_libcxx_modules_json
         "${_mdux_llvm_root}/lib/*/libc++.modules.json"
         "${_mdux_llvm_root}/lib/libc++.modules.json"
@@ -64,6 +77,8 @@ if(NOT DEFINED CMAKE_CXX_STDLIB_MODULES_JSON)
     endif()
     set(CMAKE_CXX_STDLIB_MODULES_JSON "${_mdux_libcxx_modules_json_first}"
         CACHE FILEPATH "" FORCE)
+    set(MDUX_STDLIB_MODULES_JSON_ROOT "${_mdux_llvm_root}"
+        CACHE INTERNAL "LLVM root the cached libc++ module manifest was discovered under")
 endif()
 
 foreach(_mdux_required_tool

--- a/cmake/toolchains/linux-clang21-libcxx.cmake
+++ b/cmake/toolchains/linux-clang21-libcxx.cmake
@@ -46,7 +46,21 @@ if(NOT DEFINED CMAKE_CXX_STDLIB_MODULES_JSON)
             "answer, not a configuration mistake: this LLVM packaging does not ship the std module "
             "manifest, so `import std` cannot resolve for libc++ here. Record it on the issue.")
     endif()
+
+    # `file(GLOB_RECURSE)` does not guarantee an order, so taking element 0 of the raw result would
+    # let the chosen manifest depend on directory iteration order - and this toolchain feeds a
+    # pipeline whose entire claim is byte-identical output across machines. Sort first, so the same
+    # installation always selects the same manifest.
+    list(SORT _mdux_libcxx_modules_json)
     list(GET _mdux_libcxx_modules_json 0 _mdux_libcxx_modules_json_first)
+    if(_mdux_libcxx_modules_json_count GREATER 1)
+        # More than one packaging is installed under the same root. Which one is right is a judgement
+        # this file should not make silently, so name them all and let the operator pin it.
+        message(WARNING
+            "Multiple libc++.modules.json under '${_mdux_llvm_root}': "
+            "${_mdux_libcxx_modules_json}. Using '${_mdux_libcxx_modules_json_first}'. Set "
+            "CMAKE_CXX_STDLIB_MODULES_JSON explicitly to choose a different one.")
+    endif()
     set(CMAKE_CXX_STDLIB_MODULES_JSON "${_mdux_libcxx_modules_json_first}"
         CACHE FILEPATH "" FORCE)
 endif()

--- a/cmake/toolchains/linux-clang21-libcxx.cmake
+++ b/cmake/toolchains/linux-clang21-libcxx.cmake
@@ -4,9 +4,10 @@
 # resolve for Clang on macOS, and the part that made it work is not macOS-specific: CMake needs to be
 # pointed at libc++'s own `libc++.modules.json`, and the compile must actually select libc++.
 #
-# This leg is manual-dispatch until #246 records whether it runs green. Read the FATAL_ERROR
-# messages below as the experiment's output rather than as breakage: each one names what was missing
-# on the runner, which is the result the issue asks for.
+# #246 established that this works: libc++-21-dev ships its manifest and `import std` resolves, so
+# the leg now runs on every push. The FATAL_ERROR messages below stay verbose anyway - they are what
+# a contributor on a different LLVM packaging will read, and each names what was missing rather than
+# failing later as an unresolved `std` module.
 if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
     message(FATAL_ERROR "The linux-clang21-libcxx toolchain is only valid on Linux hosts.")
 endif()

--- a/cmake/toolchains/linux-clang21-libcxx.cmake
+++ b/cmake/toolchains/linux-clang21-libcxx.cmake
@@ -1,0 +1,62 @@
+# Candidate Linux toolchain for issue #246.
+#
+# The counterpart to cmake/toolchains/macos-arm64-llvm.cmake. That file is what made `import std`
+# resolve for Clang on macOS, and the part that made it work is not macOS-specific: CMake needs to be
+# pointed at libc++'s own `libc++.modules.json`, and the compile must actually select libc++.
+#
+# This leg is manual-dispatch until #246 records whether it runs green. Read the FATAL_ERROR
+# messages below as the experiment's output rather than as breakage: each one names what was missing
+# on the runner, which is the result the issue asks for.
+if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+    message(FATAL_ERROR "The linux-clang21-libcxx toolchain is only valid on Linux hosts.")
+endif()
+
+set(_mdux_llvm_root "$ENV{MDUX_LLVM_ROOT}")
+if(NOT _mdux_llvm_root)
+    # apt.llvm.org installs versioned roots here; this is the layout clang-build.yml provisions.
+    set(_mdux_llvm_root "/usr/lib/llvm-21")
+endif()
+if(NOT IS_DIRECTORY "${_mdux_llvm_root}")
+    message(FATAL_ERROR
+        "No LLVM 21 root at '${_mdux_llvm_root}'. Set MDUX_LLVM_ROOT, or install the packages "
+        "clang-build.yml installs: clang-21, libc++-21-dev, libc++abi-21-dev.")
+endif()
+
+set(CMAKE_C_COMPILER "${_mdux_llvm_root}/bin/clang" CACHE FILEPATH "" FORCE)
+set(CMAKE_CXX_COMPILER "${_mdux_llvm_root}/bin/clang++" CACHE FILEPATH "" FORCE)
+set(CMAKE_AR "${_mdux_llvm_root}/bin/llvm-ar" CACHE FILEPATH "" FORCE)
+set(CMAKE_RANLIB "${_mdux_llvm_root}/bin/llvm-ranlib" CACHE FILEPATH "" FORCE)
+
+# libc++ rather than libstdc++, for the same reason the macOS lane uses it: the `std` module is
+# shipped by the standard library, and only libc++ ships one this project has been built against.
+set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
+
+# Where Debian/Ubuntu put `libc++.modules.json` is not fixed across LLVM packagings, so search the
+# layouts that exist rather than asserting one. A wrong guess here would fail later and less
+# legibly, as a missing `std` module rather than a missing file.
+if(NOT DEFINED CMAKE_CXX_STDLIB_MODULES_JSON)
+    file(GLOB_RECURSE _mdux_libcxx_modules_json
+        "${_mdux_llvm_root}/lib/*/libc++.modules.json"
+        "${_mdux_llvm_root}/lib/libc++.modules.json"
+        "${_mdux_llvm_root}/share/libc++/*/libc++.modules.json")
+    list(LENGTH _mdux_libcxx_modules_json _mdux_libcxx_modules_json_count)
+    if(_mdux_libcxx_modules_json_count EQUAL 0)
+        message(FATAL_ERROR
+            "No libc++.modules.json under '${_mdux_llvm_root}'. This is the #246 experiment's "
+            "answer, not a configuration mistake: this LLVM packaging does not ship the std module "
+            "manifest, so `import std` cannot resolve for libc++ here. Record it on the issue.")
+    endif()
+    list(GET _mdux_libcxx_modules_json 0 _mdux_libcxx_modules_json_first)
+    set(CMAKE_CXX_STDLIB_MODULES_JSON "${_mdux_libcxx_modules_json_first}"
+        CACHE FILEPATH "" FORCE)
+endif()
+
+foreach(_mdux_required_tool
+        "${CMAKE_CXX_COMPILER}"
+        "${CMAKE_AR}"
+        "${CMAKE_RANLIB}"
+        "${CMAKE_CXX_STDLIB_MODULES_JSON}")
+    if(NOT EXISTS "${_mdux_required_tool}")
+        message(FATAL_ERROR "Required Linux Clang toolchain input is missing: ${_mdux_required_tool}")
+    endif()
+endforeach()

--- a/docs/adr/ADR-007-evidence-pipeline-doctrine.md
+++ b/docs/adr/ADR-007-evidence-pipeline-doctrine.md
@@ -123,14 +123,23 @@ generated/<kind>/<id>/report.json` already tells an auditor exactly which commit
 changed a committed artifact, authoritatively, for free. Duplicating that inside the file itself
 was redundant even before it turned out to be broken.
 
-### 6. Two toolchains, in the same PR — a claim TrustSC cannot make
-The evidence tests run on Windows/MSVC **and** Linux/GCC (and Clang, now that issue #48 re-enabled
-that leg) in the same pull request. Byte-identity across independent toolchains, standard libraries
-and floating-point code generators is a strictly stronger determinism claim than TrustSC obtains from
-a single rustc, and it costs nothing extra because both legs already exist.
+### 6. Three toolchains, in the same PR — a claim TrustSC cannot make
+The evidence tests run on Windows/MSVC, Linux/GCC 16, and — since #222 — macOS/Clang 21 with libc++,
+in the same pull request. Byte-identity across independent toolchains, standard libraries and
+floating-point code generators is a strictly stronger determinism claim than TrustSC obtains from a
+single rustc, and it costs nothing extra because all three legs already exist.
 
 This is written down here specifically so that a future change cannot "simplify" CI to one leg
 without knowingly discarding the claim.
+
+**A correction, kept rather than silently overwritten.** This paragraph previously read "Windows/MSVC
+**and** Linux/GCC (and Clang, now that issue #48 re-enabled that leg)". Issue #48 did not re-enable
+that leg: it added the GCC 16 leg and left the Clang half of its own title open, and
+`clang-build.yml` has carried no `push` or `pull_request` trigger since. The parenthesis asserted in
+the present tense a leg that has never run automatically — the same defect class #116 found in
+ADR-005, in the paragraph written to stop exactly this claim being weakened by accident. The third
+toolchain is real now, but it arrived via macOS rather than the Linux Clang leg, which remains
+manual-dispatch pending #246.
 
 ## Alternatives Considered
 

--- a/docs/adr/ADR-007-evidence-pipeline-doctrine.md
+++ b/docs/adr/ADR-007-evidence-pipeline-doctrine.md
@@ -123,11 +123,17 @@ generated/<kind>/<id>/report.json` already tells an auditor exactly which commit
 changed a committed artifact, authoritatively, for free. Duplicating that inside the file itself
 was redundant even before it turned out to be broken.
 
-### 6. Three toolchains, in the same PR — a claim TrustSC cannot make
-The evidence tests run on Windows/MSVC, Linux/GCC 16, and — since #222 — macOS/Clang 21 with libc++,
-in the same pull request. Byte-identity across independent toolchains, standard libraries and
-floating-point code generators is a strictly stronger determinism claim than TrustSC obtains from a
-single rustc, and it costs nothing extra because all three legs already exist.
+### 6. Four legs, in the same PR — a claim TrustSC cannot make
+The evidence tests run on Windows/MSVC, Linux/GCC 16, macOS/Clang 21 with libc++ (#222), and
+Linux/Clang 21 with libc++ (#246), in the same pull request. Byte-identity across independent
+toolchains, standard libraries and floating-point code generators is a strictly stronger determinism
+claim than TrustSC obtains from a single rustc, and it costs nothing extra because all four legs
+already exist.
+
+The fourth leg is not a fourth toolchain, and it is worth saying why it was added anyway. It runs
+the same compiler and standard library as the macOS lane, on the same operating system as the GCC
+lane. That is what separates "a different toolchain produced identical bytes" from "a different
+*platform* produced identical bytes" — two claims this doctrine had been making as one.
 
 This is written down here specifically so that a future change cannot "simplify" CI to one leg
 without knowingly discarding the claim.
@@ -138,8 +144,10 @@ that leg: it added the GCC 16 leg and left the Clang half of its own title open,
 `clang-build.yml` has carried no `push` or `pull_request` trigger since. The parenthesis asserted in
 the present tense a leg that has never run automatically — the same defect class #116 found in
 ADR-005, in the paragraph written to stop exactly this claim being weakened by accident. The third
-toolchain is real now, but it arrived via macOS rather than the Linux Clang leg, which remains
-manual-dispatch pending #246.
+toolchain arrived via macOS rather than the Linux Clang leg. #246 then made that leg run too, and it
+earned its place immediately: it caught a stack-frame guard violation in `ShaderPackage::toJson()`
+and a standard-library mismatch in the install-tree consumer, both of which three green legs had
+missed.
 
 ## Alternatives Considered
 

--- a/docs/adr/ADR-007-evidence-pipeline-doctrine.md
+++ b/docs/adr/ADR-007-evidence-pipeline-doctrine.md
@@ -195,7 +195,7 @@ byte-compared, committed artifacts.
 - Six bakers produce one audit record shape, so an auditor learns it once.
 - Authoring dependencies are absent from the device build by construction, verified by the existing
   trust-zone link-graph check rather than by convention.
-- Determinism becomes a test rather than a claim, on two toolchains at once.
+- Determinism becomes a test rather than a claim, on three toolchains and three operating systems at once.
 - The evidence kernel is reusable as-is by issue #18's `ml.determinism.crossToolchain` check, which
   is the same comparison applied to a baked model package.
 
@@ -210,11 +210,11 @@ byte-compared, committed artifacts.
 ### Risks and Mitigations
 - **A baker introduces nondeterminism** (hash-map iteration order, a timestamp, an absolute path, a
   locale-dependent conversion). *Mitigation*: the canonical writer sorts keys and rejects
-  timestamps, absolute paths and decimal floats by construction; the two-leg CI check catches what
+  timestamps, absolute paths and decimal floats by construction; the four-leg CI check catches what
   the writer cannot.
 - **Someone hand-edits a file under `generated/`.** *Mitigation*: the strict reader rejects
   permissive JSON, and re-baking overwrites the edit while the byte-comparison fails the PR.
-- **CI is reduced to one leg for speed.** *Mitigation*: Decision 6 records why both legs exist;
+- **CI is reduced to fewer legs for speed.** *Mitigation*: Decision 6 records what each leg buys;
   removing one is then a documented reversal rather than an unnoticed regression.
 - **`generated/` is swallowed by `.gitignore` again.** *Mitigation*: the `git status --porcelain`
   assertion that follows the evidence tests catches both an uncommitted artifact and a build that

--- a/src/shader/Schema.cpp
+++ b/src/shader/Schema.cpp
@@ -319,6 +319,120 @@ ResultVoid<SchemaError> ShaderPackage::validate() const noexcept {
 // ShaderPackage::toJson() / write()
 // ---------------------------------------------------------------------------
 
+namespace {
+
+// `toJson()` used to build all four sections inline. That put every section's `json::Value`
+// temporaries in sibling scopes of one frame, and Clang - unlike GCC - does not reuse those stack
+// slots aggressively: on x86-64 the function measured 4120 bytes against the 4096-byte
+// `-Wframe-larger-than` limit that issue #63 set so "no heap" could not quietly become "enormous
+// stack" (see cmake/MduXDeterminism.cmake). Splitting the sections out gives each its own frame and
+// leaves `toJson()` holding one section's value at a time. The guard stays where it is; the
+// function fits under it. Found by #246's Linux Clang leg, which is the only leg that compiles this
+// for x86-64 with Clang.
+//
+// Each helper is the whole of one section, not a fragment of it, so the composition below reads as
+// the document's shape.
+
+[[nodiscard]] Result<json::Value, SchemaError> sidecarSection(std::string_view path, std::uint64_t byteLength,
+                                                              const evidence::Digest& sha256) noexcept {
+    json::Value sidecar = json::Value::emptyObject();
+    if (auto done = setMember(sidecar, "path", json::Value::string(std::string{path})); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(sidecar, "byteLength", json::Value::unsignedInteger(byteLength)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(sidecar, "sha256", digestToJson(sha256)); !done.has_value()) {
+        return err(done.error());
+    }
+    return sidecar;
+}
+
+[[nodiscard]] Result<json::Value, SchemaError> moduleEntry(const ShaderModule& module) noexcept {
+    json::Value entry = json::Value::emptyObject();
+    if (auto done = setMember(entry, "id", json::Value::string(module.id)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "stage", json::Value::string(std::string{toWire(module.stage)})); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "entryPoint", json::Value::string(module.entryPoint)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "byteOffset", json::Value::unsignedInteger(module.byteOffset)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "byteLength", json::Value::unsignedInteger(module.byteLength)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "sha256", digestToJson(module.sha256)); !done.has_value()) {
+        return err(done.error());
+    }
+    return entry;
+}
+
+[[nodiscard]] Result<json::Value, SchemaError> descriptorEntry(const DescriptorBinding& descriptor) noexcept {
+    json::Value entry = json::Value::emptyObject();
+    if (auto done = setMember(entry, "set", json::Value::unsignedInteger(descriptor.set)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "binding", json::Value::unsignedInteger(descriptor.binding)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "kind", json::Value::string(std::string{toWire(descriptor.kind)})); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "count", json::Value::unsignedInteger(descriptor.count)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "stages", stagesToJson(descriptor.stages)); !done.has_value()) {
+        return err(done.error());
+    }
+    return entry;
+}
+
+[[nodiscard]] Result<json::Value, SchemaError> pushConstantEntry(const PushConstantRange& range) noexcept {
+    json::Value entry = json::Value::emptyObject();
+    if (auto done = setMember(entry, "offset", json::Value::unsignedInteger(range.offset)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "size", json::Value::unsignedInteger(range.size)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = setMember(entry, "stages", stagesToJson(range.stages)); !done.has_value()) {
+        return err(done.error());
+    }
+    return entry;
+}
+
+/// One array section, built by applying `entryOf` to each element. The array lives here rather than
+/// in `toJson()`, which is the point of the split.
+template <typename Element, typename EntryOf>
+[[nodiscard]] Result<json::Value, SchemaError> arraySection(std::span<const Element> elements, EntryOf entryOf) noexcept {
+    json::Value array = json::Value::array({});
+    for (const Element& element : elements) {
+        auto entry = entryOf(element);
+        if (!entry.has_value()) {
+            return err(entry.error());
+        }
+        if (auto done = pushElement(array, std::move(*entry)); !done.has_value()) {
+            return err(done.error());
+        }
+    }
+    return array;
+}
+
+/// Attaches one built section to `root`, so the composition below is one line per member.
+[[nodiscard]] ResultVoid<SchemaError> attach(json::Value& root, std::string key,
+                                             Result<json::Value, SchemaError> section) noexcept {
+    if (!section.has_value()) {
+        return err(section.error());
+    }
+    return setMember(root, std::move(key), std::move(*section));
+}
+
+}  // namespace
+
 Result<json::Value, SchemaError> ShaderPackage::toJson() const noexcept {
     if (auto valid = validate(); !valid.has_value()) {
         return err(valid.error());
@@ -329,115 +443,19 @@ Result<json::Value, SchemaError> ShaderPackage::toJson() const noexcept {
         return err(SchemaError::MalformedPackage);
     }
 
-    json::Value sidecar = json::Value::emptyObject();
-    if (auto done = setMember(sidecar, "path", json::Value::string(sidecarPath));
+    if (auto done = attach(root, "sidecar", sidecarSection(sidecarPath, sidecarByteLength, sidecarSha256));
         !done.has_value()) {
         return err(done.error());
     }
-    if (auto done = setMember(sidecar, "byteLength",
-                              json::Value::unsignedInteger(sidecarByteLength));
+    if (auto done = attach(root, "modules", arraySection(std::span{modules}, moduleEntry)); !done.has_value()) {
+        return err(done.error());
+    }
+    if (auto done = attach(root, "descriptors", arraySection(std::span{descriptors}, descriptorEntry));
         !done.has_value()) {
         return err(done.error());
     }
-    if (auto done = setMember(sidecar, "sha256", digestToJson(sidecarSha256)); !done.has_value()) {
-        return err(done.error());
-    }
-    if (auto done = setMember(root, "sidecar", std::move(sidecar)); !done.has_value()) {
-        return err(done.error());
-    }
-
-    json::Value moduleArray = json::Value::array({});
-    for (const ShaderModule& module : modules) {
-        json::Value entry = json::Value::emptyObject();
-        if (auto done = setMember(entry, "id", json::Value::string(module.id));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "stage",
-                                  json::Value::string(std::string{toWire(module.stage)}));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "entryPoint", json::Value::string(module.entryPoint));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "byteOffset",
-                                  json::Value::unsignedInteger(module.byteOffset));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "byteLength",
-                                  json::Value::unsignedInteger(module.byteLength));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "sha256", digestToJson(module.sha256));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = pushElement(moduleArray, std::move(entry)); !done.has_value()) {
-            return err(done.error());
-        }
-    }
-    if (auto done = setMember(root, "modules", std::move(moduleArray)); !done.has_value()) {
-        return err(done.error());
-    }
-
-    json::Value descriptorArray = json::Value::array({});
-    for (const DescriptorBinding& descriptor : descriptors) {
-        json::Value entry = json::Value::emptyObject();
-        if (auto done = setMember(entry, "set", json::Value::unsignedInteger(descriptor.set));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done =
-                setMember(entry, "binding", json::Value::unsignedInteger(descriptor.binding));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "kind",
-                                  json::Value::string(std::string{toWire(descriptor.kind)}));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "count", json::Value::unsignedInteger(descriptor.count));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "stages", stagesToJson(descriptor.stages));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = pushElement(descriptorArray, std::move(entry)); !done.has_value()) {
-            return err(done.error());
-        }
-    }
-    if (auto done = setMember(root, "descriptors", std::move(descriptorArray));
+    if (auto done = attach(root, "pushConstants", arraySection(std::span{pushConstants}, pushConstantEntry));
         !done.has_value()) {
-        return err(done.error());
-    }
-
-    json::Value pushArray = json::Value::array({});
-    for (const PushConstantRange& range : pushConstants) {
-        json::Value entry = json::Value::emptyObject();
-        if (auto done = setMember(entry, "offset", json::Value::unsignedInteger(range.offset));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "size", json::Value::unsignedInteger(range.size));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = setMember(entry, "stages", stagesToJson(range.stages));
-            !done.has_value()) {
-            return err(done.error());
-        }
-        if (auto done = pushElement(pushArray, std::move(entry)); !done.has_value()) {
-            return err(done.error());
-        }
-    }
-    if (auto done = setMember(root, "pushConstants", std::move(pushArray)); !done.has_value()) {
         return err(done.error());
     }
 


### PR DESCRIPTION
Closes #246.

## Result: the leg is green, and it caught two things three green legs did not

[Run 33023734904](https://github.com/ambroise-leclerc/MduX/actions/runs/33023734904): **616/616**,
evidence step included. It now runs on every push, and has already verified itself on this PR.

The premise it was disabled on was wrong. `import std` was never the remaining blocker: libc++-21-dev
ships its manifest at `/usr/lib/llvm-21/lib/libc++.modules.json`, the new toolchain file finds it,
and configure succeeds. Two real defects were the blocker, and **neither was reachable on any other
leg**:

### 1. `ShaderPackage::toJson()` exceeded the frame-size guard

```
error: stack frame size (4120) exceeds limit (4096) [-Werror,-Wframe-larger-than]
```

24 bytes. The limit is the determinism guard from #63, and `cmake/MduXDeterminism.cmake` states why
beside it: *"no heap" must not quietly become "enormous stack", which on a device is the same bug
wearing a different hat.* **The limit was left alone and the function shrank instead** — raising it
would retire a device-safety guard to accommodate a CI lane.

The cause was structural, not one large object: all four sections were built inline, so their
`json::Value` temporaries lived in sibling scopes of one frame, and Clang reuses those slots less
aggressively than GCC. Each section is now its own function; `toJson()` holds one at a time and reads
as one line per member of the document.

Behaviour is unchanged *by construction*, and the byte-identity tests are what say so rather than
inspection: `ctest -L evidence` 7/7, 103/103 shader tests, identical emitted `package.json`.

This is the only leg that compiles that function for x86-64 with Clang, which is why arm64 macOS and
GCC never saw it.

### 2. `InstallTreeConsumer` built against the wrong standard library

Failed on `'__config' file not found`. The nested consumer configure already forwarded `AR`,
`RANLIB`, the std module manifest and the macOS sysroot — but not the compiler flags, so it never
received `-stdlib=libc++`. Invisible on macOS, where libc++ *is* Clang's default.

The symptom is a missing header; the defect is worse than that. The consumer could compile against
one standard library while linking a MduX built against another — precisely what this test exists to
catch rather than to reproduce.

## Documentation corrected

- **ADR-007 decision 6** claimed the evidence tests run on Clang "now that issue #48 re-enabled that
  leg". #48 did not — `clang-build.yml` never carried a `push` trigger. That false present-tense
  claim sat in the paragraph written to stop the byte-identity claim being weakened by accident,
  which is the defect class #116 found in ADR-005. The correction is kept visible in the ADR rather
  than silently overwritten.
- It now says **four legs across three operating systems**, and says what the fourth buys, which is
  *not* a fourth toolchain: the same compiler and standard library as the macOS lane, on the same OS
  as the GCC lane. That separates "a different toolchain produced identical bytes" from "a different
  *platform* produced identical bytes" — two claims the doctrine had been making as one.
- The workflow header keeps the obsolete Clang 20 rationale as a visible correction, so the next
  reader sees why it was wrong.

## One consequence worth a reviewer's judgement

**Every PR now carries a fourth lane.** The argument for it is above — it caught two defects on its
first real run. If the CI cost is judged badly spent, removing the triggers is a one-line revert and
the leg reverts to manual dispatch with everything else intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated Linux Clang 21/libc++ validation for pushes and pull requests.
  - Added build configuration for discovering and validating the required LLVM and libc++ tooling.

- **Bug Fixes**
  - Fixed install-tree consumer builds to use the same standard-library configuration as the main build.
  - Addressed issues detected by the expanded Clang validation.

- **Documentation**
  - Updated build preset and evidence-pipeline documentation to reflect automatic Linux Clang coverage and its findings.

- **Refactor**
  - Reorganized shader package JSON generation without changing its output or validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->