### PR TITLE
Close ClockFormat and SystemEvent, and measure a clock instead of looking it up [#219]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -122,6 +122,31 @@ Screen NeuroSense500 {
 | `Image` | `id`, `width`, `height`, `source` | `position` |
 | `TextInput` | `id`, `width`, `height`, `source`, `max_length`, `color` | `position`, `charset`, `requirement` |
 
+## Closed named values: `format:` and `on_press:`
+
+Two fields take a member of a fixed set rather than any identifier. The sets are the shared
+contract's (MEDUI-DEC-006), not this compiler's, so the same spellings hold for every
+implementation.
+
+| Field | Component | Members | Renders |
+|---|---|---|---|
+| `format` | `Clock` | `TimeSeconds` | `HH:MM:SS` |
+| | | `DateTimeSeconds` | `YYYY-MM-DD HH:MM:SS` |
+| `on_press` | `CriticalButton` | `NoOp` | nothing |
+| | | `TriggerHalt` | the host's halt path |
+
+A well-formed identifier outside the set is **`MEDUI-E034`**, not `MEDUI-E033`. The distinction is
+worth knowing because the fix differs: `MEDUI-E033` means the *kind* is wrong (`format: 42`), while
+`MEDUI-E034` means the kind is right and only the membership is wrong (`format: HH_MM`).
+
+Because the renderings are fixed above, a clock's box is **measured** rather than declared: the
+compiler knows a `TimeSeconds` clock draws eight glyphs and checks them against the node's bounds.
+There is no product-supplied table to configure, and a box too narrow for the format is a compile
+error.
+
+`charset:` on `TextInput` stays an open name — it resolves against the character sets a build bakes,
+which the contract does not enumerate.
+
 ## `@safety_critical` — when it's mandatory, and when it's automatic
 
 `@safety_critical(cv_check: [Bounds, ColorHash])` on the line before a component emits a golden

--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -58,7 +58,7 @@ bounded vertex, index and command buffers with a compiler-computed budget, and
 [issue #15](https://github.com/ambroise-leclerc/MduX/issues/15). The implementation pins the shared
 contract in `medui-conformance.toml`. This skill records MduX status and integration; canonical
 grammar, component semantics, diagnostics, and portable guidance live in
-[`Compliatory/MedUI` at `d5136a8`](https://github.com/Compliatory/MedUI/tree/d5136a8518bd499760ecff2aad215d3721329f20).
+[`Compliatory/MedUI` at `265df19`](https://github.com/Compliatory/MedUI/tree/265df1925a672bd556f69123e287215b45cfd210).
 A `.medui` file builds something in MduX today, and it reaches the screen: register it with
 `mdux_compile_screen()` and it becomes a committed, byte-compared artifact plus generated C++ a
 device links, which the governed runtime draws and `ScreenPixelTests` compares pixel by pixel under

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -144,8 +144,9 @@ a governed, allocation-free runtime can do.
 behind a `std::variant`, not a single record with every field on it. The flat form was tried first
 and was lossy: it had nowhere to put a `Clock`'s format, a `NumericDisplay`'s template and source, a
 `StatusIndicator`'s state keys and per-state tints, a `CriticalButton`'s `on_press`, or a
-`VulkanViewport`'s stream, so a device could not have rendered four of the eleven components. Every
-field remains a validated *name* rather than a resolved value, which keeps the boundary ADR-011 fixes.
+`VulkanViewport`'s stream, so a device could not have rendered four of the eleven components. Open
+fields remain validated *names* rather than resolved values; the closed `Clock.format` and
+`CriticalButton.on_press` fields are typed members. Both keep the boundary ADR-011 fixes.
 
 ### 3. Generated C++ is emitted, never committed
 

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -81,6 +81,15 @@ device performs the substitution by a bounded lookup in a governed table. Carryi
 values is also what makes the package readable in a diff: a reviewer sees
 `Theme.Colors.ScoreDigits`, not `[33, 184, 107, 255]`.
 
+**Two fields are members rather than names**, since #219: a `Clock`'s `format` and a
+`CriticalButton`'s `on_press` are enumerations, because the shared contract closes those sets
+(MEDUI-DEC-006) and a name outside one is `MEDUI-E034`. The distinction matters here rather than
+being a typing detail. A validated *name* is proved to resolve against a table a build supplies, so
+what it means is configuration; a *member* means one thing everywhere, which is what lets the
+compiler measure a clock's rendering against its bounds instead of looking it up. `charset` stays a
+name, because the character sets it resolves against are baked per build and the contract does not
+enumerate them.
+
 **All three files spell their members in camelCase**, as the committed font, shader and model
 packages do (`byteLength`, `occupancyPercent`, `advanceWidth`). The one file that could have differed is
 `goldens.json`, whose entry ADR-011 originally spelled in snake_case; that amendment explains why it

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -119,10 +119,16 @@ enum class SchemaError : std::uint8_t {
     EmptyApprovedPackageDigest,  ///< a text-package approval carries no package identity
     DuplicateApprovedLocale,     ///< two text-package approvals claim the same locale
     MissingTextPackageApproval,  ///< a text-bearing screen approves no text package
+    UnspecifiedNamedValue,       ///< a closed-set field left at its `Unspecified` sentinel
+    NamedValueOutOfRange,        ///< a closed-set field holding no enumerator of its type
 };
 
 [[nodiscard]] constexpr std::string_view describe(SchemaError error) noexcept {
     switch (error) {
+        case SchemaError::UnspecifiedNamedValue:
+            return "a field whose value must come from a closed set was left unspecified";
+        case SchemaError::NamedValueOutOfRange:
+            return "a closed-set field holds a value that is not one of its members";
         case SchemaError::UnsupportedSchemaVersion:
             return "the package declares an unsupported schemaVersion";
         case SchemaError::EmptyId:
@@ -325,20 +331,18 @@ struct NodeRect {
  * tokens against the governed table, named values against the tables a build supplies (#195) - so
  * the device performs bounded lookups and no parsing.
  *
- * One consequence worth stating because it diverges from the sibling: `format`, `charset` and
- * `onPress` stay `std::string_view` rather than becoming enumerations. TrustSC closes two of those
- * three in its own crate (`ClockFormat`, `SystemEvent`) and leaves the third - a text input's glyph
- * set - open, so the divergence is real and narrower than it looks.
+ * Two of those fields are **not** names: `format` is a `ClockFormat` and `onPress` a `SystemEvent`,
+ * both closed enumerations. `charset` stays a name, because a glyph set is resolved against the
+ * packages a build bakes rather than against a fixed vocabulary - which is also where TrustSC
+ * leaves it, so all three now agree with the sibling.
  *
- * Closing them here was tried and withdrawn, and the reason is worth recording so the next attempt
- * starts from it: the implemented front end accepts any identifier for `format:` and `on_press:`,
- * #195's budget stage resolves a clock format through a product-supplied table, and the fixtures
- * across three suites write names no two-value enumeration can hold. Closing the set in this module
- * alone would leave the canonical type unable to represent a screen the compiler accepts. Doing it
- * properly needs the semantic domains, the budget rule, the fixtures, the authoring skill and a
- * diagnostic code for "a named value outside a closed set" - which the shared contract does not
- * define today - to move together. That is a coordinated change with its own issue, not a paragraph
- * of this one.
+ * Closing them was tried once and withdrawn (#218), and what made the second attempt work is worth
+ * recording. The blocker was never this module: it was that the shared contract required unknown
+ * formats and system events to fail compilation while never saying what a *known* one is. Two
+ * implementations rejecting different sets both conformed. MEDUI-DEC-006 enumerates the members and
+ * allocates `MEDUI-E034` for one outside the set, so this file transcribes a contract rather than
+ * inventing a local rule - and the fixtures, the semantic domains and #195's budget rule moved with
+ * it in the same change.
  */
 // Every spec member carries a default initialiser. `-Wmissing-field-initializers` is an error in
 // this tree, and the emitter (#197) writes these initialisers from a screen - a type whose optional
@@ -357,8 +361,40 @@ struct LabelSpec {
     [[nodiscard]] constexpr bool operator==(const LabelSpec&) const noexcept = default;
 };
 
+/**
+ * @brief A clock's rendering, closed by the shared contract (MEDUI-DEC-006).
+ *
+ * `Unspecified` is first so that a value-initialised aggregate lands on it. A C++ aggregate fills an
+ * omitted member with the first enumerator, where the Rust sibling's struct literal must name every
+ * field; the sentinel is what recovers the property C++ does not give for free, and
+ * `validatePayload()` refuses it. Without it, an omitted `format` would silently mean `TimeSeconds`.
+ *
+ * The renderings are fixed by the contract, not by this implementation, which is what lets the
+ * budget stage measure a clock rather than look it up.
+ */
+enum class ClockFormat : std::uint8_t {
+    Unspecified,      ///< never valid in a compiled screen; the aggregate default
+    TimeSeconds,      ///< `HH:MM:SS`
+    DateTimeSeconds,  ///< `YYYY-MM-DD HH:MM:SS`
+};
+
+/// The widest rendering each format produces, which is what a text budget measures.
+[[nodiscard]] constexpr std::string_view rendering(ClockFormat format) noexcept {
+    switch (format) {
+        case ClockFormat::TimeSeconds:
+            return "HH:MM:SS";
+        case ClockFormat::DateTimeSeconds:
+            return "YYYY-MM-DD HH:MM:SS";
+        case ClockFormat::Unspecified:
+            return {};
+    }
+    // Named rather than defaulted so that a new enumerator is a warning at this switch instead of a
+    // silent empty rendering, and an out-of-range cast returns nothing rather than aliasing a member.
+    return {};
+}
+
 struct ClockSpec {
-    std::string_view format{};  ///< a named value the build's governed table defines
+    ClockFormat format{ClockFormat::Unspecified};
 
     [[nodiscard]] constexpr bool operator==(const ClockSpec&) const noexcept = default;
 };
@@ -391,11 +427,74 @@ struct ButtonSpec {
     [[nodiscard]] constexpr bool operator==(const ButtonSpec&) const noexcept = default;
 };
 
+/**
+ * @brief What a critical control can ask the host to do, closed by the shared contract.
+ *
+ * Closing this is not tidiness. A screen able to name any event can name one the host does not
+ * implement, and the press of a critical button is the worst place to find that out. `Unspecified`
+ * leads for the same reason it does in `ClockFormat`.
+ */
+enum class SystemEvent : std::uint8_t {
+    Unspecified,  ///< never valid in a compiled screen; the aggregate default
+    NoOp,         ///< the press is recorded and does nothing else
+    TriggerHalt,  ///< the press requests the host's halt path
+};
+
+/// The contract spelling of a clock format. Empty for `Unspecified` or an out-of-range cast, so a
+/// caller writing this into a package writes nothing rather than a member the value is not.
+[[nodiscard]] constexpr std::string_view toWire(ClockFormat format) noexcept {
+    switch (format) {
+        case ClockFormat::TimeSeconds:
+            return "TimeSeconds";
+        case ClockFormat::DateTimeSeconds:
+            return "DateTimeSeconds";
+        case ClockFormat::Unspecified:
+            return {};
+    }
+    return {};
+}
+
+/// The contract spelling of a system event, under the same rule as `toWire(ClockFormat)`.
+[[nodiscard]] constexpr std::string_view toWire(SystemEvent event) noexcept {
+    switch (event) {
+        case SystemEvent::NoOp:
+            return "NoOp";
+        case SystemEvent::TriggerHalt:
+            return "TriggerHalt";
+        case SystemEvent::Unspecified:
+            return {};
+    }
+    return {};
+}
+
+/// The inverse. Nothing for a spelling outside the set - including `""`, so a missing member in a
+/// package is refused rather than read as `Unspecified` and caught later.
+[[nodiscard]] constexpr std::optional<ClockFormat> clockFormatFromWire(std::string_view wire) noexcept {
+    if (wire == "TimeSeconds") {
+        return ClockFormat::TimeSeconds;
+    }
+    if (wire == "DateTimeSeconds") {
+        return ClockFormat::DateTimeSeconds;
+    }
+    return std::nullopt;
+}
+
+/// The inverse for a system event, under the same rule.
+[[nodiscard]] constexpr std::optional<SystemEvent> systemEventFromWire(std::string_view wire) noexcept {
+    if (wire == "NoOp") {
+        return SystemEvent::NoOp;
+    }
+    if (wire == "TriggerHalt") {
+        return SystemEvent::TriggerHalt;
+    }
+    return std::nullopt;
+}
+
 struct CriticalButtonSpec {
     std::string_view requirement{};  ///< required by the dictionary, and by #196's annotation rule
     std::string_view labelKey{};
     std::string_view colorToken{};
-    std::string_view onPress{};
+    SystemEvent      onPress{SystemEvent::Unspecified};
 
     [[nodiscard]] constexpr bool operator==(const CriticalButtonSpec&) const noexcept = default;
 };
@@ -657,6 +756,25 @@ struct ScreenPackage {
 }
 
 /**
+ * @brief Requires a closed-set field to hold one of its members.
+ *
+ * Two rejections rather than one, because they are different mistakes. `Unspecified` means the field
+ * was never set - the aggregate default, which is what a C++ struct gives an omitted member. An
+ * out-of-range value means something cast a number the type has no enumerator for; `toWire` returns
+ * an empty spelling for it, so this catches what that spelling would otherwise hide.
+ */
+template <typename Member>
+[[nodiscard]] constexpr mdux::core::ResultVoid<SchemaError> requireMember(Member value) noexcept {
+    if (value == Member::Unspecified) {
+        return mdux::core::err(SchemaError::UnspecifiedNamedValue);
+    }
+    if (toWire(value).empty()) {
+        return mdux::core::err(SchemaError::NamedValueOutOfRange);
+    }
+    return {};
+}
+
+/**
  * @brief Checks one node's payload against what its component's dictionary entry requires.
  *
  * Only what the dictionary already fixes, and nothing this module invents on its own: a name a
@@ -702,7 +820,7 @@ struct ScreenPackage {
         return requireColor(spec->colorToken);
     }
     if (const auto* spec = std::get_if<ClockSpec>(&payload)) {
-        return require(spec->format);
+        return requireMember(spec->format);
     }
     if (const auto* spec = std::get_if<ImageSpec>(&payload)) {
         return require(spec->source);
@@ -726,10 +844,13 @@ struct ScreenPackage {
         return requireColor(spec->colorToken);
     }
     if (const auto* spec = std::get_if<CriticalButtonSpec>(&payload)) {
-        for (const std::string_view name : {spec->requirement, spec->labelKey, spec->onPress}) {
+        for (const std::string_view name : {spec->requirement, spec->labelKey}) {
             if (const auto named = require(name); !named.has_value()) {
                 return named;
             }
+        }
+        if (const auto member = requireMember(spec->onPress); !member.has_value()) {
+            return member;
         }
         return requireColor(spec->colorToken);
     }

--- a/medui-conformance.toml
+++ b/medui-conformance.toml
@@ -1,6 +1,6 @@
 repository = "https://github.com/Compliatory/MedUI"
 version = "0.1.0"
-commit = "d5136a8518bd499760ecff2aad215d3721329f20"
+commit = "265df1925a672bd556f69123e287215b45cfd210"
 capabilities = ["syntax", "semantics", "layout", "safety"]
 # Diagnostic position precision, per `spec/diagnostics.md`. The lexer carries exact 1-based UTF-8
 # byte columns, so every pinned position is matched in full.

--- a/tests/medui/DiagnosticsTests.cpp
+++ b/tests/medui/DiagnosticsTests.cpp
@@ -29,7 +29,7 @@ namespace cli = mdux::tools::cli;
 /// cast in a loop would assume contiguity this enum does not promise. The duplication is the point
 /// - adding an enumerator without adding it here fails `every code is registered`, which is the
 /// nudge that also gets it a table row.
-constexpr std::array<md::Code, 23> allCodes{
+constexpr std::array<md::Code, 24> allCodes{
     md::Code::RecipeUnreadable,
     md::Code::RecipeUnparsed,
     md::Code::RecipeMissingMember,
@@ -47,6 +47,7 @@ constexpr std::array<md::Code, 23> allCodes{
     md::Code::UnknownTextKey,
     md::Code::TextKeyMissingForLocale,
     md::Code::FieldValueKind,
+    md::Code::NamedValueOutsideSet,
     md::Code::TextBudgetExceeded,
     md::Code::LayoutOverflow,
     md::Code::SurfaceExceeded,

--- a/tests/medui/GeneratedScreenTests.cpp
+++ b/tests/medui/GeneratedScreenTests.cpp
@@ -91,7 +91,7 @@ const mdux::spec::Register theGeneratedScreenIsTheCompiledOne{
                       const ms::CompiledNode* clock = screen.find("wall-clock");
                       if (clock != nullptr) {
                           const auto* spec = std::get_if<ms::ClockSpec>(&clock->payload);
-                          checks.expect(spec != nullptr && spec->format == "TimeSeconds", "the Clock's format survives emission");
+                          checks.expect(spec != nullptr && spec->format == ms::ClockFormat::TimeSeconds, "the Clock's format survives emission");
                       } else {
                           checks.expect(false, "the generated screen holds the Clock");
                       }
@@ -99,7 +99,7 @@ const mdux::spec::Register theGeneratedScreenIsTheCompiledOne{
                       const ms::CompiledNode* critical = screen.find("halt");
                       if (critical != nullptr) {
                           const auto* spec = std::get_if<ms::CriticalButtonSpec>(&critical->payload);
-                          checks.expect(spec != nullptr && spec->onPress == "TriggerHalt", "the CriticalButton's action survives emission");
+                          checks.expect(spec != nullptr && spec->onPress == ms::SystemEvent::TriggerHalt, "the CriticalButton's action survives emission");
                           checks.expect(spec != nullptr && spec->requirement == "REQ-EC-002", "its requirement survives, for the trace");
                       } else {
                           checks.expect(false, "the generated screen holds the CriticalButton");

--- a/tests/medui/GoldenTests.cpp
+++ b/tests/medui/GoldenTests.cpp
@@ -404,7 +404,7 @@ const mdux::spec::Register colorHashNeedsATintToCompare{
                       checks.expect(refused != nullptr && refused->message.find("ColorHash") != std::string::npos, "the diagnostic names the check it refuses");
 
                       const md::ast::Screen clock = parseOrFail(screenWith("    @safety_critical(cv_check: [ColorHash])\n"
-                                                                           "    Clock { id: now; width: 100px; height: 40px; format: HH_MM; }\n"));
+                                                                           "    Clock { id: now; width: 100px; height: 40px; format: TimeSeconds; }\n"));
                       checks.expect(find(md::validateSafetyAnnotations(clock, "goldens.medui"), md::Code::UnknownCvCheck) != nullptr,
                                     "a component with no colour field cannot be tint-checked either");
 

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -393,6 +393,36 @@ const mdux::spec::Register anUndefinedMemberIsRefused{"A member the format does 
                                                               .Execute();
                                                       }};
 
+const mdux::spec::Register unknownClosedMembersAreReported{
+    "Unknown closed-set package spellings fail with an actionable diagnostic",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-unknown-closed-member")
+            .Given("canonical bytes carrying an unknown ClockFormat and an unknown SystemEvent", [] {})
+            .When("each package is read", [] {})
+            .Then("both fail as SCP002 and name the field, spelling and closed type",
+                  [] {
+                      mdux::spec::Checks          checks;
+                      const md::ScreenDocument    document = everyComponent();
+                      const std::string           written  = md::writePackage(document.package());
+                      const md::PackageReadResult clock    = md::readPackage(editing(written, "\"TimeSeconds\"", "\"UnknownTime\""), "clock.json");
+                      const md::PackageReadResult event    = md::readPackage(editing(written, "\"TriggerHalt\"", "\"UnknownEvent\""), "event.json");
+
+                      checks.expect(!clock.ok() && firstCode(clock) == "SCP002", std::format("the unknown format is SCP002, got '{}'", firstCode(clock)));
+                      checks.expect(!clock.diagnostics.empty() && clock.diagnostics.front().message.find("format") != std::string::npos
+                                        && clock.diagnostics.front().message.find("ClockFormat") != std::string::npos
+                                        && clock.diagnostics.front().message.find("UnknownTime") != std::string::npos,
+                                    "the format diagnostic identifies the member, type and spelling");
+                      checks.expect(!event.ok() && firstCode(event) == "SCP002", std::format("the unknown event is SCP002, got '{}'", firstCode(event)));
+                      checks.expect(!event.diagnostics.empty() && event.diagnostics.front().message.find("onPress") != std::string::npos
+                                        && event.diagnostics.front().message.find("SystemEvent") != std::string::npos
+                                        && event.diagnostics.front().message.find("UnknownEvent") != std::string::npos,
+                                    "the event diagnostic identifies the member, type and spelling");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register anUnknownComponentIsRefused{"A node naming a component outside the dictionary is refused", "evidence-unit", [] {
                                                            return speclab::Test("medui-package-unknown-kind")
                                                                .Given("committed bytes naming a component that does not exist", [] {})

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -193,6 +193,42 @@ const mdux::spec::Register referenceScreenValidates{"The reference screen valida
                                                             .Execute();
                                                     }};
 
+const mdux::spec::Register closedMembersMustBeSpecifiedAndInRange{
+    "Closed-set payload fields distinguish omission from an out-of-range value",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-closed-members")
+            .Given("Clock and CriticalButton payloads with valid, unspecified and out-of-range members", [] {})
+            .When("each single-node package is validated", [] {})
+            .Then("valid members pass and the two malformed classes report distinct schema errors",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         errorFor = [](ms::NodePayload payload) -> std::optional<ms::SchemaError> {
+                          Fixture fixture;
+                          fixture.nodes = {
+                              ms::CompiledNode{.id = "member", .bounds = {0, 0, 120, 40}, .payload = std::move(payload)}
+                          };
+                          return errorOf(fixture);
+                      };
+
+                      checks.expect(!errorFor(ms::ClockSpec{.format = ms::ClockFormat::TimeSeconds}).has_value(), "a known clock format validates");
+                      checks.expect(errorFor(ms::ClockSpec{}) == ms::SchemaError::UnspecifiedNamedValue, "an omitted clock format is unspecified");
+                      checks.expect(errorFor(ms::ClockSpec{.format = static_cast<ms::ClockFormat>(255)}) == ms::SchemaError::NamedValueOutOfRange,
+                                    "an out-of-range clock format is distinguished from omission");
+
+                      const auto button = [](ms::SystemEvent event) {
+                          return ms::CriticalButtonSpec{.requirement = "REQ-1", .labelKey = "STR-HALT", .colorToken = "Theme.Colors.Fault", .onPress = event};
+                      };
+                      checks.expect(!errorFor(button(ms::SystemEvent::TriggerHalt)).has_value(), "a known system event validates");
+                      checks.expect(errorFor(button(ms::SystemEvent::Unspecified)) == ms::SchemaError::UnspecifiedNamedValue,
+                                    "an omitted system event is unspecified");
+                      checks.expect(errorFor(button(static_cast<ms::SystemEvent>(255))) == ms::SchemaError::NamedValueOutOfRange,
+                                    "an out-of-range system event is distinguished from omission");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register identityIsRequired{"A screen with no id and one with an unreadable version are both refused", "evidence-unit", [] {
                                                   return speclab::Test("medui-schema-identity")
                                                       .Given("the reference screen", [] {})

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -582,7 +582,7 @@ const mdux::spec::Register everyComponentNamesItself{
                       const ms::CompiledNode untraced{
                           .id      = "now",
                           .bounds  = {0, 0, 1, 1},
-                          .payload = ms::ClockSpec{.format = "HH_MM"}
+                          .payload = ms::ClockSpec{.format = ms::ClockFormat::TimeSeconds}
                       };
                       checks.expect(ms::requirementOf(traced) == "REQ-1", "a status indicator yields its requirement");
                       checks.expect(ms::requirementOf(untraced).empty(), "a clock has none to yield");

--- a/tests/medui/ScreenNoHeapTests.cpp
+++ b/tests/medui/ScreenNoHeapTests.cpp
@@ -37,7 +37,7 @@ constexpr mdux::draw::DrawBudget budget{.maxVertices = 512, .maxIndices = 768, .
 
 constexpr ms::PanelSpec panel{.colorToken = "Theme.Colors.TopbarBackground"};
 constexpr ms::LabelSpec label{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"};
-constexpr ms::ClockSpec clock{.format = "TimeSeconds"};
+constexpr ms::ClockSpec clock{.format = ms::ClockFormat::TimeSeconds};
 
 // Every alternative the walk can take: one it draws, and two it defers. A screen of panels alone
 // would leave the deferred branch - the one that touches a variant it does not draw - unmeasured.

--- a/tests/medui/SemanticTests.cpp
+++ b/tests/medui/SemanticTests.cpp
@@ -303,9 +303,9 @@ const mdux::spec::Register semanticSpecialValueForms{"Image references, positive
                                                                        constexpr std::string_view                   source = R"(Screen Forms {
     layout: Vertical { spacing: 0px; padding: 0px; }
     Image { id: logo; width: 32px; height: 32px; source: img("LOGO"); }
-    TextInput { id: input; width: 120px; height: 20px; source: "NAME"; max_length: 16; color: Theme.Colors.Title; }
-    Clock { id: clock; width: 80px; height: 20px; format: TimeFormat.HoursMinutes; }
-    CriticalButton { id: stop; requirement: "REQ-1"; width: 80px; height: 24px; label: t("STR-STOP"); color: Theme.Colors.Title; on_press: SystemEvent.Stop; }
+    TextInput { id: input; width: 120px; height: 20px; source: "NAME"; max_length: 16; color: Theme.Colors.Title; charset: Charset.DigitsToA; }
+    Clock { id: clock; width: 80px; height: 20px; format: TimeSeconds; }
+    CriticalButton { id: stop; requirement: "REQ-1"; width: 80px; height: 24px; label: t("STR-STOP"); color: Theme.Colors.Title; on_press: TriggerHalt; }
 })";
                                                                        const std::array<std::string_view, 1>        themes{"Theme.Colors.Title"};
                                                                        const std::array<mdux::text::TextPackage, 1> packages{package("en-US", {"STR-STOP"})};

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -533,6 +533,66 @@ const mdux::spec::Register diagnosticsFollowNodeAndLocaleOrder{
             .Execute();
     }};
 
+const mdux::spec::Register clocksSelectAndRunTheBudgetStage{
+    "A Clock-only screen needs a font and measures decimal slots rather than template letters",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-clock-fixed-rendering")
+            .Given("a TimeSeconds clock and a font containing digits and a colon but no H, M or S", [] {})
+            .When("the screen is selected for budgeting and its fixed rendering is measured", [] {})
+            .Then("the Clock selects the stage and its 43px digit rendering fits a 50px box",
+                  [] {
+                      mdux::spec::Checks      checks;
+                      const font::FontPackage fontPackage = fixtureFont();
+                      const ApprovedText      approved    = approvedText("STR-UNUSED", 1, 1);
+                      const auto              locales     = approved.views();
+                      const std::string       source      = screenWith("    Clock { id: now; width: 50px; height: 20px; format: TimeSeconds; }\n");
+                      const md::ParseResult   parsed      = md::parse(source, "budget.medui");
+
+                      checks.expect(parsed.screen.has_value() && md::needsTextBudget(*parsed.screen), "a Clock-only screen selects the text-budget stage");
+                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+                      checks.expect(result.ok(), std::format("the digit rendering fits, got {} diagnostics", result.diagnostics.size()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register clockBoundsUseRenderedInk{
+    "Clock bounds cover the widest digit ink, including bitmap overhang",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-textbudget-clock-ink-envelope")
+            .Given("a valid tabular font whose zero bitmap begins 20px left of its pen", [] {})
+            .When("a 50px TimeSeconds clock is measured", [] {})
+            .Then("MEDUI-E050 reports the 63px ink envelope rather than accepting its 40px advance sum",
+                  [] {
+                      mdux::spec::Checks checks;
+                      font::FontPackage  fontPackage = fixtureFont();
+                      const auto         zero        = std::ranges::find(fontPackage.glyphs, U'0', &font::GlyphRecord::codePoint);
+                      checks.expect(zero != fontPackage.glyphs.end(), "the fixture contains zero");
+                      if (zero != fontPackage.glyphs.end()) {
+                          zero->bitmapOriginX = -20;
+                      }
+                      checks.expect(fontPackage.validate().has_value(), "bitmap overhang does not invalidate a font package");
+
+                      const ApprovedText         approved = approvedText("STR-UNUSED", 1, 1);
+                      const auto                 locales  = approved.views();
+                      const std::string          source   = screenWith("    Clock { id: now; width: 50px; height: 20px; format: TimeSeconds; }\n");
+                      const md::TextBudgetResult result   = md::checkTextBudgets(layoutOf(source),
+                                                                               "budget.medui",
+                                                                                 {.font = &fontPackage, .locales = locales, .dynamicText = {}});
+
+                      const cli::Diagnostic* reported = find(result, md::Code::TextBudgetExceeded);
+                      checks.expect(!result.ok(), "the overhanging clock is rejected");
+                      checks.expect(mentions(reported, "63px"), "the diagnostic names the full ink envelope");
+                      checks.expect(mentions(reported, "50px"), "the diagnostic names the available width");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register dynamicTextCannotEscapeTheCharset{
     "A format that can produce an unbaked character is MEDUI-E053",
     "evidence-unit",
@@ -550,7 +610,8 @@ const mdux::spec::Register dynamicTextCannotEscapeTheCharset{
                           md::DynamicTextRule{.name = "HH_MM_TZ", .produces = digitsAndZone}
                       };
 
-                      const std::string          source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM_TZ; }\n");
+                      const std::string source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: "
+                                                            "Theme.Colors.Title; charset: HH_MM_TZ; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
                                                                                {.font = &fontPackage, .locales = locales, .dynamicText = table});
@@ -581,7 +642,8 @@ const mdux::spec::Register charsetWalkCrossesRangeBoundaries{
                           md::DynamicTextRule{.name = "DIGITS_TO_A", .produces = digitsThroughLetter}
                       };
 
-                      const std::string          source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: DIGITS_TO_A; }\n");
+                      const std::string source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: "
+                                                            "Theme.Colors.Title; charset: DIGITS_TO_A; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
                                                                                {.font = &fontPackage, .locales = locales, .dynamicText = table});
@@ -649,7 +711,8 @@ const mdux::spec::Register unresolvedDynamicTextFailsClosed{
                       const ApprovedText      approved    = approvedText("STR-UNUSED", 1, 1);
                       const auto              locales     = approved.views();
 
-                      const std::string          source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM; }\n");
+                      const std::string source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: "
+                                                            "Theme.Colors.Title; charset: HH_MM; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
                                                                                {.font = &fontPackage, .locales = locales, .dynamicText = {}});
@@ -670,27 +733,29 @@ const mdux::spec::Register boundedDynamicTextIsAccepted{
         return speclab::Test("medui-textbudget-charset-accepted")
             .Given("a Clock producing digits and a colon, and a TextInput with no charset field", [] {})
             .When("the screen is checked against the font package's restricted charset", [] {})
-            .Then("neither component is reported",
-                  [] {
-                      mdux::spec::Checks                       checks;
-                      const font::FontPackage                  fontPackage = fixtureFont();
-                      const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
-                      const auto                               locales     = approved.views();
-                      const std::array<md::DynamicTextRule, 1> table{
-                          md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
-                      };
+            .Then(
+                "neither component is reported",
+                [] {
+                    mdux::spec::Checks                       checks;
+                    const font::FontPackage                  fontPackage = fixtureFont();
+                    const ApprovedText                       approved    = approvedText("STR-UNUSED", 1, 1);
+                    const auto                               locales     = approved.views();
+                    const std::array<md::DynamicTextRule, 1> table{
+                        md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
+                    };
 
-                      const std::string          source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM; }\n"
-                                                                     "    TextInput { id: note; width: 100px; height: 20px; source: \"OPERATOR_NOTE\"; "
-                                                                     "max_length: 16; color: Theme.Colors.Title; }\n");
-                      const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
-                                                                               "budget.medui",
-                                                                               {.font = &fontPackage, .locales = locales, .dynamicText = table});
+                    const std::string source = screenWith(
+                        "    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM; }\n"
+                        "    TextInput { id: note; width: 100px; height: 20px; source: \"OPERATOR_NOTE\"; "
+                        "max_length: 16; color: Theme.Colors.Title; }\n");
+                    const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
+                                                                             "budget.medui",
+                                                                             {.font = &fontPackage, .locales = locales, .dynamicText = table});
 
-                      checks.expect(result.ok(), std::format("the screen compiles, got {} diagnostics", result.diagnostics.size()));
-                      checks.expect(result.measurements.empty(), "a screen with no text key measures nothing");
-                      checks.raise();
-                  })
+                    checks.expect(result.ok(), std::format("the screen compiles, got {} diagnostics", result.diagnostics.size()));
+                    checks.expect(result.measurements.empty(), "a screen with no text key measures nothing");
+                    checks.raise();
+                })
             .Execute();
     }};
 
@@ -761,7 +826,8 @@ const mdux::spec::Register unwalkableFontCharsetIsRefused{
                       const std::array<md::DynamicTextRule, 1> table{
                           md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
                       };
-                      const md::LayoutResult resolved = layoutOf(screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM; }\n"));
+                      const md::LayoutResult resolved = layoutOf(screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; "
+                                                                            "max_length: 8; color: Theme.Colors.Title; charset: HH_MM; }\n"));
 
                       const auto check = [&](const font::FontPackage& fontPackage) {
                           return throwsWiringError([&] {

--- a/tests/medui/TextBudgetTests.cpp
+++ b/tests/medui/TextBudgetTests.cpp
@@ -550,7 +550,7 @@ const mdux::spec::Register dynamicTextCannotEscapeTheCharset{
                           md::DynamicTextRule{.name = "HH_MM_TZ", .produces = digitsAndZone}
                       };
 
-                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM_TZ; }\n");
+                      const std::string          source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM_TZ; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
                                                                                {.font = &fontPackage, .locales = locales, .dynamicText = table});
@@ -581,7 +581,7 @@ const mdux::spec::Register charsetWalkCrossesRangeBoundaries{
                           md::DynamicTextRule{.name = "DIGITS_TO_A", .produces = digitsThroughLetter}
                       };
 
-                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: DIGITS_TO_A; }\n");
+                      const std::string          source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: DIGITS_TO_A; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
                                                                                {.font = &fontPackage, .locales = locales, .dynamicText = table});
@@ -613,7 +613,9 @@ const mdux::spec::Register nonScalarRangesAreReported{
                           const std::array<md::DynamicTextRule, 1> table{
                               md::DynamicTextRule{.name = name, .produces = produces}
                           };
-                          const std::string source = screenWith(std::format("    Clock {{ id: now; width: 100px; height: 20px; format: {}; }}\n", name));
+                          const std::string source = screenWith(std::format("    TextInput {{ id: entry; width: 100px; height: 20px; source: \"NAME\"; "
+                                                                            "max_length: 8; color: Theme.Colors.Title; charset: {}; }}\n",
+                                                                            name));
                           return md::checkTextBudgets(layoutOf(source), "budget.medui", {.font = &fontPackage, .locales = locales, .dynamicText = table});
                       };
 
@@ -647,7 +649,7 @@ const mdux::spec::Register unresolvedDynamicTextFailsClosed{
                       const ApprovedText      approved    = approvedText("STR-UNUSED", 1, 1);
                       const auto              locales     = approved.views();
 
-                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n");
+                      const std::string          source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
                                                                                {.font = &fontPackage, .locales = locales, .dynamicText = {}});
@@ -678,8 +680,8 @@ const mdux::spec::Register boundedDynamicTextIsAccepted{
                           md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
                       };
 
-                      const std::string          source = screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n"
-                                                                     "    TextInput { id: entry; width: 100px; height: 20px; source: \"OPERATOR_NOTE\"; "
+                      const std::string          source = screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM; }\n"
+                                                                     "    TextInput { id: note; width: 100px; height: 20px; source: \"OPERATOR_NOTE\"; "
                                                                      "max_length: 16; color: Theme.Colors.Title; }\n");
                       const md::TextBudgetResult result = md::checkTextBudgets(layoutOf(source),
                                                                                "budget.medui",
@@ -759,7 +761,7 @@ const mdux::spec::Register unwalkableFontCharsetIsRefused{
                       const std::array<md::DynamicTextRule, 1> table{
                           md::DynamicTextRule{.name = "HH_MM", .produces = digitsAndColon}
                       };
-                      const md::LayoutResult resolved = layoutOf(screenWith("    Clock { id: now; width: 100px; height: 20px; format: HH_MM; }\n"));
+                      const md::LayoutResult resolved = layoutOf(screenWith("    TextInput { id: entry; width: 100px; height: 20px; source: \"NAME\"; max_length: 8; color: Theme.Colors.Title; charset: HH_MM; }\n"));
 
                       const auto check = [&](const font::FontPackage& fontPackage) {
                           return throwsWiringError([&] {

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -313,8 +313,9 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
     }
 
     // The governed dynamic-text table. Optional as a table for the same reason [text] is: a screen
-    // with no `format:` and no `charset:` has no name to resolve, and the budget stage refuses an
-    // unknown name rather than accepting one, so an absent table is fail-closed.
+    // with no `charset:` has no open name to resolve, and the budget stage refuses an unknown name
+    // rather than accepting one, so an absent table is fail-closed. A Clock's closed `format:` is
+    // measured directly and never resolves through this table.
     if (const toml::Table* dynamicTable = document.table("dynamicText"); dynamicTable != nullptr) {
         std::vector<std::string>  names;
         std::vector<std::int64_t> firstPoints;

--- a/tools/medui/Compile.cppm
+++ b/tools/medui/Compile.cppm
@@ -64,10 +64,11 @@ inline constexpr std::string_view compilerToolName = "mdux-meduic";
 /**
  * @brief One named dynamic-text source from the recipe, and every code point it can produce.
  *
- * The governed table an author's `format: TimeSeconds` or `charset: Ascii` resolves against. It is a
- * recipe input rather than a compiler constant for the reason `DynamicTextRule` gives: the names
- * belong to a product's governed tables, and a compiler shipping its own list would be authoritative
- * about a set it does not own.
+ * The governed table an author's `charset: Ascii` resolves against. It is a recipe input rather than
+ * a compiler constant for the reason `DynamicTextRule` gives: charset names belong to a product's
+ * governed tables, and a compiler shipping its own list would be authoritative about a set it does
+ * not own. `Clock.format` is a closed member whose rendering the compiler measures directly, so it
+ * does not appear here.
  *
  * Spelled as parallel arrays because `mdux.tools.toml` implements a subset with no array-of-tables
  * support - the same shape `recipes/font/dejavu-ui.toml` uses for its charset, and the same

--- a/tools/medui/Diagnostics.cpp
+++ b/tools/medui/Diagnostics.cpp
@@ -26,7 +26,7 @@ using cli::Severity;
 // Numbers are assigned in blocks, with gaps left inside each block on purpose: a new grammar rule
 // should land next to the grammar rules rather than at the end of the table, and it can only do
 // that if its block has room. The blocks are documented on the enum in Diagnostics.cppm.
-constexpr std::array<CodeInfo, 23> table{{
+constexpr std::array<CodeInfo, 24> table{{
     {Code::RecipeUnreadable, "MEDUI-E000", Severity::Error,
      "the recipe file could not be opened",
      "check the path passed on the command line, and that the file is readable"},
@@ -84,6 +84,11 @@ constexpr std::array<CodeInfo, 23> table{{
     {Code::FieldValueKind, "MEDUI-E033", Severity::Error,
      "a field value has the wrong semantic kind",
      "use the value form assigned to this field in the shared component model"},
+    {Code::NamedValueOutsideSet, "MEDUI-E034", Severity::Error,
+     "a named value is outside the closed set its field admits",
+     "use one of the members the shared component model lists for this field. This is not "
+     "MEDUI-E033: the value is a well-formed identifier, so its kind is right and only its "
+     "membership is wrong"},
 
     {Code::TextBudgetExceeded, "MEDUI-E050", Severity::Error,
      "a component's bounds cannot contain the widest approved translation",

--- a/tools/medui/Diagnostics.cppm
+++ b/tools/medui/Diagnostics.cppm
@@ -88,6 +88,7 @@ enum class Code : std::uint8_t {
     UnknownTextKey,
     TextKeyMissingForLocale,
     FieldValueKind,
+    NamedValueOutsideSet,
 
     // 050-069: the bounds and budgets that make the runtime's job finite.
     TextBudgetExceeded,

--- a/tools/medui/Emit.cpp
+++ b/tools/medui/Emit.cpp
@@ -120,6 +120,20 @@ void appendName(std::string& out, bool& first, std::string_view member, std::str
     first = false;
 }
 
+/// A closed-set member, emitted as the enumerator rather than as its wire spelling: generated code
+/// that named a string would reintroduce the parse this whole path exists to remove. `Unspecified`
+/// is never written, because `validate()` has already refused it - so an omitted member here is a
+/// screen that would not have compiled.
+template <typename Member>
+void appendMember(std::string& out, bool& first, std::string_view member, std::string_view type, Member value) {
+    const std::string_view spelling = ms::toWire(value);
+    if (spelling.empty()) {
+        return;
+    }
+    out  += std::format("{}.{} = mdux::medui::{}::{}", first ? "" : ", ", member, type, spelling);
+    first = false;
+}
+
 void appendSpan(std::string& out, bool& first, std::string_view member, std::string_view arrayName) {
     out  += std::format("{}.{} = {}", first ? "" : ", ", member, arrayName);
     first = false;
@@ -202,7 +216,7 @@ void appendSpan(std::string& out, bool& first, std::string_view member, std::str
         appendName(out, first, "colorToken", label->colorToken);
     } else if (const auto* clock = std::get_if<ms::ClockSpec>(&node.payload)) {
         out = "mdux::medui::ClockSpec{";
-        appendName(out, first, "format", clock->format);
+        appendMember(out, first, "format", "ClockFormat", clock->format);
     } else if (const auto* image = std::get_if<ms::ImageSpec>(&node.payload)) {
         out = "mdux::medui::ImageSpec{";
         appendName(out, first, "source", image->source);
@@ -224,7 +238,7 @@ void appendSpan(std::string& out, bool& first, std::string_view member, std::str
         appendName(out, first, "requirement", critical->requirement);
         appendName(out, first, "labelKey", critical->labelKey);
         appendName(out, first, "colorToken", critical->colorToken);
-        appendName(out, first, "onPress", critical->onPress);
+        appendMember(out, first, "onPress", "SystemEvent", critical->onPress);
     } else if (const auto* numeric = std::get_if<ms::NumericDisplaySpec>(&node.payload)) {
         out = "mdux::medui::NumericDisplaySpec{";
         appendName(out, first, "requirement", numeric->requirement);

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -157,8 +157,10 @@ constexpr std::string_view schemaRefused = "SCP005";
         return ms::ButtonSpec{.labelKey = name("label"), .colorToken = name("color"), .source = name("source"), .requirement = name("requirement")};
     }
     if (resolved.component == "CriticalButton") {
-        return ms::CriticalButtonSpec{
-            .requirement = name("requirement"), .labelKey = name("label"), .colorToken = name("color"), .onPress = systemEvent("on_press")};
+        return ms::CriticalButtonSpec{.requirement = name("requirement"),
+                                      .labelKey    = name("label"),
+                                      .colorToken  = name("color"),
+                                      .onPress     = systemEvent("on_press")};
     }
     if (resolved.component == "NumericDisplay") {
         return ms::NumericDisplaySpec{.requirement = name("requirement"),
@@ -714,7 +716,7 @@ readSpec(const json::Value& node, std::string_view kind, std::string_view what, 
         // only refusing here keeps them apart.
         const auto clockFormat = ms::clockFormatFromWire(*format);
         if (!clockFormat.has_value()) {
-            return false;
+            return sink.fail(memberWrong, std::format("{} member 'format' names unknown ClockFormat '{}'", where, *format));
         }
         payload = ms::ClockSpec{.format = *clockFormat};
         return true;
@@ -780,7 +782,7 @@ readSpec(const json::Value& node, std::string_view kind, std::string_view what, 
         }
         const auto event = ms::systemEventFromWire(*onPress);
         if (!event.has_value()) {
-            return false;
+            return sink.fail(memberWrong, std::format("{} member 'onPress' names unknown SystemEvent '{}'", where, *onPress));
         }
         payload = ms::CriticalButtonSpec{.requirement = *requirement, .labelKey = *labelKey, .colorToken = *colorToken, .onPress = *event};
         return true;

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -123,6 +123,15 @@ constexpr std::string_view schemaRefused = "SCP005";
     const auto       name   = [&](std::string_view field) {
         return document.intern(textOf(source, field));
     };
+    // Semantic analysis has already refused any spelling outside the set with MEDUI-E034, so a
+    // failure here would mean the two disagree. `Unspecified` then reaches `validate()`, which
+    // refuses it - a loud stop rather than a screen carrying a member it was not given.
+    const auto clockFormat = [&](std::string_view field) {
+        return ms::clockFormatFromWire(textOf(source, field)).value_or(ms::ClockFormat::Unspecified);
+    };
+    const auto systemEvent = [&](std::string_view field) {
+        return ms::systemEventFromWire(textOf(source, field)).value_or(ms::SystemEvent::Unspecified);
+    };
 
     // The only synthetic node the solver produces, and the only way a Panel is ever compiled: an
     // author cannot write one, because `Panel` is not in the component dictionary.
@@ -133,7 +142,7 @@ constexpr std::string_view schemaRefused = "SCP005";
         return ms::LabelSpec{.textKey = name("text"), .colorToken = name("color")};
     }
     if (resolved.component == "Clock") {
-        return ms::ClockSpec{.format = name("format")};
+        return ms::ClockSpec{.format = clockFormat("format")};
     }
     if (resolved.component == "Image") {
         return ms::ImageSpec{.source = name("source")};
@@ -148,7 +157,8 @@ constexpr std::string_view schemaRefused = "SCP005";
         return ms::ButtonSpec{.labelKey = name("label"), .colorToken = name("color"), .source = name("source"), .requirement = name("requirement")};
     }
     if (resolved.component == "CriticalButton") {
-        return ms::CriticalButtonSpec{.requirement = name("requirement"), .labelKey = name("label"), .colorToken = name("color"), .onPress = name("on_press")};
+        return ms::CriticalButtonSpec{
+            .requirement = name("requirement"), .labelKey = name("label"), .colorToken = name("color"), .onPress = systemEvent("on_press")};
     }
     if (resolved.component == "NumericDisplay") {
         return ms::NumericDisplaySpec{.requirement = name("requirement"),
@@ -259,7 +269,7 @@ template <typename Rect>
         putName(spec, "colorToken", label->colorToken);
         putName(spec, "textKey", label->textKey);
     } else if (const auto* clock = std::get_if<ms::ClockSpec>(&payload)) {
-        putName(spec, "format", clock->format);
+        putName(spec, "format", ms::toWire(clock->format));
     } else if (const auto* image = std::get_if<ms::ImageSpec>(&payload)) {
         putName(spec, "source", image->source);
     } else if (const auto* viewport = std::get_if<ms::VulkanViewportSpec>(&payload)) {
@@ -275,7 +285,7 @@ template <typename Rect>
     } else if (const auto* critical = std::get_if<ms::CriticalButtonSpec>(&payload)) {
         putName(spec, "colorToken", critical->colorToken);
         putName(spec, "labelKey", critical->labelKey);
-        putName(spec, "onPress", critical->onPress);
+        putName(spec, "onPress", ms::toWire(critical->onPress));
         putName(spec, "requirement", critical->requirement);
     } else if (const auto* numeric = std::get_if<ms::NumericDisplaySpec>(&payload)) {
         putName(spec, "colorToken", numeric->colorToken);
@@ -699,7 +709,14 @@ readSpec(const json::Value& node, std::string_view kind, std::string_view what, 
         if (!format.has_value()) {
             return false;
         }
-        payload = ms::ClockSpec{.format = *format};
+        // A spelling outside the set fails the read rather than becoming `Unspecified`. The two are
+        // different faults - a package written by another tool versus one this reader mangled - and
+        // only refusing here keeps them apart.
+        const auto clockFormat = ms::clockFormatFromWire(*format);
+        if (!clockFormat.has_value()) {
+            return false;
+        }
+        payload = ms::ClockSpec{.format = *clockFormat};
         return true;
     }
     if (kind == "Image") {
@@ -761,7 +778,11 @@ readSpec(const json::Value& node, std::string_view kind, std::string_view what, 
         if (!requirement.has_value() || !labelKey.has_value() || !colorToken.has_value() || !onPress.has_value()) {
             return false;
         }
-        payload = ms::CriticalButtonSpec{.requirement = *requirement, .labelKey = *labelKey, .colorToken = *colorToken, .onPress = *onPress};
+        const auto event = ms::systemEventFromWire(*onPress);
+        if (!event.has_value()) {
+            return false;
+        }
+        payload = ms::CriticalButtonSpec{.requirement = *requirement, .labelKey = *labelKey, .colorToken = *colorToken, .onPress = *event};
         return true;
     }
     if (kind == "NumericDisplay") {

--- a/tools/medui/Semantic.cpp
+++ b/tools/medui/Semantic.cpp
@@ -13,6 +13,7 @@ import std;
 import mdux.text.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.ast;
+import mdux.medui.schema;
 import mdux.tools.medui.diagnostics;
 
 namespace mdux::tools::medui {
@@ -35,7 +36,7 @@ constexpr std::array criticalButtonFields{field("id", true, Identifier),
                                           field("height", true, Size),
                                           field("label", true, TextKey),
                                           field("color", true, ColorToken),
-                                          field("on_press", true, Identifier),
+                                          field("on_press", true, SystemEventName),
                                           field("position", false, Point)};
 constexpr std::array buttonFields{field("id", true, Identifier),
                                   field("width", true, Size),
@@ -81,7 +82,7 @@ constexpr std::array labelFields{field("id", true, Identifier),
 constexpr std::array clockFields{field("id", true, Identifier),
                                  field("width", true, Size),
                                  field("height", true, Size),
-                                 field("format", true, Identifier),
+                                 field("format", true, ClockFormatName),
                                  field("position", false, Point)};
 constexpr std::array imageFields{field("id", true, Identifier),
                                  field("width", true, Size),
@@ -157,8 +158,37 @@ constexpr std::array<ComponentRule, 11> componentRules{
             return value.kind == ast::ValueKind::ImageRef;
         case Number:
             return value.kind == ast::ValueKind::Number && value.number > 0;
+        case ClockFormatName:
+        case SystemEventName:
+            // Kind only. Membership is a separate check, so that a non-member is reported as one
+            // rather than as a value of the wrong kind.
+            return value.kind == ast::ValueKind::Identifier;
     }
     return false;
+}
+
+/// Whether an identifier names a member of the closed set the field admits.
+[[nodiscard]] bool isMember(std::string_view text, FieldDomain domain) noexcept {
+    switch (domain) {
+        case ClockFormatName:
+            return mdux::medui::clockFormatFromWire(text).has_value();
+        case SystemEventName:
+            return mdux::medui::systemEventFromWire(text).has_value();
+        default:
+            return true;
+    }
+}
+
+/// The members a closed-set field admits, listed in a diagnostic so the fix needs no other document.
+[[nodiscard]] std::string_view members(FieldDomain domain) noexcept {
+    switch (domain) {
+        case ClockFormatName:
+            return "TimeSeconds, DateTimeSeconds";
+        case SystemEventName:
+            return "NoOp, TriggerHalt";
+        default:
+            return {};
+    }
 }
 
 [[nodiscard]] std::string_view describe(FieldDomain domain) noexcept {
@@ -183,6 +213,9 @@ constexpr std::array<ComponentRule, 11> componentRules{
             return "img(\"ID\")";
         case Number:
             return "a positive integer";
+        case ClockFormatName:
+        case SystemEventName:
+            return "a named value";
     }
     return "the field's declared value domain";
 }
@@ -309,6 +342,13 @@ private:
                     report(Code::FieldValueKind,
                            fieldValue.value->position,
                            std::format("field '{}' requires {}", fieldValue.name, describe(fieldRule->domain)));
+                } else if (!isMember(fieldValue.value->text, fieldRule->domain)) {
+                    report(Code::NamedValueOutsideSet,
+                           fieldValue.value->position,
+                           std::format("'{}' is not a member of the set '{}' admits; the members are {}",
+                                       fieldValue.value->text,
+                                       fieldValue.name,
+                                       members(fieldRule->domain)));
                 }
             }
         }

--- a/tools/medui/Semantic.cppm
+++ b/tools/medui/Semantic.cppm
@@ -33,6 +33,11 @@ enum class FieldDomain : std::uint8_t {
     ColorTokenList,
     ImageRef,
     Number,
+    /// An identifier that must also be a member of a closed set the shared contract enumerates.
+    /// Kind and membership are separate failures: a wrong kind is `MEDUI-E033`, a non-member
+    /// `MEDUI-E034`, and an author fixes them differently.
+    ClockFormatName,
+    SystemEventName,
 };
 
 /// One field admitted by a component and the value form that field accepts.

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -12,6 +12,7 @@ module mdux.tools.medui.textbudget;
 
 import std;
 import mdux.font.schema;
+import mdux.medui.schema;
 import mdux.text.draw;
 import mdux.text.schema;
 import mdux.tools.cli;
@@ -35,10 +36,11 @@ struct DynamicField {
     std::string_view field;
 };
 
-constexpr std::array dynamicFields{
-    DynamicField{    .component = "Clock",  .field = "format"},
-    DynamicField{.component = "TextInput", .field = "charset"}
-};
+// `Clock` is deliberately absent. Its `format:` is a member of a closed set whose rendering the
+// shared contract fixes (MEDUI-DEC-006), so it is *measured* by `checkClockFormat()` rather than
+// resolved through a product-supplied table. `TextInput`'s `charset:` stays here because a glyph
+// set is still an open name, resolved against the packages a build bakes.
+constexpr std::array dynamicFields{DynamicField{.component = "TextInput", .field = "charset"}};
 
 [[nodiscard]] bool namesDynamicText(std::string_view component, std::string_view field) noexcept {
     return std::ranges::any_of(dynamicFields, [component, field](const DynamicField& entry) {
@@ -294,6 +296,8 @@ private:
                         checkTextKey(node, field, *element);
                     }
                 }
+            } else if (node.source.component == "Clock" && field.name == "format") {
+                checkClockFormat(node, field, *field.value);
             } else if (namesDynamicText(node.source.component, field.name)) {
                 checkDynamicText(field, *field.value);
             }
@@ -377,6 +381,78 @@ private:
         }
 
         return measureRun(*inputs_.font, locale.sidecar.subspan(static_cast<std::size_t>(run->byteOffset), static_cast<std::size_t>(run->byteLength)));
+    }
+
+    /**
+     * @brief Measures a clock against its node, from the rendering its format fixes.
+     *
+     * This is what closing `ClockFormat` bought. The contract pins each member's rendering, so the
+     * widest string a clock can draw is known here - `HH:MM:SS` is six digits and two colons - and
+     * the box can be checked at compile time instead of being trusted.
+     *
+     * The measurement is exact rather than an upper bound because the font package guarantees
+     * tabular figures: `FontPackage::validate()` requires every decimal digit it contains to share
+     * one advance width, so "the widest digit" is *the* digit. Without that rule this would have to
+     * assume the widest glyph in the set and would reject boxes that fit.
+     */
+    void checkClockFormat(const ResolvedNode& node, const ast::Field& field, const ast::Value& value) {
+        if (value.kind != ast::ValueKind::Identifier) {
+            return;  // MEDUI-E033, already reported by analyze().
+        }
+        const auto format = mdux::medui::clockFormatFromWire(value.text);
+        if (!format.has_value()) {
+            return;  // MEDUI-E034, already reported by analyze().
+        }
+
+        std::int64_t width{0};
+        std::int64_t height{0};
+        for (const char character : mdux::medui::rendering(*format)) {
+            // A digit position can hold any decimal digit, so it is measured as the widest one -
+            // which tabular figures make a single value. Every other character in a rendering is a
+            // literal separator and measures as itself.
+            const char32_t point = (character >= '0' && character <= '9') ? U'0' : static_cast<char32_t>(character);
+            const auto     glyph = std::ranges::find(inputs_.font->glyphs, point, &mdux::font::GlyphRecord::codePoint);
+            if (glyph == inputs_.font->glyphs.end()) {
+                report(Code::CharsetEscape,
+                       value.position,
+                       std::format("format '{}' renders U+{:04X}, which font package '{}' cannot draw",
+                                   value.text,
+                                   static_cast<std::uint32_t>(point),
+                                   inputs_.font->id));
+                return;
+            }
+            width  += static_cast<std::int64_t>(glyph->advanceWidth);
+            height  = std::max(height, static_cast<std::int64_t>(glyph->height));
+        }
+
+        // Font units to pixels, the same conversion `measureRun()` rests on. Integer throughout:
+        // this stage decides a compile outcome, and a rounding difference between host toolchains
+        // would make that outcome depend on the compiler.
+        const auto units      = static_cast<std::int64_t>(inputs_.font->unitsPerEm);
+        const auto pixelSize  = static_cast<std::int64_t>(inputs_.font->pixelSize);
+        const std::int64_t px = units == 0 ? 0 : (width * pixelSize) / units;
+
+        if (px > node.bounds.width) {
+            report(Code::TextBudgetExceeded,
+                   value.position,
+                   std::format("a '{}' clock renders '{}', which needs {}px of width, and '{}' resolved to {}px",
+                               value.text,
+                               mdux::medui::rendering(*format),
+                               px,
+                               node.id,
+                               node.bounds.width));
+        }
+        if (height > node.bounds.height) {
+            report(Code::TextBudgetExceeded,
+                   value.position,
+                   std::format("a '{}' clock renders '{}', which needs {}px of height, and '{}' resolved to {}px",
+                               value.text,
+                               mdux::medui::rendering(*format),
+                               height,
+                               node.id,
+                               node.bounds.height));
+        }
+        static_cast<void>(field);
     }
 
     /// Checks that a named dynamic-text source can only produce glyphs the font package holds.

--- a/tools/medui/TextBudget.cpp
+++ b/tools/medui/TextBudget.cpp
@@ -37,15 +37,50 @@ struct DynamicField {
 };
 
 // `Clock` is deliberately absent. Its `format:` is a member of a closed set whose rendering the
-// shared contract fixes (MEDUI-DEC-006), so it is *measured* by `checkClockFormat()` rather than
-// resolved through a product-supplied table. `TextInput`'s `charset:` stays here because a glyph
-// set is still an open name, resolved against the packages a build bakes.
-constexpr std::array dynamicFields{DynamicField{.component = "TextInput", .field = "charset"}};
+// shared contract fixes (MEDUI-DEC-006), so it is measured rather than resolved through a
+// product-supplied table. `TextInput`'s `charset:` stays here because a glyph set is still an open
+// name, resolved against the packages a build bakes.
+constexpr std::array dynamicFields{
+    DynamicField{.component = "TextInput", .field = "charset"}
+};
 
 [[nodiscard]] bool namesDynamicText(std::string_view component, std::string_view field) noexcept {
     return std::ranges::any_of(dynamicFields, [component, field](const DynamicField& entry) {
         return entry.component == component && entry.field == field;
     });
+}
+
+/// Whether a field carries a fixed rendering the compiler measures without a dynamic-text table.
+[[nodiscard]] bool carriesFixedText(std::string_view component, std::string_view field) noexcept {
+    return component == "Clock" && field == "format";
+}
+
+/// The five format-template letters that stand for a decimal digit rather than a literal glyph.
+[[nodiscard]] bool isClockDigitSlot(char character) noexcept {
+    return character == 'H' || character == 'M' || character == 'S' || character == 'Y' || character == 'D';
+}
+
+/// The possible code points at one position of a clock rendering.
+struct ClockSlot {
+    std::array<char32_t, 10> points{};
+    std::size_t              count{0};
+};
+
+[[nodiscard]] ClockSlot clockSlot(char character) noexcept {
+    ClockSlot slot;
+    if (isClockDigitSlot(character)) {
+        for (char32_t digit = U'0'; digit <= U'9'; ++digit) {
+            slot.points[slot.count++] = digit;
+        }
+    } else {
+        slot.points[slot.count++] = static_cast<char32_t>(character);
+    }
+    return slot;
+}
+
+/// Font units to pixels, using the half-up rule the text baker uses for every pen position.
+[[nodiscard]] std::int64_t toPixels(std::int64_t units, const mdux::font::FontPackage& font) noexcept {
+    return (units * static_cast<std::int64_t>(font.pixelSize) + static_cast<std::int64_t>(font.unitsPerEm) / 2) / static_cast<std::int64_t>(font.unitsPerEm);
 }
 
 /// Finds a component in the dictionary semantic analysis published, rather than a second copy of it.
@@ -197,6 +232,9 @@ private:
      */
     void checkFontCharset() const {
         constexpr std::uint32_t lastScalarValue = 0x10FFFF;
+        if (inputs_.font->unitsPerEm == 0 || inputs_.font->pixelSize == 0) {
+            throw std::logic_error(std::format("font package '{}' has no usable font-unit-to-pixel scale", inputs_.font->id));
+        }
         for (const mdux::font::CharsetRange& range : inputs_.font->restrictedCharset) {
             if (range.last < range.first) {
                 throw std::logic_error(std::format("font package '{}' declares a charset range from U+{:04X} down to U+{:04X}",
@@ -296,7 +334,7 @@ private:
                         checkTextKey(node, field, *element);
                     }
                 }
-            } else if (node.source.component == "Clock" && field.name == "format") {
+            } else if (carriesFixedText(node.source.component, field.name)) {
                 checkClockFormat(node, field, *field.value);
             } else if (namesDynamicText(node.source.component, field.name)) {
                 checkDynamicText(field, *field.value);
@@ -387,13 +425,14 @@ private:
      * @brief Measures a clock against its node, from the rendering its format fixes.
      *
      * This is what closing `ClockFormat` bought. The contract pins each member's rendering, so the
-     * widest string a clock can draw is known here - `HH:MM:SS` is six digits and two colons - and
-     * the box can be checked at compile time instead of being trusted.
+     * widest shape a clock can draw is known here - `HH:MM:SS` is six digit slots and two colons -
+     * and the box can be checked at compile time instead of being trusted.
      *
-     * The measurement is exact rather than an upper bound because the font package guarantees
-     * tabular figures: `FontPackage::validate()` requires every decimal digit it contains to share
-     * one advance width, so "the widest digit" is *the* digit. Without that rule this would have to
-     * assume the widest glyph in the set and would reject boxes that fit.
+     * Equal digit advances stop the clock from jittering, but they do not make digit ink identical:
+     * bitmap origins and dimensions may differ, and a package may carry kerning. The envelope below
+     * therefore considers all ten digits at every placeholder and the full rendered geometry. Its
+     * extrema may come from different clock values, making it conservative rather than falsely
+     * exact; that is the fail-closed direction for a compile-time bound.
      */
     void checkClockFormat(const ResolvedNode& node, const ast::Field& field, const ast::Value& value) {
         if (value.kind != ast::ValueKind::Identifier) {
@@ -404,51 +443,97 @@ private:
             return;  // MEDUI-E034, already reported by analyze().
         }
 
-        std::int64_t width{0};
-        std::int64_t height{0};
-        for (const char character : mdux::medui::rendering(*format)) {
-            // A digit position can hold any decimal digit, so it is measured as the widest one -
-            // which tabular figures make a single value. Every other character in a rendering is a
-            // literal separator and measures as itself.
-            const char32_t point = (character >= '0' && character <= '9') ? U'0' : static_cast<char32_t>(character);
-            const auto     glyph = std::ranges::find(inputs_.font->glyphs, point, &mdux::font::GlyphRecord::codePoint);
-            if (glyph == inputs_.font->glyphs.end()) {
-                report(Code::CharsetEscape,
-                       value.position,
-                       std::format("format '{}' renders U+{:04X}, which font package '{}' cannot draw",
-                                   value.text,
-                                   static_cast<std::uint32_t>(point),
-                                   inputs_.font->id));
-                return;
+        const std::string_view rendering = mdux::medui::rendering(*format);
+        std::int64_t           penMin{0};
+        std::int64_t           penMax{0};
+        std::int64_t           left{0};
+        std::int64_t           right{0};
+        std::int64_t           top{0};
+        std::int64_t           bottom{0};
+        bool                   inked{false};
+
+        for (std::size_t index = 0; index < rendering.size(); ++index) {
+            const ClockSlot slot = clockSlot(rendering[index]);
+            std::int64_t    minAdvance{std::numeric_limits<std::int64_t>::max()};
+            std::int64_t    maxAdvance{0};
+
+            for (std::size_t candidate = 0; candidate < slot.count; ++candidate) {
+                const char32_t                 point = slot.points[candidate];
+                const mdux::font::GlyphRecord* glyph = inputs_.font->find(point);
+                if (glyph == nullptr) {
+                    report(Code::CharsetEscape,
+                           value.position,
+                           std::format("format '{}' can render U+{:04X}, which font package '{}' cannot draw",
+                                       value.text,
+                                       static_cast<std::uint32_t>(point),
+                                       inputs_.font->id));
+                    return;
+                }
+
+                minAdvance = std::min(minAdvance, static_cast<std::int64_t>(glyph->advanceWidth));
+                maxAdvance = std::max(maxAdvance, static_cast<std::int64_t>(glyph->advanceWidth));
+                if (glyph->isBlank()) {
+                    continue;
+                }
+
+                const std::int64_t glyphLeft   = toPixels(penMin, *inputs_.font) + glyph->bitmapOriginX;
+                const std::int64_t glyphRight  = toPixels(penMax, *inputs_.font) + glyph->bitmapOriginX + glyph->width;
+                const std::int64_t glyphTop    = -static_cast<std::int64_t>(glyph->bitmapOriginY);
+                const std::int64_t glyphBottom = glyphTop + glyph->height;
+                if (!inked) {
+                    left   = glyphLeft;
+                    right  = glyphRight;
+                    top    = glyphTop;
+                    bottom = glyphBottom;
+                    inked  = true;
+                } else {
+                    left   = std::min(left, glyphLeft);
+                    right  = std::max(right, glyphRight);
+                    top    = std::min(top, glyphTop);
+                    bottom = std::max(bottom, glyphBottom);
+                }
             }
-            width  += static_cast<std::int64_t>(glyph->advanceWidth);
-            height  = std::max(height, static_cast<std::int64_t>(glyph->height));
+
+            if (index + 1 < rendering.size()) {
+                const ClockSlot next = clockSlot(rendering[index + 1]);
+                std::int64_t    minKerning{std::numeric_limits<std::int64_t>::max()};
+                std::int64_t    maxKerning{std::numeric_limits<std::int64_t>::min()};
+                for (std::size_t current = 0; current < slot.count; ++current) {
+                    for (std::size_t following = 0; following < next.count; ++following) {
+                        const std::int64_t adjustment = inputs_.font->kerningFor(slot.points[current], next.points[following]);
+                        minKerning                    = std::min(minKerning, adjustment);
+                        maxKerning                    = std::max(maxKerning, adjustment);
+                    }
+                }
+                penMin += minAdvance + minKerning;
+                penMax += maxAdvance + maxKerning;
+                if (penMin < 0) {
+                    report(Code::CharsetEscape,
+                           value.position,
+                           std::format("format '{}' can move its pen left of the clock origin with font package '{}'", value.text, inputs_.font->id));
+                    return;
+                }
+            }
         }
 
-        // Font units to pixels, the same conversion `measureRun()` rests on. Integer throughout:
-        // this stage decides a compile outcome, and a rounding difference between host toolchains
-        // would make that outcome depend on the compiler.
-        const auto units      = static_cast<std::int64_t>(inputs_.font->unitsPerEm);
-        const auto pixelSize  = static_cast<std::int64_t>(inputs_.font->pixelSize);
-        const std::int64_t px = units == 0 ? 0 : (width * pixelSize) / units;
-
-        if (px > node.bounds.width) {
+        const TextExtent extent{.width = inked ? right - left : 0, .height = inked ? bottom - top : 0};
+        if (extent.width > node.bounds.width) {
             report(Code::TextBudgetExceeded,
                    value.position,
                    std::format("a '{}' clock renders '{}', which needs {}px of width, and '{}' resolved to {}px",
                                value.text,
-                               mdux::medui::rendering(*format),
-                               px,
+                               rendering,
+                               extent.width,
                                node.id,
                                node.bounds.width));
         }
-        if (height > node.bounds.height) {
+        if (extent.height > node.bounds.height) {
             report(Code::TextBudgetExceeded,
                    value.position,
                    std::format("a '{}' clock renders '{}', which needs {}px of height, and '{}' resolved to {}px",
                                value.text,
-                               mdux::medui::rendering(*format),
-                               height,
+                               rendering,
+                               extent.height,
                                node.id,
                                node.bounds.height));
         }
@@ -561,7 +646,7 @@ bool needsTextBudget(const ast::Screen& screen) {
             }
             // Asked through the same predicate the measuring pass uses, so a third dynamic-text
             // field reaches this question without anyone having to remember it.
-            if (namesDynamicText(node.component, field.name)) {
+            if (carriesFixedText(node.component, field.name) || namesDynamicText(node.component, field.name)) {
                 return true;
             }
         }

--- a/tools/medui/TextBudget.cppm
+++ b/tools/medui/TextBudget.cppm
@@ -234,14 +234,14 @@ struct TextBudgetResult {
 /**
  * @brief Whether this screen has anything for the budget stage to measure.
  *
- * True when the screen carries a text key, or a field whose value names a dynamic-text source -
- * `Clock`'s `format:` and `TextInput`'s `charset:`, the two the table in this module's
- * implementation lists. Both are things `checkTextBudgets()` checks and nothing else does.
+ * True when the screen carries a text key, a fixed rendering such as `Clock.format`, or a field
+ * whose value names a dynamic-text source such as `TextInput.charset`. All three are things
+ * `checkTextBudgets()` checks and nothing else does.
  *
  * Exported so a compiler driver can decide whether a recipe *must* supply a font package and its
- * approved locales, rather than deciding by inspecting the screen itself. The list of dynamic-text
- * fields would otherwise exist in two places, and the second copy is the one that would go stale the
- * day a third field joins them.
+ * approved locales, rather than deciding by inspecting the screen itself. The predicates for fixed
+ * and dynamic text would otherwise exist in two places, and the second copy is the one that would go
+ * stale the day another field joins them.
  */
 [[nodiscard]] bool needsTextBudget(const ast::Screen& screen);
 


### PR DESCRIPTION
## Summary

Close `Clock.format` and `CriticalButton.on_press` as typed sets throughout the schema, semantic analysis, package format, generated code, and text-budget stage. This implements the contract fixed by Compliatory/MedUI MEDUI-DEC-006 and closes #219.

The contract now distinguishes an omitted member, an out-of-range typed value, a wrong source kind, and an unknown well-formed spelling. Clock renderings are fixed by their `ClockFormat`; `TextInput.charset` remains an open, product-supplied name.

The review corrections in `6af4fa1` additionally:

- ensure a Clock-only screen selects the text-budget stage;
- interpret `H`, `M`, `S`, `Y`, and `D` as decimal digit slots rather than literal glyphs;
- measure a conservative rendered-ink envelope, including bitmap origins, dimensions, advances, and kerning, so overhanging glyphs cannot pass an advance-only check;
- emit actionable `SCP002` diagnostics for unknown `ClockFormat` and `SystemEvent` package spellings;
- cover valid, unspecified, and out-of-range typed members in schema tests; and
- synchronize ADR-012 and the MedUI authoring skill with the closed-member contract and pinned conformance revision.

`medui-conformance.toml` remains pinned to `265df19`, where the four new conformance cases live.

## Invitation and contributor agreement

- [ ] I was invited by a maintainer to contribute this change. *(Not applicable: the repository owner/maintainer authored issue #219 and this PR.)*
- [ ] I accepted the repository's Contributor Licence Agreement in the GitHub issue identified below. *(Not applicable to the repository owner.)*

Invitation / CLA issue: #219 (implementation issue; no separate invitation/CLA issue)

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`
- [x] None of the above

## Rebase state

- **Rebased onto:** `682206eba2e1271506015254c185aaeb3e3e03a2`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run locally; CI covers GCC 16
- [ ] `ctest --test-dir build-gcc` — not run locally; CI covers GCC 16
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 82 files checked, 0 findings
- [x] Other: `cmake --build build-macos-clang` — passed with the repository's configured upstream Clang 21.1.8 toolchain
- [x] Other: four focused correction scenarios — 4/4 passed
- [ ] Other: selected MedUI suites — 155/165 passed locally; the remaining ten are the documented macOS 26.5.2 compiler/runtime anomaly.
- [x] Other: PR CI for `6af4fa1` — all required checks passed, including Linux Clang 21, Linux GCC 16, Windows MSVC, macOS 15 arm64, ASan/UBSan, CodeQL, security, compliance/documentation, evidence, and OSV checks.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green. *(Not applicable before merge; there is no successor.)*

## Regulatory impact

Safety-relevant compiler validation is affected: this change restores fail-closed compile-time text-bound enforcement for Clock-only screens and makes package rejection observable through diagnostics. Tests cover stage selection, placeholder expansion, rendered-ink overhang, package diagnostics, and typed-member validation. ADR-012 and the authoring guidance were updated for traceability. This is implementation and verification evidence for an experimental proof of concept; it does not establish certification, validation, production readiness, or regulatory compliance.
