### PR TITLE
Bump codeql-action to 4.37.9 in one move, and group it so it stays that way

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,18 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      # `github/codeql-action/init` and `.../analyze` must run at the same version: the analyze step
-      # rejects a configuration written by a different one with "Loaded a configuration file for
-      # version X, but running version Y". Ungrouped, Dependabot opens one PR per sub-action and
-      # each is red on its own, because each leaves the other behind. Grouping them makes the unit
-      # of update the unit that has to move together.
+      # One action, one version, everywhere it is used.
+      #
+      # `init` and `.../analyze` must match or the build breaks outright: analyze rejects a
+      # configuration written by a different version with "Loaded a configuration file for version
+      # X, but running version Y". Ungrouped, Dependabot opens one PR per sub-action, and each is
+      # red on its own because each leaves the other behind.
+      #
+      # The pattern deliberately covers `upload-sarif` in scorecard.yml too, which is a different
+      # workflow and cannot break that way. Letting it drift is still not worth it: #267 merged
+      # ahead of #269 and left this repository running upload-sarif at v4.37.9 against init and
+      # analyze at v4.37.7 - a skew with no upside, from three parts of one release moving
+      # separately. Grouping makes the unit of update the release it comes from.
       codeql-action:
         patterns:
           - "github/codeql-action*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # `github/codeql-action/init` and `.../analyze` must run at the same version: the analyze step
+      # rejects a configuration written by a different one with "Loaded a configuration file for
+      # version X, but running version Y". Ungrouped, Dependabot opens one PR per sub-action and
+      # each is red on its own, because each leaves the other behind. Grouping them makes the unit
+      # of update the unit that has to move together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,14 +55,14 @@ jobs:
     # windows-build.yml both build this tree on every PR, so nothing here was the only thing
     # proving it compiles.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: cpp
         build-mode: none
         config-file: ./.github/codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: "/language:cpp"
 


### PR DESCRIPTION
Bump codeql-action to 4.37.9 in one move, and group it so it stays that way

Dependabot opened #266 and #268 for the two codeql-action sub-actions in codeql.yml. Both are red on
their own, and neither is wrong: the analyze step rejects a configuration written by a different
version.

    ##[error]Loaded a configuration file for version '4.37.7', but running version '4.37.9'

Each PR bumps one sub-action and leaves the other behind, so each produces exactly that mismatch.
They are only green together, which no individual Dependabot PR can be.

This bumps both refs in one commit, and adds a `groups:` entry so future codeql-action updates
arrive as one PR. Without it this recurs on every CodeQL release, and the failure looks like a
CodeQL problem rather than a split update.

The target SHA was verified upstream rather than trusted from the PR title: cdf488f is tagged
v4.37.9 in github/codeql-action, and its commit is that release's merge. Pinning by SHA only helps
if the SHA is the right one.

#267 is untouched by this - it bumps upload-sarif in scorecard.yml, is green on its own, and merges
independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security scanning tools to a newer version.
  * Grouped related security tool updates so they can be delivered together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->