### PR TITLE
Check that documents name CI mechanisms that actually run [#249]

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -49,6 +49,15 @@ jobs:
         PYTHONDONTWRITEBYTECODE: "1"
       run: python3 tools/docs-lint/check_file_headers.py
 
+    # Issue #249: prose can name a control that does not exist, or a workflow whose green tick
+    # proves nothing because it never runs automatically. This resolves only the mechanical subset:
+    # workflow triggers, ctest labels and literal CMake/tool target names. It deliberately does not
+    # claim to decide whether the surrounding prose is true.
+    - name: Resolve CI mechanisms named by documentation
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: python3 tools/docs-lint/check_named_mechanisms.py
+
     # Every AI-Reference.md is generated, so an edited module with a stale index is a defect the
     # build should catch rather than a reader. --check writes nothing; it fails when regenerating
     # would change a byte, and when a clause is cited in prose that no index row covers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,15 @@ We use **Doxygen** syntax for code documentation. Follow these guidelines:
   `tools/docs-lint/check_file_headers.py` now enforces it, in the `Documentation Lint` job. #223
   added it after finding ten files back in the retired order, all in one epic and all copied from
   a neighbour: settling a rule in prose twice had not been enough to keep it true.
+- **Named CI mechanisms:** when prose under `docs/` or a full-line workflow comment names a local
+  `*.yml` workflow, a `ctest -L <label>`, or a standalone `mdux-*` CMake/tool target,
+  `tools/docs-lint/check_named_mechanisms.py` requires that name to resolve. For workflows,
+  resolving includes having a `push` or `pull_request` trigger. This proves only that the named
+  mechanism exists and is wired up, not that the surrounding claim is true. Fenced code blocks are
+  skipped because they commonly propose future files. For a deliberately aspirational citation in
+  prose, append `<!-- mdux-named-mechanisms:aspirational; issue #NNN -->` on the same line; in a
+  workflow comment, append `mdux-named-mechanisms:aspirational` and the tracking issue to that
+  comment. Keep the exception beside the claim—there is deliberately no suppression list.
 - **Class documentation:** Include `@brief` with detailed description and usage examples.
 - **Method documentation:**
   - Use compact notation `/** @brief Description */` for simple one-line descriptions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,12 +92,16 @@ We use **Doxygen** syntax for code documentation. Follow these guidelines:
 - **Named CI mechanisms:** when prose under `docs/` or a full-line workflow comment names a local
   `*.yml` workflow, a `ctest -L <label>`, or a standalone `mdux-*` CMake/tool target,
   `tools/docs-lint/check_named_mechanisms.py` requires that name to resolve. For workflows,
-  resolving includes having a `push` or `pull_request` trigger. This proves only that the named
-  mechanism exists and is wired up, not that the surrounding claim is true. Fenced code blocks are
-  skipped because they commonly propose future files. For a deliberately aspirational citation in
-  prose, append `<!-- mdux-named-mechanisms:aspirational; issue #NNN -->` on the same line; in a
-  workflow comment, append `mdux-named-mechanisms:aspirational` and the tracking issue to that
-  comment. Keep the exception beside the claim—there is deliberately no suppression list.
+  resolving includes having a trigger that fires without a human: `push`, `pull_request`,
+  `pull_request_target` or `workflow_call`. This proves only that the named mechanism exists and is
+  wired up, not that the surrounding claim is true. Fenced code blocks are skipped because they
+  commonly propose future files, and a fence that is never closed is reported rather than silently
+  hiding the rest of the document. For a deliberately aspirational citation, append
+  `<!-- mdux-named-mechanisms:aspirational; issue #NNN -->` in prose, or
+  `mdux-named-mechanisms:aspirational, issue #NNN` in a workflow comment — **on the same line as the
+  citation**, since the marker exempts its own line and not a surrounding comment block. The
+  tracking issue is required, not decorative: the checker rejects a bare marker, because an
+  exception nobody is tracking is the suppression list this deliberately does not have.
 - **Class documentation:** Include `@brief` with detailed description and usage examples.
 - **Method documentation:**
   - Use compact notation `/** @brief Description */` for simple one-line descriptions.

--- a/tools/docs-lint/check_named_mechanisms.py
+++ b/tools/docs-lint/check_named_mechanisms.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Fails when documentation names a CI mechanism that the repository cannot resolve.
+
+Host-only tool (ADR-004): standard library only, no third-party dependencies.
+
+This checker deliberately proves less than the prose around a mechanism may claim. It resolves
+only three mechanical facts:
+
+- a cited workflow exists under ``.github/workflows`` and has a ``push`` or ``pull_request``
+  trigger;
+- a label passed to ``ctest -L`` is attached to at least one test in CMake or the test sources;
+- a standalone name beginning ``mdux-`` is an ``add_executable`` /
+  ``add_custom_target`` target or one of the repository's Python lint tools.
+
+It scans Markdown under ``docs/`` and full-line comments in ``.github/workflows/*.yml``. Markdown
+fenced code blocks are examples, not claims about the current tree, and are skipped. A deliberately
+aspirational citation outside a fence may be exempted on that line with the visible marker
+``mdux-named-mechanisms:aspirational``. The marker is local on purpose: there is no suppression list
+where exceptions can become detached from the prose they qualify.
+
+Usage:
+    python3 tools/docs-lint/check_named_mechanisms.py [--repo-root PATH]
+
+Exit status 0 when every citation resolves, 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ASPIRATIONAL_MARKER = "mdux-named-mechanisms:aspirational"
+
+FENCE_PATTERN = re.compile(r"^\s*(?P<fence>`{3,}|~{3,})")
+WORKFLOW_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_./-])(?P<path>(?:\.github/workflows/)?[A-Za-z0-9_.-]+\.ya?ml)\b"
+)
+CTEST_LABEL_PATTERN = re.compile(
+    r"\bctest\b[^\n]*?(?:-L|--label-regex)(?:\s+|=)[\"']?"
+    r"(?P<label>[A-Za-z0-9_]+(?:[.-][A-Za-z0-9_-]+)*)"
+)
+MECHANISM_CITATION_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_./-])(?P<name>mdux-[a-z0-9][a-z0-9_.-]*)(?![A-Za-z0-9_./-])"
+)
+
+CMAKE_TARGET_PATTERN = re.compile(
+    r"\badd_(?:executable|custom_target)\s*\(\s*(?P<name>[A-Za-z0-9_.+-]+)", re.MULTILINE
+)
+CMAKE_LABEL_PATTERN = re.compile(r"\bLABELS\s+(?:\"(?P<quoted>[^\"]+)\"|(?P<bare>[A-Za-z0-9_.;,+-]+))")
+STRING_PATTERN = re.compile(r'"(?P<value>(?:\\.|[^"\\])*)"')
+TEST_CASE_PATTERN = re.compile(
+    r'\bTEST_CASE\s*\(\s*"(?:\\.|[^"\\])*"\s*,(?P<labels>.*?)\)', re.DOTALL
+)
+SPEC_REGISTER_PATTERN = re.compile(
+    r'\bRegister\s+[A-Za-z_][A-Za-z0-9_]*\s*\{\s*"(?:\\.|[^"\\])*"\s*,\s*'
+    r'"(?P<labels>(?:\\.|[^"\\])*)"',
+    re.DOTALL,
+)
+CPP_COMMENT_OR_QUOTED_PATTERN = re.compile(
+    r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|//[^\n]*|/\*.*?\*/', re.DOTALL
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    message: str
+
+
+@dataclass(frozen=True)
+class MechanismIndex:
+    workflows: dict[str, Path]
+    automatic_workflows: frozenset[str]
+    labels: frozenset[str]
+    targets: frozenset[str]
+
+
+def has_automatic_trigger(text: str) -> bool:
+    """Whether a workflow's top-level ``on`` mapping includes push or pull_request."""
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        inline = re.match(r"^on:\s*\[(?P<events>[^]]*)\]\s*(?:#.*)?$", line)
+        if inline is not None:
+            events = {event.strip().strip("'\"") for event in inline.group("events").split(",")}
+            return bool(events.intersection({"push", "pull_request"}))
+
+        if not re.match(r"^on:\s*(?:#.*)?$", line):
+            continue
+        for child in lines[index + 1 :]:
+            if child and not child[0].isspace():
+                break
+            match = re.match(r"^\s+(push|pull_request):(?:\s|$)", child)
+            if match is not None:
+                return True
+        return False
+    return False
+
+
+def cmake_files(root: Path) -> list[Path]:
+    """Project CMake inputs, excluding fetched dependencies and build trees."""
+    found: list[Path] = []
+    for raw_directory, directories, files in os.walk(root):
+        directories[:] = [
+            name
+            for name in directories
+            if name not in {".git", "_deps", "__pycache__"} and not name.startswith("build")
+        ]
+        directory = Path(raw_directory)
+        found.extend(
+            directory / name for name in files if name == "CMakeLists.txt" or name.endswith(".cmake")
+        )
+    return sorted(found)
+
+
+def split_labels(value: str) -> set[str]:
+    return {label for label in re.split(r"[\s,;]+", value) if label and "${" not in label}
+
+
+def cmake_code(text: str) -> str:
+    """CMake text with full-line comments blanked so proposals are not target evidence."""
+    return "\n".join("" if line.lstrip().startswith("#") else line for line in text.splitlines())
+
+
+def cpp_without_comments(text: str) -> str:
+    """Blank C++ comments while preserving quoted strings and source positions."""
+    def replace(match: re.Match[str]) -> str:
+        token = match.group(0)
+        if not token.startswith("/"):
+            return token
+        return "".join("\n" if character == "\n" else " " for character in token)
+
+    return CPP_COMMENT_OR_QUOTED_PATTERN.sub(replace, text)
+
+
+def labels_from_test_source(text: str) -> set[str]:
+    """Literal labels registered through MduXTest or the SpecLab bridge."""
+    text = cpp_without_comments(text)
+    labels: set[str] = set()
+    for match in TEST_CASE_PATTERN.finditer(text):
+        labels.update(string.group("value") for string in STRING_PATTERN.finditer(match.group("labels")))
+    for match in SPEC_REGISTER_PATTERN.finditer(text):
+        labels.update(split_labels(match.group("labels")))
+    return labels
+
+
+def build_index(root: Path) -> MechanismIndex:
+    workflow_dir = root / ".github" / "workflows"
+    workflow_paths = sorted((*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")))
+    workflows = {path.name: path for path in workflow_paths}
+    automatic = frozenset(
+        path.name for path in workflow_paths if has_automatic_trigger(path.read_text(encoding="utf-8"))
+    )
+
+    targets: set[str] = set()
+    labels: set[str] = set()
+    for path in cmake_files(root):
+        text = cmake_code(path.read_text(encoding="utf-8", errors="replace"))
+        targets.update(match.group("name") for match in CMAKE_TARGET_PATTERN.finditer(text))
+        for match in CMAKE_LABEL_PATTERN.finditer(text):
+            labels.update(split_labels(match.group("quoted") or match.group("bare")))
+
+    test_root = root / "tests"
+    if test_root.is_dir():
+        for path in sorted(test_root.rglob("*")):
+            if path.is_file() and path.suffix in {".cpp", ".hpp"} and "_deps" not in path.parts:
+                labels.update(labels_from_test_source(path.read_text(encoding="utf-8", errors="replace")))
+
+    tools_root = root / "tools"
+    if tools_root.is_dir():
+        for path in tools_root.rglob("mdux_*.py"):
+            targets.add(path.stem.replace("_", "-"))
+
+    # A standalone `mdux-*` code span can also name one of the repository's working procedures.
+    # Discover those directories rather than maintaining an allow-list: they are real, resolvable
+    # mechanisms, but not CMake targets or installed tool binaries.
+    skills_root = root / ".agents" / "skills"
+    if skills_root.is_dir():
+        targets.update(path.name for path in skills_root.glob("mdux-*") if path.is_dir())
+
+    return MechanismIndex(workflows, automatic, frozenset(labels), frozenset(targets))
+
+
+def markdown_prose_lines(text: str) -> list[tuple[int, str]]:
+    """Numbered Markdown lines outside backtick and tilde fenced blocks."""
+    visible: list[tuple[int, str]] = []
+    fence_character: str | None = None
+    fence_length = 0
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        fence = FENCE_PATTERN.match(line)
+        if fence is not None:
+            token = fence.group("fence")
+            if fence_character is None:
+                fence_character = token[0]
+                fence_length = len(token)
+                continue
+            if token[0] == fence_character and len(token) >= fence_length:
+                fence_character = None
+                fence_length = 0
+                continue
+        if fence_character is None:
+            visible.append((line_number, line))
+    return visible
+
+
+def workflow_comment_lines(text: str) -> list[tuple[int, str]]:
+    """Numbered full-line YAML comments; run scripts and action configuration are not prose."""
+    return [
+        (line_number, match.group("comment"))
+        for line_number, line in enumerate(text.splitlines(), start=1)
+        if (match := re.match(r"^\s*#(?P<comment>.*)$", line)) is not None
+    ]
+
+
+def check_lines(path: Path, lines: list[tuple[int, str]], index: MechanismIndex) -> list[Finding]:
+    findings: list[Finding] = []
+    for line_number, line in lines:
+        if ASPIRATIONAL_MARKER in line:
+            continue
+
+        for match in WORKFLOW_PATTERN.finditer(line):
+            citation = match.group("path")
+            name = Path(citation).name
+            if name not in index.workflows:
+                findings.append(Finding(path, line_number, f"workflow '{citation}' does not exist"))
+            elif name not in index.automatic_workflows:
+                findings.append(
+                    Finding(
+                        path,
+                        line_number,
+                        f"workflow '{citation}' has no push or pull_request trigger",
+                    )
+                )
+
+        for match in CTEST_LABEL_PATTERN.finditer(line):
+            label = match.group("label")
+            if label not in index.labels:
+                findings.append(Finding(path, line_number, f"ctest label '{label}' is not attached to any test"))
+
+        for match in MECHANISM_CITATION_PATTERN.finditer(line):
+            name = match.group("name")
+            if name not in index.targets:
+                findings.append(Finding(path, line_number, f"CMake/tool target '{name}' does not exist"))
+    return findings
+
+
+def check_repository(root: Path) -> tuple[list[Finding], int]:
+    index = build_index(root)
+    findings: list[Finding] = []
+    checked = 0
+
+    docs_root = root / "docs"
+    if docs_root.is_dir():
+        for path in sorted(docs_root.rglob("*.md")):
+            checked += 1
+            findings.extend(
+                check_lines(path, markdown_prose_lines(path.read_text(encoding="utf-8", errors="replace")), index)
+            )
+
+    workflow_root = root / ".github" / "workflows"
+    if workflow_root.is_dir():
+        for path in sorted((*workflow_root.glob("*.yml"), *workflow_root.glob("*.yaml"))):
+            checked += 1
+            findings.extend(
+                check_lines(path, workflow_comment_lines(path.read_text(encoding="utf-8", errors="replace")), index)
+            )
+    return findings, checked
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (default: inferred from this script's location)",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.repo_root.resolve()
+    findings, checked = check_repository(root)
+    if findings:
+        for finding in findings:
+            relative = finding.path.relative_to(root) if finding.path.is_relative_to(root) else finding.path
+            print(
+                f"mdux-named-mechanisms: {relative}:{finding.line}: {finding.message}",
+                file=sys.stderr,
+            )
+        print(f"mdux-named-mechanisms: {len(findings)} finding(s)", file=sys.stderr)
+        print(
+            "mdux-named-mechanisms: fix the citation or append "
+            f"'{ASPIRATIONAL_MARKER}' to a deliberately aspirational line",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"mdux-named-mechanisms: OK ({checked} documents/workflows checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/docs-lint/check_named_mechanisms.py
+++ b/tools/docs-lint/check_named_mechanisms.py
@@ -38,7 +38,7 @@ ASPIRATIONAL_MARKER = "mdux-named-mechanisms:aspirational"
 # difference between an exception and an untracked permanent one - the suppression list this
 # checker deliberately does not have, spelled differently.
 ASPIRATIONAL_ISSUE_PATTERN = re.compile(re.escape(ASPIRATIONAL_MARKER) + r"[^\n]*?issue\s+#\d+")
-AUTOMATIC_EVENTS = frozenset({"push", "pull_request", "pull_request_target", "workflow_call"})
+AUTOMATIC_EVENTS = frozenset({"push", "pull_request"})
 
 FENCE_PATTERN = re.compile(r"^\s*(?P<fence>`{3,}|~{3,})")
 WORKFLOW_PATTERN = re.compile(
@@ -67,6 +67,8 @@ CMAKE_TARGET_PATTERN = re.compile(
 # `LABELS a b` is valid CMake and attaches both. The unquoted branch therefore runs to the end of
 # the argument list, and `split_labels` drops the ALL-CAPS property keyword that follows.
 CMAKE_LABEL_PATTERN = re.compile(r"\bLABELS\s+(?:\"(?P<quoted>[^\"]+)\"|(?P<bare>[^\n)\"]+))")
+CMAKE_BRACKET_ARGUMENT_PATTERN = re.compile(r"\[(?P<equals>=*)\[")
+CMAKE_BRACKET_COMMENT_PATTERN = re.compile(r"#\[(?P<equals>=*)\[")
 STRING_PATTERN = re.compile(r'"(?P<value>(?:\\.|[^"\\])*)"')
 TEST_CASE_PATTERN = re.compile(
     r'\bTEST_CASE\s*\(\s*"(?:\\.|[^"\\])*"\s*,(?P<labels>.*?)\)', re.DOTALL
@@ -98,10 +100,6 @@ class MechanismIndex:
 
 def has_automatic_trigger(text: str) -> bool:
     """Whether a workflow's top-level ``on`` includes an event that fires without a human.
-
-    ``workflow_call`` counts: a reusable workflow runs on every pull request that its callers run
-    on, and reporting it as manual would call a live check dormant - the error this checker exists
-    to catch, made by the checker itself.
 
     All three YAML spellings are accepted, because rejecting one reports a workflow that does run
     on every push as having no trigger, which is worse than saying nothing.
@@ -219,8 +217,75 @@ def split_labels(value: str) -> set[str]:
 
 
 def cmake_code(text: str) -> str:
-    """CMake text with full-line comments blanked so proposals are not target evidence."""
-    return "\n".join("" if line.lstrip().startswith("#") else line for line in text.splitlines())
+    """CMake text with comments blanked while quoted and bracket arguments remain intact."""
+    output: list[str] = []
+    index = 0
+    quoted = False
+    bracket_end: str | None = None
+    comment_end: str | None = None
+    while index < len(text):
+        if comment_end is not None:
+            if text.startswith(comment_end, index):
+                output.extend(" " * len(comment_end))
+                index += len(comment_end)
+                comment_end = None
+            else:
+                output.append("\n" if text[index] == "\n" else " ")
+                index += 1
+            continue
+
+        if bracket_end is not None:
+            if text.startswith(bracket_end, index):
+                output.extend(bracket_end)
+                index += len(bracket_end)
+                bracket_end = None
+            else:
+                output.append(text[index])
+                index += 1
+            continue
+
+        character = text[index]
+        if quoted:
+            output.append(character)
+            index += 1
+            if character == "\\" and index < len(text):
+                output.append(text[index])
+                index += 1
+            elif character == '"':
+                quoted = False
+            continue
+
+        if character == '"':
+            quoted = True
+            output.append(character)
+            index += 1
+            continue
+
+        bracket = CMAKE_BRACKET_ARGUMENT_PATTERN.match(text, index)
+        if bracket is not None:
+            opener = bracket.group(0)
+            bracket_end = "]" + bracket.group("equals") + "]"
+            output.extend(opener)
+            index += len(opener)
+            continue
+
+        if character == "#":
+            bracket_comment = CMAKE_BRACKET_COMMENT_PATTERN.match(text, index)
+            if bracket_comment is not None:
+                opener = bracket_comment.group(0)
+                comment_end = "]" + bracket_comment.group("equals") + "]"
+                output.extend(" " * len(opener))
+                index += len(opener)
+                continue
+            newline = text.find("\n", index)
+            end = len(text) if newline == -1 else newline
+            output.extend(" " * (end - index))
+            index = end
+            continue
+
+        output.append(character)
+        index += 1
+    return "".join(output)
 
 
 def cpp_without_comments(text: str) -> str:

--- a/tools/docs-lint/check_named_mechanisms.py
+++ b/tools/docs-lint/check_named_mechanisms.py
@@ -54,7 +54,7 @@ CTEST_LABEL_PATTERN = re.compile(
 # A name may contain dots but never end on one: a citation closing a sentence would otherwise
 # swallow the full stop and be reported as the target `mdux-shaderbake.`, which nobody wrote.
 MECHANISM_CITATION_PATTERN = re.compile(
-    r"(?<![A-Za-z0-9_./-])(?P<name>mdux-[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)(?![A-Za-z0-9_./-])"
+    r"(?<![A-Za-z0-9_./-])(?P<name>mdux-[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)(?![A-Za-z0-9_/-])"
 )
 # Diagnostic prefixes the Python checkers print. They are real, resolvable mechanisms that are
 # neither CMake targets nor `mdux_*.py` files - `mdux-file-headers` lives in `check_file_headers.py`

--- a/tools/docs-lint/check_named_mechanisms.py
+++ b/tools/docs-lint/check_named_mechanisms.py
@@ -137,6 +137,12 @@ def has_automatic_trigger(text: str) -> bool:
             key = re.match(r"\s*(?P<key>[A-Za-z_][A-Za-z0-9_-]*)\s*:", child)
             if key is not None and key.group("key") in AUTOMATIC_EVENTS:
                 return True
+            sequence_item = re.match(
+                r"\s*-\s*[\"']?(?P<event>[A-Za-z_][A-Za-z0-9_-]*)[\"']?\s*(?:#.*)?$",
+                child,
+            )
+            if sequence_item is not None and sequence_item.group("event") in AUTOMATIC_EVENTS:
+                return True
         return False
     return False
 
@@ -220,6 +226,7 @@ def cmake_code(text: str) -> str:
 def cpp_without_comments(text: str) -> str:
     """Blank C++ comments while preserving quoted strings and source positions."""
     def replace(match: re.Match[str]) -> str:
+        """Blank a comment token without changing its line count or quoted tokens."""
         token = match.group(0)
         if not token.startswith("/"):
             return token
@@ -240,6 +247,7 @@ def labels_from_test_source(text: str) -> set[str]:
 
 
 def build_index(root: Path) -> MechanismIndex:
+    """Resolve the workflows, labels, targets, tools, and skills present under ``root``."""
     workflow_dir = root / ".github" / "workflows"
     workflow_paths = sorted((*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")))
     workflows = {path.name: path for path in workflow_paths}
@@ -316,6 +324,7 @@ def workflow_comment_lines(text: str) -> list[tuple[int, str]]:
 
 
 def check_lines(path: Path, lines: list[tuple[int, str]], index: MechanismIndex) -> list[Finding]:
+    """Report every unresolved mechanism citation in numbered prose or comment lines."""
     findings: list[Finding] = []
     for line_number, line in lines:
         if ASPIRATIONAL_MARKER in line:
@@ -361,6 +370,7 @@ def check_lines(path: Path, lines: list[tuple[int, str]], index: MechanismIndex)
 
 
 def check_repository(root: Path) -> tuple[list[Finding], int]:
+    """Check every Markdown document and workflow comment, returning findings and file count."""
     index = build_index(root)
     findings: list[Finding] = []
     checked = 0
@@ -392,6 +402,7 @@ def check_repository(root: Path) -> tuple[list[Finding], int]:
 
 
 def main(argv: list[str]) -> int:
+    """Run the repository check and render its stable text diagnostic envelope."""
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
         "--repo-root",

--- a/tools/docs-lint/check_named_mechanisms.py
+++ b/tools/docs-lint/check_named_mechanisms.py
@@ -48,8 +48,8 @@ WORKFLOW_PATTERN = re.compile(
 # a bound, "Run ctest -L pixel and see ctest(1) for -L semantics" reads `semantics` as a label.
 # Brackets and commas end a command and start a sentence about one.
 CTEST_LABEL_PATTERN = re.compile(
-    r"\bctest\b(?P<gap>[^\n(),]{0,60}?)(?:-L|--label-regex)(?:\s+|=)[\"']?"
-    r"(?P<label>[A-Za-z0-9_]+(?:[.-][A-Za-z0-9_-]+)*)"
+    r"\bctest\b(?P<gap>[^\n(),]{0,60}?)(?:-L|--label-regex)(?:\s+|=)"
+    r"(?:(?P<quote>[\"'])(?P<quoted>[^\n]*?)(?P=quote)|(?P<bare>[^\s,\])`]+))"
 )
 # A name may contain dots but never end on one: a citation closing a sentence would otherwise
 # swallow the full stop and be reported as the target `mdux-shaderbake.`, which nobody wrote.
@@ -316,11 +316,37 @@ def markdown_prose_lines(text: str) -> list[tuple[int, str]]:
 
 def workflow_comment_lines(text: str) -> list[tuple[int, str]]:
     """Numbered full-line YAML comments; run scripts and action configuration are not prose."""
-    return [
-        (line_number, match.group("comment"))
-        for line_number, line in enumerate(text.splitlines(), start=1)
-        if (match := re.match(r"^\s*#(?P<comment>.*)$", line)) is not None
-    ]
+    comments: list[tuple[int, str]] = []
+    scalar_parent_indent: int | None = None
+    scalar_header = re.compile(
+        r"^(?P<indent>\s*)(?:(?:-\s*)?[^#:\n]+:\s*|-(?:\s*))"
+        r"[|>][1-9+-]{0,2}\s*(?:#.*)?$"
+    )
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        indent = len(line) - len(line.lstrip())
+        if scalar_parent_indent is not None:
+            if not line.strip() or indent > scalar_parent_indent:
+                continue
+            scalar_parent_indent = None
+
+        header = scalar_header.match(line)
+        if header is not None:
+            scalar_parent_indent = len(header.group("indent"))
+            continue
+
+        comment = re.match(r"^\s*#(?P<comment>.*)$", line)
+        if comment is not None:
+            comments.append((line_number, comment.group("comment")))
+    return comments
+
+
+def ctest_label_expression(match: re.Match[str]) -> str:
+    """Complete CTest label expression captured with or without shell quotes."""
+    if match.group("quoted") is not None:
+        return match.group("quoted")
+    # Keep the historical sentence-boundary behavior: a full stop closing prose is not part of
+    # the unquoted expression. Quoted expressions remain byte-for-byte intact.
+    return match.group("bare").rstrip(".")
 
 
 def check_lines(path: Path, lines: list[tuple[int, str]], index: MechanismIndex) -> list[Finding]:
@@ -358,7 +384,7 @@ def check_lines(path: Path, lines: list[tuple[int, str]], index: MechanismIndex)
                 )
 
         for match in CTEST_LABEL_PATTERN.finditer(line):
-            label = match.group("label")
+            label = ctest_label_expression(match)
             if not label_is_attached(label, index.labels):
                 findings.append(Finding(path, line_number, f"ctest label '{label}' is not attached to any test"))
 

--- a/tools/docs-lint/check_named_mechanisms.py
+++ b/tools/docs-lint/check_named_mechanisms.py
@@ -34,23 +34,39 @@ from pathlib import Path
 
 
 ASPIRATIONAL_MARKER = "mdux-named-mechanisms:aspirational"
+# CONTRIBUTING tells authors to name a tracking issue beside the marker. Checking it is the
+# difference between an exception and an untracked permanent one - the suppression list this
+# checker deliberately does not have, spelled differently.
+ASPIRATIONAL_ISSUE_PATTERN = re.compile(re.escape(ASPIRATIONAL_MARKER) + r"[^\n]*?issue\s+#\d+")
+AUTOMATIC_EVENTS = frozenset({"push", "pull_request", "pull_request_target", "workflow_call"})
 
 FENCE_PATTERN = re.compile(r"^\s*(?P<fence>`{3,}|~{3,})")
 WORKFLOW_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_./-])(?P<path>(?:\.github/workflows/)?[A-Za-z0-9_.-]+\.ya?ml)\b"
 )
+# The gap between `ctest` and its `-L` may hold options and preset names, but not prose: without
+# a bound, "Run ctest -L pixel and see ctest(1) for -L semantics" reads `semantics` as a label.
+# Brackets and commas end a command and start a sentence about one.
 CTEST_LABEL_PATTERN = re.compile(
-    r"\bctest\b[^\n]*?(?:-L|--label-regex)(?:\s+|=)[\"']?"
+    r"\bctest\b(?P<gap>[^\n(),]{0,60}?)(?:-L|--label-regex)(?:\s+|=)[\"']?"
     r"(?P<label>[A-Za-z0-9_]+(?:[.-][A-Za-z0-9_-]+)*)"
 )
+# A name may contain dots but never end on one: a citation closing a sentence would otherwise
+# swallow the full stop and be reported as the target `mdux-shaderbake.`, which nobody wrote.
 MECHANISM_CITATION_PATTERN = re.compile(
-    r"(?<![A-Za-z0-9_./-])(?P<name>mdux-[a-z0-9][a-z0-9_.-]*)(?![A-Za-z0-9_./-])"
+    r"(?<![A-Za-z0-9_./-])(?P<name>mdux-[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)(?![A-Za-z0-9_./-])"
 )
+# Diagnostic prefixes the Python checkers print. They are real, resolvable mechanisms that are
+# neither CMake targets nor `mdux_*.py` files - `mdux-file-headers` lives in `check_file_headers.py`
+# - so without this a true sentence naming one is rejected.
+PYTHON_DIAGNOSTIC_PATTERN = re.compile(r"""["'](?P<name>mdux-[a-z0-9][a-z0-9-]*)(?::|["'])""")
 
 CMAKE_TARGET_PATTERN = re.compile(
-    r"\badd_(?:executable|custom_target)\s*\(\s*(?P<name>[A-Za-z0-9_.+-]+)", re.MULTILINE
+    r"\badd_(?:executable|library|custom_target)\s*\(\s*(?P<name>[A-Za-z0-9_.+-]+)", re.MULTILINE
 )
-CMAKE_LABEL_PATTERN = re.compile(r"\bLABELS\s+(?:\"(?P<quoted>[^\"]+)\"|(?P<bare>[A-Za-z0-9_.;,+-]+))")
+# `LABELS a b` is valid CMake and attaches both. The unquoted branch therefore runs to the end of
+# the argument list, and `split_labels` drops the ALL-CAPS property keyword that follows.
+CMAKE_LABEL_PATTERN = re.compile(r"\bLABELS\s+(?:\"(?P<quoted>[^\"]+)\"|(?P<bare>[^\n)\"]+))")
 STRING_PATTERN = re.compile(r'"(?P<value>(?:\\.|[^"\\])*)"')
 TEST_CASE_PATTERN = re.compile(
     r'\bTEST_CASE\s*\(\s*"(?:\\.|[^"\\])*"\s*,(?P<labels>.*?)\)', re.DOTALL
@@ -81,24 +97,84 @@ class MechanismIndex:
 
 
 def has_automatic_trigger(text: str) -> bool:
-    """Whether a workflow's top-level ``on`` mapping includes push or pull_request."""
+    """Whether a workflow's top-level ``on`` includes an event that fires without a human.
+
+    ``workflow_call`` counts: a reusable workflow runs on every pull request that its callers run
+    on, and reporting it as manual would call a live check dormant - the error this checker exists
+    to catch, made by the checker itself.
+
+    All three YAML spellings are accepted, because rejecting one reports a workflow that does run
+    on every push as having no trigger, which is worse than saying nothing.
+    """
     lines = text.splitlines()
     for index, line in enumerate(lines):
-        inline = re.match(r"^on:\s*\[(?P<events>[^]]*)\]\s*(?:#.*)?$", line)
-        if inline is not None:
-            events = {event.strip().strip("'\"") for event in inline.group("events").split(",")}
-            return bool(events.intersection({"push", "pull_request"}))
-
-        if not re.match(r"^on:\s*(?:#.*)?$", line):
+        # Column 0 only. A `push:` nested under some job's `workflow_call: inputs:` is an input
+        # named push, not a trigger.
+        header = re.match(r"""^(?:on|["']on["']):(?P<rest>.*)$""", line)
+        if header is None:
             continue
+
+        rest = header.group("rest").split("#", 1)[0].strip()
+        if rest.startswith("["):
+            events = {event.strip().strip("'\"") for event in rest.strip("[]").split(",")}
+            return bool(events.intersection(AUTOMATIC_EVENTS))
+        if rest:
+            return rest.strip("'\"") in AUTOMATIC_EVENTS
+
+        # Block form. Only direct children count, and comments and blank lines inside the block
+        # are skipped rather than ending it.
+        child_indent: int | None = None
         for child in lines[index + 1 :]:
-            if child and not child[0].isspace():
+            if not child.strip() or child.lstrip().startswith("#"):
+                continue
+            indent = len(child) - len(child.lstrip())
+            if indent == 0:
                 break
-            match = re.match(r"^\s+(push|pull_request):(?:\s|$)", child)
-            if match is not None:
+            if child_indent is None:
+                child_indent = indent
+            if indent != child_indent:
+                continue
+            key = re.match(r"\s*(?P<key>[A-Za-z_][A-Za-z0-9_-]*)\s*:", child)
+            if key is not None and key.group("key") in AUTOMATIC_EVENTS:
                 return True
         return False
     return False
+
+
+def label_is_attached(label: str, labels: frozenset[str]) -> bool:
+    """Whether ``ctest -L <label>`` would select anything.
+
+    ``-L`` takes a regular expression, so `-L determin` really does select `determinism`. Matching
+    ctest's own semantics keeps a legitimate partial citation from being called unattached.
+    """
+    if label in labels:
+        return True
+    try:
+        pattern = re.compile(label)
+    except re.error:
+        return False
+    return any(pattern.search(known) is not None for known in labels)
+
+
+def unclosed_fence_line(text: str) -> int | None:
+    """Line number of a fence that is never closed, if there is one.
+
+    An unterminated fence makes every later line invisible to this checker. Silently skipping the
+    rest of a document is the blind spot this tool exists to prevent, so it is reported.
+    """
+    fence_character: str | None = None
+    fence_length = 0
+    opened_at = 0
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        fence = FENCE_PATTERN.match(line)
+        if fence is None:
+            continue
+        token = fence.group("fence")
+        if fence_character is None:
+            fence_character, fence_length, opened_at = token[0], len(token), line_number
+        elif token[0] == fence_character and len(token) >= fence_length:
+            fence_character, fence_length = None, 0
+    return opened_at if fence_character is not None else None
 
 
 def cmake_files(root: Path) -> list[Path]:
@@ -118,7 +194,22 @@ def cmake_files(root: Path) -> list[Path]:
 
 
 def split_labels(value: str) -> set[str]:
-    return {label for label in re.split(r"[\s,;]+", value) if label and "${" not in label}
+    """Label tokens from one LABELS argument list.
+
+    `LABELS a b` attaches both, so the unquoted match runs to the end of the argument list and the
+    next property keyword has to be recognised here. CMake property keywords are ALL-CAPS and this
+    project's labels are lowercase, so the first ALL-CAPS token ends the list.
+    """
+    labels: set[str] = set()
+    for token in re.split(r"[\s,;]+", value):
+        if not token:
+            continue
+        if re.fullmatch(r"[A-Z][A-Z_]*", token):
+            break
+        if "${" in token:
+            continue
+        labels.add(token)
+    return labels
 
 
 def cmake_code(text: str) -> str:
@@ -174,6 +265,14 @@ def build_index(root: Path) -> MechanismIndex:
     if tools_root.is_dir():
         for path in tools_root.rglob("mdux_*.py"):
             targets.add(path.stem.replace("_", "-"))
+        # A checker's diagnostic name is not always its filename: `mdux-file-headers` is printed by
+        # `check_file_headers.py`. Read the names they print rather than inferring from the path,
+        # so documenting a check does not fail the check.
+        for path in sorted(tools_root.rglob("*.py")):
+            if path.name.startswith("test_"):
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            targets.update(match.group("name") for match in PYTHON_DIAGNOSTIC_PATTERN.finditer(text))
 
     # A standalone `mdux-*` code span can also name one of the repository's working procedures.
     # Discover those directories rather than maintaining an allow-list: they are real, resolvable
@@ -220,12 +319,25 @@ def check_lines(path: Path, lines: list[tuple[int, str]], index: MechanismIndex)
     findings: list[Finding] = []
     for line_number, line in lines:
         if ASPIRATIONAL_MARKER in line:
+            if ASPIRATIONAL_ISSUE_PATTERN.search(line) is None:
+                findings.append(
+                    Finding(
+                        path,
+                        line_number,
+                        "aspirational marker names no tracking issue; append 'issue #NNN' to it",
+                    )
+                )
             continue
 
         for match in WORKFLOW_PATTERN.finditer(line):
             citation = match.group("path")
             name = Path(citation).name
             if name not in index.workflows:
+                # A bare filename is only a workflow citation if it names one. The tree holds YAML
+                # that is not a workflow - `.github/dependabot.yml`, `.github/codeql/*.yml` - and
+                # calling a file that exists missing would be a false positive on true prose.
+                if "/" not in citation:
+                    continue
                 findings.append(Finding(path, line_number, f"workflow '{citation}' does not exist"))
             elif name not in index.automatic_workflows:
                 findings.append(
@@ -238,7 +350,7 @@ def check_lines(path: Path, lines: list[tuple[int, str]], index: MechanismIndex)
 
         for match in CTEST_LABEL_PATTERN.finditer(line):
             label = match.group("label")
-            if label not in index.labels:
+            if not label_is_attached(label, index.labels):
                 findings.append(Finding(path, line_number, f"ctest label '{label}' is not attached to any test"))
 
         for match in MECHANISM_CITATION_PATTERN.finditer(line):
@@ -257,9 +369,17 @@ def check_repository(root: Path) -> tuple[list[Finding], int]:
     if docs_root.is_dir():
         for path in sorted(docs_root.rglob("*.md")):
             checked += 1
-            findings.extend(
-                check_lines(path, markdown_prose_lines(path.read_text(encoding="utf-8", errors="replace")), index)
-            )
+            text = path.read_text(encoding="utf-8", errors="replace")
+            opened_at = unclosed_fence_line(text)
+            if opened_at is not None:
+                findings.append(
+                    Finding(
+                        path,
+                        opened_at,
+                        "fenced block is never closed, so the rest of this document is unchecked",
+                    )
+                )
+            findings.extend(check_lines(path, markdown_prose_lines(text), index))
 
     workflow_root = root / ".github" / "workflows"
     if workflow_root.is_dir():
@@ -294,6 +414,17 @@ def main(argv: list[str]) -> int:
         print(
             "mdux-named-mechanisms: fix the citation or append "
             f"'{ASPIRATIONAL_MARKER}' to a deliberately aspirational line",
+            file=sys.stderr,
+        )
+        return 1
+
+    if checked == 0:
+        # A gate that scans nothing and reports success is a green tick over zero assertions - the
+        # exact shape this checker exists to catch. It is reachable: the root is inferred from this
+        # file's location, so moving or vendoring the script would silently empty the scan.
+        print(
+            "mdux-named-mechanisms: no documents or workflows found under "
+            f"'{root}'; --repo-root is wrong or the layout moved",
             file=sys.stderr,
         )
         return 1

--- a/tools/docs-lint/test_check_named_mechanisms.py
+++ b/tools/docs-lint/test_check_named_mechanisms.py
@@ -167,3 +167,87 @@ class CheckNamedMechanismsTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ReviewRegressionTests(CheckNamedMechanismsTests):
+    """One test per defect found reviewing this checker, so none of them can come back quietly."""
+
+    def test_a_citation_closing_a_sentence_keeps_its_full_stop_out_of_the_name(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            self.assertEqual(self.findings_for(root, "Built by mdux-shaderbake.\n"), [])
+
+    def test_yaml_that_is_not_a_workflow_is_not_read_as_a_missing_workflow(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            self.assertEqual(self.findings_for(root, "The dependabot.yml file pins actions.\n"), [])
+            # A path that does claim to be a workflow is still checked.
+            self.assertEqual(
+                self.findings_for(root, "See .github/workflows/absent.yml\n"),
+                ["workflow '.github/workflows/absent.yml' does not exist"],
+            )
+
+    def test_every_spelling_of_an_automatic_trigger_is_recognised(self) -> None:
+        block = "name: A\non:\n  # push:\n  push:\n    branches: [ main ]\njobs: {}\n"
+        self.assertTrue(mechanisms.has_automatic_trigger(block))
+        self.assertTrue(mechanisms.has_automatic_trigger("name: A\non: push\njobs: {}\n"))
+        self.assertTrue(mechanisms.has_automatic_trigger('name: A\n"on":\n  pull_request:\njobs: {}\n'))
+        self.assertTrue(mechanisms.has_automatic_trigger("name: A\non: [push]\njobs: {}\n"))
+        self.assertTrue(mechanisms.has_automatic_trigger("name: A\non:\n  workflow_call:\njobs: {}\n"))
+        # A commented-out trigger is not a trigger, and a nested key named push is not one either.
+        self.assertFalse(
+            mechanisms.has_automatic_trigger("name: A\non:\n  # push:\n  workflow_dispatch:\njobs: {}\n")
+        )
+        self.assertFalse(
+            mechanisms.has_automatic_trigger(
+                "name: A\non:\n  workflow_dispatch:\n    inputs:\n      push:\n        type: boolean\njobs: {}\n"
+            )
+        )
+
+    def test_a_checkers_own_diagnostic_name_resolves(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            (root / "tools" / "docs-lint").mkdir(parents=True)
+            (root / "tools" / "docs-lint" / "check_file_headers.py").write_text(
+                'print("mdux-file-headers: OK")\n', encoding="utf-8"
+            )
+            self.assertEqual(self.findings_for(root, "The mdux-file-headers check gates every PR.\n"), [])
+
+    def test_prose_after_a_command_does_not_invent_a_label(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            text = "Run ctest -L evidence and see ctest(1) for -L semantics.\n"
+            self.assertEqual(self.findings_for(root, text), [])
+
+    def test_a_partial_label_selects_the_way_ctest_would(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            self.assertEqual(self.findings_for(root, "ctest -L determin runs it.\n"), [])
+            self.assertEqual(
+                self.findings_for(root, "ctest -L zzz runs it.\n"),
+                ["ctest label 'zzz' is not attached to any test"],
+            )
+
+    def test_unquoted_labels_after_the_first_are_attached(self) -> None:
+        self.assertEqual(mechanisms.split_labels("unit fast"), {"unit", "fast"})
+        # The next property keyword ends the list rather than becoming a label.
+        self.assertEqual(mechanisms.split_labels("unit fast TIMEOUT 5"), {"unit", "fast"})
+
+    def test_an_unclosed_fence_is_reported_rather_than_blinding_the_file(self) -> None:
+        self.assertEqual(mechanisms.unclosed_fence_line("a\n```\nb\n"), 2)
+        self.assertIsNone(mechanisms.unclosed_fence_line("a\n```\nb\n```\n"))
+
+    def test_the_marker_must_name_a_tracking_issue(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            bare = "ctest -L invented <!-- mdux-named-mechanisms:aspirational -->\n"
+            self.assertEqual(
+                self.findings_for(root, bare),
+                ["aspirational marker names no tracking issue; append 'issue #NNN' to it"],
+            )
+            tracked = "ctest -L invented <!-- mdux-named-mechanisms:aspirational; issue #249 -->\n"
+            self.assertEqual(self.findings_for(root, tracked), [])
+
+    def test_scanning_nothing_is_a_failure_rather_than_a_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            self.assertEqual(mechanisms.main(["--repo-root", raw]), 1)

--- a/tools/docs-lint/test_check_named_mechanisms.py
+++ b/tools/docs-lint/test_check_named_mechanisms.py
@@ -104,9 +104,14 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             root = self.make_repository(raw)
             with (root / "CMakeLists.txt").open("a", encoding="utf-8") as cmake:
                 cmake.write("# add_custom_target(mdux-proposed-target)\n")
+                cmake.write("set(a b) # add_custom_target(mdux-inline-target)\n")
             self.assertEqual(
                 self.findings_for(root, "The `mdux-proposed-target` runs on every change.\n"),
                 ["CMake/tool target 'mdux-proposed-target' does not exist"],
+            )
+            self.assertEqual(
+                self.findings_for(root, "The `mdux-inline-target` runs on every change.\n"),
+                ["CMake/tool target 'mdux-inline-target' does not exist"],
             )
 
     def test_commented_tests_do_not_register_labels(self) -> None:
@@ -221,7 +226,10 @@ class ReviewRegressionTests(CheckNamedMechanismsTests):
         self.assertTrue(mechanisms.has_automatic_trigger("name: A\non: push\njobs: {}\n"))
         self.assertTrue(mechanisms.has_automatic_trigger('name: A\n"on":\n  pull_request:\njobs: {}\n'))
         self.assertTrue(mechanisms.has_automatic_trigger("name: A\non: [push]\njobs: {}\n"))
-        self.assertTrue(mechanisms.has_automatic_trigger("name: A\non:\n  workflow_call:\njobs: {}\n"))
+        self.assertFalse(mechanisms.has_automatic_trigger("name: A\non:\n  workflow_call:\njobs: {}\n"))
+        self.assertFalse(
+            mechanisms.has_automatic_trigger("name: A\non:\n  pull_request_target:\njobs: {}\n")
+        )
         self.assertTrue(mechanisms.has_automatic_trigger("name: A\non:\n  - schedule\n  - push\njobs: {}\n"))
         self.assertTrue(mechanisms.has_automatic_trigger("name: A\non:\n  - 'pull_request' # PRs\njobs: {}\n"))
         # A commented-out trigger is not a trigger, and a nested key named push is not one either.

--- a/tools/docs-lint/test_check_named_mechanisms.py
+++ b/tools/docs-lint/test_check_named_mechanisms.py
@@ -188,6 +188,10 @@ class ReviewRegressionTests(CheckNamedMechanismsTests):
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(self.findings_for(root, "Built by mdux-shaderbake.\n"), [])
+            self.assertEqual(
+                self.findings_for(root, "Blocked by mdux-missing.\n"),
+                ["CMake/tool target 'mdux-missing' does not exist"],
+            )
 
     def test_yaml_that_is_not_a_workflow_is_not_read_as_a_missing_workflow(self) -> None:
         """Distinguish ordinary YAML names from explicit local workflow paths."""

--- a/tools/docs-lint/test_check_named_mechanisms.py
+++ b/tools/docs-lint/test_check_named_mechanisms.py
@@ -1,0 +1,169 @@
+"""Tests for check_named_mechanisms.
+
+The failure cases are the control: each mechanism class has a test proving that an unresolved name
+is rejected, while the proposal and opt-out cases pin the boundaries that keep the checker usable.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_named_mechanisms as mechanisms
+
+
+class CheckNamedMechanismsTests(unittest.TestCase):
+    def make_repository(self, raw: str) -> Path:
+        root = Path(raw)
+        (root / "docs").mkdir()
+        (root / ".github" / "workflows").mkdir(parents=True)
+        (root / "tools" / "governed-lint").mkdir(parents=True)
+        (root / "tests").mkdir()
+        (root / "CMakeLists.txt").write_text(
+            'add_custom_target(mdux-bake-update)\n'
+            'set_tests_properties(a PROPERTIES LABELS "evidence")\n',
+            encoding="utf-8",
+        )
+        (root / "tools" / "CMakeLists.txt").write_text(
+            "add_executable(mdux-shaderbake main.cpp)\n", encoding="utf-8"
+        )
+        (root / "tools" / "governed-lint" / "mdux_governed_lint.py").write_text("", encoding="utf-8")
+        (root / "tests" / "Cases.cpp").write_text(
+            'TEST_CASE("A deterministic case", "determinism") {}\n'
+            'const mdux::spec::Register noHeap{"No allocation", "noheap", [] {}};\n',
+            encoding="utf-8",
+        )
+        (root / ".github" / "workflows" / "build.yml").write_text(
+            "name: Build\non:\n  pull_request:\njobs: {}\n", encoding="utf-8"
+        )
+        (root / ".github" / "workflows" / "manual.yml").write_text(
+            "name: Manual\non:\n  workflow_dispatch:\njobs: {}\n", encoding="utf-8"
+        )
+        return root
+
+    def findings_for(self, root: Path, text: str) -> list[str]:
+        path = root / "docs" / "claim.md"
+        path.write_text(text, encoding="utf-8")
+        index = mechanisms.build_index(root)
+        return [
+            finding.message
+            for finding in mechanisms.check_lines(path, mechanisms.markdown_prose_lines(text), index)
+        ]
+
+    def test_accepts_resolved_workflow_labels_targets_and_python_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            text = (
+                "`build.yml` runs `mdux-shaderbake` and `mdux-governed-lint`.\n"
+                "Use `mdux-bake-update`, then ctest -L evidence and ctest --label-regex=determinism.\n"
+                "ctest -L noheap is registered through SpecLab.\n"
+            )
+            self.assertEqual(self.findings_for(root, text), [])
+
+    def test_rejects_a_missing_workflow(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            self.assertEqual(
+                self.findings_for(root, "`.github/workflows/absent.yml` runs in CI.\n"),
+                ["workflow '.github/workflows/absent.yml' does not exist"],
+            )
+
+    def test_rejects_a_dispatch_only_workflow(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            self.assertEqual(
+                self.findings_for(root, "`manual.yml` runs on every change.\n"),
+                ["workflow 'manual.yml' has no push or pull_request trigger"],
+            )
+
+    def test_rejects_an_unregistered_ctest_label(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            self.assertEqual(
+                self.findings_for(root, "Run ctest --label-regex missing-label.\n"),
+                ["ctest label 'missing-label' is not attached to any test"],
+            )
+
+    def test_rejects_an_unknown_standalone_mdux_name(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            self.assertEqual(
+                self.findings_for(root, "The `mdux-imaginary-lint` check gates every PR.\n"),
+                ["CMake/tool target 'mdux-imaginary-lint' does not exist"],
+            )
+
+    def test_a_commented_cmake_target_is_not_implementation_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            with (root / "CMakeLists.txt").open("a", encoding="utf-8") as cmake:
+                cmake.write("# add_custom_target(mdux-proposed-target)\n")
+            self.assertEqual(
+                self.findings_for(root, "The `mdux-proposed-target` runs on every change.\n"),
+                ["CMake/tool target 'mdux-proposed-target' does not exist"],
+            )
+
+    def test_commented_tests_do_not_register_labels(self) -> None:
+        source = (
+            '// TEST_CASE("Disabled", "ghost-line") {}\n'
+            '/* const mdux::spec::Register disabled{"Disabled", "ghost-block", [] {}}; */\n'
+            'TEST_CASE("Live", "live") {}\n'
+        )
+        self.assertEqual(mechanisms.labels_from_test_source(source), {"live"})
+
+    def test_does_not_treat_a_package_path_as_a_target(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            self.assertEqual(self.findings_for(root, "See `generated/shader/mdux-ui/`.\n"), [])
+
+    def test_skips_backtick_and_tilde_fenced_proposals(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            text = (
+                "```yaml\n# .github/workflows/future.yml\n```\n"
+                "~~~sh\nctest -L future\n`mdux-future-tool`\n~~~\n"
+            )
+            self.assertEqual(self.findings_for(root, text), [])
+
+    def test_accepts_a_visible_same_line_aspirational_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            text = (
+                "A future `mdux-audit` will run in `future.yml`. "
+                "<!-- mdux-named-mechanisms:aspirational; issue #300 -->\n"
+            )
+            self.assertEqual(self.findings_for(root, text), [])
+
+    def test_scans_only_full_line_workflow_comments(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            index = mechanisms.build_index(root)
+            path = root / ".github" / "workflows" / "claim.yml"
+            text = (
+                "# build.yml and `mdux-shaderbake` are current controls.\n"
+                "uses: owner/repo/.github/workflows/external.yml@deadbeef\n"
+            )
+            findings = mechanisms.check_lines(path, mechanisms.workflow_comment_lines(text), index)
+            self.assertEqual(findings, [])
+
+    def test_rejects_an_unknown_bare_tool_in_a_workflow_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = self.make_repository(raw)
+            index = mechanisms.build_index(root)
+            path = root / ".github" / "workflows" / "claim.yml"
+            text = "# mdux-imaginary-lint gates this job.\n"
+            findings = mechanisms.check_lines(path, mechanisms.workflow_comment_lines(text), index)
+            self.assertEqual(
+                [finding.message for finding in findings],
+                ["CMake/tool target 'mdux-imaginary-lint' does not exist"],
+            )
+
+    def test_the_current_tree_resolves_without_suppressions(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        findings, _ = mechanisms.check_repository(root)
+        rendered = [
+            f"{finding.path.relative_to(root)}:{finding.line}: {finding.message}" for finding in findings
+        ]
+        self.assertEqual(rendered, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/docs-lint/test_check_named_mechanisms.py
+++ b/tools/docs-lint/test_check_named_mechanisms.py
@@ -13,6 +13,7 @@ import check_named_mechanisms as mechanisms
 
 class CheckNamedMechanismsTests(unittest.TestCase):
     def make_repository(self, raw: str) -> Path:
+        """Create the smallest repository carrying one mechanism of every supported kind."""
         root = Path(raw)
         (root / "docs").mkdir()
         (root / ".github" / "workflows").mkdir(parents=True)
@@ -41,6 +42,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
         return root
 
     def findings_for(self, root: Path, text: str) -> list[str]:
+        """Check one Markdown document and return only its diagnostic messages."""
         path = root / "docs" / "claim.md"
         path.write_text(text, encoding="utf-8")
         index = mechanisms.build_index(root)
@@ -50,6 +52,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
         ]
 
     def test_accepts_resolved_workflow_labels_targets_and_python_tools(self) -> None:
+        """Accept citations backed by each indexed mechanism kind."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             text = (
@@ -60,6 +63,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             self.assertEqual(self.findings_for(root, text), [])
 
     def test_rejects_a_missing_workflow(self) -> None:
+        """Reject an explicit local workflow path that is absent."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(
@@ -68,6 +72,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             )
 
     def test_rejects_a_dispatch_only_workflow(self) -> None:
+        """Reject a cited workflow that requires a human dispatch."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(
@@ -76,6 +81,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             )
 
     def test_rejects_an_unregistered_ctest_label(self) -> None:
+        """Reject a CTest label expression that selects no registered label."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(
@@ -84,6 +90,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             )
 
     def test_rejects_an_unknown_standalone_mdux_name(self) -> None:
+        """Reject a standalone MduX mechanism name with no implementation."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(
@@ -92,6 +99,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             )
 
     def test_a_commented_cmake_target_is_not_implementation_evidence(self) -> None:
+        """Do not index a CMake target declaration that exists only in a comment."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             with (root / "CMakeLists.txt").open("a", encoding="utf-8") as cmake:
@@ -102,6 +110,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             )
 
     def test_commented_tests_do_not_register_labels(self) -> None:
+        """Do not index labels from disabled C++ test declarations."""
         source = (
             '// TEST_CASE("Disabled", "ghost-line") {}\n'
             '/* const mdux::spec::Register disabled{"Disabled", "ghost-block", [] {}}; */\n'
@@ -110,11 +119,13 @@ class CheckNamedMechanismsTests(unittest.TestCase):
         self.assertEqual(mechanisms.labels_from_test_source(source), {"live"})
 
     def test_does_not_treat_a_package_path_as_a_target(self) -> None:
+        """Do not read an MduX package ID embedded in a path as a tool citation."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(self.findings_for(root, "See `generated/shader/mdux-ui/`.\n"), [])
 
     def test_skips_backtick_and_tilde_fenced_proposals(self) -> None:
+        """Skip proposed mechanisms inside either Markdown fence style."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             text = (
@@ -124,6 +135,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             self.assertEqual(self.findings_for(root, text), [])
 
     def test_accepts_a_visible_same_line_aspirational_marker(self) -> None:
+        """Accept a deliberately future mechanism with its visible tracked exemption."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             text = (
@@ -133,6 +145,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             self.assertEqual(self.findings_for(root, text), [])
 
     def test_scans_only_full_line_workflow_comments(self) -> None:
+        """Scan workflow prose without treating action configuration as a citation."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             index = mechanisms.build_index(root)
@@ -145,6 +158,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             self.assertEqual(findings, [])
 
     def test_rejects_an_unknown_bare_tool_in_a_workflow_comment(self) -> None:
+        """Reject an unresolved tool named without Markdown markup in a YAML comment."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             index = mechanisms.build_index(root)
@@ -157,6 +171,7 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             )
 
     def test_the_current_tree_resolves_without_suppressions(self) -> None:
+        """Keep the checked-in tree free of unresolved mechanism citations."""
         root = Path(__file__).resolve().parents[2]
         findings, _ = mechanisms.check_repository(root)
         rendered = [
@@ -165,19 +180,17 @@ class CheckNamedMechanismsTests(unittest.TestCase):
         self.assertEqual(rendered, [])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class ReviewRegressionTests(CheckNamedMechanismsTests):
     """One test per defect found reviewing this checker, so none of them can come back quietly."""
 
     def test_a_citation_closing_a_sentence_keeps_its_full_stop_out_of_the_name(self) -> None:
+        """Exclude sentence punctuation from a bare tool name."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(self.findings_for(root, "Built by mdux-shaderbake.\n"), [])
 
     def test_yaml_that_is_not_a_workflow_is_not_read_as_a_missing_workflow(self) -> None:
+        """Distinguish ordinary YAML names from explicit local workflow paths."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(self.findings_for(root, "The dependabot.yml file pins actions.\n"), [])
@@ -188,12 +201,15 @@ class ReviewRegressionTests(CheckNamedMechanismsTests):
             )
 
     def test_every_spelling_of_an_automatic_trigger_is_recognised(self) -> None:
+        """Recognise scalar, inline-list, mapping, and block-sequence automatic events."""
         block = "name: A\non:\n  # push:\n  push:\n    branches: [ main ]\njobs: {}\n"
         self.assertTrue(mechanisms.has_automatic_trigger(block))
         self.assertTrue(mechanisms.has_automatic_trigger("name: A\non: push\njobs: {}\n"))
         self.assertTrue(mechanisms.has_automatic_trigger('name: A\n"on":\n  pull_request:\njobs: {}\n'))
         self.assertTrue(mechanisms.has_automatic_trigger("name: A\non: [push]\njobs: {}\n"))
         self.assertTrue(mechanisms.has_automatic_trigger("name: A\non:\n  workflow_call:\njobs: {}\n"))
+        self.assertTrue(mechanisms.has_automatic_trigger("name: A\non:\n  - schedule\n  - push\njobs: {}\n"))
+        self.assertTrue(mechanisms.has_automatic_trigger("name: A\non:\n  - 'pull_request' # PRs\njobs: {}\n"))
         # A commented-out trigger is not a trigger, and a nested key named push is not one either.
         self.assertFalse(
             mechanisms.has_automatic_trigger("name: A\non:\n  # push:\n  workflow_dispatch:\njobs: {}\n")
@@ -205,6 +221,7 @@ class ReviewRegressionTests(CheckNamedMechanismsTests):
         )
 
     def test_a_checkers_own_diagnostic_name_resolves(self) -> None:
+        """Index a Python checker's printed name when it differs from its filename."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             (root / "tools" / "docs-lint").mkdir(parents=True)
@@ -214,12 +231,14 @@ class ReviewRegressionTests(CheckNamedMechanismsTests):
             self.assertEqual(self.findings_for(root, "The mdux-file-headers check gates every PR.\n"), [])
 
     def test_prose_after_a_command_does_not_invent_a_label(self) -> None:
+        """Stop label parsing at prose that follows a completed CTest command."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             text = "Run ctest -L evidence and see ctest(1) for -L semantics.\n"
             self.assertEqual(self.findings_for(root, text), [])
 
     def test_a_partial_label_selects_the_way_ctest_would(self) -> None:
+        """Apply CTest's regular-expression semantics to cited labels."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(self.findings_for(root, "ctest -L determin runs it.\n"), [])
@@ -229,15 +248,18 @@ class ReviewRegressionTests(CheckNamedMechanismsTests):
             )
 
     def test_unquoted_labels_after_the_first_are_attached(self) -> None:
+        """Collect every unquoted CMake label until the next property keyword."""
         self.assertEqual(mechanisms.split_labels("unit fast"), {"unit", "fast"})
         # The next property keyword ends the list rather than becoming a label.
         self.assertEqual(mechanisms.split_labels("unit fast TIMEOUT 5"), {"unit", "fast"})
 
     def test_an_unclosed_fence_is_reported_rather_than_blinding_the_file(self) -> None:
+        """Report a fence that would otherwise hide the remainder of a document."""
         self.assertEqual(mechanisms.unclosed_fence_line("a\n```\nb\n"), 2)
         self.assertIsNone(mechanisms.unclosed_fence_line("a\n```\nb\n```\n"))
 
     def test_the_marker_must_name_a_tracking_issue(self) -> None:
+        """Require every aspirational exemption to remain tied to tracked work."""
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             bare = "ctest -L invented <!-- mdux-named-mechanisms:aspirational -->\n"
@@ -249,5 +271,10 @@ class ReviewRegressionTests(CheckNamedMechanismsTests):
             self.assertEqual(self.findings_for(root, tracked), [])
 
     def test_scanning_nothing_is_a_failure_rather_than_a_pass(self) -> None:
+        """Refuse a green result when the configured root contains no inputs."""
         with tempfile.TemporaryDirectory() as raw:
             self.assertEqual(mechanisms.main(["--repo-root", raw]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/docs-lint/test_check_named_mechanisms.py
+++ b/tools/docs-lint/test_check_named_mechanisms.py
@@ -152,7 +152,17 @@ class CheckNamedMechanismsTests(unittest.TestCase):
             path = root / ".github" / "workflows" / "claim.yml"
             text = (
                 "# build.yml and `mdux-shaderbake` are current controls.\n"
+                "run: |\n"
+                "  # mdux-imaginary-lint is shell content, not workflow prose.\n"
+                "# build.yml remains a genuine workflow comment after the scalar.\n"
                 "uses: owner/repo/.github/workflows/external.yml@deadbeef\n"
+            )
+            self.assertEqual(
+                mechanisms.workflow_comment_lines(text),
+                [
+                    (1, " build.yml and `mdux-shaderbake` are current controls."),
+                    (4, " build.yml remains a genuine workflow comment after the scalar."),
+                ],
             )
             findings = mechanisms.check_lines(path, mechanisms.workflow_comment_lines(text), index)
             self.assertEqual(findings, [])
@@ -246,6 +256,9 @@ class ReviewRegressionTests(CheckNamedMechanismsTests):
         with tempfile.TemporaryDirectory() as raw:
             root = self.make_repository(raw)
             self.assertEqual(self.findings_for(root, "ctest -L determin runs it.\n"), [])
+            self.assertEqual(
+                self.findings_for(root, "ctest -L 'missing|determinism' runs it.\n"), []
+            )
             self.assertEqual(
                 self.findings_for(root, "ctest -L zzz runs it.\n"),
                 ["ctest label 'zzz' is not attached to any test"],


### PR DESCRIPTION
## Summary

Add a standard-library-only documentation checker for the narrow subset of CI claims the tree can
resolve mechanically:

- local workflow citations must name an existing workflow with a `push` or `pull_request` trigger;
- `ctest -L` citations must name a label attached to at least one test;
- standalone `mdux-*` citations must resolve to a CMake target, host tool, lint script, or repository
  skill.

The checker scans Markdown prose under `docs/` and full-line workflow comments. It skips fenced
examples and supports a visible, same-line aspirational marker instead of a suppression list. The
failure paths, comment/fence boundaries, and the clean current tree are covered by unit tests, and
the checker now runs in Documentation Lint.

Closes #249

## Invitation and contributor agreement

- [x] Maintainer-authored change; an invitation is not applicable.
- [x] Maintainer-authored change; contributor CLA acceptance is not applicable.

Invitation / CLA issue: none — maintainer-authored

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`
- [x] None of the above

## Rebase state

- **Rebased onto:** `develop` at `4c4413f2f0e6eda55a5e873cfc5e7a4676717a6d`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run; this is host-only Python/documentation tooling with no C++ or CMake build-graph change
- [ ] `ctest --test-dir build-gcc` — not run for the same reason
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 82 files checked, zero findings
- [x] Other:
  - `python3 -m unittest discover -s tools/docs-lint -p "test_*.py"` — 130 tests passed
  - `python3 tools/docs-lint/check_named_mechanisms.py` — 77 documents/workflows checked, zero findings or suppressions
  - `python3 tools/docs-lint/check_file_headers.py` — 195 sources checked
  - `python3 tools/docs-lint/generate_ai_reference.py --check` — all five indexes current
  - `python3 tools/docs-lint/check_schema_type_drift.py` — 7 schemas / 7 bindings / 2 vocabularies current
  - `git diff --check` — clean

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green.

## Regulatory impact

**Potentially safety-relevant.** This strengthens auditability by checking that named verification
mechanisms exist and are wired, but it does not change device runtime behavior, rendering, safety
controls, compliance metadata, or any claim of conformity with a medical-device standard.

Affected artifacts are the new host checker and unit tests, the Documentation Lint workflow, and
the author-facing convention in `CONTRIBUTING.md`. No regulatory corpus, requirement, hazard, risk
control, public interface, or generated evidence artifact changes. Residual uncertainty: the checker
intentionally does not decide whether surrounding prose is true; it verifies only the named
mechanism's existence and wiring described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for validating referenced workflows, test labels, and build targets.
  * Documented exemptions for aspirational references and fenced code blocks.

* **Quality Improvements**
  * Added automated validation to ensure named CI and build mechanisms resolve correctly.
  * Improved detection of missing triggers, labels, targets, malformed code fences, and invalid exemptions.

* **Tests**
  * Added comprehensive coverage for valid references, invalid references, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->