### PR TITLE
Open Wave 6: promote #16 and #17's children, and stop calling them blocked

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -160,8 +160,9 @@ lane that strengthens the byte-identity claim rather than moving any epic. Nothi
 
 ### Thirteen epics
 
-Child issues exist for the six actionable epics. The rest keep their breakdown as a
-checklist in the epic body, promoted when unblocked.
+Child issues exist for every actionable epic. #16's and #17's were promoted on 28 August 2026, when
+#15's closure unblocked them; the convention is that a blocked epic keeps its breakdown as a
+checklist in its own body until then.
 
 ---
 
@@ -370,30 +371,46 @@ table for a format that could have been measured.
 
 _Blocks #16, #17_
 
-#### #16 — Rendered-truth verification · **Blocked #13, #15**
+#### #16 — Rendered-truth verification · **Open, unblocked**
 
 Render offscreen, then check that critical content appears where the compiled screen says
 it will, in the declared tint, in every approved locale — and emit that as evidence. Bounds
 and colour checks are exercisable before a single glyph exists.
 
-- S1 ADR: automated UI verification
-- S2 Bounds, ink containment, colour hash
-- S3 The verify driver
-- S4 Evidence report emission
-- S5 CI across all locales
+- #251 S1 ADR: automated UI verification
+- #252 S2 Bounds, ink containment, colour hash
+- #253 S3 The verify driver
+- #254 S4 Evidence report emission
+- #255 S5 CI across all locales
 
-#### #17 — Content components · **Blocked #15**
+Sequential: each child is blocked by its predecessor. Two things landed after the epic was written
+that make it cheaper than it reads — #242 draws a `Label`, so ink containment has real ink to check
+rather than waiting on #17, and #244 makes "every approved locale" a property of the screen's own
+manifest rather than a caller-supplied list. **#252's bounds and colour-hash checks wait on
+nothing**: the epic's own note calls them fully exercisable at the solid-rect slice, which shipped
+in v0.6.0.
+
+#### #17 — Content components · **Open, unblocked**
 
 The rest of the component dictionary. Two deliberate scope cuts: QOI rather than PNG in v1,
 and no IME — input-method editing is a platform concern that does not belong inside a
 governed renderer.
 
-- S1 Image baker and the `Image` component
-- S2 `SignalTrace` — shares the demonstrator's sample ring
-- S3 `NumericDisplay` and `Clock`
-- S4 `StatusIndicator` — has a waiting consumer in the ECG demonstrator
-- S5 `TextInput` (display and caret only)
-- S6 Buttons with requirement binding
+- #256 S1 Image baker and the `Image` component
+- #257 S2 `SignalTrace` — shares the demonstrator's sample ring
+- #258 S3 `NumericDisplay` and `Clock` — **blocked by #219**
+- #259 S4 `StatusIndicator` — has a waiting consumer in the ECG demonstrator
+- #260 S5 `TextInput` (display and caret only)
+- #261 S6 Buttons with requirement binding — touches #219
+
+Largely independent of one another, unlike #16's. **#256 is the one to start**, depending on nothing
+else here.
+
+**#219 orders two of them, and is a prerequisite rather than a nicety.** It closes `ClockFormat` and
+`SystemEvent`. An open format name cannot be *measured*, only looked up, so #258's `Clock` would be
+built against the product-supplied table #195 needs today and then have it removed; and a screen
+that can name any system event can name one nothing implements, which is worst discovered on the
+press of the critical button #261 builds.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,12 +1,12 @@
 # MduX → TrustSC parity roadmap
 
-> Backlog · ambroise-leclerc/MduX · updated 26 August 2026
-> Epic status re-verified against `develop` @ `6124bcb` · 26 August 2026. All thirteen epics were
-> queried on GitHub: ten closed, three open (`#16`, `#17`, `#19`). **No epic changed state since the
-> v0.6.0 baseline** — what moved is post-tag content work and one new platform, recorded under
-> [Since the tag](#since-the-tag).
-> Two open non-epic issues are tracked in their owning sections rather than only on GitHub:
-> `#219` under #15 and `#153` under #18.
+> Backlog · ambroise-leclerc/MduX · updated 29 August 2026
+> Epic status re-verified against `develop` @ `bdf539c` · 29 August 2026. All thirteen epics were
+> queried on GitHub: ten closed, three open (`#16`, `#17`, `#19`). **No epic has changed state since
+> the v0.6.0 baseline** — what moved is post-tag content work, one new platform and one new CI lane,
+> recorded under [Since the tag](#since-the-tag).
+> Sixteen non-epic issues are open: fourteen are epic children, promoted on 28 August and listed in
+> their epic's section below, and two are standalone — `#219` under #15 and `#153` under #18.
 > The divergence table below has its *UI authoring*, *Tests* and *Packaging* rows re-verified on
 > 26 August 2026; the other five date from 17 August 2026 and are not re-checked here.
 
@@ -43,7 +43,8 @@ describes, which is #16 over content #17 teaches to draw.
 | Delivered | 10 |
 | Remaining | 3 |
 | Waves shipped | 5 |
-| Open issues outside an epic | 2 (#153, #219) |
+| Standalone open issues | 2 (#153, #219) |
+| Open epic children | 14 (#251–#265) |
 
 ## The thesis
 
@@ -62,14 +63,16 @@ the whole of Track C.
 | Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time, `mdux-governed-lint` rejects the banned construct at source level, and `governed.noThrow.symbolScan` rejects it in the emitted objects (#116). | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Closed (#8, #10). Five standards on real clause structure with per-clause indexes and JSON Schemas, plus the documentation architecture — README derived from real targets, a contiguous ADR index, and a CI lint for internal links and retired paths. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
 | Copyright | Closed (#7). Reproduced text removed from the tree and from history, with `mdux-docs-lint` in CI to keep it out. | Reproducing normative text is forbidden outright; original prose only. |
-| Tests | Closed. **616 tests, 616 passing** at `develop` @ `6124bcb`, across the in-repository `MduXTest` and SpecLab BDD scenarios — counted from the macOS CI run for that commit, not from a local build (see the note under the table). Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification, governed-zone no-throw (`governed`, #116, with a negative fixture) and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. Since #222 a third platform runs the same labelled suites on every push: macOS 15 on Apple Silicon under Clang 21 and libc++, with `pixel` executed through MoltenVK and the job failing if it is skipped. #246 added a fourth lane, Linux under Clang 21 and libc++, which caught a stack-frame guard violation and a standard-library mismatch that the other three had all missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
+| Tests | Closed. **616 tests, 616 passing** at `develop` @ `bdf539c`, across the in-repository `MduXTest` and SpecLab BDD scenarios — counted from the macOS CI run for that commit, not from a local build (see the note under the table). Labelled suites for cross-toolchain byte identity (`evidence`), FP determinism, no-heap verification, governed-zone no-throw (`governed`, #116, with a negative fixture) and rendered truth (`pixel`), plus an ASan/UBSan leg (#179) that found two use-after-frees a green build had missed. Since #222 a third platform runs the same labelled suites on every push: macOS 15 on Apple Silicon under Clang 21 and libc++, with `pixel` executed through MoltenVK and the job failing if it is skipped. #246 added a fourth lane, Linux under Clang 21 and libc++, which caught a stack-frame guard violation and a standard-library mismatch that the other three had all missed. | Real suites, including cross-toolchain byte-identity and rendered-truth checks. |
 | Packaging | Closed (#11). Install/export restored; MSVC, GCC and Clang presets, with MSVC, GCC 16, macOS arm64 / Clang 21 (#222) and Linux / Clang 21 (#246) all green in CI. | Workspace builds `--locked` on Linux and in containers. |
 
 > **Why the test count is sourced from CI rather than a local run.** 616/616 is what the macOS lane
-> reports for `6124bcb`, and the GCC 16 and MSVC lanes are green on the same commit. A clean local
-> build of the same commit, with the same preset and the same Clang 21.1.8, fails three
-> `evidence-unit` scenarios — two `SEGFAULT`, one failed assertion — on a host running **macOS
-> 26.5.2 with SDK 26.5**, where the verified lane runs macOS 15. The generated module's own
+> reports for `bdf539c` (run 33149254738), and the GCC 16, MSVC and Linux/Clang lanes are green on
+> the same commit. A local build of the
+> same commit, with the same preset and the same Clang 21.1.8, fails three `evidence-unit` scenarios
+> — two `SEGFAULT`, one failed assertion — on a host running **macOS 26.5.2 with SDK 26.5**, where
+> the verified lane runs macOS 15. The same three failed at `6124bcb` from a build directory deleted
+> and reconfigured from scratch, so they are not stale incremental state. The generated module's own
 > `static_assert(screen.validate().has_value())` compiles, so the same expression is true at compile
 > time and false at run time on that host. The supported configuration is the one in
 > `cmake/toolchains/macos-arm64-llvm.cmake`, and macOS 26 is not it — but a constexpr/runtime
@@ -518,7 +521,7 @@ lint — is real, but it is narrower. The wording is fixed in #40 and #38:
 
 ---
 
-_Epic status re-verified against `develop` @ `6124bcb` · 26 August 2026_
+_Epic status re-verified against `develop` @ `bdf539c` · 29 August 2026_
 _13 epics · 10 delivered · Waves 1–5 shipped · Wave 6 open (#16, #17) · no enforcement gaps outstanding_
-_2 open issues outside an epic: #219 (under #15), #153 (under #18)_
+_2 standalone open issues: #219 (under #15), #153 (under #18) · 14 open epic children (#251–#265)_
 _All epics on GitHub_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -160,9 +160,11 @@ lane that strengthens the byte-identity claim rather than moving any epic. Nothi
 
 ### Thirteen epics
 
-Child issues exist for every actionable epic. #16's and #17's were promoted on 28 August 2026, when
-#15's closure unblocked them; the convention is that a blocked epic keeps its breakdown as a
-checklist in its own body until then.
+Child issues exist for every actionable epic, and as of 28 August 2026 that is every open epic.
+#16's and #17's children were promoted when #15's closure unblocked them, and #19's remaining
+S4–S6 with them: those had followed #15 and #18, both long closed, so they were actionable under
+this convention and had simply not been promoted. The convention is that a *blocked* epic keeps its
+breakdown as a checklist in its own body until its dependencies close.
 
 ---
 
@@ -386,9 +388,10 @@ and colour checks are exercisable before a single glyph exists.
 Sequential: each child is blocked by its predecessor. Two things landed after the epic was written
 that make it cheaper than it reads — #242 draws a `Label`, so ink containment has real ink to check
 rather than waiting on #17, and #244 makes "every approved locale" a property of the screen's own
-manifest rather than a caller-supplied list. **#252's bounds and colour-hash checks wait on
-nothing**: the epic's own note calls them fully exercisable at the solid-rect slice, which shipped
-in v0.6.0.
+manifest rather than a caller-supplied list. **#252's bounds and colour-hash checks wait on no
+further content** — the epic's own note calls them fully exercisable at the solid-rect slice, which
+shipped in v0.6.0 — but they still follow #251, which fixes the derive-don't-trust rule they
+implement. Content is not the constraint; the governing decision is.
 
 #### #17 — Content components · **Open, unblocked**
 
@@ -451,11 +454,13 @@ machine-readable contract side, which follows the surfaces it describes.
 - #65 Land and align `AGENTS.md` · _closed_
 - #66 Repository skills · _closed_
 - #118 Stable JSON diagnostic envelope across all tools · _closed_
-- S4 Machine-readable `.medui` grammar
-- S5 Recipe schemas
-- S6 IR dump and tool manifest
+- #263 S4 Machine-readable `.medui` grammar and `--explain`
+- #264 S5 JSON Schemas for every recipe kind
+- #265 S6 `--dump-ir` JSON and a generated tool manifest
 
-_S1–S3 closed; S4–S6 follow #15 and #18_
+_S1–S3 closed. S4–S6 followed #15 and #18 — closed on 23 August and 3 August — so they are
+actionable and were promoted on 28 August 2026. They are independent of one another; #264 needs no
+compiler work and is the cheapest of the three._
 
 ---
 


### PR DESCRIPTION
Open Wave 6: promote #16 and #17's children, and stop calling them blocked

#15 closed on 23 August at 12/12, which unblocked both Wave 6 epics. Neither noticed: #16 still
carried a "Current status (2026-08-15) — Blocked on #15" block and #17 a bare "Blocked by: #15",
five days after the fact, and this document repeated both.

The eleven children are now individual issues (#251-#255, #256-#261), which is this document's own
stated convention for an unblocked epic rather than a new one.

Two orderings are worth having written down, because neither is visible from the epic titles:

- **#219 is a prerequisite for #17's Clock and Button work**, not a nicety. It closes `ClockFormat`
  and `SystemEvent`. An open format name cannot be measured, only looked up, so #258 would be built
  against the product-supplied table #195 needs today and then have it removed. And a screen that
  can name any system event can name one nothing implements — worst discovered on the press of the
  critical button #261 builds.
- **#16's bounds and colour-hash checks wait on nothing.** The epic's own sequencing note calls them
  fully exercisable at the solid-rect slice, which shipped in v0.6.0, and #242's Label has since
  given ink containment real ink to check. The epic reads as gated on content it no longer needs.

#256 is the one to start in #17: it depends on nothing else in either epic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the product roadmap through 29 August 2026.
  * Updated epic statuses, sequencing, prerequisites, and promoted roadmap items.
  * Added current tracking details for open work and standalone items.
  * Updated test verification information, including macOS CI references and successful Linux/Clang status.
  * Revised roadmap footer metadata to reflect the latest project status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->