### PR TITLE
Check a rendered frame against the screen that produced it [#252]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ code*; treat this subsection as the direction that code is moving in.
 | `mdux.ml.kernels` (governed) | `include/mdux/ml/Kernels.cppm` | `src/ml/Kernels.cpp` |
 | `mdux.ml.runtime` (governed) | `include/mdux/ml/Runtime.cppm` | `src/ml/Runtime.cpp` |
 | `mdux.draw` (governed) | `include/mdux/draw/Draw.cppm` | `src/draw/Draw.cpp` |
+| `mdux.verify` (governed) | `include/mdux/verify/Verify.cppm` | `src/verify/Verify.cpp` |
 | `mdux.render.vulkan`, `mdux.render.offscreen` (adapter) | `include/mdux/render/` | `src/render/` |
 | `mdux.vulkansc.memory` | `include/mdux/vulkansc/MemoryPoolManager.cppm` | `src/vulkansc/MemoryPoolManager.cpp` |
 | `mdux.vulkansc.objects` (imports `mdux.vulkansc.memory`) | `include/mdux/vulkansc/DeviceObjectManager.cppm` | `src/vulkansc/DeviceObjectManager.cpp` |
@@ -235,11 +236,12 @@ look-alike command line; they are not needed to build by hand, and each uses its
   GCC 15 ICE guard was removed when the floor rose to GCC 16); `EcgClassifierExample` (epic #18 -
   links `MduX::Core`, needs no Vulkan or window, consumes generated `constexpr` model metadata, and
   embeds only its weight blob with `mdux_embed_blob()`)
-- Tests: sixteen executables. Nine on the in-repository MduXTest framework (`core_tests`,
+- Tests: twenty-three executables. Nine on the in-repository MduXTest framework (`core_tests`,
   `evidence_tests`, `tools_tests`, `unit_tests`, `compliance_tests`, `render_tests`,
-  `offscreen_tests`, `vulkansc_memory_tests`, `vulkansc_object_tests`) and seven on SpecLab
+  `offscreen_tests`, `vulkansc_memory_tests`, `vulkansc_object_tests`) and fourteen on SpecLab
   (`shader_spec`, `draw_spec`, `tools_spec`, `bridge_spec`, `ml_spec`, `ml_tools_spec`,
-  `ml_noheap_spec`) — see ADR-009. `mdux_discover_tests()` registers one CTest entry per case, so
+  `ml_noheap_spec`, `font_spec`, `text_spec`, `text_tools_spec`, `medui_spec`,
+  `medui_tools_spec`, `medui_noheap_spec`, `verify_spec`) — see ADR-009. `mdux_discover_tests()` registers one CTest entry per case, so
   `ctest -R <scenario>` selects an individual test.
 - Test labels, which the CI steps select on: `evidence` (a committed artifact is byte-identical to
   a freshly baked one, and nothing else carries it), `evidence-unit`, `determinism`, `noheap`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ target_sources(MduXCore
             include/mdux/text/Schema.cppm
             include/mdux/medui/Schema.cppm
             include/mdux/medui/Screen.cppm
+            include/mdux/verify/Verify.cppm
     PRIVATE
         src/evidence/Digest.cpp
         src/evidence/Json.cpp
@@ -279,6 +280,7 @@ target_sources(MduXCore
         src/text/Draw.cpp
         src/text/Schema.cpp
         src/medui/Screen.cpp
+        src/verify/Verify.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp
         src/governance/Program.cpp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,7 @@ are ordinary `PRIVATE` sources.
 | `mdux.ml.runtime` | `include/mdux/ml/Runtime.cppm` | `src/ml/Runtime.cpp` |
 | `mdux.medui.schema` | `include/mdux/medui/Schema.cppm` | header-only |
 | `mdux.medui.screen` | `include/mdux/medui/Screen.cppm` | `src/medui/Screen.cpp` |
+| `mdux.verify` | `include/mdux/verify/Verify.cppm` | `src/verify/Verify.cpp` |
 
 `mdux.core.result` is a naming alias over `std::expected`, not a reimplementation
 ([ADR-005](adr/ADR-005-error-handling-and-exceptions-policy.md)).
@@ -209,7 +210,7 @@ from anywhere — including through a dependency's interface options.
 ## Tests
 
 Two frameworks, one discovery contract ([ADR-009](adr/ADR-009-in-repository-test-framework.md)):
-the in-repository `MduXTest` across nine executables, and SpecLab for Given/When/Then across seven.
+the in-repository `MduXTest` across nine executables, and SpecLab for Given/When/Then across fourteen.
 `mdux_discover_tests()` registers one CTest entry per case, so a failure names the scenario rather
 than the binary.
 

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -318,9 +318,20 @@ inline constexpr std::array<ThemeColor, 8> themeColors{
  * against the same token. Two copies of this arithmetic would agree until the day one of them
  * rounded differently, and the failure would read as a rendering defect rather than as the drift it
  * was.
+ *
+ * **NaN is mapped to zero rather than clamped.** A NaN compares false against every bound, so the
+ * two clamps below would both let it through and the conversion to `std::uint8_t` would be undefined
+ * - which is a poor way for a governed function to answer a question. `!(channel >= 0.0F)` is the
+ * one test that catches it and negatives together. Zero because a channel this function cannot
+ * interpret contributes nothing, and because the alternative is an error path on a function whose
+ * only production input is a `constexpr` table of literals: the value is unreachable through
+ * `resolveColorToken()`, and being total costs one comparison.
  */
 [[nodiscard]] constexpr std::uint8_t quantise(float channel) noexcept {
-    const float clamped = channel < 0.0F ? 0.0F : (channel > 1.0F ? 1.0F : channel);
+    if (!(channel >= 0.0F)) {
+        return 0;
+    }
+    const float clamped = channel > 1.0F ? 1.0F : channel;
     const float scaled  = clamped * 255.0F;
     const float rounded = scaled + 0.5F;
     return static_cast<std::uint8_t>(rounded);

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -84,6 +84,7 @@ export module mdux.medui.schema;
 
 import std;
 import mdux.core.result;
+import mdux.core.units;
 import mdux.draw;
 import mdux.evidence.digest;
 import mdux.evidence.report;
@@ -297,6 +298,37 @@ inline constexpr std::array<ThemeColor, 8> themeColors{
         }
     }
     return mdux::core::err(ThemeError::UnknownToken);
+}
+
+/**
+ * @brief A linear channel as the byte an `R8G8B8A8_UNORM` target carries.
+ *
+ * Quantisation and nothing else: the governed table stores linear RGBA, a vertex colour is read by
+ * the shader as a plain 0..1 UNORM value, so the byte is the linear value scaled. No transfer
+ * function is applied here, because whether the *swapchain* is sRGB is the renderer's decision and
+ * applying one in two places is how a colour ends up encoded twice.
+ *
+ * The multiply and the add are separate statements so that neither the rounding nor the result
+ * depends on whether the compiler fuses them. `mdux_enforce_fp_determinism(MduXCore)` already turns
+ * contraction off for this target, and this is the belt to that pair of braces: a frame that is
+ * byte-compared across toolchains cannot afford a last-bit difference in a colour.
+ *
+ * Exported rather than kept private to the runtime, and that move is #252's rather than tidiness.
+ * The runtime turns a token into the bytes a frame carries; the verifier compares those bytes back
+ * against the same token. Two copies of this arithmetic would agree until the day one of them
+ * rounded differently, and the failure would read as a rendering defect rather than as the drift it
+ * was.
+ */
+[[nodiscard]] constexpr std::uint8_t quantise(float channel) noexcept {
+    const float clamped = channel < 0.0F ? 0.0F : (channel > 1.0F ? 1.0F : channel);
+    const float scaled  = clamped * 255.0F;
+    const float rounded = scaled + 0.5F;
+    return static_cast<std::uint8_t>(rounded);
+}
+
+/// The governed table's linear RGBA as the quantised colour a frame actually shows.
+[[nodiscard]] constexpr mdux::core::ColorRgba8 quantise(const std::array<float, 4>& linear) noexcept {
+    return mdux::core::ColorRgba8{.r = quantise(linear[0]), .g = quantise(linear[1]), .b = quantise(linear[2]), .a = quantise(linear[3])};
 }
 
 /**

--- a/include/mdux/verify/Verify.cppm
+++ b/include/mdux/verify/Verify.cppm
@@ -1,0 +1,766 @@
+/**
+ * @file Verify.cppm
+ * @brief Rendered-truth checks: four pure functions over a CPU framebuffer and an artifact-derived
+ *        expectation, answering whether a frame shows what the compiled screen said it would.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ *
+ * Part of MduXCore, and that placement is ADR-014 decision 1 rather than an inheritance: the checks
+ * have the same shape as the screen runtime - bounded arithmetic over caller-owned storage, no
+ * allocation, no throw, no file - and putting them in the governed zone is what turns "the verifier
+ * does no work a device could not do" from a convention into a lint result. `mdux-governed-lint`
+ * and `governed.noThrow.symbolScan` cover this module with no second registration.
+ *
+ * **The driver is not here.** Rendering a frame, reading `goldens.json`, enumerating obligations and
+ * writing `verification.json` are what ADR-004 and ADR-005 keep out of this zone; they are #253's
+ * and #254's, and they call in. What this module owns is the four questions themselves.
+ *
+ * ## The four checks, and which are opt-in
+ *
+ * - **`goldenBounds()`** - the golden node's rendered content occupies the declared rectangle;
+ * - **`colorHash()`** - that content carries the tint its colour token resolves to;
+ * - **`inkContainment()`** - a compiled text node's run stays inside its node bounds;
+ * - **`localizedTextPresence()`** - the approved locale's bound run is the one on screen.
+ *
+ * The first two are `Bounds` and `ColorHash`, the closed `CvCheck` set an author opts into per node.
+ * That set belongs to the shared language's `safety` capability, pinned in `medui-conformance.toml`,
+ * and `MEDUI-E071` rejects a name outside it - so widening it is an upstream change and a re-pin,
+ * never an edit here. `CvCheck` is *defined* in this module and aliased by
+ * `mdux.tools.medui.goldens` rather than declared twice, for the reason ADR-012 decision 4 gives
+ * about the golden predicate: two implementations of one closed set agree until the day they matter.
+ *
+ * The last two are **not** opt-in and are deliberately not `CvCheck` enumerators. They apply to
+ * every compiled node whose spec carries a `textKey`, in every approved locale, whether or not that
+ * node has a golden entry. A glyph run leaving the box that was budgeted for it is a defect however
+ * the author annotated the node, and #195 already measured that box at compile time - these are the
+ * same claim, verified against pixels.
+ *
+ * ## What a check is given, and what it may never be given
+ *
+ * A check takes a `FramebufferView` - bytes, extent, row stride, format - and one of two expectation
+ * views. Both views are read-only, caller-owned, and obtainable only through a `create()` that
+ * resolves them against a compiled screen; neither carries a Vulkan type, allocates, throws or opens
+ * a file. The GPU's involvement ended at the readback that already exists in
+ * `mdux.render.offscreen`.
+ *
+ * ADR-014 decision 2 is the rule the `create()` functions enforce: **every expectation is derived
+ * from a committed artifact, and none is supplied by the caller.** A golden expectation is built
+ * from a `goldens.json` entry *and* the compiled node it names, and it fails closed when the id does
+ * not resolve or when the entry's duplicated bounds, text key or colour token disagree with that
+ * node. A text expectation is built from the compiled node, the approved locale, the run the
+ * approved text package binds and the font package it was baked against. A production caller has
+ * exactly those sources. A unit test may construct a synthetic view to exercise a pure check, which
+ * is what makes the suite runnable with no GPU.
+ *
+ * The verifier **never re-applies ADR-011's golden predicate**. `collectGoldens()` is its single
+ * implementation, it runs in the baker while the AST still carries the predicate's inputs, and
+ * `evidence.screen.<id>` re-derives `goldens.json` and byte-compares it on all four automatic CI
+ * legs. A golden missing for a node the predicate selects fails four byte comparisons before it can
+ * reach this module. What this module owns is the other direction: a golden naming a node that does
+ * not exist, or naming one whose rectangle it does not agree with.
+ *
+ * ## Two resolved colours, and why one is not enough
+ *
+ * Both expectation views carry a **tint** and a **ground**, and both are resolved through the same
+ * governed table (`mdux::medui::resolveColorToken()`) rather than measured from any frame.
+ *
+ * The tint is what a check compares *against*: it is the colour the node's token names. The ground
+ * is what the frame would show at that node if the node painted nothing - the surface the driver
+ * cleared to, or the tint of the compiled panel underneath. Deciding whether a pixel was painted at
+ * all needs that second value, and no amount of knowing the tint supplies it: a node drawn in
+ * `Theme.Colors.Nominal` over a cleared surface and the same node not drawn at all differ only in
+ * what the untouched pixels are. The ground is a property of the screen and of the driver's own
+ * fixed clear colour, so it is still derived rather than argued - what it must never be is a value
+ * read back out of the frame under test, which would make every check compare a measurement against
+ * itself.
+ *
+ * With both in hand the two colour claims are exact, and stay exact without a tolerance:
+ *
+ * - a pixel the run or the node painted is an alpha blend of the tint over the ground, so each of
+ *   its channels lies **between** the ground's and the tint's. A painted pixel outside that closed
+ *   interval was painted by something else, and `Finding::ForeignColour` says so.
+ * - a **fully covered** pixel is exactly the tint, because coverage modulates alpha and never rgb.
+ *   So "carries its tint" is an equality rather than a proximity, which is the same discipline
+ *   `tests/render/PixelTests.cpp` applies to a whole frame: a one-channel difference is the smallest
+ *   wrong answer a renderer can give, and the one a tolerance would wave through.
+ *
+ * The cost of that second rule is stated rather than discovered: content that never reaches full
+ * coverage anywhere - a hairline trace, or a glyph run rasterised too small for any pixel to be
+ * solid - cannot be said to carry its tint, and `colorHash()` reports `TintAbsent` rather than
+ * passing on a blend. That is fail-closed in the direction this epic wants.
+ *
+ * ## What each check can see, and what it cannot
+ *
+ * Worth stating here rather than leaving a reader to infer it from the implementation, because the
+ * limits are structural rather than temporary.
+ *
+ * `goldenBounds()` asks whether the content inside the declared rectangle *is* that rectangle: the
+ * bounding box of everything painted there has to be the box the compiler resolved, edge for edge.
+ * ADR-014's worked example is what fixes that reading rather than the weaker "there is something in
+ * there" - "a unit test paints a rectangle into one and asserts that `GoldenBounds` passes, then
+ * moves it by a pixel and asserts that it fails", and only an equality fails on a rectangle that
+ * moved by one pixel while still overlapping its own box.
+ *
+ * Two consequences, both stated because a reader would otherwise meet them as surprises. Content
+ * that deliberately fills part of its node - digits inset in a `NumericDisplay`'s box - does not
+ * discharge `Bounds` against that node's rectangle, because the rectangle the golden pins is the
+ * node's; a component whose painted extent is smaller than its box needs a golden that says so, and
+ * that is a question for whoever gives such a component its geometry. And overflow *into a
+ * neighbour* is not attributable to this node at all: the committed screen packs
+ * `insufflation-pressure` and `ecg-lead-ii` edge to edge, so a band scanned outside the rectangle
+ * would report the neighbour's pixels as this node's spill. Attribution from a framebuffer alone is
+ * not available, and a check that guessed at it would fail on a correct screen - which trains a team
+ * to ignore it.
+ *
+ * `inkContainment()` compares the ink the committed run and font metrics *predict*, placed by the
+ * rule `mdux.medui.screen` fixes, against the ink the frame actually shows inside the node. A run
+ * whose predicted box leaves the node fails on the prediction; a frame that clipped, moved or lost
+ * the run fails on the comparison.
+ *
+ * `localizedTextPresence()` is the one that distinguishes one locale from another, and it does so
+ * per glyph: every non-blank record of the approved locale's run must have painted something inside
+ * its own placed rectangle, and every pixel of the node *outside* every such rectangle must still be
+ * the ground. The second half is what makes it a presence check rather than a plausibility check.
+ * The baked atlas slot is exactly the glyph's bitmap, so the renderer paints nothing outside it, and
+ * a different translation's run - different glyphs, different advances, different spaces - cannot
+ * satisfy both halves at this locale's rectangles. Its limit is the mirror of `goldenBounds()`': a
+ * second node overlapping this one would show up as ink where this locale's run paints none.
+ *
+ * ## No allocation, no throw, and a `create()` that cannot be brace-elided
+ *
+ * Every check is a bounded walk over the caller's pixels: the loops are over the node's rectangle
+ * and the run's records, both fixed before the check runs, and nothing is accumulated into storage
+ * this module owns. `FramebufferView`, `GoldenExpectation` and `TextExpectation` are classes with
+ * private members rather than aggregates, so `GoldenExpectation{...}` cannot brace-elide its way
+ * past the checks `create()` performs - the same guarantee, held the same way, as
+ * `mdux::medui::TextBinding`.
+ */
+module;
+
+export module mdux.verify;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.font.schema;
+import mdux.medui.schema;
+import mdux.medui.screen;
+import mdux.text.draw;
+
+export namespace mdux::verify {
+
+/**
+ * @brief Why an expectation could not be built, or a framebuffer could not be read.
+ *
+ * Distinct from `Finding`, and the split carries the distinction ADR-014 decision 3 requires CI to
+ * be able to make: a `VerifyError` says the check could not be *made*, a `Finding` says it was made
+ * and did not hold. A driver that collapsed the two would report a dangling golden id as a rendering
+ * defect, or worse, as a pass.
+ */
+enum class VerifyError : std::uint8_t {
+    EmptyFramebuffer,           ///< zero width or height; there is nothing to look at
+    UnsupportedFormat,          ///< the format is not one this module can decode
+    RowStrideTooSmall,          ///< a row cannot hold `width` pixels of the declared format
+    FramebufferTooSmall,        ///< the byte span is shorter than the declared extent needs
+    DanglingGoldenId,           ///< the golden names a node the compiled screen does not have
+    GoldenBoundsDisagree,       ///< the golden's rectangle is not the named node's rectangle
+    GoldenTextKeyDisagrees,     ///< the golden's text key is not the named node's
+    GoldenColorTokenDisagrees,  ///< the golden's colour token is not the named node's
+    NoChecksDeclared,           ///< the entry opts into nothing, so it can discharge nothing
+    ChecksNotCanonical,         ///< `cvChecks` is not sorted and deduplicated as the sidecar is
+    ColorHashWithoutTint,       ///< a `ColorHash` entry names no colour token to compare against
+    UnresolvedColorToken,       ///< the governed table does not define the named tint
+    NodeCarriesNoTextKey,       ///< a text obligation was raised over a node that draws no text
+    ScopeIsLocaleFree,          ///< a text obligation must name the approved locale it runs in
+    MalformedRun,               ///< the run's bytes are not a whole number of records
+    EmptyRun,                   ///< the approved locale's run paints nothing for this node
+    RunTooLong,                 ///< more records than `mdux::medui::maxGlyphsPerRun` admits
+    GlyphIndexOutOfRange,       ///< a record names a glyph the font package does not hold
+};
+
+[[nodiscard]] std::string_view describe(VerifyError error) noexcept;
+
+/**
+ * @brief The pixel formats a framebuffer may be read in.
+ *
+ * One entry, and it is the one `mdux.render.offscreen` reads back: `VK_FORMAT_R8G8B8A8_UNORM` maps
+ * onto `mdux::core::ColorRgba8` with no conversion and no channel swizzle. Named as an enumeration
+ * anyway, so that a second format arrives as a new enumerator and a refused `create()` rather than
+ * as a silently misread buffer.
+ */
+enum class PixelFormat : std::uint8_t {
+    Rgba8Unorm,
+};
+
+/// Bytes one pixel of `format` occupies.
+[[nodiscard]] constexpr std::size_t bytesPerPixel(PixelFormat format) noexcept {
+    switch (format) {
+        case PixelFormat::Rgba8Unorm:
+            return 4;
+    }
+    // Named rather than defaulted, so a new enumerator is a warning at this switch. Zero for an
+    // out-of-range cast, which `FramebufferView::create()` then refuses rather than dividing by.
+    return 0;
+}
+
+/**
+ * @brief A read-only CPU framebuffer: somebody else's pixels, described well enough to index.
+ *
+ * The whole of the GPU's contribution to verification, and deliberately the last of it. A caller
+ * hands over the span `OffscreenTarget::renderAndRead()` returned - or, in a unit test, an array it
+ * painted by hand - and every check from here on is arithmetic.
+ *
+ * Row stride is separate from width because a readback is not obliged to be tightly packed, and a
+ * check that assumed it was would read the next row's first pixels as this row's last ones: a
+ * plausible wrong answer rather than a failure.
+ */
+class FramebufferView {
+public:
+    /**
+     * @brief Describes `bytes` as a `width` x `height` image, or refuses.
+     *
+     * Refuses an empty extent, a stride too small to hold a row, a span too small to hold the image
+     * and a format outside the enumeration. Every `pixelAt()` on the result is therefore in range by
+     * construction rather than by the caller's discipline.
+     *
+     * The last row is allowed to be unpadded: the requirement is `(height - 1) * rowStride` plus one
+     * row of pixels, computed in 64-bit arithmetic so a hostile extent cannot wrap into admitting
+     * the buffer it should refuse.
+     */
+    [[nodiscard]] static mdux::core::Result<FramebufferView, VerifyError>
+    create(std::span<const std::byte> bytes, mdux::core::Px width, mdux::core::Px height, std::size_t rowStride, PixelFormat format) noexcept;
+
+    /// Describes `pixels` as a tightly packed `width` x `height` `Rgba8Unorm` image.
+    ///
+    /// The shape `OffscreenTarget::renderAndRead()` actually returns, so a driver does not restate
+    /// the stride and the format at every call site - and so a test painting an expectation does not
+    /// either.
+    [[nodiscard]] static mdux::core::Result<FramebufferView, VerifyError>
+    createPacked(std::span<const mdux::core::ColorRgba8> pixels, mdux::core::Px width, mdux::core::Px height) noexcept;
+
+    [[nodiscard]] constexpr mdux::core::Px width() const noexcept {
+        return width_;
+    }
+    [[nodiscard]] constexpr mdux::core::Px height() const noexcept {
+        return height_;
+    }
+    [[nodiscard]] constexpr std::size_t rowStride() const noexcept {
+        return rowStride_;
+    }
+    [[nodiscard]] constexpr PixelFormat format() const noexcept {
+        return format_;
+    }
+
+    /// Whether `rect` lies wholly inside this image. Non-positive extents are not inside anything.
+    [[nodiscard]] constexpr bool contains(mdux::medui::NodeRect rect) const noexcept {
+        if (rect.width <= 0 || rect.height <= 0 || rect.x < 0 || rect.y < 0) {
+            return false;
+        }
+        const auto right  = static_cast<std::int64_t>(rect.x) + rect.width;
+        const auto bottom = static_cast<std::int64_t>(rect.y) + rect.height;
+        return right <= static_cast<std::int64_t>(width_) && bottom <= static_cast<std::int64_t>(height_);
+    }
+
+    /// The pixel at (x, y), or nothing when it is outside the image.
+    ///
+    /// An optional rather than an index, for `OffscreenTarget::pixelAt()`'s reason: an out-of-range
+    /// read is a mistake in an expectation, and it should say so rather than compare whatever was
+    /// next in memory.
+    [[nodiscard]] std::optional<mdux::core::ColorRgba8> pixelAt(mdux::core::Px x, mdux::core::Px y) const noexcept;
+
+private:
+    constexpr FramebufferView(std::span<const std::byte> bytes, mdux::core::Px width, mdux::core::Px height, std::size_t rowStride, PixelFormat format) noexcept
+        : bytes_{bytes}, width_{width}, height_{height}, rowStride_{rowStride}, format_{format} {}
+
+    std::span<const std::byte> bytes_{};
+    mdux::core::Px             width_{0};
+    mdux::core::Px             height_{0};
+    std::size_t                rowStride_{0};
+    PixelFormat                format_{PixelFormat::Rgba8Unorm};
+};
+
+static_assert(!std::is_aggregate_v<FramebufferView>, "a FramebufferView must only be obtainable through create()");
+
+/**
+ * @brief A verification the shared language lets an author opt a node into.
+ *
+ * The closed set, defined here and aliased by `mdux.tools.medui.goldens` so that the compiler that
+ * writes `cvChecks` and the verifier that reads them cannot drift apart. Order is the serialisation
+ * order: a sidecar's `cvChecks` is sorted by this enumeration so that one screen has one canonical
+ * form.
+ *
+ * Widening this is an upstream change to the shared `safety` capability followed by a re-pin of
+ * `medui-conformance.toml`, never an edit here. In particular the two mandatory text checks are not
+ * members: they are not opt-in, and adding them to make the four checks symmetrical would put a
+ * local invention in a contract-owned set.
+ */
+enum class CvCheck : std::uint8_t {
+    Bounds,     ///< the node's content occupies the rectangle the compiler resolved
+    ColorHash,  ///< the node's content carries the tint its colour token resolves to
+};
+
+/// The spelling an author writes and the serialiser emits, e.g. `Bounds`.
+[[nodiscard]] constexpr std::string_view spell(CvCheck check) noexcept {
+    switch (check) {
+        case CvCheck::Bounds:
+            return "Bounds";
+        case CvCheck::ColorHash:
+            return "ColorHash";
+    }
+    return {};
+}
+
+/// The check `name` spells, or nothing when the name is not one of the closed set.
+///
+/// Nothing rather than a default is the whole point: ADR-014 decision 3 requires a driver to fail on
+/// an entry naming a check it does not know, because such an entry did not come from a compiler this
+/// repository builds.
+[[nodiscard]] constexpr std::optional<CvCheck> parseCvCheck(std::string_view name) noexcept {
+    if (name == spell(CvCheck::Bounds)) {
+        return CvCheck::Bounds;
+    }
+    if (name == spell(CvCheck::ColorHash)) {
+        return CvCheck::ColorHash;
+    }
+    return std::nullopt;
+}
+
+/**
+ * @brief A verification every compiled node carrying a `textKey` receives, in every approved locale.
+ *
+ * Separate from `CvCheck` because these are separate things: an author selects a `CvCheck`, and
+ * nobody selects one of these. Keeping the two types apart is what stops the mandatory pair from
+ * being written into a sidecar, and stops a golden from being required before a text node can be
+ * checked at all.
+ */
+enum class TextCheck : std::uint8_t {
+    InkContainment,         ///< the run's ink stays inside the node that names it
+    LocalizedTextPresence,  ///< the approved locale's bound run is the one on screen
+};
+
+/// The spelling a report uses, e.g. `InkContainment`.
+[[nodiscard]] constexpr std::string_view spell(TextCheck check) noexcept {
+    switch (check) {
+        case TextCheck::InkContainment:
+            return "InkContainment";
+        case TextCheck::LocalizedTextPresence:
+            return "LocalizedTextPresence";
+    }
+    return {};
+}
+
+/// How a locale-free render scope names itself in a report.
+inline constexpr std::string_view localeFreeScopeName = "(locale-free)";
+
+/**
+ * @brief One render scope: an approved locale, or the single locale-free scope a textless screen has.
+ *
+ * A type rather than a `std::string_view` that happens to be empty, because ADR-014 decision 3 makes
+ * the locale-free scope *explicit* and load-bearing: a textless screen's `Bounds` and `ColorHash`
+ * obligations would otherwise vanish in a Cartesian product with an empty locale set, and a run that
+ * verified nothing would report success. Spelling it as a named constructor is what makes "this
+ * screen has one scope, deliberately" something a reader sees rather than infers from an empty
+ * string.
+ */
+class RenderScope {
+public:
+    /// The one scope a screen carrying no text is rendered in.
+    [[nodiscard]] static constexpr RenderScope localeFree() noexcept {
+        return RenderScope{};
+    }
+
+    /// The scope for one approved locale, named by its BCP 47 tag.
+    ///
+    /// An empty tag names no locale, so it collapses to the locale-free scope rather than to a
+    /// locale called "". `TextExpectation::create()` then refuses it, which is where a caller that
+    /// lost a locale tag finds out.
+    [[nodiscard]] static constexpr RenderScope forLocale(std::string_view tag) noexcept {
+        return RenderScope{tag};
+    }
+
+    [[nodiscard]] constexpr bool isLocaleFree() const noexcept {
+        return tag_.empty();
+    }
+
+    /// The locale tag, empty for the locale-free scope.
+    [[nodiscard]] constexpr std::string_view tag() const noexcept {
+        return tag_;
+    }
+
+    /// What a report calls this scope: the tag, or `localeFreeScopeName`.
+    [[nodiscard]] constexpr std::string_view name() const noexcept {
+        return tag_.empty() ? localeFreeScopeName : tag_;
+    }
+
+    [[nodiscard]] constexpr bool operator==(const RenderScope&) const noexcept = default;
+
+private:
+    constexpr RenderScope() noexcept = default;
+    constexpr explicit RenderScope(std::string_view tag) noexcept : tag_{tag} {}
+
+    std::string_view tag_{};
+};
+
+/**
+ * @brief One entry of `goldens.json`, as a governed reader sees it.
+ *
+ * Spans and views over storage the caller owns - the parsed sidecar - so this module reads a golden
+ * without owning one. Members mirror the canonical JSON one for one, the same vocabulary
+ * `mdux::tools::medui::GoldenReference` writes: `textKey` and `colorToken` are empty when the node
+ * draws neither, and `cvChecks` is sorted and deduplicated.
+ *
+ * The duplication of `bounds`, `textKey` and `colorToken` between the sidecar and the compiled
+ * package is not redundancy to be trusted away. `GoldenExpectation::create()` requires every
+ * duplicated field to agree with the node the entry names, so a sidecar that drifted from the
+ * package addresses content no verifier could find, and says so on the first lookup.
+ */
+struct GoldenEntry {
+    std::string_view         nodeId{};
+    mdux::medui::NodeRect    bounds{};
+    std::string_view         textKey{};
+    std::string_view         colorToken{};
+    std::span<const CvCheck> cvChecks{};
+};
+
+/// The single static text key a node's compiled spec carries, or empty when it carries none.
+///
+/// The governed counterpart of the compiler's `textKeyOf()`, over a `CompiledNode` rather than an
+/// AST node, and selecting the same fields: a `Label`'s `textKey` and a `Button`'s or
+/// `CriticalButton`'s `labelKey`. A `StatusIndicator`'s `states:` is a list and is deliberately not
+/// read - the state on screen is the varying part - and a `TextInput`'s `source:` names live data
+/// rather than a key.
+[[nodiscard]] constexpr std::string_view textKeyOf(const mdux::medui::CompiledNode& node) noexcept {
+    if (const auto* label = std::get_if<mdux::medui::LabelSpec>(&node.payload); label != nullptr) {
+        return label->textKey;
+    }
+    if (const auto* button = std::get_if<mdux::medui::ButtonSpec>(&node.payload); button != nullptr) {
+        return button->labelKey;
+    }
+    if (const auto* critical = std::get_if<mdux::medui::CriticalButtonSpec>(&node.payload); critical != nullptr) {
+        return critical->labelKey;
+    }
+    return {};
+}
+
+/// The single colour token a node's compiled spec carries, or empty when it carries none or several.
+///
+/// The governed counterpart of the compiler's `colorTokenOf()`. A `StatusIndicator`'s `colors:` is
+/// one token per state, so which one is on screen is the varying part and none of them is the node's
+/// tint; that is the same rule that makes `collectGoldens()` refuse `ColorHash` for such a node.
+[[nodiscard]] constexpr std::string_view colorTokenOf(const mdux::medui::CompiledNode& node) noexcept {
+    if (const auto* panel = std::get_if<mdux::medui::PanelSpec>(&node.payload); panel != nullptr) {
+        return panel->colorToken;
+    }
+    if (const auto* label = std::get_if<mdux::medui::LabelSpec>(&node.payload); label != nullptr) {
+        return label->colorToken;
+    }
+    if (const auto* trace = std::get_if<mdux::medui::SignalTraceSpec>(&node.payload); trace != nullptr) {
+        return trace->colorToken;
+    }
+    if (const auto* button = std::get_if<mdux::medui::ButtonSpec>(&node.payload); button != nullptr) {
+        return button->colorToken;
+    }
+    if (const auto* critical = std::get_if<mdux::medui::CriticalButtonSpec>(&node.payload); critical != nullptr) {
+        return critical->colorToken;
+    }
+    if (const auto* numeric = std::get_if<mdux::medui::NumericDisplaySpec>(&node.payload); numeric != nullptr) {
+        return numeric->colorToken;
+    }
+    if (const auto* input = std::get_if<mdux::medui::TextInputSpec>(&node.payload); input != nullptr) {
+        return input->colorToken;
+    }
+    return {};
+}
+
+/**
+ * @brief One golden entry, resolved against the screen it describes, in one render scope.
+ *
+ * Obtainable only through `create()`, which is where ADR-014 decision 2's "derive, don't trust"
+ * stops being a slogan: the entry's node id is looked up in the compiled package, and every field
+ * the sidecar duplicates has to agree with what it found. A caller cannot amend any of it
+ * afterwards, and there is no constructor that skips the checks.
+ */
+class GoldenExpectation {
+public:
+    /**
+     * @brief Resolves `entry` against `screen`, or refuses.
+     *
+     * @param entry  one entry of the committed `goldens.json`
+     * @param screen the compiled screen the sidecar was emitted beside
+     * @param scope  the render scope this obligation is discharged in
+     * @param ground what this node's rectangle shows when the node paints nothing
+     *
+     * Refuses a dangling node id, a rectangle or a duplicated name that disagrees with the node, an
+     * empty or non-canonical `cvChecks`, a `ColorHash` with no colour token to compare against, and
+     * a colour token the governed table does not define.
+     *
+     * `ground` is the driver's resolved value - its fixed clear colour, or the tint of the compiled
+     * panel beneath this node - and never a colour read back out of the frame under test. See this
+     * file's header for why a check needs it as well as the tint.
+     */
+    [[nodiscard]] static mdux::core::Result<GoldenExpectation, VerifyError>
+    create(const GoldenEntry& entry, const mdux::medui::ScreenPackage& screen, RenderScope scope, mdux::core::ColorRgba8 ground) noexcept;
+
+    /// The compiled node the golden names. Never null for an expectation that exists.
+    [[nodiscard]] const mdux::medui::CompiledNode& node() const noexcept {
+        return *node_;
+    }
+    [[nodiscard]] std::string_view nodeId() const noexcept {
+        return node_->id;
+    }
+    /// The declared rectangle, which `create()` has proved is also the node's.
+    [[nodiscard]] mdux::medui::NodeRect bounds() const noexcept {
+        return node_->bounds;
+    }
+    [[nodiscard]] RenderScope scope() const noexcept {
+        return scope_;
+    }
+    [[nodiscard]] mdux::core::ColorRgba8 ground() const noexcept {
+        return ground_;
+    }
+    /// Whether a tint was resolved. False only for an entry that opts into `Bounds` alone and names
+    /// no colour token - a positioned `VulkanViewport`, say.
+    [[nodiscard]] bool hasTint() const noexcept {
+        return hasTint_;
+    }
+    /// The resolved tint. Meaningless unless `hasTint()`; `colorHash()` refuses to run without it.
+    [[nodiscard]] mdux::core::ColorRgba8 tint() const noexcept {
+        return tint_;
+    }
+    [[nodiscard]] std::span<const CvCheck> checks() const noexcept {
+        return checks_;
+    }
+    /// Whether the author opted this node into `check`.
+    [[nodiscard]] bool declares(CvCheck check) const noexcept {
+        return std::ranges::find(checks_, check) != checks_.end();
+    }
+
+private:
+    GoldenExpectation(const mdux::medui::CompiledNode* node,
+                      RenderScope                      scope,
+                      std::span<const CvCheck>         checks,
+                      mdux::core::ColorRgba8           ground,
+                      bool                             hasTint,
+                      mdux::core::ColorRgba8           tint) noexcept
+        : node_{node}, scope_{scope}, checks_{checks}, ground_{ground}, tint_{tint}, hasTint_{hasTint} {}
+
+    const mdux::medui::CompiledNode* node_{nullptr};
+    RenderScope                      scope_{RenderScope::localeFree()};
+    std::span<const CvCheck>         checks_{};
+    mdux::core::ColorRgba8           ground_{};
+    mdux::core::ColorRgba8           tint_{};
+    bool                             hasTint_{false};
+};
+
+static_assert(!std::is_aggregate_v<GoldenExpectation>, "a GoldenExpectation must only be obtainable through create()");
+
+/**
+ * @brief One compiled text node, in one approved locale, with the run that locale binds to it.
+ *
+ * The mandatory pair's view. It carries no golden entry and needs none: a `textKey` node's two
+ * obligations exist whether or not ADR-011's predicate selected it.
+ *
+ * The placement rule is not re-decided here. `mdux.medui.screen` puts the run's *ink* box at the
+ * node's top-left corner - the box #195 measured against that rectangle - and this view computes the
+ * same origin from the same records and the same font, so a check compares the frame against where
+ * the runtime would have drawn rather than against a second opinion about where text belongs.
+ */
+class TextExpectation {
+public:
+    /**
+     * @brief Binds `node` to the run `records` holds, or refuses.
+     *
+     * @param node    the compiled node whose spec carries a `textKey`
+     * @param scope   the approved locale this obligation is discharged in; never locale-free
+     * @param records the run's bytes, as the approved locale's text package addresses them
+     * @param font    the font package those records were baked against
+     * @param ground  what this node's rectangle shows where the run paints nothing
+     *
+     * Refuses a node that carries no text key, a locale-free scope, a partial run, a run longer than
+     * `mdux::medui::maxGlyphsPerRun`, a record naming a glyph the package does not hold, a node whose
+     * colour token does not resolve, and a run that paints no ink at all.
+     *
+     * The last refusal is a policy rather than an accident. A run whose glyphs are all blank - a
+     * single space - is legitimate for the runtime, which draws nothing and does not count the node
+     * as deferred. It is not something a rendered-truth obligation can discharge: there is no ink to
+     * find, so a pass would be indistinguishable from a screen that lost its text. ADR-014 decision
+     * 3 says a check this build cannot perform fails, so this refuses rather than passing vacuously,
+     * and the screen is what changes.
+     */
+    [[nodiscard]] static mdux::core::Result<TextExpectation, VerifyError> create(const mdux::medui::CompiledNode& node,
+                                                                                 RenderScope                      scope,
+                                                                                 std::span<const std::byte>       records,
+                                                                                 const mdux::font::FontPackage&   font,
+                                                                                 mdux::core::ColorRgba8           ground) noexcept;
+
+    [[nodiscard]] const mdux::medui::CompiledNode& node() const noexcept {
+        return *node_;
+    }
+    [[nodiscard]] std::string_view nodeId() const noexcept {
+        return node_->id;
+    }
+    [[nodiscard]] std::string_view textKey() const noexcept {
+        return textKeyOf(*node_);
+    }
+    [[nodiscard]] mdux::medui::NodeRect bounds() const noexcept {
+        return node_->bounds;
+    }
+    [[nodiscard]] RenderScope scope() const noexcept {
+        return scope_;
+    }
+    /// The approved locale's tag. Never empty: `create()` refuses a locale-free scope.
+    [[nodiscard]] std::string_view locale() const noexcept {
+        return scope_.tag();
+    }
+    [[nodiscard]] std::span<const std::byte> records() const noexcept {
+        return records_;
+    }
+    [[nodiscard]] const mdux::font::FontPackage& font() const noexcept {
+        return *font_;
+    }
+    [[nodiscard]] mdux::core::ColorRgba8 tint() const noexcept {
+        return tint_;
+    }
+    [[nodiscard]] mdux::core::ColorRgba8 ground() const noexcept {
+        return ground_;
+    }
+    /// How many records the run holds, blanks included.
+    [[nodiscard]] std::size_t glyphCount() const noexcept {
+        return records_.size() / mdux::text::draw::recordSize;
+    }
+    /// Where the run's ink lands once placed by the runtime's rule. Never empty.
+    [[nodiscard]] mdux::medui::NodeRect ink() const noexcept {
+        return ink_;
+    }
+    /// Where record `index` paints, or nothing when it is blank or out of range.
+    [[nodiscard]] std::optional<mdux::medui::NodeRect> glyphRect(std::size_t index) const noexcept;
+
+private:
+    TextExpectation(const mdux::medui::CompiledNode* node,
+                    RenderScope                      scope,
+                    std::span<const std::byte>       records,
+                    const mdux::font::FontPackage*   font,
+                    mdux::core::ColorRgba8           tint,
+                    mdux::core::ColorRgba8           ground,
+                    mdux::medui::NodeRect            ink,
+                    mdux::core::Px                   originX,
+                    mdux::core::Px                   originY) noexcept
+        : node_{node}, scope_{scope}, records_{records}, font_{font}, tint_{tint}, ground_{ground}, ink_{ink}, originX_{originX}, originY_{originY} {}
+
+    const mdux::medui::CompiledNode* node_{nullptr};
+    RenderScope                      scope_{RenderScope::localeFree()};
+    std::span<const std::byte>       records_{};
+    const mdux::font::FontPackage*   font_{nullptr};
+    mdux::core::ColorRgba8           tint_{};
+    mdux::core::ColorRgba8           ground_{};
+    mdux::medui::NodeRect            ink_{};
+    mdux::core::Px                   originX_{0};
+    mdux::core::Px                   originY_{0};
+};
+
+static_assert(!std::is_aggregate_v<TextExpectation>, "a TextExpectation must only be obtainable through create()");
+
+/**
+ * @brief What a check found, when it did not hold.
+ *
+ * One enumerator per way a frame can disagree with its expectation, rather than a single "failed":
+ * ADR-014 decision 1 says a failure has to be a sentence someone can act on, and "the region the
+ * golden pins shows nothing" and "the region shows something in the wrong colour" send a reader to
+ * different places.
+ */
+enum class Finding : std::uint8_t {
+    Held,                ///< the check passed
+    RegionOutsideFrame,  ///< the rectangle to inspect is not inside the framebuffer
+    NoTintToCompare,     ///< `colorHash()` was asked about an expectation that resolved no tint
+    NothingPainted,      ///< the rectangle shows the ground everywhere; nothing was drawn
+    BoundsDiffer,        ///< content is there, and its extent is not the declared rectangle
+    TintAbsent,          ///< content is there, and no pixel of it carries the resolved tint
+    ForeignColour,       ///< a painted pixel is not a blend of the ground and the resolved tint
+    InkLeftItsNode,      ///< the run's placed ink box is not inside the node's rectangle
+    InkExtentDiffers,    ///< the frame's ink is not where the committed run says it would be
+    GlyphMissing,        ///< a non-blank record of the approved run painted nothing
+    InkOutsideTheRun,    ///< the node shows ink where this locale's run paints none
+};
+
+[[nodiscard]] std::string_view describe(Finding finding) noexcept;
+
+/**
+ * @brief One obligation's result: what was expected, what was found, and where.
+ *
+ * Structured rather than a formatted string, because this module allocates nothing and a governed
+ * type that carried a message would have to. #253's driver renders these into the sentence ADR-014
+ * asks for; everything that sentence needs is here, including the render scope, so a reader can tell
+ * a failure in `de-DE` from the same node's pass in `en-US`.
+ *
+ * `found` is only meaningful for the findings that measured something. `expected` is always the
+ * rectangle the check was asked about.
+ */
+struct CheckOutcome {
+    Finding                finding{Finding::Held};
+    std::string_view       nodeId{};
+    std::string_view       scope{};     ///< the locale tag, or `localeFreeScopeName`
+    std::string_view       check{};     ///< the check's spelling, e.g. `Bounds`
+    mdux::medui::NodeRect  expected{};  ///< the rectangle the expectation named
+    mdux::medui::NodeRect  found{};     ///< what the frame showed, when the finding measured it
+    bool                   foundValid{false};
+    mdux::core::ColorRgba8 expectedColor{};
+    mdux::core::ColorRgba8 foundColor{};
+    bool                   foundColorValid{false};
+    std::size_t            glyphIndex{0};  ///< which record, for a glyph-level finding
+
+    [[nodiscard]] constexpr bool held() const noexcept {
+        return finding == Finding::Held;
+    }
+};
+
+/**
+ * @brief `Bounds`: the golden node's rendered content occupies the declared rectangle.
+ *
+ * The bounding box of everything painted inside the declared rectangle has to be that rectangle.
+ * Fails when the rectangle is not inside the frame, when it shows the ground everywhere - a node
+ * that vanished or was never drawn - and when what it shows does not reach every edge, which is what
+ * a node that moved looks like from inside its own box. `found` carries the extent that was actually
+ * measured, so a report says where the content was as well as where it should have been.
+ *
+ * What it cannot see is content that overflowed into a neighbouring node's rectangle; see this
+ * file's header for that limit and for the component whose partial fill this reading excludes.
+ */
+[[nodiscard]] CheckOutcome goldenBounds(const FramebufferView& frame, const GoldenExpectation& expectation) noexcept;
+
+/**
+ * @brief `ColorHash`: the golden node's rendered content carries the tint its token resolves to.
+ *
+ * Two claims, both exact. Every painted pixel lies channel-wise between the ground and the tint, so
+ * nothing in the rectangle was painted by something else; and at least one is exactly the tint, so
+ * the content really carries it rather than merely tending towards it.
+ *
+ * Refuses to run - `Finding::NoTintToCompare` - on an expectation that resolved no tint, rather than
+ * reporting a pass it did not establish.
+ */
+[[nodiscard]] CheckOutcome colorHash(const FramebufferView& frame, const GoldenExpectation& expectation) noexcept;
+
+/**
+ * @brief `InkContainment`: a compiled text node's run stays inside its node bounds.
+ *
+ * The compile-time claim #195 made, verified against pixels. The committed run and font metrics
+ * predict an ink box, the runtime's placement rule puts its corner on the node's corner, and this
+ * fails when that box leaves the node - and, separately, when the frame's ink inside the node is not
+ * the box the artifacts predicted, which is what a clipped, moved or partially drawn run looks like.
+ */
+[[nodiscard]] CheckOutcome inkContainment(const FramebufferView& frame, const TextExpectation& expectation) noexcept;
+
+/**
+ * @brief `LocalizedTextPresence`: the approved locale's bound run is the one on screen.
+ *
+ * Per glyph, in both directions: every non-blank record of this locale's run must have painted
+ * something inside its own placed rectangle, and every pixel of the node outside all of those
+ * rectangles must still be the ground. A different translation satisfies neither half at this
+ * locale's rectangles, which is what makes this a presence check rather than a plausibility one.
+ */
+[[nodiscard]] CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpectation& expectation) noexcept;
+
+}  // namespace mdux::verify

--- a/include/mdux/verify/Verify.cppm
+++ b/include/mdux/verify/Verify.cppm
@@ -908,8 +908,12 @@ struct CheckOutcome {
  *
  * Per glyph and per pixel, in both directions.
  *
- * Inside each placed glyph, every pixel must be what the *baked coverage* for that texel produces
- * when the node's tint is composited over the ground - `blend()`, within one UNORM step. That is the
+ * Inside the run's ink, every pixel must be what the *baked coverage* reaching it produces when the
+ * node's tint is composited over the ground - `blend()`, within one UNORM step per composite. Where
+ * two placed glyphs overlap, the coverages compose as `1 - (1 - a1)(1 - a2)`, because the draw path
+ * records one quad per glyph and blends them in turn and nothing in `FontPackage::validate()`
+ * requires an advance to clear its own bitmap. Comparing such a pixel against either glyph alone
+ * would fail a correct frame. That is the
  * half that makes this a claim about the approved run rather than about ink in the right boxes: a
  * texel the atlas leaves at zero must be exactly the ground, a fully covered one must be exactly the
  * tint, and every value between is pinned to the coverage the baker recorded. A different letter of
@@ -919,10 +923,10 @@ struct CheckOutcome {
  * Outside every placed glyph, every pixel of the node must still be the ground. The atlas slot is
  * exactly the glyph's bitmap, so a correct frame paints nothing there.
  *
- * The one-step allowance is for UNORM rounding and nothing else: the blend is computed in floating
- * point on the device and quantised back to eight bits, and two conforming implementations may
- * differ in the last bit. It is not a similarity threshold - a wrong shape misses by far more than
- * one step, and a wrong tint by more still.
+ * The allowance is for UNORM rounding and nothing else: the blend is computed in floating point on
+ * the device and quantised back to eight bits at every composite, so it is one step per glyph
+ * covering the pixel rather than a fixed slack. It is not a similarity threshold - a wrong shape
+ * misses by far more, and a wrong tint by more still.
  */
 [[nodiscard]] CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpectation& expectation) noexcept;
 

--- a/include/mdux/verify/Verify.cppm
+++ b/include/mdux/verify/Verify.cppm
@@ -42,19 +42,24 @@
  * ## What a check is given, and what it may never be given
  *
  * A check takes a `FramebufferView` - bytes, extent, row stride, format - and one of two expectation
- * views. Both views are read-only, caller-owned, and obtainable only through a `create()` that
- * resolves them against a compiled screen; neither carries a Vulkan type, allocates, throws or opens
- * a file. The GPU's involvement ended at the readback that already exists in
- * `mdux.render.offscreen`.
+ * views. Both views are read-only, caller-owned, and obtainable only through a factory that resolves
+ * them against a compiled screen; neither carries a Vulkan type, allocates, throws or opens a file.
+ * The GPU's involvement ended at the readback that already exists in `mdux.render.offscreen`.
  *
  * ADR-014 decision 2 is the rule the `create()` functions enforce: **every expectation is derived
  * from a committed artifact, and none is supplied by the caller.** A golden expectation is built
  * from a `goldens.json` entry *and* the compiled node it names, and it fails closed when the id does
  * not resolve or when the entry's duplicated bounds, text key or colour token disagree with that
- * node. A text expectation is built from the compiled node, the approved locale, the run the
- * approved text package binds and the font package it was baked against. A production caller has
- * exactly those sources. A unit test may construct a synthetic view to exercise a pure check, which
- * is what makes the suite runnable with no GPU.
+ * node. A text expectation is built from the screen, the node and a `mdux::medui::TextBinding` -
+ * the one type in this repository that has already proved the screen's manifest approves this
+ * locale, package id and canonical digest, that the text package was baked against this font, and
+ * that every run's range hashes to what the package recorded. It looks the run up by the node's own
+ * `textKey`; the caller supplies no locale, no bytes and no font.
+ *
+ * The one admitted exception is `TextExpectation::createSynthetic()`, which ADR-014 decision 1
+ * names and bounds in the same sentence: a unit test may construct a synthetic view to exercise a
+ * pure check, and production expectations have exactly the artifact sources decision 2 gives them.
+ * It establishes no provenance and says so; a driver reaching for it is a review finding on #253.
  *
  * The verifier **never re-applies ADR-011's golden predicate**. `collectGoldens()` is its single
  * implementation, it runs in the baker while the AST still carries the predicate's inputs, and
@@ -80,9 +85,13 @@
  *
  * With both in hand the two colour claims are exact, and stay exact without a tolerance:
  *
- * - a pixel the run or the node painted is an alpha blend of the tint over the ground, so each of
- *   its channels lies **between** the ground's and the tint's. A painted pixel outside that closed
- *   interval was painted by something else, and `Finding::ForeignColour` says so.
+ * - a pixel the run or the node painted is an alpha blend of the tint over the ground at **one**
+ *   coverage, so every channel has to agree on which coverage that was. Channel-wise membership of
+ *   the interval between ground and tint is necessary and is *not* sufficient: with a black ground
+ *   and `Theme.Colors.ScoreDigits`, the pixel `(33, 0, 107)` sits inside every channel's interval
+ *   while demanding full coverage of red and blue and none of green, which no blend can produce.
+ *   `colorHash()` therefore intersects the coverage interval each channel implies, in integer
+ *   cross-products, and reports `Finding::ForeignColour` when that intersection is empty.
  * - a **fully covered** pixel is exactly the tint, because coverage modulates alpha and never rgb.
  *   So "carries its tint" is an equality rather than a proximity, which is the same discipline
  *   `tests/render/PixelTests.cpp` applies to a whole frame: a one-channel difference is the smallest
@@ -122,13 +131,14 @@
  * the run fails on the comparison.
  *
  * `localizedTextPresence()` is the one that distinguishes one locale from another, and it does so
- * per glyph: every non-blank record of the approved locale's run must have painted something inside
- * its own placed rectangle, and every pixel of the node *outside* every such rectangle must still be
- * the ground. The second half is what makes it a presence check rather than a plausibility check.
- * The baked atlas slot is exactly the glyph's bitmap, so the renderer paints nothing outside it, and
- * a different translation's run - different glyphs, different advances, different spaces - cannot
- * satisfy both halves at this locale's rectangles. Its limit is the mirror of `goldenBounds()`': a
- * second node overlapping this one would show up as ink where this locale's run paints none.
+ * against the **baked coverage** rather than against the glyph boxes. Every pixel inside a placed
+ * glyph must be what that texel's coverage produces for this node's tint over its ground, and every
+ * pixel of the node outside every placed glyph must still be the ground. Metrics alone would only
+ * support "something is in the right rectangles", which a sparse handful of pixels satisfies and
+ * which two different letters of the same size satisfy equally - so the view carries the sheet, and
+ * the check compares the shape the approved run actually has. Its limit is the mirror of
+ * `goldenBounds()`': a second node overlapping this one would show up as ink where this locale's run
+ * paints none.
  *
  * ## No allocation, no throw, and a `create()` that cannot be brace-elided
  *
@@ -150,6 +160,7 @@ import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.medui.screen;
 import mdux.text.draw;
+import mdux.text.schema;
 
 export namespace mdux::verify {
 
@@ -180,6 +191,13 @@ enum class VerifyError : std::uint8_t {
     EmptyRun,                   ///< the approved locale's run paints nothing for this node
     RunTooLong,                 ///< more records than `mdux::medui::maxGlyphsPerRun` admits
     GlyphIndexOutOfRange,       ///< a record names a glyph the font package does not hold
+    TextBindingUnbound,         ///< the caller offered a binding carrying no packages
+    BindingNotApproved,         ///< the screen's manifest does not approve the bound package
+    NodeNotInScreen,            ///< the node is not one of this screen's, so nothing authorises it
+    ScopeIsNotTheBoundLocale,   ///< the render scope names a locale other than the bound package's
+    UnknownTextKey,             ///< the bound package carries no run for this node's text key
+    AtlasSizeMismatch,          ///< the coverage sheet is not the size the font package declares
+    GlyphOutsideAtlas,          ///< a glyph's slot leaves the coverage sheet
 };
 
 [[nodiscard]] std::string_view describe(VerifyError error) noexcept;
@@ -559,43 +577,129 @@ private:
 static_assert(!std::is_aggregate_v<GoldenExpectation>, "a GoldenExpectation must only be obtainable through create()");
 
 /**
+ * @brief The colour a coverage value paints when the tint is composited over the ground.
+ *
+ * The blend the coverage draw path performs, written down where a check can compute it:
+ * `result = tint * a + ground * (1 - a)`, with `a = (tint.a / 255) * (coverage / 255)`.
+ * `tests/render/TextPixelTests.cpp` derives its expectations from the same equation and compares
+ * them to real pixels with no tolerance under lavapipe and MoltenVK, so this is the repository's
+ * established statement of what a covered texel produces rather than a second opinion about it.
+ *
+ * Integer throughout, rounding to nearest: a governed check that reached for a float here would make
+ * its own answer depend on the host's rounding mode, which is the property ADR-007 exists to keep
+ * out of anything evidence-adjacent.
+ */
+[[nodiscard]] mdux::core::ColorRgba8 blend(mdux::core::ColorRgba8 ground, mdux::core::ColorRgba8 tint, std::uint8_t coverage) noexcept;
+
+/**
+ * @brief One placed glyph: where it paints, and which texels of the sheet it paints from.
+ *
+ * Both halves, because a check that had only the rectangle could establish that *something* was
+ * painted in the right box and nothing more - which is exactly the gap that made an earlier revision
+ * of `localizedTextPresence()` claim more than it verified.
+ */
+struct PlacedGlyph {
+    mdux::medui::NodeRect rect{};     ///< where it paints, in frame coordinates
+    std::uint32_t         atlasX{0};  ///< the slot's left edge in the coverage sheet
+    std::uint32_t         atlasY{0};  ///< the slot's top edge in the coverage sheet
+};
+
+/**
  * @brief One compiled text node, in one approved locale, with the run that locale binds to it.
  *
  * The mandatory pair's view. It carries no golden entry and needs none: a `textKey` node's two
  * obligations exist whether or not ADR-011's predicate selected it.
  *
- * The placement rule is not re-decided here. `mdux.medui.screen` puts the run's *ink* box at the
- * node's top-left corner - the box #195 measured against that rectangle - and this view computes the
- * same origin from the same records and the same font, so a check compares the frame against where
- * the runtime would have drawn rather than against a second opinion about where text belongs.
+ * ## Where its authority comes from
+ *
+ * A production expectation is built from a `mdux::medui::TextBinding` and the screen the obligation
+ * is about, and from nothing else. That is not a convenience: `TextBinding::create()` is the one
+ * place in this repository that proves the four artifacts agree - the screen's manifest approves
+ * this locale, package id and canonical digest; the text package was baked against this font; the
+ * sidecar is the one the package describes; and every run's range hashes to what the package
+ * recorded. An expectation that took a locale string and a span of bytes could be pointed at an
+ * unapproved translation and would then produce a *passing* verification outcome, which is a worse
+ * failure than a refusal because it ends up in an evidence artifact.
+ *
+ * So `create()` takes the binding, checks it against the screen and the node, and looks the run up
+ * by the node's own `textKey`. `createSynthetic()` exists beside it for the unit suite and
+ * establishes none of that - see its comment.
+ *
+ * ## The placement rule is not re-decided here
+ *
+ * `mdux.medui.screen` puts the run's *ink* box at the node's top-left corner - the box #195 measured
+ * against that rectangle - and this view computes the same origin from the same records and the same
+ * font, so a check compares the frame against where the runtime would have drawn rather than against
+ * a second opinion about where text belongs.
+ *
+ * ## The coverage sheet, and why the view carries it
+ *
+ * The glyph metrics say where a glyph paints; only the baked atlas says *what* it paints. A view
+ * holding metrics alone can support "something is inside this rectangle", which a sparse handful of
+ * pixels satisfies and which two different letters of the same size satisfy equally. Carrying the
+ * sheet is what lets `localizedTextPresence()` compare against the shape the approved run actually
+ * has, and it costs nothing on the device side: the bytes are the ones the renderer already uploaded
+ * as its atlas.
  */
 class TextExpectation {
 public:
     /**
-     * @brief Binds `node` to the run `records` holds, or refuses.
+     * @brief Raises this node's text obligation for the locale `binding` was proved against.
      *
-     * @param node    the compiled node whose spec carries a `textKey`
-     * @param scope   the approved locale this obligation is discharged in; never locale-free
-     * @param records the run's bytes, as the approved locale's text package addresses them
-     * @param font    the font package those records were baked against
+     * @param screen  the compiled screen whose manifest authorises the bound package
+     * @param node    the compiled node whose spec carries a `textKey`; must be one of `screen`'s
+     * @param binding the packages `TextBinding::create()` has already proved describe each other
+     * @param atlas   the coverage sheet the bound font package describes
+     * @param scope   the render scope; must name the locale the binding carries
      * @param ground  what this node's rectangle shows where the run paints nothing
      *
-     * Refuses a node that carries no text key, a locale-free scope, a partial run, a run longer than
-     * `mdux::medui::maxGlyphsPerRun`, a record naming a glyph the package does not hold, a node whose
-     * colour token does not resolve, and a run that paints no ink at all.
+     * Refuses an unbound binding, a binding the screen does not approve, a node the screen does not
+     * contain, a scope naming a different locale from the bound package's, a node carrying no text
+     * key, a text key the package has no run for, an atlas that is not the size the font package
+     * declares, a glyph slot outside that sheet, a node whose colour token does not resolve, and a
+     * run that paints no ink at all.
      *
-     * The last refusal is a policy rather than an accident. A run whose glyphs are all blank - a
+     * That last refusal is a policy rather than an accident. A run whose glyphs are all blank - a
      * single space - is legitimate for the runtime, which draws nothing and does not count the node
      * as deferred. It is not something a rendered-truth obligation can discharge: there is no ink to
      * find, so a pass would be indistinguishable from a screen that lost its text. ADR-014 decision
      * 3 says a check this build cannot perform fails, so this refuses rather than passing vacuously,
      * and the screen is what changes.
      */
-    [[nodiscard]] static mdux::core::Result<TextExpectation, VerifyError> create(const mdux::medui::CompiledNode& node,
-                                                                                 RenderScope                      scope,
-                                                                                 std::span<const std::byte>       records,
-                                                                                 const mdux::font::FontPackage&   font,
-                                                                                 mdux::core::ColorRgba8           ground) noexcept;
+    [[nodiscard]] static mdux::core::Result<TextExpectation, VerifyError> create(const mdux::medui::ScreenPackage& screen,
+                                                                                 const mdux::medui::CompiledNode&  node,
+                                                                                 const mdux::medui::TextBinding&   binding,
+                                                                                 std::span<const std::byte>        atlas,
+                                                                                 RenderScope                       scope,
+                                                                                 mdux::core::ColorRgba8            ground) noexcept;
+
+    /**
+     * @brief Builds a view over caller-supplied parts, establishing no provenance whatever.
+     *
+     * **For unit tests.** ADR-014 decision 1 admits exactly this and bounds it in the same sentence:
+     * "A unit test may construct a synthetic view to exercise a pure check, but production
+     * expectations have exactly the artifact sources decision 2 names." A check is a pure function,
+     * so proving it needs a framebuffer and a view - not a screen, a digest and a baked package -
+     * and refusing to offer that path would mean every scenario carried four real artifacts to test
+     * arithmetic.
+     *
+     * What it does not do is anything `create()` does. It does not see a screen, so it cannot know
+     * that this locale was approved; it does not see a `TextBinding`, so it cannot know that these
+     * records came from the package the screen names, or that the font they index is the one they
+     * were baked against. A driver that reached for this would be producing verification outcomes
+     * about a run nothing authorised, and that is the review finding to raise on #253 rather than a
+     * runtime condition this module can detect.
+     *
+     * The structural refusals `create()` makes are still made here: a node with no text key, a
+     * locale-free scope, a partial or over-long run, a dangling glyph index, an atlas of the wrong
+     * size, a slot outside it, an unresolvable colour token and a run with no ink.
+     */
+    [[nodiscard]] static mdux::core::Result<TextExpectation, VerifyError> createSynthetic(const mdux::medui::CompiledNode& node,
+                                                                                          RenderScope                      scope,
+                                                                                          std::span<const std::byte>       records,
+                                                                                          const mdux::font::FontPackage&   font,
+                                                                                          std::span<const std::byte>       atlas,
+                                                                                          mdux::core::ColorRgba8           ground) noexcept;
 
     [[nodiscard]] const mdux::medui::CompiledNode& node() const noexcept {
         return *node_;
@@ -612,7 +716,7 @@ public:
     [[nodiscard]] RenderScope scope() const noexcept {
         return scope_;
     }
-    /// The approved locale's tag. Never empty: `create()` refuses a locale-free scope.
+    /// The approved locale's tag. Never empty: both factories refuse a locale-free scope.
     [[nodiscard]] std::string_view locale() const noexcept {
         return scope_.tag();
     }
@@ -621,6 +725,10 @@ public:
     }
     [[nodiscard]] const mdux::font::FontPackage& font() const noexcept {
         return *font_;
+    }
+    /// The coverage sheet the run paints from.
+    [[nodiscard]] std::span<const std::byte> atlas() const noexcept {
+        return atlas_;
     }
     [[nodiscard]] mdux::core::ColorRgba8 tint() const noexcept {
         return tint_;
@@ -636,25 +744,55 @@ public:
     [[nodiscard]] mdux::medui::NodeRect ink() const noexcept {
         return ink_;
     }
-    /// Where record `index` paints, or nothing when it is blank or out of range.
-    [[nodiscard]] std::optional<mdux::medui::NodeRect> glyphRect(std::size_t index) const noexcept;
+    /// Where record `index` paints and paints from, or nothing when it is blank or out of range.
+    [[nodiscard]] std::optional<PlacedGlyph> glyph(std::size_t index) const noexcept;
+
+    /// The coverage the sheet holds for the texel at (`dx`, `dy`) inside `placed`.
+    ///
+    /// Zero for a coordinate outside the glyph, which `create()` has already made unreachable -
+    /// answered rather than assumed, because the alternative is indexing a span with a number this
+    /// function did not check.
+    [[nodiscard]] std::uint8_t coverage(const PlacedGlyph& placed, mdux::core::Px dx, mdux::core::Px dy) const noexcept;
 
 private:
+    /// The structural half both factories share: the run, the sheet, the tint and the ink box.
+    ///
+    /// Deliberately private. What separates a production expectation from a synthetic one is
+    /// provenance, and provenance is established by the caller-facing factories - so the shared part
+    /// must not be reachable as a third way to build one.
+    [[nodiscard]] static mdux::core::Result<TextExpectation, VerifyError> build(const mdux::medui::CompiledNode& node,
+                                                                                RenderScope                      scope,
+                                                                                std::span<const std::byte>       records,
+                                                                                const mdux::font::FontPackage&   font,
+                                                                                std::span<const std::byte>       atlas,
+                                                                                mdux::core::ColorRgba8           ground) noexcept;
+
     TextExpectation(const mdux::medui::CompiledNode* node,
                     RenderScope                      scope,
                     std::span<const std::byte>       records,
                     const mdux::font::FontPackage*   font,
+                    std::span<const std::byte>       atlas,
                     mdux::core::ColorRgba8           tint,
                     mdux::core::ColorRgba8           ground,
                     mdux::medui::NodeRect            ink,
                     mdux::core::Px                   originX,
                     mdux::core::Px                   originY) noexcept
-        : node_{node}, scope_{scope}, records_{records}, font_{font}, tint_{tint}, ground_{ground}, ink_{ink}, originX_{originX}, originY_{originY} {}
+        : node_{node},
+          scope_{scope},
+          records_{records},
+          font_{font},
+          atlas_{atlas},
+          tint_{tint},
+          ground_{ground},
+          ink_{ink},
+          originX_{originX},
+          originY_{originY} {}
 
     const mdux::medui::CompiledNode* node_{nullptr};
     RenderScope                      scope_{RenderScope::localeFree()};
     std::span<const std::byte>       records_{};
     const mdux::font::FontPackage*   font_{nullptr};
+    std::span<const std::byte>       atlas_{};
     mdux::core::ColorRgba8           tint_{};
     mdux::core::ColorRgba8           ground_{};
     mdux::medui::NodeRect            ink_{};
@@ -683,6 +821,7 @@ enum class Finding : std::uint8_t {
     InkLeftItsNode,      ///< the run's placed ink box is not inside the node's rectangle
     InkExtentDiffers,    ///< the frame's ink is not where the committed run says it would be
     GlyphMissing,        ///< a non-blank record of the approved run painted nothing
+    CoverageDiffers,     ///< a glyph's pixels are not what its baked coverage would produce
     InkOutsideTheRun,    ///< the node shows ink where this locale's run paints none
 };
 
@@ -696,8 +835,13 @@ enum class Finding : std::uint8_t {
  * asks for; everything that sentence needs is here, including the render scope, so a reader can tell
  * a failure in `de-DE` from the same node's pass in `en-US`.
  *
- * `found` is only meaningful for the findings that measured something. `expected` is always the
- * rectangle the check was asked about.
+ * `expected` is **the rectangle this outcome's claim is about**, which is not always the node's box.
+ * `goldenBounds()` and `colorHash()` name the golden's declared rectangle; `inkContainment()` names
+ * the node's rectangle while the failure is about containment and the predicted ink box once the
+ * comparison has moved on to the frame; `localizedTextPresence()` names one glyph's rectangle for a
+ * glyph-level finding and the node's otherwise. `found` is what was measured against it, and is only
+ * meaningful for the findings that measured something - `foundValid` says which. Spelled out here
+ * because a driver formatting "expected X, found Y" has to know what X refers to.
  */
 struct CheckOutcome {
     Finding                finding{Finding::Held};
@@ -750,16 +894,35 @@ struct CheckOutcome {
  * predict an ink box, the runtime's placement rule puts its corner on the node's corner, and this
  * fails when that box leaves the node - and, separately, when the frame's ink inside the node is not
  * the box the artifacts predicted, which is what a clipped, moved or partially drawn run looks like.
+ *
+ * An **extent** claim, deliberately and only. It says the run's ink occupies the box the artifacts
+ * predict and no more; it does not say the glyphs in that box are the approved locale's, and a few
+ * pixels at the box's corners would preserve the extent while saying nothing about what is between
+ * them. Establishing the run's shape is `localizedTextPresence()`'s job, which is why that one
+ * carries the coverage sheet and this one does not.
  */
 [[nodiscard]] CheckOutcome inkContainment(const FramebufferView& frame, const TextExpectation& expectation) noexcept;
 
 /**
  * @brief `LocalizedTextPresence`: the approved locale's bound run is the one on screen.
  *
- * Per glyph, in both directions: every non-blank record of this locale's run must have painted
- * something inside its own placed rectangle, and every pixel of the node outside all of those
- * rectangles must still be the ground. A different translation satisfies neither half at this
- * locale's rectangles, which is what makes this a presence check rather than a plausibility one.
+ * Per glyph and per pixel, in both directions.
+ *
+ * Inside each placed glyph, every pixel must be what the *baked coverage* for that texel produces
+ * when the node's tint is composited over the ground - `blend()`, within one UNORM step. That is the
+ * half that makes this a claim about the approved run rather than about ink in the right boxes: a
+ * texel the atlas leaves at zero must be exactly the ground, a fully covered one must be exactly the
+ * tint, and every value between is pinned to the coverage the baker recorded. A different letter of
+ * the same size, a run drawn from another package's slots, and a sparse handful of pixels that
+ * merely occupy the rectangles all fail it.
+ *
+ * Outside every placed glyph, every pixel of the node must still be the ground. The atlas slot is
+ * exactly the glyph's bitmap, so a correct frame paints nothing there.
+ *
+ * The one-step allowance is for UNORM rounding and nothing else: the blend is computed in floating
+ * point on the device and quantised back to eight bits, and two conforming implementations may
+ * differ in the last bit. It is not a similarity threshold - a wrong shape misses by far more than
+ * one step, and a wrong tint by more still.
  */
 [[nodiscard]] CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpectation& expectation) noexcept;
 

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -21,28 +21,6 @@ namespace mdux::medui {
 
 namespace {
 
-/// A linear channel as the byte a `R8G8B8A8_UNORM` vertex colour carries.
-///
-/// Quantisation and nothing else: the governed table stores linear RGBA, the vertex colour is read
-/// by the shader as a plain 0..1 UNORM value, so the byte is the linear value scaled. No transfer
-/// function is applied here, because whether the *swapchain* is sRGB is the renderer's decision and
-/// applying one in two places is how a colour ends up encoded twice.
-///
-/// The multiply and the add are separate statements so that neither the rounding nor the result
-/// depends on whether the compiler fuses them. `mdux_enforce_fp_determinism(MduXCore)` already turns
-/// contraction off for this target, and this is the belt to that pair of braces: a frame that is
-/// byte-compared across toolchains cannot afford a last-bit difference in a colour.
-[[nodiscard]] std::uint8_t quantise(float channel) noexcept {
-    const float clamped = channel < 0.0F ? 0.0F : (channel > 1.0F ? 1.0F : channel);
-    const float scaled  = clamped * 255.0F;
-    const float rounded = scaled + 0.5F;
-    return static_cast<std::uint8_t>(rounded);
-}
-
-[[nodiscard]] mdux::core::ColorRgba8 toColor(const std::array<float, 4>& linear) noexcept {
-    return mdux::core::ColorRgba8{.r = quantise(linear[0]), .g = quantise(linear[1]), .b = quantise(linear[2]), .a = quantise(linear[3])};
-}
-
 [[nodiscard]] mdux::core::Rect toRect(const NodeRect& bounds) noexcept {
     return mdux::core::Rect{.x      = static_cast<mdux::core::Px>(bounds.x),
                             .y      = static_cast<mdux::core::Px>(bounds.y),
@@ -313,7 +291,7 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
             const auto originY = static_cast<mdux::core::Px>(node.bounds.y) - ink->top;
 
             const std::size_t verticesBefore = list.vertices().size();
-            if (const auto recorded = mdux::text::draw::recordRun(list, *text.font(), *records, originX, originY, toColor(*labelColour));
+            if (const auto recorded = mdux::text::draw::recordRun(list, *text.font(), *records, originX, originY, quantise(*labelColour));
                 !recorded.has_value()) {
                 // `recordRun()` rolls its own run back and this rolls the whole frame back. Its error
                 // is not forwarded: every way it can fail here is either something `runFor()` and
@@ -344,7 +322,7 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage& screen, 
             return refuse(colour.error() == ThemeError::MalformedToken ? ScreenError::MalformedColorToken : ScreenError::UnknownColorToken);
         }
 
-        if (const auto recorded = list.addSolidRect(toRect(node.bounds), toColor(*colour)); !recorded.has_value()) {
+        if (const auto recorded = list.addSolidRect(toRect(node.bounds), quantise(*colour)); !recorded.has_value()) {
             return refuse(ScreenError::BudgetExhausted);
         }
         // Measured rather than predicted: a rectangle costs four vertices and six indices, and

--- a/src/verify/Verify.cpp
+++ b/src/verify/Verify.cpp
@@ -1,0 +1,567 @@
+/**
+ * @file Verify.cpp
+ * @brief Implementation of the four rendered-truth checks and the two expectation views.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-005 Error handling and exceptions policy
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ *
+ * See Verify.cppm for what each check claims, why an expectation carries two resolved colours, and
+ * which failures each check is structurally unable to see. This file adds only the arithmetic.
+ */
+module;
+
+module mdux.verify;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.font.schema;
+import mdux.medui.schema;
+import mdux.medui.screen;
+import mdux.text.draw;
+
+namespace mdux::verify {
+
+using mdux::core::ColorRgba8;
+using mdux::core::err;
+using mdux::core::Px;
+using mdux::core::Result;
+using mdux::medui::NodeRect;
+
+namespace {
+
+/// A measured rectangle, with exclusive right and bottom edges.
+///
+/// The same shape `mdux.medui.screen`'s `InkBox` and `ScreenPixelTests`' both use, and for the same
+/// reason: a union of rectangles is written far more simply against edges than against an origin and
+/// an extent, and converting once at the end keeps the conversion in one place.
+struct Box {
+    bool inked{false};
+    Px   left{0};
+    Px   top{0};
+    Px   right{0};
+    Px   bottom{0};
+
+    void add(Px x, Px y, Px width, Px height) noexcept {
+        const Px boxRight  = x + width;
+        const Px boxBottom = y + height;
+        if (!inked) {
+            inked  = true;
+            left   = x;
+            top    = y;
+            right  = boxRight;
+            bottom = boxBottom;
+            return;
+        }
+        left   = x < left ? x : left;
+        top    = y < top ? y : top;
+        right  = boxRight > right ? boxRight : right;
+        bottom = boxBottom > bottom ? boxBottom : bottom;
+    }
+};
+
+[[nodiscard]] NodeRect asRect(const Box& box) noexcept {
+    return NodeRect{.x = box.left, .y = box.top, .width = box.right - box.left, .height = box.bottom - box.top};
+}
+
+/// A one-pixel rectangle, so a finding about a single pixel can still name a place.
+[[nodiscard]] NodeRect atPixel(Px x, Px y) noexcept {
+    return NodeRect{.x = x, .y = y, .width = 1, .height = 1};
+}
+
+/// Whether `inner` lies wholly inside `outer`. 64-bit, for `containedBy()`'s reason: two `int32_t`
+/// at their extremes overflow on addition, and an overflowed comparison admits what it should refuse.
+[[nodiscard]] bool inside(NodeRect inner, NodeRect outer) noexcept {
+    const auto innerRight  = static_cast<std::int64_t>(inner.x) + inner.width;
+    const auto innerBottom = static_cast<std::int64_t>(inner.y) + inner.height;
+    const auto outerRight  = static_cast<std::int64_t>(outer.x) + outer.width;
+    const auto outerBottom = static_cast<std::int64_t>(outer.y) + outer.height;
+    return inner.x >= outer.x && inner.y >= outer.y && innerRight <= outerRight && innerBottom <= outerBottom;
+}
+
+[[nodiscard]] bool holds(NodeRect rect, Px x, Px y) noexcept {
+    return x >= rect.x && y >= rect.y && x < rect.x + rect.width && y < rect.y + rect.height;
+}
+
+/// Whether `value` is within the closed interval the two bounds span, in either order.
+[[nodiscard]] bool between(std::uint8_t value, std::uint8_t first, std::uint8_t second) noexcept {
+    const std::uint8_t low  = first < second ? first : second;
+    const std::uint8_t high = first < second ? second : first;
+    return value >= low && value <= high;
+}
+
+/**
+ * @brief Whether `pixel` could be the tint blended over the ground at some coverage.
+ *
+ * Channel-wise containment, and it needs no tolerance. Alpha blending produces a convex combination
+ * of two integer channel values, and rounding a value that lies between two integers cannot leave
+ * the closed interval they span - so a correct blend is always inside, and a pixel outside was
+ * painted by something the expectation does not describe.
+ */
+[[nodiscard]] bool blendOf(ColorRgba8 pixel, ColorRgba8 ground, ColorRgba8 tint) noexcept {
+    return between(pixel.r, ground.r, tint.r) && between(pixel.g, ground.g, tint.g) && between(pixel.b, ground.b, tint.b) && between(pixel.a, ground.a, tint.a);
+}
+
+/// The bounding box of every pixel of `region` that is not `ground`.
+///
+/// "Painted" is defined against the ground rather than against the tint deliberately: an
+/// anti-aliased edge is a blend, so it is neither the ground nor the tint, and a scan that looked
+/// only for the tint would measure a box one pixel small on every side.
+[[nodiscard]] Box paintedBox(const FramebufferView& frame, NodeRect region, ColorRgba8 ground) noexcept {
+    Box box;
+    for (Px y = region.y; y < region.y + region.height; ++y) {
+        for (Px x = region.x; x < region.x + region.width; ++x) {
+            const std::optional<ColorRgba8> pixel = frame.pixelAt(x, y);
+            if (!pixel.has_value() || *pixel == ground) {
+                continue;
+            }
+            box.add(x, y, 1, 1);
+        }
+    }
+    return box;
+}
+
+/// The outcome every check starts from, so the reporting fields are filled in one place.
+[[nodiscard]] CheckOutcome opened(std::string_view nodeId, RenderScope scope, std::string_view check, NodeRect expected) noexcept {
+    return CheckOutcome{.finding = Finding::Held, .nodeId = nodeId, .scope = scope.name(), .check = check, .expected = expected};
+}
+
+[[nodiscard]] CheckOutcome failed(CheckOutcome outcome, Finding finding) noexcept {
+    outcome.finding = finding;
+    return outcome;
+}
+
+}  // namespace
+
+std::string_view describe(VerifyError error) noexcept {
+    switch (error) {
+        case VerifyError::EmptyFramebuffer:
+            return "the framebuffer has zero width or height";
+        case VerifyError::UnsupportedFormat:
+            return "the framebuffer's pixel format is not one this module decodes";
+        case VerifyError::RowStrideTooSmall:
+            return "the row stride cannot hold one row of pixels of the declared format";
+        case VerifyError::FramebufferTooSmall:
+            return "the byte span is shorter than the declared extent requires";
+        case VerifyError::DanglingGoldenId:
+            return "the golden names a node the compiled screen does not contain";
+        case VerifyError::GoldenBoundsDisagree:
+            return "the golden's rectangle is not the rectangle the named node occupies";
+        case VerifyError::GoldenTextKeyDisagrees:
+            return "the golden's text key is not the one the named node carries";
+        case VerifyError::GoldenColorTokenDisagrees:
+            return "the golden's colour token is not the one the named node carries";
+        case VerifyError::NoChecksDeclared:
+            return "the golden entry declares no cvChecks, so it can discharge nothing";
+        case VerifyError::ChecksNotCanonical:
+            return "the golden entry's cvChecks are not sorted and deduplicated";
+        case VerifyError::ColorHashWithoutTint:
+            return "the golden entry asks for ColorHash and names no colour token";
+        case VerifyError::UnresolvedColorToken:
+            return "the governed colour table does not define this token";
+        case VerifyError::NodeCarriesNoTextKey:
+            return "a text obligation was raised over a node whose spec carries no textKey";
+        case VerifyError::ScopeIsLocaleFree:
+            return "a text obligation must name the approved locale it is discharged in";
+        case VerifyError::MalformedRun:
+            return "the run's byte length is not a whole number of records";
+        case VerifyError::EmptyRun:
+            return "the approved locale's run paints no ink for this node";
+        case VerifyError::RunTooLong:
+            return "the run holds more records than the runtime's per-node cap admits";
+        case VerifyError::GlyphIndexOutOfRange:
+            return "a record names a glyph index the font package does not contain";
+    }
+    return "unknown verification error";
+}
+
+std::string_view describe(Finding finding) noexcept {
+    switch (finding) {
+        case Finding::Held:
+            return "the check held";
+        case Finding::RegionOutsideFrame:
+            return "the rectangle to inspect is not inside the rendered frame";
+        case Finding::NoTintToCompare:
+            return "the expectation resolved no tint, so no colour claim can be made";
+        case Finding::NothingPainted:
+            return "the rectangle shows its ground everywhere: nothing was drawn there";
+        case Finding::BoundsDiffer:
+            return "the content in the rectangle does not occupy the rectangle it was pinned to";
+        case Finding::TintAbsent:
+            return "content is present and no pixel of it carries the resolved tint";
+        case Finding::ForeignColour:
+            return "a painted pixel is not the resolved tint blended over the ground";
+        case Finding::InkLeftItsNode:
+            return "the run's ink, placed as the runtime places it, is not inside its node";
+        case Finding::InkExtentDiffers:
+            return "the ink in the frame is not where the committed run says it would be";
+        case Finding::GlyphMissing:
+            return "a non-blank record of the approved run painted nothing";
+        case Finding::InkOutsideTheRun:
+            return "the node shows ink where this locale's run paints none";
+    }
+    return "unknown verification finding";
+}
+
+Result<FramebufferView, VerifyError>
+FramebufferView::create(std::span<const std::byte> bytes, Px width, Px height, std::size_t rowStride, PixelFormat format) noexcept {
+    if (width <= 0 || height <= 0) {
+        return err(VerifyError::EmptyFramebuffer);
+    }
+    const std::size_t stride = bytesPerPixel(format);
+    if (stride == 0) {
+        // Only reachable from a cast outside the enumeration. Refused rather than divided by, for
+        // the reason the enumeration exists at all: a misread buffer is a plausible wrong answer.
+        return err(VerifyError::UnsupportedFormat);
+    }
+
+    const auto rowBytes = static_cast<std::uint64_t>(width) * stride;
+    if (static_cast<std::uint64_t>(rowStride) < rowBytes) {
+        return err(VerifyError::RowStrideTooSmall);
+    }
+    // The last row need not be padded, so the requirement is every full row but the last, plus one
+    // row of pixels. 64-bit throughout: a large extent multiplied in `size_t` on a 32-bit host would
+    // wrap into admitting exactly the buffer this refuses.
+    const auto required = (static_cast<std::uint64_t>(height) - 1) * static_cast<std::uint64_t>(rowStride) + rowBytes;
+    if (static_cast<std::uint64_t>(bytes.size()) < required) {
+        return err(VerifyError::FramebufferTooSmall);
+    }
+    return FramebufferView{bytes, width, height, rowStride, format};
+}
+
+Result<FramebufferView, VerifyError> FramebufferView::createPacked(std::span<const ColorRgba8> pixels, Px width, Px height) noexcept {
+    if (width <= 0 || height <= 0) {
+        return err(VerifyError::EmptyFramebuffer);
+    }
+    const std::size_t rowStride = static_cast<std::size_t>(width) * bytesPerPixel(PixelFormat::Rgba8Unorm);
+    return create(std::as_bytes(pixels), width, height, rowStride, PixelFormat::Rgba8Unorm);
+}
+
+std::optional<ColorRgba8> FramebufferView::pixelAt(Px x, Px y) const noexcept {
+    if (x < 0 || y < 0 || x >= width_ || y >= height_) {
+        return std::nullopt;
+    }
+    const std::size_t offset = static_cast<std::size_t>(y) * rowStride_ + static_cast<std::size_t>(x) * bytesPerPixel(format_);
+    if (offset + bytesPerPixel(format_) > bytes_.size()) {
+        // Unreachable for a view `create()` admitted, and kept because "unreachable" is a property
+        // of an invariant rather than of the compiler: a future format with a different stride would
+        // find this here instead of past the end of the caller's span.
+        return std::nullopt;
+    }
+    const auto channel = [this, offset](std::size_t index) noexcept {
+        return std::to_integer<std::uint8_t>(bytes_[offset + index]);
+    };
+    return ColorRgba8{.r = channel(0), .g = channel(1), .b = channel(2), .a = channel(3)};
+}
+
+Result<GoldenExpectation, VerifyError>
+GoldenExpectation::create(const GoldenEntry& entry, const mdux::medui::ScreenPackage& screen, RenderScope scope, ColorRgba8 ground) noexcept {
+    const mdux::medui::CompiledNode* node = screen.find(entry.nodeId);
+    if (node == nullptr) {
+        // The verifier's first lookup, and the failure ADR-014's ownership table assigns to it. A
+        // golden addressing a node that does not exist is a sidecar that drifted from its package.
+        return err(VerifyError::DanglingGoldenId);
+    }
+    if (entry.bounds != node->bounds) {
+        return err(VerifyError::GoldenBoundsDisagree);
+    }
+    if (entry.textKey != textKeyOf(*node)) {
+        return err(VerifyError::GoldenTextKeyDisagrees);
+    }
+    if (entry.colorToken != colorTokenOf(*node)) {
+        return err(VerifyError::GoldenColorTokenDisagrees);
+    }
+    if (entry.cvChecks.empty()) {
+        return err(VerifyError::NoChecksDeclared);
+    }
+    for (std::size_t index = 1; index < entry.cvChecks.size(); ++index) {
+        // Strictly ascending, which is sorted and deduplicated in one comparison. The sidecar is
+        // byte-compared across four toolchains, so a set whose order depended on which rule selected
+        // the node first could not survive that - an entry that is not in canonical form did not
+        // come from the compiler that writes them.
+        if (static_cast<std::uint8_t>(entry.cvChecks[index - 1]) >= static_cast<std::uint8_t>(entry.cvChecks[index])) {
+            return err(VerifyError::ChecksNotCanonical);
+        }
+    }
+
+    const bool wantsTint = std::ranges::find(entry.cvChecks, CvCheck::ColorHash) != entry.cvChecks.end();
+    if (wantsTint && entry.colorToken.empty()) {
+        // The two halves of one claim, as `collectGoldens()` treats them: a verifier asked to
+        // compare a tint has to be told which tint, and an entry that asked without saying is one
+        // this module could only skip.
+        return err(VerifyError::ColorHashWithoutTint);
+    }
+
+    bool       hasTint = false;
+    ColorRgba8 tint{};
+    if (!entry.colorToken.empty()) {
+        const auto resolved = mdux::medui::resolveColorToken(entry.colorToken);
+        if (!resolved.has_value()) {
+            return err(VerifyError::UnresolvedColorToken);
+        }
+        hasTint = true;
+        tint    = mdux::medui::quantise(*resolved);
+    }
+    return GoldenExpectation{node, scope, entry.cvChecks, ground, hasTint, tint};
+}
+
+Result<TextExpectation, VerifyError> TextExpectation::create(const mdux::medui::CompiledNode& node,
+                                                             RenderScope                      scope,
+                                                             std::span<const std::byte>       records,
+                                                             const mdux::font::FontPackage&   font,
+                                                             ColorRgba8                       ground) noexcept {
+    if (textKeyOf(node).empty()) {
+        return err(VerifyError::NodeCarriesNoTextKey);
+    }
+    if (scope.isLocaleFree()) {
+        // A text obligation is one node, one check and one *approved locale*: the locale-free scope
+        // exists so a textless screen keeps its geometric obligations, not so a text node can lose
+        // the only thing that distinguishes one of its two obligations from another.
+        return err(VerifyError::ScopeIsLocaleFree);
+    }
+    if (records.size() % mdux::text::draw::recordSize != 0) {
+        return err(VerifyError::MalformedRun);
+    }
+    const std::size_t count = records.size() / mdux::text::draw::recordSize;
+    if (count == 0) {
+        return err(VerifyError::EmptyRun);
+    }
+    if (count > mdux::medui::maxGlyphsPerRun) {
+        // The runtime's cap rather than a second one. A run the device would refuse to draw is not a
+        // run a verifier should describe as checkable.
+        return err(VerifyError::RunTooLong);
+    }
+
+    const auto resolved = mdux::medui::resolveColorToken(colorTokenOf(node));
+    if (!resolved.has_value()) {
+        return err(VerifyError::UnresolvedColorToken);
+    }
+
+    // The ink box, measured exactly as `mdux.medui.screen` measures it before placing a run: the
+    // union of the non-blank glyph rectangles, in the run's own coordinate frame. Computed here so
+    // that a check compares the frame against where the runtime would have drawn, rather than
+    // against a second opinion about where text belongs.
+    Box ink;
+    for (std::size_t index = 0; index < count; ++index) {
+        const auto placement = mdux::text::draw::decodeRecord(records.subspan(index * mdux::text::draw::recordSize, mdux::text::draw::recordSize));
+        if (!placement.has_value()) {
+            return err(VerifyError::MalformedRun);
+        }
+        if (placement->packageIndex >= font.glyphs.size()) {
+            return err(VerifyError::GlyphIndexOutOfRange);
+        }
+        const mdux::font::GlyphRecord& glyph = font.glyphs[placement->packageIndex];
+        if (glyph.isBlank()) {
+            continue;
+        }
+        ink.add(placement->x + glyph.bitmapOriginX, placement->y - glyph.bitmapOriginY, static_cast<Px>(glyph.width), static_cast<Px>(glyph.height));
+    }
+    if (!ink.inked) {
+        // Every glyph blank. Legitimate for the runtime, which draws nothing; not something a
+        // rendered-truth obligation can discharge, because a pass would be indistinguishable from a
+        // screen that lost its text. See the interface comment for why this refuses rather than
+        // passing vacuously.
+        return err(VerifyError::EmptyRun);
+    }
+
+    // The placement rule, restated as the arithmetic it is: the ink box's corner goes on the node's
+    // corner, so the origin added to every record is the node's corner less where the ink starts.
+    const Px       originX = node.bounds.x - ink.left;
+    const Px       originY = node.bounds.y - ink.top;
+    const NodeRect placed{.x = node.bounds.x, .y = node.bounds.y, .width = ink.right - ink.left, .height = ink.bottom - ink.top};
+
+    return TextExpectation{&node, scope, records, &font, mdux::medui::quantise(*resolved), ground, placed, originX, originY};
+}
+
+std::optional<NodeRect> TextExpectation::glyphRect(std::size_t index) const noexcept {
+    if (index >= glyphCount()) {
+        return std::nullopt;
+    }
+    const auto placement = mdux::text::draw::decodeRecord(records_.subspan(index * mdux::text::draw::recordSize, mdux::text::draw::recordSize));
+    if (!placement.has_value() || placement->packageIndex >= font_->glyphs.size()) {
+        // Both refused by `create()`, so neither is reachable through a live expectation. Answered
+        // as "no rectangle" rather than assumed away, because the alternative is indexing a vector
+        // with a number this function did not check.
+        return std::nullopt;
+    }
+    const mdux::font::GlyphRecord& glyph = font_->glyphs[placement->packageIndex];
+    if (glyph.isBlank()) {
+        return std::nullopt;
+    }
+    return NodeRect{.x      = originX_ + placement->x + glyph.bitmapOriginX,
+                    .y      = originY_ + placement->y - glyph.bitmapOriginY,
+                    .width  = static_cast<Px>(glyph.width),
+                    .height = static_cast<Px>(glyph.height)};
+}
+
+CheckOutcome goldenBounds(const FramebufferView& frame, const GoldenExpectation& expectation) noexcept {
+    CheckOutcome outcome = opened(expectation.nodeId(), expectation.scope(), spell(CvCheck::Bounds), expectation.bounds());
+    if (!frame.contains(expectation.bounds())) {
+        return failed(outcome, Finding::RegionOutsideFrame);
+    }
+
+    const Box painted = paintedBox(frame, expectation.bounds(), expectation.ground());
+    if (!painted.inked) {
+        // What a node that vanished, or was never drawn, looks like from the frame. It is also
+        // exactly the state `tests/render/ScreenPixelTests.cpp` asserts as a tripwire today, since
+        // both of the committed screen's golden nodes are still deferred.
+        return failed(outcome, Finding::NothingPainted);
+    }
+    outcome.found      = asRect(painted);
+    outcome.foundValid = true;
+    if (outcome.found != expectation.bounds()) {
+        // An equality rather than a containment, which is ADR-014's own worked example: a rectangle
+        // moved by one pixel still overlaps its declared box, so only "the content *is* the box"
+        // fails on it. See Verify.cppm for the partial fill this reading deliberately excludes.
+        return failed(outcome, Finding::BoundsDiffer);
+    }
+    return outcome;
+}
+
+CheckOutcome colorHash(const FramebufferView& frame, const GoldenExpectation& expectation) noexcept {
+    CheckOutcome outcome  = opened(expectation.nodeId(), expectation.scope(), spell(CvCheck::ColorHash), expectation.bounds());
+    outcome.expectedColor = expectation.tint();
+    if (!expectation.hasTint()) {
+        return failed(outcome, Finding::NoTintToCompare);
+    }
+    if (!frame.contains(expectation.bounds())) {
+        return failed(outcome, Finding::RegionOutsideFrame);
+    }
+
+    const NodeRect   region = expectation.bounds();
+    const ColorRgba8 ground = expectation.ground();
+    const ColorRgba8 tint   = expectation.tint();
+
+    Box  painted;
+    bool carriesTint = false;
+    for (Px y = region.y; y < region.y + region.height; ++y) {
+        for (Px x = region.x; x < region.x + region.width; ++x) {
+            const std::optional<ColorRgba8> pixel = frame.pixelAt(x, y);
+            if (!pixel.has_value() || *pixel == ground) {
+                continue;
+            }
+            if (!blendOf(*pixel, ground, tint)) {
+                outcome.found           = atPixel(x, y);
+                outcome.foundValid      = true;
+                outcome.foundColor      = *pixel;
+                outcome.foundColorValid = true;
+                return failed(outcome, Finding::ForeignColour);
+            }
+            painted.add(x, y, 1, 1);
+            carriesTint = carriesTint || *pixel == tint;
+        }
+    }
+
+    if (!painted.inked) {
+        return failed(outcome, Finding::NothingPainted);
+    }
+    outcome.found      = asRect(painted);
+    outcome.foundValid = true;
+    if (!carriesTint) {
+        // Content that never reaches full coverage cannot be said to carry its tint. Reported rather
+        // than rounded away: see Verify.cppm for why this direction is the fail-closed one.
+        return failed(outcome, Finding::TintAbsent);
+    }
+    return outcome;
+}
+
+CheckOutcome inkContainment(const FramebufferView& frame, const TextExpectation& expectation) noexcept {
+    CheckOutcome outcome = opened(expectation.nodeId(), expectation.scope(), spell(TextCheck::InkContainment), expectation.bounds());
+    if (!inside(expectation.ink(), expectation.bounds())) {
+        // The compile-time claim, failing before a pixel is read. #195 proved this box fits this
+        // rectangle for the package it measured; a run that overflows here was bound from a package
+        // nobody measured against this screen.
+        outcome.found      = expectation.ink();
+        outcome.foundValid = true;
+        return failed(outcome, Finding::InkLeftItsNode);
+    }
+    if (!frame.contains(expectation.bounds())) {
+        return failed(outcome, Finding::RegionOutsideFrame);
+    }
+
+    const Box painted = paintedBox(frame, expectation.bounds(), expectation.ground());
+    outcome.expected  = expectation.ink();
+    if (!painted.inked) {
+        return failed(outcome, Finding::NothingPainted);
+    }
+    outcome.found      = asRect(painted);
+    outcome.foundValid = true;
+    if (outcome.found != expectation.ink()) {
+        // The rendered half. A run that was clipped at the node's edge, displaced, or drawn from a
+        // different package leaves ink whose extent is not the one the committed records predict.
+        return failed(outcome, Finding::InkExtentDiffers);
+    }
+    return outcome;
+}
+
+CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpectation& expectation) noexcept {
+    CheckOutcome outcome  = opened(expectation.nodeId(), expectation.scope(), spell(TextCheck::LocalizedTextPresence), expectation.bounds());
+    outcome.expectedColor = expectation.tint();
+    if (!frame.contains(expectation.bounds())) {
+        return failed(outcome, Finding::RegionOutsideFrame);
+    }
+
+    const NodeRect   region = expectation.bounds();
+    const ColorRgba8 ground = expectation.ground();
+    const ColorRgba8 tint   = expectation.tint();
+
+    // Half one: every glyph this locale's run paints has painted something of its own.
+    for (std::size_t index = 0; index < expectation.glyphCount(); ++index) {
+        const std::optional<NodeRect> glyph = expectation.glyphRect(index);
+        if (!glyph.has_value()) {
+            // A blank, most often the space. It advances the pen and paints nothing, so there is
+            // nothing to find and nothing missing.
+            continue;
+        }
+        outcome.glyphIndex = index;
+        if (!frame.contains(*glyph)) {
+            outcome.found      = *glyph;
+            outcome.foundValid = true;
+            return failed(outcome, Finding::RegionOutsideFrame);
+        }
+        if (!paintedBox(frame, *glyph, ground).inked) {
+            outcome.expected   = *glyph;
+            outcome.found      = *glyph;
+            outcome.foundValid = true;
+            return failed(outcome, Finding::GlyphMissing);
+        }
+    }
+    outcome.glyphIndex = 0;
+    outcome.expected   = region;
+
+    // Half two: nothing painted anywhere else in the node. The atlas slot is exactly the glyph's
+    // bitmap, so a correct frame paints outside no rectangle - which is what stops a different
+    // translation, whose glyphs land elsewhere, from satisfying half one and being called present.
+    for (Px y = region.y; y < region.y + region.height; ++y) {
+        for (Px x = region.x; x < region.x + region.width; ++x) {
+            const std::optional<ColorRgba8> pixel = frame.pixelAt(x, y);
+            if (!pixel.has_value() || *pixel == ground) {
+                continue;
+            }
+            bool attributed = false;
+            for (std::size_t index = 0; index < expectation.glyphCount() && !attributed; ++index) {
+                const std::optional<NodeRect> glyph = expectation.glyphRect(index);
+                attributed                          = glyph.has_value() && holds(*glyph, x, y);
+            }
+            outcome.found           = atPixel(x, y);
+            outcome.foundValid      = true;
+            outcome.foundColor      = *pixel;
+            outcome.foundColorValid = true;
+            if (!attributed) {
+                return failed(outcome, Finding::InkOutsideTheRun);
+            }
+            if (!blendOf(*pixel, ground, tint)) {
+                return failed(outcome, Finding::ForeignColour);
+            }
+        }
+    }
+
+    outcome.found           = expectation.ink();
+    outcome.foundValid      = true;
+    outcome.foundColor      = ColorRgba8{};
+    outcome.foundColorValid = false;
+    return outcome;
+}
+
+}  // namespace mdux::verify

--- a/src/verify/Verify.cpp
+++ b/src/verify/Verify.cpp
@@ -20,6 +20,7 @@ import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.medui.screen;
 import mdux.text.draw;
+import mdux.text.schema;
 
 namespace mdux::verify {
 
@@ -84,23 +85,82 @@ struct Box {
     return x >= rect.x && y >= rect.y && x < rect.x + rect.width && y < rect.y + rect.height;
 }
 
-/// Whether `value` is within the closed interval the two bounds span, in either order.
-[[nodiscard]] bool between(std::uint8_t value, std::uint8_t first, std::uint8_t second) noexcept {
-    const std::uint8_t low  = first < second ? first : second;
-    const std::uint8_t high = first < second ? second : first;
-    return value >= low && value <= high;
+/**
+ * @brief Whether `pixel` could be the tint composited over the ground at *one* coverage.
+ *
+ * Channel-wise membership of the interval between ground and tint is necessary and not sufficient,
+ * which is the whole reason this is a function rather than four comparisons. Alpha blending applies
+ * one coverage to every channel, so each channel constrains that coverage to an interval, and the
+ * pixel is possible exactly when those intervals intersect. With a black ground and
+ * `Theme.Colors.ScoreDigits` at `(33, 184, 107)`, the pixel `(33, 0, 107)` lies inside every
+ * channel's range while demanding full coverage of red and blue and none of green - a per-channel
+ * test accepts it and no blend can produce it.
+ *
+ * Integer cross-products, no division and no float: the coverage each channel implies is the
+ * rational `(pixel - ground) / (tint - ground)`, so the intervals are compared by multiplying out.
+ * `allowance` is one UNORM step, because the device blends in floating point and quantises back to
+ * eight bits; a channel whose tint and ground are equal admits any coverage and only requires the
+ * pixel to match within the same step.
+ */
+[[nodiscard]] bool couldBeBlend(ColorRgba8 pixel, ColorRgba8 ground, ColorRgba8 tint) noexcept {
+    constexpr std::int64_t allowance = 1;
+
+    // The feasible coverage, as a closed interval of rationals, narrowed channel by channel from
+    // the whole of [0, 1].
+    std::int64_t lowNum  = 0;
+    std::int64_t lowDen  = 1;
+    std::int64_t highNum = 1;
+    std::int64_t highDen = 1;
+
+    const std::array<std::int64_t, 4> pixels{pixel.r, pixel.g, pixel.b, pixel.a};
+    const std::array<std::int64_t, 4> grounds{ground.r, ground.g, ground.b, ground.a};
+    const std::array<std::int64_t, 4> tints{tint.r, tint.g, tint.b, tint.a};
+
+    for (std::size_t channel = 0; channel < pixels.size(); ++channel) {
+        const std::int64_t span     = tints[channel] - grounds[channel];
+        const std::int64_t distance = pixels[channel] - grounds[channel];
+        if (span == 0) {
+            // Every coverage produces the ground on this channel, so the channel says nothing about
+            // the coverage - and everything about the pixel.
+            if (distance > allowance || distance < -allowance) {
+                return false;
+            }
+            continue;
+        }
+
+        // coverage * span is distance, to within one step: coverage lies between the two bounds
+        // below, in whichever order the sign of `span` puts them.
+        std::int64_t candidateLowNum  = distance - allowance;
+        std::int64_t candidateHighNum = distance + allowance;
+        std::int64_t denominator      = span;
+        if (denominator < 0) {
+            denominator                = -denominator;
+            const std::int64_t swapped = -candidateLowNum;
+            candidateLowNum            = -candidateHighNum;
+            candidateHighNum           = swapped;
+        }
+        if (candidateLowNum * lowDen > lowNum * denominator) {
+            lowNum = candidateLowNum;
+            lowDen = denominator;
+        }
+        if (candidateHighNum * highDen < highNum * denominator) {
+            highNum = candidateHighNum;
+            highDen = denominator;
+        }
+        if (lowNum * highDen > highNum * lowDen) {
+            return false;
+        }
+    }
+    return true;
 }
 
-/**
- * @brief Whether `pixel` could be the tint blended over the ground at some coverage.
- *
- * Channel-wise containment, and it needs no tolerance. Alpha blending produces a convex combination
- * of two integer channel values, and rounding a value that lies between two integers cannot leave
- * the closed interval they span - so a correct blend is always inside, and a pixel outside was
- * painted by something the expectation does not describe.
- */
-[[nodiscard]] bool blendOf(ColorRgba8 pixel, ColorRgba8 ground, ColorRgba8 tint) noexcept {
-    return between(pixel.r, ground.r, tint.r) && between(pixel.g, ground.g, tint.g) && between(pixel.b, ground.b, tint.b) && between(pixel.a, ground.a, tint.a);
+/// Whether every channel of `pixel` is within one UNORM step of `expected`.
+[[nodiscard]] bool withinOneStep(ColorRgba8 pixel, ColorRgba8 expected) noexcept {
+    const auto close = [](std::uint8_t left, std::uint8_t right) noexcept {
+        const int difference = static_cast<int>(left) - static_cast<int>(right);
+        return difference <= 1 && difference >= -1;
+    };
+    return close(pixel.r, expected.r) && close(pixel.g, expected.g) && close(pixel.b, expected.b) && close(pixel.a, expected.a);
 }
 
 /// The bounding box of every pixel of `region` that is not `ground`.
@@ -172,6 +232,20 @@ std::string_view describe(VerifyError error) noexcept {
             return "the run holds more records than the runtime's per-node cap admits";
         case VerifyError::GlyphIndexOutOfRange:
             return "a record names a glyph index the font package does not contain";
+        case VerifyError::TextBindingUnbound:
+            return "the text binding carries no packages, so it authorises nothing";
+        case VerifyError::BindingNotApproved:
+            return "this screen's manifest does not approve the bound text package";
+        case VerifyError::NodeNotInScreen:
+            return "the node is not one this screen contains";
+        case VerifyError::ScopeIsNotTheBoundLocale:
+            return "the render scope names a locale other than the bound package's";
+        case VerifyError::UnknownTextKey:
+            return "the bound text package carries no run for this node's text key";
+        case VerifyError::AtlasSizeMismatch:
+            return "the coverage sheet is not the size the font package declares";
+        case VerifyError::GlyphOutsideAtlas:
+            return "a glyph's slot leaves the coverage sheet";
     }
     return "unknown verification error";
 }
@@ -198,11 +272,31 @@ std::string_view describe(Finding finding) noexcept {
             return "the ink in the frame is not where the committed run says it would be";
         case Finding::GlyphMissing:
             return "a non-blank record of the approved run painted nothing";
+        case Finding::CoverageDiffers:
+            return "a glyph's pixels are not what its baked coverage would paint in this tint";
         case Finding::InkOutsideTheRun:
             return "the node shows ink where this locale's run paints none";
     }
     return "unknown verification finding";
 }
+
+ColorRgba8 blend(ColorRgba8 ground, ColorRgba8 tint, std::uint8_t coverage) noexcept {
+    // `a = (tint.a / 255) * (coverage / 255)`, kept as the numerator over 255*255 so the whole
+    // computation stays in integers. Rounding to nearest, with the sign of the span carried through
+    // because a tint darker than its ground moves the channel down.
+    const auto alpha = static_cast<std::int64_t>(tint.a) * static_cast<std::int64_t>(coverage);
+    const auto mix   = [alpha](std::uint8_t from, std::uint8_t to) noexcept {
+        constexpr std::int64_t full   = 255 * 255;
+        const std::int64_t     span   = static_cast<std::int64_t>(to) - static_cast<std::int64_t>(from);
+        const std::int64_t     scaled = span * alpha;
+        const std::int64_t     step   = scaled >= 0 ? (scaled + full / 2) / full : -((-scaled + full / 2) / full);
+        return static_cast<std::uint8_t>(static_cast<std::int64_t>(from) + step);
+    };
+    // The alpha channel is the destination's: the target is opaque and the blend writes coverage
+    // into the source's alpha, not into the frame's.
+    return ColorRgba8{.r = mix(ground.r, tint.r), .g = mix(ground.g, tint.g), .b = mix(ground.b, tint.b), .a = ground.a};
+}
+
 
 Result<FramebufferView, VerifyError>
 FramebufferView::create(std::span<const std::byte> bytes, Px width, Px height, std::size_t rowStride, PixelFormat format) noexcept {
@@ -216,15 +310,24 @@ FramebufferView::create(std::span<const std::byte> bytes, Px width, Px height, s
         return err(VerifyError::UnsupportedFormat);
     }
 
+    // `width` is an `int32_t` and `stride` is four, so this product cannot overflow 64 bits.
     const auto rowBytes = static_cast<std::uint64_t>(width) * stride;
     if (static_cast<std::uint64_t>(rowStride) < rowBytes) {
         return err(VerifyError::RowStrideTooSmall);
     }
+
     // The last row need not be padded, so the requirement is every full row but the last, plus one
-    // row of pixels. 64-bit throughout: a large extent multiplied in `size_t` on a 32-bit host would
-    // wrap into admitting exactly the buffer this refuses.
-    const auto required = (static_cast<std::uint64_t>(height) - 1) * static_cast<std::uint64_t>(rowStride) + rowBytes;
-    if (static_cast<std::uint64_t>(bytes.size()) < required) {
+    // row of pixels. The multiplication is *checked* rather than merely widened: `rowStride` is a
+    // `size_t` a caller chooses, and unsigned 64-bit arithmetic wraps as happily as any other. With
+    // `height = 2` and `rowStride = SIZE_MAX` the sum wraps to three, which would admit a four-byte
+    // span and then read at offset `SIZE_MAX` - so the bound is established by division and
+    // subtraction, which cannot wrap, before anything is multiplied.
+    const auto rows = static_cast<std::uint64_t>(height) - 1;
+    const auto room = static_cast<std::uint64_t>(bytes.size());
+    if (room < rowBytes) {
+        return err(VerifyError::FramebufferTooSmall);
+    }
+    if (rows != 0 && static_cast<std::uint64_t>(rowStride) > (room - rowBytes) / rows) {
         return err(VerifyError::FramebufferTooSmall);
     }
     return FramebufferView{bytes, width, height, rowStride, format};
@@ -242,11 +345,16 @@ std::optional<ColorRgba8> FramebufferView::pixelAt(Px x, Px y) const noexcept {
     if (x < 0 || y < 0 || x >= width_ || y >= height_) {
         return std::nullopt;
     }
-    const std::size_t offset = static_cast<std::size_t>(y) * rowStride_ + static_cast<std::size_t>(x) * bytesPerPixel(format_);
-    if (offset + bytesPerPixel(format_) > bytes_.size()) {
-        // Unreachable for a view `create()` admitted, and kept because "unreachable" is a property
-        // of an invariant rather than of the compiler: a future format with a different stride would
-        // find this here instead of past the end of the caller's span.
+    const std::size_t pixelBytes = bytesPerPixel(format_);
+    if (bytes_.size() < pixelBytes) {
+        return std::nullopt;
+    }
+    // Subtraction rather than `offset + pixelBytes > size`, which wraps: the addition form's own
+    // guard can overflow past the end of the caller's span, which is exactly how a `SIZE_MAX` stride
+    // used to get through. `create()` has already bounded the product below, and this is the second
+    // gate rather than the only one.
+    const std::size_t offset = static_cast<std::size_t>(y) * rowStride_ + static_cast<std::size_t>(x) * pixelBytes;
+    if (offset > bytes_.size() - pixelBytes) {
         return std::nullopt;
     }
     const auto channel = [this, offset](std::size_t index) noexcept {
@@ -306,18 +414,79 @@ GoldenExpectation::create(const GoldenEntry& entry, const mdux::medui::ScreenPac
     return GoldenExpectation{node, scope, entry.cvChecks, ground, hasTint, tint};
 }
 
-Result<TextExpectation, VerifyError> TextExpectation::create(const mdux::medui::CompiledNode& node,
-                                                             RenderScope                      scope,
-                                                             std::span<const std::byte>       records,
-                                                             const mdux::font::FontPackage&   font,
-                                                             ColorRgba8                       ground) noexcept {
+Result<TextExpectation, VerifyError> TextExpectation::create(const mdux::medui::ScreenPackage& screen,
+                                                             const mdux::medui::CompiledNode&  node,
+                                                             const mdux::medui::TextBinding&   binding,
+                                                             std::span<const std::byte>        atlas,
+                                                             RenderScope                       scope,
+                                                             ColorRgba8                        ground) noexcept {
+    // Everything below is provenance, and it is all this function adds over `createSynthetic()`.
+    // `TextBinding::create()` has already proved that the font, the text package, its canonical
+    // bytes and its sidecar describe each other; what it cannot know is which screen and which node
+    // the caller means, so those are checked here.
+    if (!binding.bound()) {
+        return err(VerifyError::TextBindingUnbound);
+    }
+    if (!binding.approvedBy(screen)) {
+        // A binding approved by screen A being used to verify screen B. The binding retains the
+        // locale, package id and canonical digest it was proved against, so this is a comparison
+        // against the manifest rather than a second hash.
+        return err(VerifyError::BindingNotApproved);
+    }
+    if (screen.find(node.id) != &node) {
+        // Not "a node with this id exists" but "this is that node". A caller holding a node from a
+        // different screen would otherwise have its bounds verified against a manifest that never
+        // mentioned it.
+        return err(VerifyError::NodeNotInScreen);
+    }
+    if (scope.tag() != binding.text()->locale) {
+        // The scope names the locale an outcome will be reported under. A scope saying `de-DE` over
+        // a binding carrying `en-US` would produce a passing German outcome from an English frame,
+        // which is precisely the confusion ADR-014 decision 3 exists to prevent.
+        return err(VerifyError::ScopeIsNotTheBoundLocale);
+    }
+
+    const std::string_view key = textKeyOf(node);
+    if (key.empty()) {
+        return err(VerifyError::NodeCarriesNoTextKey);
+    }
+    const mdux::text::TextRun* run = binding.text()->find(key);
+    if (run == nullptr) {
+        return err(VerifyError::UnknownTextKey);
+    }
+    // Bounds before the span exists. The binding proved every range lies inside the sidecar, so this
+    // is defence in depth rather than the first check - and subtraction rather than an addition that
+    // could wrap, which is the form `TextBinding::create()` uses for the same reason.
+    const std::span<const std::byte> sidecar = binding.runs();
+    if (run->byteOffset > sidecar.size() || run->byteLength > sidecar.size() - run->byteOffset) {
+        return err(VerifyError::MalformedRun);
+    }
+    const std::span<const std::byte> records = sidecar.subspan(static_cast<std::size_t>(run->byteOffset), static_cast<std::size_t>(run->byteLength));
+
+    return build(node, scope, records, *binding.font(), atlas, ground);
+}
+
+Result<TextExpectation, VerifyError> TextExpectation::createSynthetic(const mdux::medui::CompiledNode& node,
+                                                                      RenderScope                      scope,
+                                                                      std::span<const std::byte>       records,
+                                                                      const mdux::font::FontPackage&   font,
+                                                                      std::span<const std::byte>       atlas,
+                                                                      ColorRgba8                       ground) noexcept {
     if (textKeyOf(node).empty()) {
         return err(VerifyError::NodeCarriesNoTextKey);
     }
+    return build(node, scope, records, font, atlas, ground);
+}
+
+Result<TextExpectation, VerifyError> TextExpectation::build(const mdux::medui::CompiledNode& node,
+                                                            RenderScope                      scope,
+                                                            std::span<const std::byte>       records,
+                                                            const mdux::font::FontPackage&   font,
+                                                            std::span<const std::byte>       atlas,
+                                                            ColorRgba8                       ground) noexcept {
     if (scope.isLocaleFree()) {
-        // A text obligation is one node, one check and one *approved locale*: the locale-free scope
-        // exists so a textless screen keeps its geometric obligations, not so a text node can lose
-        // the only thing that distinguishes one of its two obligations from another.
+        // The locale-free scope exists so a textless screen keeps its geometric obligations, not so
+        // a text obligation can lose the only thing that distinguishes one of its two from another.
         return err(VerifyError::ScopeIsLocaleFree);
     }
     if (records.size() % mdux::text::draw::recordSize != 0) {
@@ -331,6 +500,19 @@ Result<TextExpectation, VerifyError> TextExpectation::create(const mdux::medui::
         // The runtime's cap rather than a second one. A run the device would refuse to draw is not a
         // run a verifier should describe as checkable.
         return err(VerifyError::RunTooLong);
+    }
+
+    // The sheet, before any glyph is read out of it. `byteLength` is `width * height` for a
+    // validated font package, and both are restated here because this module is handed the bytes
+    // rather than the file: a caller that passed the wrong sidecar would otherwise sample coverage
+    // from another font's shapes and find the run present in the wrong letters.
+    const auto sheetWidth  = static_cast<std::uint64_t>(font.atlas.width);
+    const auto sheetHeight = static_cast<std::uint64_t>(font.atlas.height);
+    if (sheetWidth == 0 || sheetHeight == 0 || font.atlas.byteLength != sheetWidth * sheetHeight) {
+        return err(VerifyError::AtlasSizeMismatch);
+    }
+    if (static_cast<std::uint64_t>(atlas.size()) != font.atlas.byteLength) {
+        return err(VerifyError::AtlasSizeMismatch);
     }
 
     const auto resolved = mdux::medui::resolveColorToken(colorTokenOf(node));
@@ -355,6 +537,9 @@ Result<TextExpectation, VerifyError> TextExpectation::create(const mdux::medui::
         if (glyph.isBlank()) {
             continue;
         }
+        if (static_cast<std::uint64_t>(glyph.x) + glyph.width > sheetWidth || static_cast<std::uint64_t>(glyph.y) + glyph.height > sheetHeight) {
+            return err(VerifyError::GlyphOutsideAtlas);
+        }
         ink.add(placement->x + glyph.bitmapOriginX, placement->y - glyph.bitmapOriginY, static_cast<Px>(glyph.width), static_cast<Px>(glyph.height));
     }
     if (!ink.inked) {
@@ -371,28 +556,45 @@ Result<TextExpectation, VerifyError> TextExpectation::create(const mdux::medui::
     const Px       originY = node.bounds.y - ink.top;
     const NodeRect placed{.x = node.bounds.x, .y = node.bounds.y, .width = ink.right - ink.left, .height = ink.bottom - ink.top};
 
-    return TextExpectation{&node, scope, records, &font, mdux::medui::quantise(*resolved), ground, placed, originX, originY};
+    return TextExpectation{&node, scope, records, &font, atlas, mdux::medui::quantise(*resolved), ground, placed, originX, originY};
 }
 
-std::optional<NodeRect> TextExpectation::glyphRect(std::size_t index) const noexcept {
+std::optional<PlacedGlyph> TextExpectation::glyph(std::size_t index) const noexcept {
     if (index >= glyphCount()) {
         return std::nullopt;
     }
     const auto placement = mdux::text::draw::decodeRecord(records_.subspan(index * mdux::text::draw::recordSize, mdux::text::draw::recordSize));
     if (!placement.has_value() || placement->packageIndex >= font_->glyphs.size()) {
-        // Both refused by `create()`, so neither is reachable through a live expectation. Answered
-        // as "no rectangle" rather than assumed away, because the alternative is indexing a vector
-        // with a number this function did not check.
+        // Both refused when the expectation was built, so neither is reachable through a live one.
+        // Answered as "no glyph" rather than assumed away, because the alternative is indexing a
+        // vector with a number this function did not check.
         return std::nullopt;
     }
     const mdux::font::GlyphRecord& glyph = font_->glyphs[placement->packageIndex];
     if (glyph.isBlank()) {
         return std::nullopt;
     }
-    return NodeRect{.x      = originX_ + placement->x + glyph.bitmapOriginX,
-                    .y      = originY_ + placement->y - glyph.bitmapOriginY,
-                    .width  = static_cast<Px>(glyph.width),
-                    .height = static_cast<Px>(glyph.height)};
+    return PlacedGlyph{
+        .rect   = NodeRect{.x      = originX_ + placement->x + glyph.bitmapOriginX,
+                           .y      = originY_ + placement->y - glyph.bitmapOriginY,
+                           .width  = static_cast<Px>(glyph.width),
+                           .height = static_cast<Px>(glyph.height)},
+        .atlasX = glyph.x,
+        .atlasY = glyph.y
+    };
+}
+
+std::uint8_t TextExpectation::coverage(const PlacedGlyph& placed, Px dx, Px dy) const noexcept {
+    if (dx < 0 || dy < 0 || dx >= placed.rect.width || dy >= placed.rect.height) {
+        return 0;
+    }
+    const auto texelX = static_cast<std::uint64_t>(placed.atlasX) + static_cast<std::uint64_t>(dx);
+    const auto texelY = static_cast<std::uint64_t>(placed.atlasY) + static_cast<std::uint64_t>(dy);
+    const auto offset = texelY * static_cast<std::uint64_t>(font_->atlas.width) + texelX;
+    if (offset >= static_cast<std::uint64_t>(atlas_.size())) {
+        return 0;
+    }
+    return std::to_integer<std::uint8_t>(atlas_[static_cast<std::size_t>(offset)]);
 }
 
 CheckOutcome goldenBounds(const FramebufferView& frame, const GoldenExpectation& expectation) noexcept {
@@ -441,7 +643,7 @@ CheckOutcome colorHash(const FramebufferView& frame, const GoldenExpectation& ex
             if (!pixel.has_value() || *pixel == ground) {
                 continue;
             }
-            if (!blendOf(*pixel, ground, tint)) {
+            if (!couldBeBlend(*pixel, ground, tint)) {
                 outcome.found           = atPixel(x, y);
                 outcome.foundValid      = true;
                 outcome.foundColor      = *pixel;
@@ -506,33 +708,84 @@ CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpec
     const ColorRgba8 ground = expectation.ground();
     const ColorRgba8 tint   = expectation.tint();
 
-    // Half one: every glyph this locale's run paints has painted something of its own.
+    // Half one: every glyph this locale's run paints is on screen in the shape the atlas gives it.
+    // Comparing against the baked coverage rather than against the glyph's box is what makes this a
+    // claim about the approved run: a sparse handful of pixels occupying the rectangles, and a
+    // different letter of the same size, both fail it.
     for (std::size_t index = 0; index < expectation.glyphCount(); ++index) {
-        const std::optional<NodeRect> glyph = expectation.glyphRect(index);
-        if (!glyph.has_value()) {
+        const std::optional<PlacedGlyph> placed = expectation.glyph(index);
+        if (!placed.has_value()) {
             // A blank, most often the space. It advances the pen and paints nothing, so there is
             // nothing to find and nothing missing.
             continue;
         }
         outcome.glyphIndex = index;
-        if (!frame.contains(*glyph)) {
-            outcome.found      = *glyph;
+        outcome.expected   = placed->rect;
+        if (!frame.contains(placed->rect)) {
+            outcome.found      = placed->rect;
             outcome.foundValid = true;
             return failed(outcome, Finding::RegionOutsideFrame);
         }
-        if (!paintedBox(frame, *glyph, ground).inked) {
-            outcome.expected   = *glyph;
-            outcome.found      = *glyph;
+
+        // The whole glyph is walked before anything is reported, because *which* failure this is
+        // depends on the glyph rather than on the first pixel that disagreed. A run drawn in the
+        // wrong tint disagrees at its very first pixel and has painted plenty; a glyph that is
+        // simply absent disagrees at the same pixel and has painted nothing. Deciding from scan
+        // position would call the first one "painted nothing", which sends a reader to look for a
+        // missing translation instead of a wrong colour.
+        bool       inked     = false;
+        bool       disagreed = false;
+        Px         firstX    = placed->rect.x;
+        Px         firstY    = placed->rect.y;
+        ColorRgba8 firstFound{};
+        ColorRgba8 firstWanted{};
+        for (Px dy = 0; dy < placed->rect.height; ++dy) {
+            for (Px dx = 0; dx < placed->rect.width; ++dx) {
+                const Px                        x     = placed->rect.x + dx;
+                const Px                        y     = placed->rect.y + dy;
+                const std::optional<ColorRgba8> pixel = frame.pixelAt(x, y);
+                if (!pixel.has_value()) {
+                    outcome.found      = atPixel(x, y);
+                    outcome.foundValid = true;
+                    return failed(outcome, Finding::RegionOutsideFrame);
+                }
+                inked = inked || *pixel != ground;
+
+                const ColorRgba8 wanted = blend(ground, tint, expectation.coverage(*placed, dx, dy));
+                if (!withinOneStep(*pixel, wanted) && !disagreed) {
+                    disagreed   = true;
+                    firstX      = x;
+                    firstY      = y;
+                    firstFound  = *pixel;
+                    firstWanted = wanted;
+                }
+            }
+        }
+
+        if (disagreed) {
+            outcome.found           = atPixel(firstX, firstY);
+            outcome.foundValid      = true;
+            outcome.foundColor      = firstFound;
+            outcome.foundColorValid = true;
+            outcome.expectedColor   = firstWanted;
+            // "Nothing of this glyph is on screen" and "something is, and it is not this glyph as
+            // the baker covered it" are different sentences, and a reader acts on them differently.
+            return failed(outcome, inked ? Finding::CoverageDiffers : Finding::GlyphMissing);
+        }
+        if (!inked) {
+            // Every texel of a non-blank glyph agreed with the ground, which can only mean the
+            // sheet's slot for it is empty - a package whose metrics and coverage disagree.
+            outcome.found      = placed->rect;
             outcome.foundValid = true;
             return failed(outcome, Finding::GlyphMissing);
         }
     }
-    outcome.glyphIndex = 0;
-    outcome.expected   = region;
+    outcome.glyphIndex    = 0;
+    outcome.expected      = region;
+    outcome.expectedColor = tint;
 
     // Half two: nothing painted anywhere else in the node. The atlas slot is exactly the glyph's
-    // bitmap, so a correct frame paints outside no rectangle - which is what stops a different
-    // translation, whose glyphs land elsewhere, from satisfying half one and being called present.
+    // bitmap, so a correct frame paints outside no rectangle.
     for (Px y = region.y; y < region.y + region.height; ++y) {
         for (Px x = region.x; x < region.x + region.width; ++x) {
             const std::optional<ColorRgba8> pixel = frame.pixelAt(x, y);
@@ -541,26 +794,21 @@ CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpec
             }
             bool attributed = false;
             for (std::size_t index = 0; index < expectation.glyphCount() && !attributed; ++index) {
-                const std::optional<NodeRect> glyph = expectation.glyphRect(index);
-                attributed                          = glyph.has_value() && holds(*glyph, x, y);
+                const std::optional<PlacedGlyph> placed = expectation.glyph(index);
+                attributed                              = placed.has_value() && holds(placed->rect, x, y);
             }
-            outcome.found           = atPixel(x, y);
-            outcome.foundValid      = true;
-            outcome.foundColor      = *pixel;
-            outcome.foundColorValid = true;
             if (!attributed) {
+                outcome.found           = atPixel(x, y);
+                outcome.foundValid      = true;
+                outcome.foundColor      = *pixel;
+                outcome.foundColorValid = true;
                 return failed(outcome, Finding::InkOutsideTheRun);
-            }
-            if (!blendOf(*pixel, ground, tint)) {
-                return failed(outcome, Finding::ForeignColour);
             }
         }
     }
 
-    outcome.found           = expectation.ink();
-    outcome.foundValid      = true;
-    outcome.foundColor      = ColorRgba8{};
-    outcome.foundColorValid = false;
+    outcome.found      = expectation.ink();
+    outcome.foundValid = true;
     return outcome;
 }
 

--- a/src/verify/Verify.cpp
+++ b/src/verify/Verify.cpp
@@ -154,13 +154,31 @@ struct Box {
     return true;
 }
 
-/// Whether every channel of `pixel` is within one UNORM step of `expected`.
-[[nodiscard]] bool withinOneStep(ColorRgba8 pixel, ColorRgba8 expected) noexcept {
-    const auto close = [](std::uint8_t left, std::uint8_t right) noexcept {
-        const int difference = static_cast<int>(left) - static_cast<int>(right);
-        return difference <= 1 && difference >= -1;
+/// Whether every channel of `pixel` is within `steps` UNORM steps of `expected`.
+///
+/// One step per quantisation the device performed. A single glyph is one blend and therefore one
+/// step; a pixel two overlapping quads deep was quantised to eight bits twice, so it may differ in
+/// the last bit twice. Bounded by the number of glyphs covering the pixel, never by a fixed slack.
+[[nodiscard]] bool withinSteps(ColorRgba8 pixel, ColorRgba8 expected, std::size_t steps) noexcept {
+    const auto close = [steps](std::uint8_t left, std::uint8_t right) noexcept {
+        const auto difference = static_cast<std::int64_t>(left) - static_cast<std::int64_t>(right);
+        const auto allowed    = static_cast<std::int64_t>(steps == 0 ? 1 : steps);
+        return difference <= allowed && difference >= -allowed;
     };
     return close(pixel.r, expected.r) && close(pixel.g, expected.g) && close(pixel.b, expected.b) && close(pixel.a, expected.a);
+}
+
+/**
+ * @brief Two coverages of one tint over one ground, as the draw path composites them.
+ *
+ * `1 - (1 - a1)(1 - a2)`, in integers. The draw path records one quad per glyph and blends them in
+ * turn, so expanding `t*a2 + (t*a1 + g*(1-a1))*(1-a2)` leaves the tint weighted by exactly this
+ * expression and the ground by its complement. Commutative, so the order glyphs are visited in does
+ * not change the answer.
+ */
+[[nodiscard]] std::uint8_t composeCoverage(std::uint8_t first, std::uint8_t second) noexcept {
+    const auto remaining = (255 - static_cast<int>(first)) * (255 - static_cast<int>(second));
+    return static_cast<std::uint8_t>(255 - (remaining + 127) / 255);
 }
 
 /// The bounding box of every pixel of `region` that is not `ground`.
@@ -708,107 +726,140 @@ CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpec
     const ColorRgba8 ground = expectation.ground();
     const ColorRgba8 tint   = expectation.tint();
 
-    // Half one: every glyph this locale's run paints is on screen in the shape the atlas gives it.
-    // Comparing against the baked coverage rather than against the glyph's box is what makes this a
-    // claim about the approved run: a sparse handful of pixels occupying the rectangles, and a
-    // different letter of the same size, both fail it.
+    // Every placed glyph has to be somewhere this function can look, before any of them is read.
     for (std::size_t index = 0; index < expectation.glyphCount(); ++index) {
         const std::optional<PlacedGlyph> placed = expectation.glyph(index);
-        if (!placed.has_value()) {
-            // A blank, most often the space. It advances the pen and paints nothing, so there is
-            // nothing to find and nothing missing.
-            continue;
-        }
-        outcome.glyphIndex = index;
-        outcome.expected   = placed->rect;
-        if (!frame.contains(placed->rect)) {
+        if (placed.has_value() && !frame.contains(placed->rect)) {
+            outcome.glyphIndex = index;
+            outcome.expected   = placed->rect;
             outcome.found      = placed->rect;
             outcome.foundValid = true;
             return failed(outcome, Finding::RegionOutsideFrame);
         }
+    }
 
-        // The whole glyph is walked before anything is reported, because *which* failure this is
-        // depends on the glyph rather than on the first pixel that disagreed. A run drawn in the
-        // wrong tint disagrees at its very first pixel and has painted plenty; a glyph that is
-        // simply absent disagrees at the same pixel and has painted nothing. Deciding from scan
-        // position would call the first one "painted nothing", which sends a reader to look for a
-        // missing translation instead of a wrong colour.
-        bool       inked     = false;
-        bool       disagreed = false;
-        Px         firstX    = placed->rect.x;
-        Px         firstY    = placed->rect.y;
-        ColorRgba8 firstFound{};
-        ColorRgba8 firstWanted{};
-        for (Px dy = 0; dy < placed->rect.height; ++dy) {
-            for (Px dx = 0; dx < placed->rect.width; ++dx) {
-                const Px                        x     = placed->rect.x + dx;
-                const Px                        y     = placed->rect.y + dy;
-                const std::optional<ColorRgba8> pixel = frame.pixelAt(x, y);
-                if (!pixel.has_value()) {
-                    outcome.found      = atPixel(x, y);
-                    outcome.foundValid = true;
-                    return failed(outcome, Finding::RegionOutsideFrame);
-                }
-                inked = inked || *pixel != ground;
+    // What the run paints at one pixel: the coverage of every glyph that covers it, composed, and
+    // how many did.
+    //
+    // Composed rather than taken one glyph at a time, because the draw path draws one quad per
+    // glyph and blends them in turn - so where two placed rectangles overlap, the frame holds
+    // `1 - (1 - a1)(1 - a2)` of the tint and not either coverage alone. Nothing in
+    // `FontPackage::validate()` requires an advance to clear its own bitmap, so a font with tight
+    // advances or negative kerning can produce that overlap, and comparing against a single glyph's
+    // coverage there would fail a correct frame. The composition is exact because every glyph of one
+    // run carries one tint over one ground: expanding the two blends leaves the tint weighted by
+    // exactly that expression.
+    struct Painted {
+        std::uint8_t coverage{0};
+        std::size_t  layers{0};
+        std::size_t  first{0};
+    };
+    const auto paintedAt = [&expectation](Px x, Px y) noexcept {
+        Painted painted;
+        for (std::size_t index = 0; index < expectation.glyphCount(); ++index) {
+            const std::optional<PlacedGlyph> placed = expectation.glyph(index);
+            if (!placed.has_value() || !holds(placed->rect, x, y)) {
+                continue;
+            }
+            if (painted.layers == 0) {
+                painted.first = index;
+            }
+            ++painted.layers;
+            painted.coverage = composeCoverage(painted.coverage, expectation.coverage(*placed, x - placed->rect.x, y - placed->rect.y));
+        }
+        return painted;
+    };
 
-                const ColorRgba8 wanted = blend(ground, tint, expectation.coverage(*placed, dx, dy));
-                if (!withinOneStep(*pixel, wanted) && !disagreed) {
-                    disagreed   = true;
-                    firstX      = x;
-                    firstY      = y;
-                    firstFound  = *pixel;
-                    firstWanted = wanted;
+    // Whether a glyph's rectangle shows anything at all. It is what separates "this glyph is not on
+    // screen" from "something is, and it is not this glyph as the baker covered it" - two sentences
+    // a reader acts on differently, and a distinction the first disagreeing pixel cannot make: a run
+    // in the wrong tint disagrees at its very first pixel having painted plenty.
+    const auto glyphShowsInk = [&frame, ground](const PlacedGlyph& placed) noexcept {
+        for (Px dy = 0; dy < placed.rect.height; ++dy) {
+            for (Px dx = 0; dx < placed.rect.width; ++dx) {
+                const std::optional<ColorRgba8> pixel = frame.pixelAt(placed.rect.x + dx, placed.rect.y + dy);
+                if (pixel.has_value() && *pixel != ground) {
+                    return true;
                 }
             }
         }
+        return false;
+    };
 
-        if (disagreed) {
-            outcome.found           = atPixel(firstX, firstY);
-            outcome.foundValid      = true;
-            outcome.foundColor      = firstFound;
-            outcome.foundColorValid = true;
-            outcome.expectedColor   = firstWanted;
-            // "Nothing of this glyph is on screen" and "something is, and it is not this glyph as
-            // the baker covered it" are different sentences, and a reader acts on them differently.
-            return failed(outcome, inked ? Finding::CoverageDiffers : Finding::GlyphMissing);
+    const NodeRect ink = expectation.ink();
+    for (Px y = region.y; y < region.y + region.height; ++y) {
+        for (Px x = region.x; x < region.x + region.width; ++x) {
+            const std::optional<ColorRgba8> pixel = frame.pixelAt(x, y);
+            if (!pixel.has_value()) {
+                outcome.found      = atPixel(x, y);
+                outcome.foundValid = true;
+                return failed(outcome, Finding::RegionOutsideFrame);
+            }
+
+            // Outside the run's ink box no glyph can cover this pixel, so the answer is the ground
+            // and the glyph walk is skipped. That keeps the per-pixel cost proportional to the run
+            // only where the run is, rather than over the whole node.
+            const bool    reachable = holds(ink, x, y);
+            const Painted painted   = reachable ? paintedAt(x, y) : Painted{};
+            if (painted.layers == 0) {
+                if (*pixel != ground) {
+                    // The atlas slot is exactly the glyph's bitmap, so a correct frame paints
+                    // nothing here.
+                    outcome.found           = atPixel(x, y);
+                    outcome.foundValid      = true;
+                    outcome.foundColor      = *pixel;
+                    outcome.foundColorValid = true;
+                    return failed(outcome, Finding::InkOutsideTheRun);
+                }
+                continue;
+            }
+
+            // One UNORM step per composite the device performed: it blends in floating point and
+            // quantises back to eight bits at every step, so a pixel two quads deep can differ in
+            // the last bit twice. Not a similarity threshold - a wrong shape misses by far more.
+            const ColorRgba8 wanted = blend(ground, tint, painted.coverage);
+            if (!withinSteps(*pixel, wanted, painted.layers)) {
+                const std::optional<PlacedGlyph> placed = expectation.glyph(painted.first);
+                outcome.glyphIndex                      = painted.first;
+                outcome.expected                        = placed.has_value() ? placed->rect : region;
+                outcome.found                           = atPixel(x, y);
+                outcome.foundValid                      = true;
+                outcome.foundColor                      = *pixel;
+                outcome.foundColorValid                 = true;
+                outcome.expectedColor                   = wanted;
+                return failed(outcome, placed.has_value() && glyphShowsInk(*placed) ? Finding::CoverageDiffers : Finding::GlyphMissing);
+            }
         }
-        if (!inked) {
-            // Every texel of a non-blank glyph agreed with the ground, which can only mean the
-            // sheet's slot for it is empty - a package whose metrics and coverage disagree.
+    }
+
+    // A non-blank glyph whose sheet slot is empty paints nothing, agrees with the ground everywhere,
+    // and would otherwise pass having shown nothing at all - a package whose metrics and coverage
+    // disagree, which is worth its own refusal rather than a silent hold.
+    for (std::size_t index = 0; index < expectation.glyphCount(); ++index) {
+        const std::optional<PlacedGlyph> placed = expectation.glyph(index);
+        if (!placed.has_value()) {
+            continue;
+        }
+        bool covered = false;
+        for (Px dy = 0; dy < placed->rect.height && !covered; ++dy) {
+            for (Px dx = 0; dx < placed->rect.width && !covered; ++dx) {
+                covered = expectation.coverage(*placed, dx, dy) != 0;
+            }
+        }
+        if (!covered) {
+            outcome.glyphIndex = index;
+            outcome.expected   = placed->rect;
             outcome.found      = placed->rect;
             outcome.foundValid = true;
             return failed(outcome, Finding::GlyphMissing);
         }
     }
+
     outcome.glyphIndex    = 0;
     outcome.expected      = region;
     outcome.expectedColor = tint;
-
-    // Half two: nothing painted anywhere else in the node. The atlas slot is exactly the glyph's
-    // bitmap, so a correct frame paints outside no rectangle.
-    for (Px y = region.y; y < region.y + region.height; ++y) {
-        for (Px x = region.x; x < region.x + region.width; ++x) {
-            const std::optional<ColorRgba8> pixel = frame.pixelAt(x, y);
-            if (!pixel.has_value() || *pixel == ground) {
-                continue;
-            }
-            bool attributed = false;
-            for (std::size_t index = 0; index < expectation.glyphCount() && !attributed; ++index) {
-                const std::optional<PlacedGlyph> placed = expectation.glyph(index);
-                attributed                              = placed.has_value() && holds(placed->rect, x, y);
-            }
-            if (!attributed) {
-                outcome.found           = atPixel(x, y);
-                outcome.foundValid      = true;
-                outcome.foundColor      = *pixel;
-                outcome.foundColorValid = true;
-                return failed(outcome, Finding::InkOutsideTheRun);
-            }
-        }
-    }
-
-    outcome.found      = expectation.ink();
-    outcome.foundValid = true;
+    outcome.found         = ink;
+    outcome.foundValid    = true;
     return outcome;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -795,6 +795,46 @@ endif()
 
 mdux_discover_tests(medui_spec)
 
+# Rendered-truth verification checks (issue #252)
+#
+# Links MduX::Core only, and no Vulkan target of any kind. That is the standing evidence for
+# ADR-014 decision 1's first consequence: a framebuffer is an array, so the four checks are pure
+# functions a scenario can exercise on an image it painted, and they can be built and proved before
+# #253's driver exists to render one. A scenario here that needed a GPU would mean they had stopped
+# being pure functions over pixels.
+#
+# GoldenCheckTests covers both `CvCheck`s on synthetic images and, separately,
+# `GoldenExpectation::create()` - the dangling golden id and each duplicated field disagreeing with
+# its named package node, which ADR-014's ownership table assigns to the verifier rather than to the
+# baker's re-derivation. TextCheckTests covers the two mandatory text checks over a node that has no
+# golden entry and declared no `position:`, which is the criterion easiest to satisfy by accident.
+add_executable(verify_spec
+    verify/VerifySpecMain.cpp
+    verify/FramebufferTests.cpp
+    verify/GoldenCheckTests.cpp
+    verify/TextCheckTests.cpp
+)
+
+target_link_libraries(verify_spec PRIVATE MduX::Core speclab::speclab)
+target_include_directories(verify_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(verify_spec
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(verify_spec PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(verify_spec PRIVATE /experimental:module /std:c++latest)
+endif()
+
+mdux_discover_tests(verify_spec)
+
 # .medui compiler host-tools suite (issues #191, #192, #193, #194, #195, #196)
 #
 # Links MduX::MeduiLib. Two groups of scenarios: the diagnostic registry's invariants (#191) -

--- a/tests/verify/FramebufferTests.cpp
+++ b/tests/verify/FramebufferTests.cpp
@@ -131,6 +131,14 @@ const mdux::spec::Register anImageThatCannotExistIsRefused{
                       // width * height * 4 bytes looks like.
                       checks.expect(mv::FramebufferView::create(bytes, 4, 2, 16, mv::PixelFormat::Rgba8Unorm).has_value(),
                                     "an exactly-sized packed image is admitted");
+
+                      // The regression: a stride at the top of `size_t` makes `(height - 1) * stride
+                      // + rowBytes` wrap to a tiny number, so an addition-based bound admits a
+                      // four-byte span and `pixelAt(0, 1)` then reads at offset SIZE_MAX. Widening
+                      // to 64 bits does not help - unsigned arithmetic wraps at any width - so the
+                      // bound is established by division and subtraction instead.
+                      auto hostile = mv::FramebufferView::create(bytes, 1, 2, std::numeric_limits<std::size_t>::max(), mv::PixelFormat::Rgba8Unorm);
+                      checks.expect(error(std::move(hostile)) == mv::VerifyError::FramebufferTooSmall, "a stride at the top of size_t is refused");
                       checks.raise();
                   })
             .Execute();

--- a/tests/verify/FramebufferTests.cpp
+++ b/tests/verify/FramebufferTests.cpp
@@ -1,0 +1,137 @@
+/**
+ * @file FramebufferTests.cpp
+ * @brief BDD scenarios for the read-only framebuffer view every check is given.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ *
+ * The view is the whole of the GPU's contribution to verification, so its refusals are what stand
+ * between a check and somebody else's memory. Two of them are worth their own scenarios rather than
+ * being implied by the checks that use them: a row stride that does not hold a row, and a span
+ * shorter than the extent it claims. Both describe an image that does not exist, and a view that
+ * accepted either would hand every check a plausible wrong answer instead of a failure.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.medui.schema;
+import mdux.verify;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+namespace mv = mdux::verify;
+
+using mdux::core::ColorRgba8;
+
+constexpr ColorRgba8 red{.r = 255, .g = 0, .b = 0, .a = 255};
+constexpr ColorRgba8 blue{.r = 0, .g = 0, .b = 255, .a = 255};
+
+}  // namespace
+
+const mdux::spec::Register aPackedImageIsIndexedByRowAndColumn{
+    "A packed image answers the pixel at a coordinate, and nothing outside itself",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-framebuffer-packed")
+            .Given("a four-by-two image with one pixel deliberately different", [] {})
+            .When("it is described as a framebuffer view", [] {})
+            .Then("every coordinate reads back what was written, and the rest reads as nothing",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      std::array<ColorRgba8, 8> pixels{};
+                      pixels.fill(red);
+                      pixels[5] = blue;  // (1, 1)
+
+                      auto view = mv::FramebufferView::createPacked(pixels, 4, 2);
+                      checks.expect(view.has_value(), "the view is accepted");
+                      if (!view.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+
+                      checks.expect(view->width() == 4 && view->height() == 2, "the extent is the one declared");
+                      checks.expect(view->rowStride() == 16, "and a packed row is four pixels of four bytes");
+                      checks.expect(view->pixelAt(1, 1) == blue, "the pixel written is the pixel read");
+                      checks.expect(view->pixelAt(0, 1) == red, "and its neighbour is untouched");
+                      // An optional rather than whatever was next in memory: an out-of-range read is
+                      // a mistake in an expectation, and it should say so.
+                      checks.expect(!view->pixelAt(4, 0).has_value(), "one past the last column is nothing");
+                      checks.expect(!view->pixelAt(0, 2).has_value(), "and so is one past the last row");
+                      checks.expect(!view->pixelAt(-1, 0).has_value(), "and so is a negative coordinate");
+
+                      checks.expect(view->contains(ms::NodeRect{0, 0, 4, 2}), "the whole image is inside itself");
+                      checks.expect(!view->contains(ms::NodeRect{0, 0, 5, 2}), "and one column more is not");
+                      checks.expect(!view->contains(ms::NodeRect{0, 0, 4, 0}), "a degenerate rectangle is inside nothing");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aPaddedRowIsReadAtItsStride{
+    "A padded readback is read at its stride rather than at its width",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-framebuffer-stride")
+            .Given("a two-by-two image whose rows are padded to three pixels", [] {})
+            .When("it is described with that stride", [] {})
+            .Then("the second row starts after the padding, not after the pixels",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // A readback is not obliged to be tightly packed, and a check that assumed it
+                      // was would read this row's padding as the next row's first pixel.
+                      std::array<ColorRgba8, 6> storage{};
+                      storage.fill(red);
+                      storage[3] = blue;  // the first pixel of the second row, at stride 3
+
+                      auto view = mv::FramebufferView::create(std::as_bytes(std::span{storage}), 2, 2, 12, mv::PixelFormat::Rgba8Unorm);
+                      checks.expect(view.has_value(), "the padded view is accepted");
+                      if (!view.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(view->pixelAt(0, 1) == blue, "the second row begins at the stride");
+                      checks.expect(view->pixelAt(1, 0) == red, "and the first row is unchanged");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anImageThatCannotExistIsRefused{
+    "A framebuffer whose description cannot hold its own image is refused",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-framebuffer-fails-closed")
+            .Given("an empty extent, a stride too small for a row, and a span too small for the image", [] {})
+            .When("each is described as a framebuffer view", [] {})
+            .Then("each is refused, naming what was wrong with the description",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      std::array<ColorRgba8, 8>        pixels{};
+                      const std::span<const std::byte> bytes = std::as_bytes(std::span{pixels});
+
+                      const auto error = [](auto&& made) {
+                          return made.has_value() ? std::optional<mv::VerifyError>{} : std::optional<mv::VerifyError>{made.error()};
+                      };
+
+                      checks.expect(error(mv::FramebufferView::create(bytes, 0, 2, 16, mv::PixelFormat::Rgba8Unorm)) == mv::VerifyError::EmptyFramebuffer,
+                                    "zero width is nothing to look at");
+                      checks.expect(error(mv::FramebufferView::create(bytes, 4, 2, 12, mv::PixelFormat::Rgba8Unorm)) == mv::VerifyError::RowStrideTooSmall,
+                                    "a stride that cannot hold a row");
+                      checks.expect(error(mv::FramebufferView::create(bytes, 4, 3, 16, mv::PixelFormat::Rgba8Unorm)) == mv::VerifyError::FramebufferTooSmall,
+                                    "and a span that cannot hold the image");
+                      // The last row is allowed to be unpadded, which is what a readback of exactly
+                      // width * height * 4 bytes looks like.
+                      checks.expect(mv::FramebufferView::create(bytes, 4, 2, 16, mv::PixelFormat::Rgba8Unorm).has_value(),
+                                    "an exactly-sized packed image is admitted");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/verify/GoldenCheckTests.cpp
+++ b/tests/verify/GoldenCheckTests.cpp
@@ -274,14 +274,12 @@ const mdux::spec::Register theTintIsComparedExactly{
                       checks.expect(wrong.foundColorValid && wrong.foundColor.r == 255, "and the outcome carries the pixel it found");
                       checks.expect(wrong.expectedColor == tint, "beside the tint it expected");
 
-                      // A legitimate blend of the tint over the ground at half coverage: inside the
-                      // interval everywhere, and equal to the tint nowhere.
+                      // A legitimate blend of the tint over the ground at half coverage: a possible
+                      // pixel everywhere, and equal to the tint nowhere. Through `blend()` rather
+                      // than `tint / 2`, which is not the same number when a channel is odd and
+                      // would make this scenario fail as ForeignColour for a reason it is not about.
                       Canvas partial{16, 20, ground};
-                      partial.fill({4, 4, 8, 6},
-                                   ColorRgba8{.r = static_cast<std::uint8_t>(tint.r / 2),
-                                              .g = static_cast<std::uint8_t>(tint.g / 2),
-                                              .b = static_cast<std::uint8_t>(tint.b / 2),
-                                              .a = 255});
+                      partial.fill({4, 4, 8, 6}, mv::blend(ground, tint, 128));
                       const mv::CheckOutcome faint = mv::colorHash(partial.view(), expectation);
                       checks.expect(faint.finding == mv::Finding::TintAbsent,
                                     std::format("content that never reaches its tint: {}", mv::describe(faint.finding)));

--- a/tests/verify/GoldenCheckTests.cpp
+++ b/tests/verify/GoldenCheckTests.cpp
@@ -290,6 +290,49 @@ const mdux::spec::Register theTintIsComparedExactly{
             .Execute();
     }};
 
+const mdux::spec::Register everyChannelMustAgreeOnOneCoverage{
+    "A pixel inside every channel's range still fails when no single coverage produces it",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-color-hash-common-factor")
+            .Given("a region holding one exact-tint pixel and one impossible channel combination", [] {})
+            .When("ColorHash runs", [] {})
+            .Then("the impossible pixel is reported rather than excused by the exact one",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mv::GoldenExpectation expectation = expect(readoutGolden, textlessScreen, mv::RenderScope::localeFree());
+                      const ColorRgba8            tint        = tintOf(readoutToken);
+
+                      // Over a black ground, this pixel takes red and blue from the tint and green
+                      // from the ground. Every channel is inside its own interval; no coverage
+                      // produces all three, because red and blue demand full coverage and green
+                      // demands none. A per-channel test accepts it, and the exact-tint pixels
+                      // around it would then satisfy the "carries its tint" half and return Held.
+                      const ColorRgba8 impossible{.r = tint.r, .g = ground.g, .b = tint.b, .a = tint.a};
+
+                      Canvas canvas{16, 20, ground};
+                      canvas.fill({4, 4, 8, 6}, tint);
+                      canvas.set(6, 6, impossible);
+
+                      const mv::CheckOutcome outcome = mv::colorHash(canvas.view(), expectation);
+                      checks.expect(outcome.finding == mv::Finding::ForeignColour,
+                                    std::format("no single coverage produces it: {}", mv::describe(outcome.finding)));
+                      checks.expect(outcome.found == ms::NodeRect{6, 6, 1, 1}, "and the outcome names the pixel");
+                      checks.expect(outcome.foundColorValid && outcome.foundColor == impossible, "with the colour it actually found");
+
+                      // ...while a real half-coverage blend, where every channel agrees on the same
+                      // factor, is still admitted. Without this half the assertion above could be
+                      // satisfied by a rule that rejected everything but the tint itself.
+                      Canvas honest{16, 20, ground};
+                      honest.fill({4, 4, 8, 6}, tint);
+                      honest.set(6, 6, mv::blend(ground, tint, 128));
+                      checks.expect(mv::colorHash(honest.view(), expectation).held(), "a genuine half-coverage pixel is still a blend");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register aGoldenWithNoTintCannotDischargeColorHash{
     "ColorHash over a golden that resolved no tint fails rather than passing",
     "evidence-unit",

--- a/tests/verify/GoldenCheckTests.cpp
+++ b/tests/verify/GoldenCheckTests.cpp
@@ -1,0 +1,488 @@
+/**
+ * @file GoldenCheckTests.cpp
+ * @brief BDD scenarios for `GoldenBounds`, `ColorHash`, and the golden expectation that feeds them.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ *
+ * Two halves, and the split is #252's acceptance rather than a filing convention.
+ *
+ * The first half is the checks themselves, on images a scenario paints: a rectangle in the right
+ * place passes, the same rectangle one pixel to the right fails, an empty region fails, and a region
+ * painted in a colour no coverage of the tint could produce fails differently from one painted in a
+ * blend that never reaches it. No GPU is involved anywhere, which is ADR-014 decision 1's first
+ * consequence made mechanical.
+ *
+ * The second half is `GoldenExpectation::create()`, which is where ADR-014 decision 2 lives: a
+ * golden naming a node the screen does not have, and *every* field the sidecar duplicates
+ * disagreeing with the node it names. Those are the failures the ownership table assigns to the
+ * verifier rather than to the baker's re-derivation, so they are the ones this file has to cover
+ * exhaustively rather than representatively.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.evidence.digest;
+import mdux.evidence.report;
+import mdux.medui.schema;
+import mdux.verify;
+
+#include "../framework/SpecLabBridge.hpp"
+#include "SyntheticFrame.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+namespace mv = mdux::verify;
+
+using mdux::core::ColorRgba8;
+using mdux::test::verify::Canvas;
+using mdux::test::verify::tintOf;
+
+/// What the driver clears to, and therefore what "this node painted nothing" looks like.
+constexpr ColorRgba8 ground{.r = 0, .g = 0, .b = 0, .a = 255};
+
+constexpr std::string_view readoutToken = "Theme.Colors.ScoreDigits";
+
+constexpr ms::PanelSpec          readoutPanel{.colorToken = readoutToken};
+constexpr ms::VulkanViewportSpec endoscopeFeed{.streamSource = "ENDOSCOPE_PRIMARY"};
+
+/// A screen with no text at all: exactly the case ADR-014 decision 3 gives one explicit locale-free
+/// render scope, so its geometric and chromatic obligations survive an empty locale manifest.
+constexpr std::array<ms::CompiledNode, 2> textlessNodes{
+    ms::CompiledNode{.id = "readout",   .bounds = {4, 4, 8, 6},  .payload = readoutPanel},
+    ms::CompiledNode{   .id = "feed", .bounds = {0, 12, 16, 8}, .payload = endoscopeFeed}
+};
+
+constexpr mdux::draw::DrawBudget budget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 8};
+
+constexpr ms::ScreenPackage textlessScreen{.id                   = "textless",
+                                           .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                           .surfaceWidth         = 16,
+                                           .surfaceHeight        = 20,
+                                           .approvedTextPackages = {},
+                                           .nodes                = textlessNodes,
+                                           .budget               = budget};
+
+static_assert(textlessScreen.validate().has_value(), "the textless fixture must be a screen a device could hold");
+
+/// A screen that does carry text, for the golden fields a textless one cannot exercise.
+constexpr std::array approvals{
+    ms::TextPackageApproval{.locale = "en-US", .packageId = "titled-en-us", .packageSha256 = {7}}
+};
+
+constexpr ms::LabelSpec titleLabel{.textKey = "STR-TITLE", .colorToken = "Theme.Colors.Title"};
+
+constexpr std::array<ms::CompiledNode, 1> titledNodes{
+    ms::CompiledNode{.id = "screen-title", .bounds = {0, 0, 16, 8}, .payload = titleLabel}
+};
+
+constexpr ms::ScreenPackage titledScreen{.id                   = "titled",
+                                         .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                         .surfaceWidth         = 16,
+                                         .surfaceHeight        = 20,
+                                         .approvedTextPackages = approvals,
+                                         .nodes                = titledNodes,
+                                         .budget               = budget};
+
+static_assert(titledScreen.validate().has_value(), "and so must the text-bearing one");
+
+/// A screen naming a colour the governed table does not define.
+///
+/// Deliberately *not* `static_assert`ed: `validate()` refuses it, which is the point. A screen like
+/// this cannot come out of the compiler, and `GoldenExpectation::create()` is where one built by
+/// hand at run time is stopped instead of being resolved against a table that has no such entry.
+constexpr ms::PanelSpec unknownTintPanel{.colorToken = "Theme.Colors.NotInTheTable"};
+
+constexpr std::array<ms::CompiledNode, 1> unknownTintNodes{
+    ms::CompiledNode{.id = "readout", .bounds = {4, 4, 8, 6}, .payload = unknownTintPanel}
+};
+
+constexpr ms::ScreenPackage unknownTintScreen{.id                   = "unknown-tint",
+                                              .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                              .surfaceWidth         = 16,
+                                              .surfaceHeight        = 20,
+                                              .approvedTextPackages = {},
+                                              .nodes                = unknownTintNodes,
+                                              .budget               = budget};
+
+constexpr std::array bothChecks{mv::CvCheck::Bounds, mv::CvCheck::ColorHash};
+constexpr std::array boundsOnly{mv::CvCheck::Bounds};
+constexpr std::array colorHashOnly{mv::CvCheck::ColorHash};
+constexpr std::array reversedChecks{mv::CvCheck::ColorHash, mv::CvCheck::Bounds};
+constexpr std::array repeatedChecks{mv::CvCheck::Bounds, mv::CvCheck::Bounds};
+
+/// The committed sidecar's entry for the panel: bounds and tint duplicated from the node, as
+/// `collectGoldens()` writes them.
+constexpr mv::GoldenEntry readoutGolden{
+    .nodeId     = "readout",
+    .bounds     = {4, 4, 8, 6},
+    .textKey    = {},
+    .colorToken = readoutToken,
+    .cvChecks   = bothChecks
+};
+
+/// A positioned node with no single tint: `Bounds` is claimable, `ColorHash` is not.
+constexpr mv::GoldenEntry feedGolden{
+    .nodeId     = "feed",
+    .bounds     = {0, 12, 16, 8},
+    .textKey    = {},
+    .colorToken = {},
+    .cvChecks   = boundsOnly
+};
+
+/// Builds the expectation or fails the scenario, so a `Then` reads as the claim rather than as
+/// error handling.
+[[nodiscard]] mv::GoldenExpectation expect(const mv::GoldenEntry& entry, const ms::ScreenPackage& screen, mv::RenderScope scope) {
+    auto made = mv::GoldenExpectation::create(entry, screen, scope, ground);
+    if (!made.has_value()) {
+        throw speclab::core::AssertionFailure(std::string{"the golden was refused: "} + std::string{mv::describe(made.error())},
+                                              std::source_location::current());
+    }
+    return *made;
+}
+
+/// The error `create()` reports, or nothing when it unexpectedly succeeded.
+[[nodiscard]] std::optional<mv::VerifyError> refusal(const mv::GoldenEntry& entry, const ms::ScreenPackage& screen) {
+    auto made = mv::GoldenExpectation::create(entry, screen, mv::RenderScope::localeFree(), ground);
+    if (made.has_value()) {
+        return std::nullopt;
+    }
+    return made.error();
+}
+
+}  // namespace
+
+const mdux::spec::Register aTextlessGoldenIsCheckedInOneLocaleFreeScope{
+    "A textless screen's golden is discharged in its one locale-free render scope",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-locale-free-scope")
+            .Given("a screen with no text, a golden over its panel, and a frame that drew it", [] {})
+            .When("both of the golden's checks run in the locale-free scope", [] {})
+            .Then("they hold, and each outcome names that scope rather than a locale",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Canvas canvas{16, 20, ground};
+                      canvas.fill({4, 4, 8, 6}, tintOf(readoutToken));
+
+                      const mv::GoldenExpectation expectation = expect(readoutGolden, textlessScreen, mv::RenderScope::localeFree());
+                      const mv::CheckOutcome      bounds      = mv::goldenBounds(canvas.view(), expectation);
+                      const mv::CheckOutcome      colour      = mv::colorHash(canvas.view(), expectation);
+
+                      // ADR-014 decision 3's textless case: the obligations do not disappear in a
+                      // Cartesian product with an empty locale set, because there is one explicit
+                      // scope rather than none.
+                      checks.expect(bounds.held(), std::format("Bounds holds: {}", mv::describe(bounds.finding)));
+                      checks.expect(colour.held(), std::format("ColorHash holds: {}", mv::describe(colour.finding)));
+                      checks.expect(bounds.scope == mv::localeFreeScopeName, std::format("the scope is named, got '{}'", bounds.scope));
+                      checks.expect(colour.scope == mv::localeFreeScopeName, std::format("and on the colour outcome too, got '{}'", colour.scope));
+                      checks.expect(bounds.nodeId == "readout", "the outcome names the node");
+                      checks.expect(bounds.check == "Bounds", "and the check");
+                      checks.expect(colour.check == "ColorHash", "and so does the other one");
+                      checks.expect(bounds.found == ms::NodeRect{4, 4, 8, 6}, "the content measured is the rectangle pinned");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aRectangleMovedByOnePixelFails{
+    "A golden rectangle moved by one pixel fails, and an empty one fails differently",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-bounds-moved")
+            .Given("the same screen and golden", [] {})
+            .When("the frame draws the panel one pixel right, and then not at all", [] {})
+            .Then("Bounds reports the extent it found, and then that nothing was drawn",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mv::GoldenExpectation expectation = expect(readoutGolden, textlessScreen, mv::RenderScope::localeFree());
+
+                      // ADR-014's own worked example. A containment would pass this: the moved
+                      // rectangle still overlaps seven eighths of its declared box.
+                      Canvas moved{16, 20, ground};
+                      moved.fill({5, 4, 8, 6}, tintOf(readoutToken));
+                      const mv::CheckOutcome shifted = mv::goldenBounds(moved.view(), expectation);
+                      checks.expect(shifted.finding == mv::Finding::BoundsDiffer, std::format("the move is caught: {}", mv::describe(shifted.finding)));
+                      checks.expect(shifted.expected == ms::NodeRect{4, 4, 8, 6}, "the outcome carries the expected rectangle");
+                      checks.expect(shifted.found == ms::NodeRect{5, 4, 7, 6}, "and the extent actually measured inside it");
+
+                      // The state `tests/render/ScreenPixelTests.cpp` asserts as a tripwire today,
+                      // because both of the committed screen's golden nodes are still deferred.
+                      Canvas                 empty{16, 20, ground};
+                      const mv::CheckOutcome absent = mv::goldenBounds(empty.view(), expectation);
+                      checks.expect(absent.finding == mv::Finding::NothingPainted, "an undrawn node is a different finding from a moved one");
+                      checks.expect(!absent.foundValid, "and it measured nothing to report");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aRegionOffTheFrameIsNotAPass{
+    "A golden rectangle that is not inside the frame fails rather than reading past it",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-region-outside-frame")
+            .Given("a golden pinning a rectangle at x=4 width 8", [] {})
+            .When("the frame handed in is only eight pixels wide", [] {})
+            .Then("the check fails as a region outside the frame",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Canvas                      small{8, 8, ground};
+                      const mv::GoldenExpectation expectation = expect(readoutGolden, textlessScreen, mv::RenderScope::localeFree());
+                      const mv::CheckOutcome      outcome     = mv::goldenBounds(small.view(), expectation);
+
+                      checks.expect(outcome.finding == mv::Finding::RegionOutsideFrame, "the rectangle leaves the frame");
+                      checks.expect(!outcome.held(), "which is a failure, not a skip");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theTintIsComparedExactly{
+    "ColorHash separates the wrong colour from a colour that never reaches its tint",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-color-hash")
+            .Given("a golden that opted into ColorHash", [] {})
+            .When("the panel is drawn in its tint, then in a foreign colour, then in a blend", [] {})
+            .Then("only the first holds, and the other two report different findings",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mv::GoldenExpectation expectation = expect(readoutGolden, textlessScreen, mv::RenderScope::localeFree());
+                      const ColorRgba8            tint        = tintOf(readoutToken);
+
+                      Canvas correct{16, 20, ground};
+                      correct.fill({4, 4, 8, 6}, tint);
+                      checks.expect(mv::colorHash(correct.view(), expectation).held(), "the tint the token resolves to holds");
+
+                      // Red is outside the closed interval every channel of a blend has to lie in,
+                      // so no coverage of this tint over this ground could have produced it.
+                      Canvas foreign{16, 20, ground};
+                      foreign.fill({4, 4, 8, 6}, ColorRgba8{.r = 255, .g = 0, .b = 0, .a = 255});
+                      const mv::CheckOutcome wrong = mv::colorHash(foreign.view(), expectation);
+                      checks.expect(wrong.finding == mv::Finding::ForeignColour, std::format("a foreign colour: {}", mv::describe(wrong.finding)));
+                      checks.expect(wrong.foundColorValid && wrong.foundColor.r == 255, "and the outcome carries the pixel it found");
+                      checks.expect(wrong.expectedColor == tint, "beside the tint it expected");
+
+                      // A legitimate blend of the tint over the ground at half coverage: inside the
+                      // interval everywhere, and equal to the tint nowhere.
+                      Canvas partial{16, 20, ground};
+                      partial.fill({4, 4, 8, 6},
+                                   ColorRgba8{.r = static_cast<std::uint8_t>(tint.r / 2),
+                                              .g = static_cast<std::uint8_t>(tint.g / 2),
+                                              .b = static_cast<std::uint8_t>(tint.b / 2),
+                                              .a = 255});
+                      const mv::CheckOutcome faint = mv::colorHash(partial.view(), expectation);
+                      checks.expect(faint.finding == mv::Finding::TintAbsent,
+                                    std::format("content that never reaches its tint: {}", mv::describe(faint.finding)));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aGoldenWithNoTintCannotDischargeColorHash{
+    "ColorHash over a golden that resolved no tint fails rather than passing",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-no-tint-to-compare")
+            .Given("a positioned node with no colour token, and a golden asking only for Bounds", [] {})
+            .When("ColorHash is nevertheless run against it", [] {})
+            .Then("it reports that there was no tint to compare, and Bounds still holds",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Canvas canvas{16, 20, ground};
+                      canvas.fill({0, 12, 16, 8}, ColorRgba8{.r = 12, .g = 12, .b = 12, .a = 255});
+
+                      const mv::GoldenExpectation expectation = expect(feedGolden, textlessScreen, mv::RenderScope::localeFree());
+                      checks.expect(!expectation.hasTint(), "the expectation resolved no tint");
+                      checks.expect(expectation.declares(mv::CvCheck::Bounds), "and it declares the check it can discharge");
+                      checks.expect(!expectation.declares(mv::CvCheck::ColorHash), "and not the one it cannot");
+
+                      checks.expect(mv::goldenBounds(canvas.view(), expectation).held(), "Bounds holds over content that fills the box");
+                      const mv::CheckOutcome colour = mv::colorHash(canvas.view(), expectation);
+                      checks.expect(colour.finding == mv::Finding::NoTintToCompare, "and ColorHash refuses rather than reporting a pass it did not establish");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aDanglingGoldenIdIsRefused{"A golden naming a node the screen does not have is refused on the first lookup", "evidence-unit", [] {
+                                                          return speclab::Test("verify-golden-dangling-id")
+                                                              .Given("a golden entry naming a node id no compiled node carries", [] {})
+                                                              .When("an expectation is built from it", [] {})
+                                                              .Then("it is refused, which is the failure ADR-014 assigns to the verifier",
+                                                                    [] {
+                                                                        mdux::spec::Checks checks;
+
+                                                                        constexpr mv::GoldenEntry dangling{
+                                                                            .nodeId     = "no-such-node",
+                                                                            .bounds     = {4, 4, 8, 6},
+                                                                            .textKey    = {},
+                                                                            .colorToken = readoutToken,
+                                                                            .cvChecks   = bothChecks
+                                                                        };
+
+                                                                        const std::optional<mv::VerifyError> error = refusal(dangling, textlessScreen);
+                                                                        checks.expect(error.has_value(), "the expectation was refused");
+                                                                        checks.expect(error == mv::VerifyError::DanglingGoldenId, "as a dangling golden id");
+                                                                        checks.raise();
+                                                                    })
+                                                              .Execute();
+                                                      }};
+
+const mdux::spec::Register everyDuplicatedGoldenFieldMustAgree{
+    "Every field a golden duplicates has to agree with the node it names",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-fields-agree")
+            .Given("goldens whose bounds, text key and colour token each disagree in turn", [] {})
+            .When("each is resolved against the screen it was emitted beside", [] {})
+            .Then("each is refused, and refused for the field that disagreed",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // A sidecar that drifted from its package addresses content no verifier could
+                      // find. Each field is exercised on its own so the diagnostic cannot be right
+                      // by accident.
+                      constexpr mv::GoldenEntry movedBounds{
+                          .nodeId     = "readout",
+                          .bounds     = {4, 5, 8, 6},
+                          .textKey    = {},
+                          .colorToken = readoutToken,
+                          .cvChecks   = bothChecks
+                      };
+                      checks.expect(refusal(movedBounds, textlessScreen) == mv::VerifyError::GoldenBoundsDisagree, "a rectangle that is not the node's");
+
+                      constexpr mv::GoldenEntry wrongToken{
+                          .nodeId     = "readout",
+                          .bounds     = {4, 4, 8, 6},
+                          .textKey    = {},
+                          .colorToken = "Theme.Colors.Alert",
+                          .cvChecks   = bothChecks
+                      };
+                      checks.expect(refusal(wrongToken, textlessScreen) == mv::VerifyError::GoldenColorTokenDisagrees, "a tint that is not the node's");
+
+                      // The node draws no text, so a golden claiming a key for it is one drift a
+                      // rectangle comparison would never notice.
+                      constexpr mv::GoldenEntry inventedKey{
+                          .nodeId     = "readout",
+                          .bounds     = {4, 4, 8, 6},
+                          .textKey    = "STR-INVENTED",
+                          .colorToken = readoutToken,
+                          .cvChecks   = bothChecks
+                      };
+                      checks.expect(refusal(inventedKey, textlessScreen) == mv::VerifyError::GoldenTextKeyDisagrees, "a text key the node does not carry");
+
+                      // ...and the other direction, on a node that does carry one: a golden that
+                      // dropped the key still has to be refused, or a screen could be verified
+                      // against a sidecar that forgot what the node draws.
+                      constexpr mv::GoldenEntry droppedKey{
+                          .nodeId     = "screen-title",
+                          .bounds     = {0, 0, 16, 8},
+                          .textKey    = {},
+                          .colorToken = "Theme.Colors.Title",
+                          .cvChecks   = boundsOnly
+                      };
+                      checks.expect(refusal(droppedKey, titledScreen) == mv::VerifyError::GoldenTextKeyDisagrees,
+                                    "a text key the node carries and the golden lost");
+
+                      constexpr mv::GoldenEntry agreeing{
+                          .nodeId     = "screen-title",
+                          .bounds     = {0, 0, 16, 8},
+                          .textKey    = "STR-TITLE",
+                          .colorToken = "Theme.Colors.Title",
+                          .cvChecks   = boundsOnly
+                      };
+                      checks.expect(!refusal(agreeing, titledScreen).has_value(), "and the entry that agrees with all three is admitted");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aGoldenMustDeclareCanonicalChecks{
+    "A golden that declares nothing, or declares it out of canonical order, is refused",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-checks-canonical")
+            .Given("entries with no cvChecks, reversed cvChecks and a repeated one", [] {})
+            .When("each is resolved", [] {})
+            .Then("each is refused, because none of them came from the compiler that writes them",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      constexpr mv::GoldenEntry silent{
+                          .nodeId     = "readout",
+                          .bounds     = {4, 4, 8, 6},
+                          .textKey    = {},
+                          .colorToken = readoutToken,
+                          .cvChecks   = {}
+                      };
+                      checks.expect(refusal(silent, textlessScreen) == mv::VerifyError::NoChecksDeclared, "an entry that can discharge nothing");
+
+                      constexpr mv::GoldenEntry reversed{
+                          .nodeId     = "readout",
+                          .bounds     = {4, 4, 8, 6},
+                          .textKey    = {},
+                          .colorToken = readoutToken,
+                          .cvChecks   = reversedChecks
+                      };
+                      checks.expect(refusal(reversed, textlessScreen) == mv::VerifyError::ChecksNotCanonical, "an entry that is not in the sidecar's order");
+
+                      constexpr mv::GoldenEntry repeated{
+                          .nodeId     = "readout",
+                          .bounds     = {4, 4, 8, 6},
+                          .textKey    = {},
+                          .colorToken = readoutToken,
+                          .cvChecks   = repeatedChecks
+                      };
+                      checks.expect(refusal(repeated, textlessScreen) == mv::VerifyError::ChecksNotCanonical, "and one that repeats a check");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aTintClaimNeedsATintToMake{
+    "ColorHash without a token, and a token the table does not define, are both refused",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-tint-must-resolve")
+            .Given("a golden asking for ColorHash over a node with no tint, and one naming an unknown token", [] {})
+            .When("each is resolved", [] {})
+            .Then("each is refused, rather than leaving a check with nothing to compare against",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The two halves of one claim, as `collectGoldens()` treats them: a verifier
+                      // asked to compare a tint has to be told which tint.
+                      constexpr mv::GoldenEntry untinted{
+                          .nodeId     = "feed",
+                          .bounds     = {0, 12, 16, 8},
+                          .textKey    = {},
+                          .colorToken = {},
+                          .cvChecks   = colorHashOnly
+                      };
+                      checks.expect(refusal(untinted, textlessScreen) == mv::VerifyError::ColorHashWithoutTint, "ColorHash with no colour token");
+
+                      constexpr mv::GoldenEntry unknown{
+                          .nodeId     = "readout",
+                          .bounds     = {4, 4, 8, 6},
+                          .textKey    = {},
+                          .colorToken = "Theme.Colors.NotInTheTable",
+                          .cvChecks   = bothChecks
+                      };
+                      checks.expect(refusal(unknown, unknownTintScreen) == mv::VerifyError::UnresolvedColorToken, "a token the governed table does not define");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/verify/SyntheticFrame.hpp
+++ b/tests/verify/SyntheticFrame.hpp
@@ -24,7 +24,7 @@ namespace mdux::test::verify {
 class Canvas {
 public:
     Canvas(mdux::core::Px width, mdux::core::Px height, mdux::core::ColorRgba8 ground)
-        : width_{width}, height_{height}, pixels_(static_cast<std::size_t>(width) * static_cast<std::size_t>(height), ground) {}
+        : width_{width}, height_{height}, ground_{ground}, pixels_(static_cast<std::size_t>(width) * static_cast<std::size_t>(height), ground) {}
 
     /// Paints `rect` in `colour`, clipped to the image so a scenario can deliberately overflow.
     void fill(mdux::medui::NodeRect rect, mdux::core::ColorRgba8 colour) {
@@ -40,6 +40,17 @@ public:
             return;
         }
         pixels_[static_cast<std::size_t>(y) * static_cast<std::size_t>(width_) + static_cast<std::size_t>(x)] = colour;
+    }
+
+    /// The colour at (x, y), or the ground for a coordinate outside the image.
+    ///
+    /// So a scenario can blend a glyph over whatever the previous one left, which is what the draw
+    /// path does and therefore what an overlapping run's frame actually holds.
+    [[nodiscard]] mdux::core::ColorRgba8 at(mdux::core::Px x, mdux::core::Px y) const noexcept {
+        if (x < 0 || y < 0 || x >= width_ || y >= height_) {
+            return ground_;
+        }
+        return pixels_[static_cast<std::size_t>(y) * static_cast<std::size_t>(width_) + static_cast<std::size_t>(x)];
     }
 
     [[nodiscard]] std::span<const mdux::core::ColorRgba8> pixels() const noexcept {
@@ -60,6 +71,7 @@ public:
 private:
     mdux::core::Px                      width_{0};
     mdux::core::Px                      height_{0};
+    mdux::core::ColorRgba8              ground_{};
     std::vector<mdux::core::ColorRgba8> pixels_;
 };
 

--- a/tests/verify/SyntheticFrame.hpp
+++ b/tests/verify/SyntheticFrame.hpp
@@ -1,0 +1,106 @@
+/**
+ * @file SyntheticFrame.hpp
+ * @brief A framebuffer a scenario paints by hand, so a check can be exercised with no GPU.
+ *
+ * @compliance ADR-004 Trust zones in C++ (test-only; the library allocates, this may)
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ *
+ * ADR-014 decision 1 says a framebuffer is an array, so a unit test paints a rectangle into one and
+ * asserts that `GoldenBounds` passes, then moves it by a pixel and asserts that it fails. This is
+ * that array. It is deliberately the only fixture machinery in this suite: everything else a
+ * scenario needs is a compiled screen, a golden entry or a run of records, all of which are plain
+ * data a scenario writes out where a reader can see it.
+ *
+ * A `std::vector` rather than the caller-owned storage the governed zone insists on. The rule
+ * ADR-004 states is about the library, and inverting it here would only mean sizing an array from
+ * numbers a scenario would then have to repeat.
+ */
+#ifndef MDUX_TESTS_VERIFY_SYNTHETICFRAME_HPP
+#define MDUX_TESTS_VERIFY_SYNTHETICFRAME_HPP
+
+namespace mdux::test::verify {
+
+/// A tightly packed RGBA8 image, painted rectangle by rectangle.
+class Canvas {
+public:
+    Canvas(mdux::core::Px width, mdux::core::Px height, mdux::core::ColorRgba8 ground)
+        : width_{width}, height_{height}, pixels_(static_cast<std::size_t>(width) * static_cast<std::size_t>(height), ground) {}
+
+    /// Paints `rect` in `colour`, clipped to the image so a scenario can deliberately overflow.
+    void fill(mdux::medui::NodeRect rect, mdux::core::ColorRgba8 colour) {
+        for (mdux::core::Px y = rect.y; y < rect.y + rect.height; ++y) {
+            for (mdux::core::Px x = rect.x; x < rect.x + rect.width; ++x) {
+                set(x, y, colour);
+            }
+        }
+    }
+
+    void set(mdux::core::Px x, mdux::core::Px y, mdux::core::ColorRgba8 colour) {
+        if (x < 0 || y < 0 || x >= width_ || y >= height_) {
+            return;
+        }
+        pixels_[static_cast<std::size_t>(y) * static_cast<std::size_t>(width_) + static_cast<std::size_t>(x)] = colour;
+    }
+
+    [[nodiscard]] std::span<const mdux::core::ColorRgba8> pixels() const noexcept {
+        return pixels_;
+    }
+
+    /// The view the checks take. Throws rather than returning a `Result`: a fixture that cannot
+    /// describe its own image is a broken scenario, not a verification outcome.
+    [[nodiscard]] mdux::verify::FramebufferView view() const {
+        auto made = mdux::verify::FramebufferView::createPacked(pixels_, width_, height_);
+        if (!made.has_value()) {
+            throw speclab::core::AssertionFailure(std::string{"the synthetic frame was refused: "} + std::string{mdux::verify::describe(made.error())},
+                                                  std::source_location::current());
+        }
+        return *made;
+    }
+
+private:
+    mdux::core::Px                      width_{0};
+    mdux::core::Px                      height_{0};
+    std::vector<mdux::core::ColorRgba8> pixels_;
+};
+
+/// The quantised colour a token resolves to, which is what a correct frame actually carries.
+///
+/// Through the governed table and the governed quantisation rather than four numbers written into a
+/// scenario: an expectation carrying its own copy of a colour would keep passing while the table
+/// moved, which is one of the two regressions this suite exists to catch.
+[[nodiscard]] inline mdux::core::ColorRgba8 tintOf(std::string_view token) {
+    const auto resolved = mdux::medui::resolveColorToken(token);
+    if (!resolved.has_value()) {
+        throw speclab::core::AssertionFailure(std::string{"the governed table does not define "} + std::string{token}, std::source_location::current());
+    }
+    return mdux::medui::quantise(*resolved);
+}
+
+/// A v1 run record: glyph index, then x, then y, little-endian, six bytes.
+///
+/// Written out here rather than memcpy'd over a struct for `decodeRecord()`'s reason: the sidecar's
+/// byte order is a contract, and a fixture that inherited the host's would make a byte-order defect
+/// invisible to every scenario built on it.
+[[nodiscard]] inline std::array<std::byte, 6> record(std::uint16_t glyph, std::int16_t x, std::int16_t y) {
+    const auto ux = static_cast<std::uint16_t>(x);
+    const auto uy = static_cast<std::uint16_t>(y);
+    return std::array<std::byte, 6>{static_cast<std::byte>(glyph & 0xFFU),
+                                    static_cast<std::byte>((glyph >> 8) & 0xFFU),
+                                    static_cast<std::byte>(ux & 0xFFU),
+                                    static_cast<std::byte>((ux >> 8) & 0xFFU),
+                                    static_cast<std::byte>(uy & 0xFFU),
+                                    static_cast<std::byte>((uy >> 8) & 0xFFU)};
+}
+
+/// Concatenates records into the sidecar bytes a run addresses.
+[[nodiscard]] inline std::vector<std::byte> runOf(std::span<const std::array<std::byte, 6>> records) {
+    std::vector<std::byte> bytes;
+    for (const std::array<std::byte, 6>& one : records) {
+        bytes.insert(bytes.end(), one.begin(), one.end());
+    }
+    return bytes;
+}
+
+}  // namespace mdux::test::verify
+
+#endif  // MDUX_TESTS_VERIFY_SYNTHETICFRAME_HPP

--- a/tests/verify/TextCheckTests.cpp
+++ b/tests/verify/TextCheckTests.cpp
@@ -1,0 +1,399 @@
+/**
+ * @file TextCheckTests.cpp
+ * @brief BDD scenarios for the two mandatory text checks and the expectation that feeds them.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
+ * @compliance ADR-010 No on-device text shaping
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ *
+ * The claim these scenarios exist to establish, and #252's acceptance criterion that is easiest to
+ * satisfy by accident: **a compiled text node receives both mandatory checks whether or not it has a
+ * golden entry, and whether or not it was positioned.** The screen below carries no golden sidecar
+ * at all, and its label declares no `position:` - the layout gave it its box. Both obligations are
+ * still raised, and both are discharged, because ADR-014 decision 3 makes them a property of the
+ * `textKey` rather than of an annotation.
+ *
+ * The font package and the run are synthetic, and deliberately so. Two glyphs six pixels tall with a
+ * space between them are enough to exercise every branch, and they let a scenario state the ink box
+ * it expects in numbers a reader can check by hand - which a real 12-pixel DejaVu run does not.
+ * `mdux.text.draw`'s record layout is the real one: the fixture writes little-endian bytes rather
+ * than a struct, so a byte-order defect could not hide behind a helper that shared the bug.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+import mdux.evidence.digest;
+import mdux.evidence.report;
+import mdux.font.schema;
+import mdux.medui.schema;
+import mdux.medui.screen;
+import mdux.text.draw;
+import mdux.verify;
+
+#include "../framework/SpecLabBridge.hpp"
+#include "SyntheticFrame.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+namespace mv = mdux::verify;
+
+using mdux::core::ColorRgba8;
+using mdux::test::verify::Canvas;
+using mdux::test::verify::record;
+using mdux::test::verify::runOf;
+using mdux::test::verify::tintOf;
+
+/// The panel the label is drawn over, so "painted" inside the node means "not the panel".
+constexpr ColorRgba8 ground{.r = 40, .g = 40, .b = 40, .a = 255};
+
+constexpr std::string_view titleToken = "Theme.Colors.Title";
+
+constexpr std::array approvals{
+    ms::TextPackageApproval{.locale = "en-US", .packageId = "labelled-en-us", .packageSha256 = {3}}
+};
+
+constexpr ms::LabelSpec titleLabel{.textKey = "STR-TITLE", .colorToken = titleToken};
+constexpr ms::PanelSpec backdrop{.colorToken = "Theme.Colors.TopbarBackground"};
+constexpr ms::ClockSpec wallClock{.format = ms::ClockFormat::TimeSeconds};
+
+/// A label the layout placed, with no `position:` of its own and no golden entry anywhere.
+constexpr std::array<ms::CompiledNode, 3> labelledNodes{
+    ms::CompiledNode{.id = "backdrop",   .bounds = {0, 0, 64, 48},   .payload = backdrop},
+    ms::CompiledNode{   .id = "title", .bounds = {10, 20, 40, 20}, .payload = titleLabel},
+    ms::CompiledNode{   .id = "clock",   .bounds = {0, 40, 20, 8},  .payload = wallClock}
+};
+
+constexpr mdux::draw::DrawBudget budget{.maxVertices = 256, .maxIndices = 384, .maxCommands = 32};
+
+constexpr ms::ScreenPackage labelledScreen{.id                   = "labelled",
+                                           .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                           .surfaceWidth         = 64,
+                                           .surfaceHeight        = 48,
+                                           .approvedTextPackages = approvals,
+                                           .nodes                = labelledNodes,
+                                           .budget               = budget};
+
+static_assert(labelledScreen.validate().has_value(), "the labelled fixture must be a screen a device could hold");
+
+/// A four-by-six glyph, twice, plus the blank the space is.
+///
+/// `bitmapOriginY` is measured *up* from the baseline, which is why a record's y is a baseline
+/// rather than a top edge; the values here make the arithmetic legible - a glyph whose origin is six
+/// pixels above a baseline at six lands its top edge on zero.
+[[nodiscard]] mdux::font::FontPackage twoGlyphFont() {
+    mdux::font::FontPackage font;
+    font.id         = "synthetic-ui";
+    font.unitsPerEm = 1000;
+    font.pixelSize  = 6;
+    font.atlas      = mdux::font::AtlasMetrics{.path = "atlas.bin", .width = 16, .height = 16, .byteLength = 256, .sha256 = {}, .occupancyPercent = 0};
+    font.glyphs     = {
+        mdux::font::GlyphRecord{.codePoint       = U' ',
+                                .glyphIndex      = 3,
+                                .advanceWidth    = 600,
+                                .leftSideBearing = 0,
+                                .x               = 0,
+                                .y               = 0,
+                                .width           = 0,
+                                .height          = 0,
+                                .bitmapOriginX   = 0,
+                                .bitmapOriginY   = 0},
+        mdux::font::GlyphRecord{.codePoint       = U'A',
+                                .glyphIndex      = 4,
+                                .advanceWidth    = 600,
+                                .leftSideBearing = 0,
+                                .x               = 0,
+                                .y               = 0,
+                                .width           = 4,
+                                .height          = 6,
+                                .bitmapOriginX   = 0,
+                                .bitmapOriginY   = 6},
+        mdux::font::GlyphRecord{.codePoint       = U'B',
+                                .glyphIndex      = 5,
+                                .advanceWidth    = 600,
+                                .leftSideBearing = 0,
+                                .x               = 4,
+                                .y               = 0,
+                                .width           = 4,
+                                .height          = 6,
+                                .bitmapOriginX   = 0,
+                                .bitmapOriginY   = 6}
+    };
+    return font;
+}
+
+/// `A B` as the baker would have positioned it: ink at 0 and at 10, a blank between them.
+[[nodiscard]] std::vector<std::byte> abRun() {
+    const std::array<std::array<std::byte, 6>, 3> runs{record(1, 0, 6), record(0, 6, 6), record(2, 10, 6)};
+    return runOf(runs);
+}
+
+/// The same string one glyph shorter: a different locale's run over the same layout.
+[[nodiscard]] std::vector<std::byte> aOnlyRun() {
+    const std::array<std::array<std::byte, 6>, 1> runs{record(1, 0, 6)};
+    return runOf(runs);
+}
+
+/// A run of nothing but the space.
+[[nodiscard]] std::vector<std::byte> blankRun() {
+    const std::array<std::array<std::byte, 6>, 1> runs{record(0, 0, 6)};
+    return runOf(runs);
+}
+
+[[nodiscard]] const ms::CompiledNode& titleNode() {
+    const ms::CompiledNode* node = labelledScreen.find("title");
+    if (node == nullptr) {
+        throw speclab::core::AssertionFailure("the fixture screen lost its label", std::source_location::current());
+    }
+    return *node;
+}
+
+constexpr mv::RenderScope approvedLocale = mv::RenderScope::forLocale("en-US");
+
+/// Builds the expectation or fails the scenario naming the refusal.
+[[nodiscard]] mv::TextExpectation expect(const ms::CompiledNode& node, std::span<const std::byte> records, const mdux::font::FontPackage& font) {
+    auto made = mv::TextExpectation::create(node, approvedLocale, records, font, ground);
+    if (!made.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("the text expectation was refused: {}", mv::describe(made.error())), std::source_location::current());
+    }
+    return *made;
+}
+
+/// Paints the run where the runtime's placement rule puts it.
+void paintRun(Canvas& canvas, const mv::TextExpectation& expectation, ColorRgba8 colour, mdux::core::Px shiftX = 0) {
+    for (std::size_t index = 0; index < expectation.glyphCount(); ++index) {
+        const std::optional<ms::NodeRect> glyph = expectation.glyphRect(index);
+        if (!glyph.has_value()) {
+            continue;
+        }
+        canvas.fill(ms::NodeRect{.x = glyph->x + shiftX, .y = glyph->y, .width = glyph->width, .height = glyph->height}, colour);
+    }
+}
+
+}  // namespace
+
+const mdux::spec::Register anUnpositionedTextNodeStillGetsBothChecks{
+    "An unpositioned text node with no golden still receives both mandatory checks",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-mandatory-without-a-golden")
+            .Given("a label the layout placed, with no position: and no golden entry", [] {})
+            .When("its approved locale's run is drawn where the runtime would draw it", [] {})
+            .Then("both InkContainment and LocalizedTextPresence are raised and both hold",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  records = abRun();
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font);
+
+                      // The placement rule, restated as the number it produces: the run's ink box
+                      // is fourteen wide and six tall, and its corner is the node's corner.
+                      checks.expect(title.ink() == ms::NodeRect{10, 20, 14, 6}, "the ink lands at the node's top-left corner");
+                      checks.expect(title.locale() == "en-US", "the obligation names the approved locale it runs in");
+
+                      Canvas canvas{64, 48, ground};
+                      paintRun(canvas, title, tintOf(titleToken));
+
+                      const mv::CheckOutcome containment = mv::inkContainment(canvas.view(), title);
+                      const mv::CheckOutcome presence    = mv::localizedTextPresence(canvas.view(), title);
+
+                      checks.expect(containment.held(), std::format("InkContainment holds: {}", mv::describe(containment.finding)));
+                      checks.expect(presence.held(), std::format("LocalizedTextPresence holds: {}", mv::describe(presence.finding)));
+                      checks.expect(containment.check == "InkContainment", "the outcome names its check");
+                      checks.expect(presence.check == "LocalizedTextPresence", "and so does the other");
+                      checks.expect(presence.scope == "en-US", "and both name the locale rather than a locale-free scope");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aRunThatLeavesItsNodeIsCaught{
+    "A run whose ink does not fit its node fails before a pixel is read",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-ink-leaves-the-node")
+            .Given("the same run bound to a node only eight pixels wide", [] {})
+            .When("InkContainment runs", [] {})
+            .Then("it reports the box that left the node, beside the node it left",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // #195 proved the ink fits the box for the package it measured. This is the
+                      // same claim for the package that was actually bound.
+                      constexpr ms::CompiledNode narrow{
+                          .id      = "title",
+                          .bounds  = {10, 20, 8, 20},
+                          .payload = titleLabel
+                      };
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  records = abRun();
+                      const mv::TextExpectation     title   = expect(narrow, records, font);
+
+                      Canvas canvas{64, 48, ground};
+                      paintRun(canvas, title, tintOf(titleToken));
+
+                      const mv::CheckOutcome containment = mv::inkContainment(canvas.view(), title);
+                      checks.expect(containment.finding == mv::Finding::InkLeftItsNode,
+                                    std::format("the overflow is caught: {}", mv::describe(containment.finding)));
+                      checks.expect(containment.expected == ms::NodeRect{10, 20, 8, 20}, "the outcome carries the node's rectangle");
+                      checks.expect(containment.found == ms::NodeRect{10, 20, 14, 6}, "and the ink box that would not fit it");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register inkInTheWrongPlaceIsCaught{
+    "Ink drawn one pixel across, and ink absent altogether, are different findings",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-ink-extent")
+            .Given("a label whose run the frame drew one pixel to the right, and then not at all", [] {})
+            .When("InkContainment runs on each", [] {})
+            .Then("the first reports the extent it measured and the second reports nothing painted",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  records = abRun();
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font);
+
+                      Canvas shifted{64, 48, ground};
+                      paintRun(shifted, title, tintOf(titleToken), 1);
+                      const mv::CheckOutcome moved = mv::inkContainment(shifted.view(), title);
+                      checks.expect(moved.finding == mv::Finding::InkExtentDiffers, std::format("displaced ink is caught: {}", mv::describe(moved.finding)));
+                      checks.expect(moved.expected == ms::NodeRect{10, 20, 14, 6}, "against the box the committed run predicts");
+                      checks.expect(moved.found == ms::NodeRect{11, 20, 14, 6}, "and the box the frame actually shows");
+
+                      Canvas                 empty{64, 48, ground};
+                      const mv::CheckOutcome absent = mv::inkContainment(empty.view(), title);
+                      checks.expect(absent.finding == mv::Finding::NothingPainted, "a label that drew nothing is a different fact from one that drew badly");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anotherLocalesRunIsNotThisLocalesRun{
+    "A frame carrying a different locale's run does not satisfy this locale's presence check",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-presence-is-per-locale")
+            .Given("a node whose approved run is two glyphs, and a frame showing only one", [] {})
+            .When("LocalizedTextPresence runs", [] {})
+            .Then("it names the glyph that painted nothing rather than passing on the rest",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font     = twoGlyphFont();
+                      const std::vector<std::byte>  approved = abRun();
+                      const std::vector<std::byte>  shorter  = aOnlyRun();
+
+                      const mv::TextExpectation expected = expect(titleNode(), approved, font);
+                      const mv::TextExpectation other    = expect(titleNode(), shorter, font);
+
+                      // The frame drew the *other* locale's run. Its single glyph lands where this
+                      // locale's first one does, so half of the expectation is satisfied - which is
+                      // exactly why a per-glyph check is what distinguishes them.
+                      Canvas canvas{64, 48, ground};
+                      paintRun(canvas, other, tintOf(titleToken));
+
+                      const mv::CheckOutcome presence = mv::localizedTextPresence(canvas.view(), expected);
+                      checks.expect(presence.finding == mv::Finding::GlyphMissing,
+                                    std::format("the missing glyph is named: {}", mv::describe(presence.finding)));
+                      checks.expect(presence.glyphIndex == 2, std::format("and it is the third record, got {}", presence.glyphIndex));
+                      checks.expect(presence.expected == ms::NodeRect{20, 20, 4, 6}, "with the rectangle it should have painted");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register inkOutsideTheRunIsCaught{
+    "Ink the approved run does not account for fails, and so does ink in a foreign colour",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-presence-rejects-stray-ink")
+            .Given("a correctly drawn run", [] {})
+            .When("one extra pixel is painted in the gap the space leaves, and then a glyph is recoloured", [] {})
+            .Then("the first is ink outside the run and the second is a foreign colour",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  records = abRun();
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font);
+
+                      // The gap the space leaves is where a run from another package, or a stale
+                      // frame, would show through. The atlas slot is exactly the glyph's bitmap, so
+                      // a correct frame paints nothing here.
+                      Canvas stray{64, 48, ground};
+                      paintRun(stray, title, tintOf(titleToken));
+                      stray.set(16, 22, tintOf(titleToken));
+                      const mv::CheckOutcome intruder = mv::localizedTextPresence(stray.view(), title);
+                      checks.expect(intruder.finding == mv::Finding::InkOutsideTheRun, std::format("stray ink is caught: {}", mv::describe(intruder.finding)));
+                      checks.expect(intruder.found == ms::NodeRect{16, 22, 1, 1}, "and the outcome names the pixel");
+
+                      Canvas recoloured{64, 48, ground};
+                      paintRun(recoloured, title, ColorRgba8{.r = 255, .g = 0, .b = 0, .a = 255});
+                      const mv::CheckOutcome wrongTint = mv::localizedTextPresence(recoloured.view(), title);
+                      checks.expect(wrongTint.finding == mv::Finding::ForeignColour,
+                                    std::format("a run in the wrong tint is caught: {}", mv::describe(wrongTint.finding)));
+                      checks.expect(wrongTint.expectedColor == tintOf(titleToken), "against the tint the node's token resolves to");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aTextExpectationRefusesWhatItCannotCheck{
+    "A text expectation refuses a node, a scope or a run it could not discharge an obligation over",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-expectation-fails-closed")
+            .Given("a node with no text key, a locale-free scope, a partial run and a blank one", [] {})
+            .When("an expectation is built from each", [] {})
+            .Then("each is refused, rather than leaving an obligation nobody could discharge",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  records = abRun();
+
+                      const auto refusal = [&](const ms::CompiledNode& node, mv::RenderScope scope, std::span<const std::byte> bytes) {
+                          auto made = mv::TextExpectation::create(node, scope, bytes, font, ground);
+                          return made.has_value() ? std::optional<mv::VerifyError>{} : std::optional<mv::VerifyError>{made.error()};
+                      };
+
+                      const ms::CompiledNode* backdropNode = labelledScreen.find("backdrop");
+                      checks.expect(backdropNode != nullptr, "the fixture keeps its panel");
+                      if (backdropNode != nullptr) {
+                          checks.expect(refusal(*backdropNode, approvedLocale, records) == mv::VerifyError::NodeCarriesNoTextKey,
+                                        "a panel raises no text obligation");
+                      }
+
+                      // The locale-free scope exists so a textless screen keeps its geometric
+                      // obligations, not so a text obligation can lose its locale.
+                      checks.expect(refusal(titleNode(), mv::RenderScope::localeFree(), records) == mv::VerifyError::ScopeIsLocaleFree,
+                                    "a text obligation must name its locale");
+
+                      const std::vector<std::byte> truncated{records.begin(), records.end() - 1};
+                      checks.expect(refusal(titleNode(), approvedLocale, truncated) == mv::VerifyError::MalformedRun, "a partial record is refused");
+
+                      const std::vector<std::byte> blank = blankRun();
+                      checks.expect(refusal(titleNode(), approvedLocale, blank) == mv::VerifyError::EmptyRun,
+                                    "and a run that paints nothing cannot discharge a rendered-truth obligation");
+
+                      const std::array<std::array<std::byte, 6>, 1> unknownGlyph{record(9, 0, 6)};
+                      const std::vector<std::byte>                  dangling = runOf(unknownGlyph);
+                      checks.expect(refusal(titleNode(), approvedLocale, dangling) == mv::VerifyError::GlyphIndexOutOfRange,
+                                    "a record naming a glyph the package does not hold is refused");
+
+                      const std::vector<std::byte> tooLong(mdux::text::draw::recordSize * (mdux::medui::maxGlyphsPerRun + 1), std::byte{0});
+                      checks.expect(refusal(titleNode(), approvedLocale, tooLong) == mv::VerifyError::RunTooLong,
+                                    "and so is a run the runtime itself would refuse to draw");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/verify/TextCheckTests.cpp
+++ b/tests/verify/TextCheckTests.cpp
@@ -6,18 +6,29 @@
  * @compliance ADR-010 No on-device text shaping
  * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
  *
- * The claim these scenarios exist to establish, and #252's acceptance criterion that is easiest to
- * satisfy by accident: **a compiled text node receives both mandatory checks whether or not it has a
- * golden entry, and whether or not it was positioned.** The screen below carries no golden sidecar
- * at all, and its label declares no `position:` - the layout gave it its box. Both obligations are
- * still raised, and both are discharged, because ADR-014 decision 3 makes them a property of the
- * `textKey` rather than of an annotation.
+ * Three claims these scenarios exist to establish.
  *
- * The font package and the run are synthetic, and deliberately so. Two glyphs six pixels tall with a
- * space between them are enough to exercise every branch, and they let a scenario state the ink box
- * it expects in numbers a reader can check by hand - which a real 12-pixel DejaVu run does not.
- * `mdux.text.draw`'s record layout is the real one: the fixture writes little-endian bytes rather
- * than a struct, so a byte-order defect could not hide behind a helper that shared the bug.
+ * **A compiled text node receives both mandatory checks whether or not it has a golden entry, and
+ * whether or not it was positioned.** The screen below carries no golden sidecar at all, and its
+ * label declares no `position:` - the layout gave it its box. Both obligations are still raised and
+ * both are discharged, because ADR-014 decision 3 makes them a property of the `textKey`.
+ *
+ * **`LocalizedTextPresence` is a claim about the approved run's shape, not about ink in the right
+ * boxes.** Two adversarial scenarios hold it to that: a frame painting one pixel inside each glyph
+ * rectangle, and a frame painting a *different* glyph's shape at the right placement and bounds.
+ * Both satisfy every check that knows only glyph metrics; both must fail this one.
+ *
+ * **A production expectation is authorised by artifacts, not by its arguments.** The provenance
+ * scenario builds a real `TextBinding` from a self-consistent font package, text package, canonical
+ * package bytes and sidecar, then shows that a screen whose manifest does not carry this package's
+ * digest, a node from another screen, and a scope naming a locale the binding does not carry are
+ * each refused.
+ *
+ * The font, atlas and run are synthetic. Two four-by-six glyphs with a space between them exercise
+ * every branch and let a scenario state the ink box it expects in numbers a reader can check by
+ * hand, which a real 12-pixel DejaVu run does not. `mdux.text.draw`'s record layout is the real one:
+ * the fixture writes little-endian bytes rather than a struct, so a byte-order defect could not hide
+ * behind a helper that shared the bug.
  */
 
 import std;
@@ -31,6 +42,7 @@ import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.medui.screen;
 import mdux.text.draw;
+import mdux.text.schema;
 import mdux.verify;
 
 #include "../framework/SpecLabBridge.hpp"
@@ -42,6 +54,7 @@ namespace ms = mdux::medui;
 namespace mv = mdux::verify;
 
 using mdux::core::ColorRgba8;
+using mdux::core::Px;
 using mdux::test::verify::Canvas;
 using mdux::test::verify::record;
 using mdux::test::verify::runOf;
@@ -51,14 +64,18 @@ using mdux::test::verify::tintOf;
 constexpr ColorRgba8 ground{.r = 40, .g = 40, .b = 40, .a = 255};
 
 constexpr std::string_view titleToken = "Theme.Colors.Title";
+constexpr std::string_view titleKey   = "STR-TITLE";
+constexpr std::string_view fontId     = "synthetic-ui";
+constexpr std::string_view packageId  = "labelled-en-us";
+constexpr std::string_view localeTag  = "en-US";
 
-constexpr std::array approvals{
-    ms::TextPackageApproval{.locale = "en-US", .packageId = "labelled-en-us", .packageSha256 = {3}}
-};
-
-constexpr ms::LabelSpec titleLabel{.textKey = "STR-TITLE", .colorToken = titleToken};
+constexpr ms::LabelSpec titleLabel{.textKey = titleKey, .colorToken = titleToken};
 constexpr ms::PanelSpec backdrop{.colorToken = "Theme.Colors.TopbarBackground"};
 constexpr ms::ClockSpec wallClock{.format = ms::ClockFormat::TimeSeconds};
+
+constexpr std::array approvals{
+    ms::TextPackageApproval{.locale = localeTag, .packageId = packageId, .packageSha256 = {3}}
+};
 
 /// A label the layout placed, with no `position:` of its own and no golden entry anywhere.
 constexpr std::array<ms::CompiledNode, 3> labelledNodes{
@@ -79,6 +96,37 @@ constexpr ms::ScreenPackage labelledScreen{.id                   = "labelled",
 
 static_assert(labelledScreen.validate().has_value(), "the labelled fixture must be a screen a device could hold");
 
+constexpr std::uint32_t atlasEdge  = 16;
+constexpr std::uint32_t glyphWidth = 4;
+constexpr std::uint32_t glyphRows  = 6;
+
+/**
+ * @brief The coverage sheet the two glyphs paint from.
+ *
+ * `A` is solid: every texel of its slot is fully covered, which is the case where a covered pixel
+ * must come out exactly the tint. `B` is deliberately *not* solid - a full-coverage left column and
+ * a half-covered top row, the rest untouched - so that a scenario painting `A`'s shape at `B`'s
+ * placement is painting a different letter of the same size, which is the substitution glyph metrics
+ * alone cannot detect. The half-covered row also exercises the blend at a value that is neither
+ * endpoint.
+ */
+[[nodiscard]] std::vector<std::byte> syntheticAtlas() {
+    std::vector<std::byte> sheet(static_cast<std::size_t>(atlasEdge) * atlasEdge, std::byte{0});
+    const auto             at = [&sheet](std::uint32_t x, std::uint32_t y) -> std::byte& {
+        return sheet[static_cast<std::size_t>(y) * atlasEdge + x];
+    };
+    for (std::uint32_t y = 0; y < glyphRows; ++y) {
+        for (std::uint32_t x = 0; x < glyphWidth; ++x) {
+            at(x, y) = std::byte{255};
+        }
+        at(glyphWidth, y) = std::byte{255};
+    }
+    for (std::uint32_t x = 1; x < glyphWidth; ++x) {
+        at(glyphWidth + x, 0) = std::byte{128};
+    }
+    return sheet;
+}
+
 /// A four-by-six glyph, twice, plus the blank the space is.
 ///
 /// `bitmapOriginY` is measured *up* from the baseline, which is why a record's y is a baseline
@@ -86,10 +134,15 @@ static_assert(labelledScreen.validate().has_value(), "the labelled fixture must 
 /// pixels above a baseline at six lands its top edge on zero.
 [[nodiscard]] mdux::font::FontPackage twoGlyphFont() {
     mdux::font::FontPackage font;
-    font.id         = "synthetic-ui";
+    font.id         = std::string{fontId};
     font.unitsPerEm = 1000;
-    font.pixelSize  = 6;
-    font.atlas      = mdux::font::AtlasMetrics{.path = "atlas.bin", .width = 16, .height = 16, .byteLength = 256, .sha256 = {}, .occupancyPercent = 0};
+    font.pixelSize  = glyphRows;
+    font.atlas      = mdux::font::AtlasMetrics{.path             = "atlas.bin",
+                                               .width            = atlasEdge,
+                                               .height           = atlasEdge,
+                                               .byteLength       = static_cast<std::uint64_t>(atlasEdge) * atlasEdge,
+                                               .sha256           = {},
+                                               .occupancyPercent = 0};
     font.glyphs     = {
         mdux::font::GlyphRecord{.codePoint       = U' ',
                                 .glyphIndex      = 3,
@@ -100,27 +153,27 @@ static_assert(labelledScreen.validate().has_value(), "the labelled fixture must 
                                 .width           = 0,
                                 .height          = 0,
                                 .bitmapOriginX   = 0,
-                                .bitmapOriginY   = 0},
+                                .bitmapOriginY   = 0                                   },
         mdux::font::GlyphRecord{.codePoint       = U'A',
                                 .glyphIndex      = 4,
                                 .advanceWidth    = 600,
                                 .leftSideBearing = 0,
                                 .x               = 0,
                                 .y               = 0,
-                                .width           = 4,
-                                .height          = 6,
+                                .width           = glyphWidth,
+                                .height          = glyphRows,
                                 .bitmapOriginX   = 0,
-                                .bitmapOriginY   = 6},
+                                .bitmapOriginY   = static_cast<std::int32_t>(glyphRows)},
         mdux::font::GlyphRecord{.codePoint       = U'B',
                                 .glyphIndex      = 5,
                                 .advanceWidth    = 600,
                                 .leftSideBearing = 0,
-                                .x               = 4,
+                                .x               = glyphWidth,
                                 .y               = 0,
-                                .width           = 4,
-                                .height          = 6,
+                                .width           = glyphWidth,
+                                .height          = glyphRows,
                                 .bitmapOriginX   = 0,
-                                .bitmapOriginY   = 6}
+                                .bitmapOriginY   = static_cast<std::int32_t>(glyphRows)}
     };
     return font;
 }
@@ -131,7 +184,7 @@ static_assert(labelledScreen.validate().has_value(), "the labelled fixture must 
     return runOf(runs);
 }
 
-/// The same string one glyph shorter: a different locale's run over the same layout.
+/// The same string one glyph shorter: another locale's run over the same layout.
 [[nodiscard]] std::vector<std::byte> aOnlyRun() {
     const std::array<std::array<std::byte, 6>, 1> runs{record(1, 0, 6)};
     return runOf(runs);
@@ -151,27 +204,104 @@ static_assert(labelledScreen.validate().has_value(), "the labelled fixture must 
     return *node;
 }
 
-constexpr mv::RenderScope approvedLocale = mv::RenderScope::forLocale("en-US");
+constexpr mv::RenderScope approvedLocale = mv::RenderScope::forLocale(localeTag);
 
-/// Builds the expectation or fails the scenario naming the refusal.
-[[nodiscard]] mv::TextExpectation expect(const ms::CompiledNode& node, std::span<const std::byte> records, const mdux::font::FontPackage& font) {
-    auto made = mv::TextExpectation::create(node, approvedLocale, records, font, ground);
+/// Builds a synthetic expectation or fails the scenario naming the refusal.
+///
+/// `createSynthetic()` deliberately, and only here: what these scenarios exercise is the arithmetic
+/// of four pure functions, and ADR-014 decision 1 admits exactly this path for that purpose. The
+/// provenance-bearing `create()` has its own scenario at the end of this file.
+[[nodiscard]] mv::TextExpectation
+expect(const ms::CompiledNode& node, std::span<const std::byte> records, const mdux::font::FontPackage& font, std::span<const std::byte> atlas) {
+    auto made = mv::TextExpectation::createSynthetic(node, approvedLocale, records, font, atlas, ground);
     if (!made.has_value()) {
         throw speclab::core::AssertionFailure(std::format("the text expectation was refused: {}", mv::describe(made.error())), std::source_location::current());
     }
     return *made;
 }
 
-/// Paints the run where the runtime's placement rule puts it.
-void paintRun(Canvas& canvas, const mv::TextExpectation& expectation, ColorRgba8 colour, mdux::core::Px shiftX = 0) {
+/// Paints the run exactly as the coverage draw path would: every texel blended over the ground.
+void paintRun(Canvas& canvas, const mv::TextExpectation& expectation, ColorRgba8 tint, Px shiftX = 0) {
     for (std::size_t index = 0; index < expectation.glyphCount(); ++index) {
-        const std::optional<ms::NodeRect> glyph = expectation.glyphRect(index);
-        if (!glyph.has_value()) {
+        const std::optional<mv::PlacedGlyph> placed = expectation.glyph(index);
+        if (!placed.has_value()) {
             continue;
         }
-        canvas.fill(ms::NodeRect{.x = glyph->x + shiftX, .y = glyph->y, .width = glyph->width, .height = glyph->height}, colour);
+        for (Px dy = 0; dy < placed->rect.height; ++dy) {
+            for (Px dx = 0; dx < placed->rect.width; ++dx) {
+                canvas.set(placed->rect.x + dx + shiftX, placed->rect.y + dy, mv::blend(ground, tint, expectation.coverage(*placed, dx, dy)));
+            }
+        }
     }
 }
+
+/**
+ * @brief A self-consistent font package, text package, canonical bytes and sidecar, plus the screen
+ *        that approves them - everything `TextBinding::create()` insists on.
+ *
+ * Assembled rather than hand-written: the package's digests are computed from the bytes the fixture
+ * actually holds, and the screen's approval from the package's own canonical form. A fixture with a
+ * digest typed out by hand would be one that could only ever be wrong.
+ */
+struct BoundArtifacts {
+    mdux::font::FontPackage                font{twoGlyphFont()};
+    std::vector<std::byte>                 atlas{syntheticAtlas()};
+    std::vector<std::byte>                 runs{abRun()};
+    mdux::text::TextPackage                text{};
+    std::string                            packageJson{};
+    std::vector<std::byte>                 packageBytes{};
+    std::array<ms::TextPackageApproval, 1> approval{};
+    std::array<ms::CompiledNode, 3>        nodes{labelledNodes};
+    ms::ScreenPackage                      screen{};
+
+    BoundArtifacts() {
+        text.header.schemaVersion = mdux::evidence::kSchemaVersion;
+        text.header.id            = std::string{packageId};
+        text.header.kind          = std::string{mdux::text::packageKind};
+        text.atlasId              = std::string{fontId};
+        text.locale               = std::string{localeTag};
+        text.sidecarPath          = "runs.bin";
+        text.sidecarByteLength    = runs.size();
+        text.sidecarSha256        = mdux::evidence::sha256(runs);
+        text.runs                 = {
+            mdux::text::TextRun{.id = std::string{titleKey}, .byteOffset = 0, .byteLength = runs.size(), .sha256 = mdux::evidence::sha256(runs)}
+        };
+
+        auto written = text.write();
+        if (!written.has_value()) {
+            throw speclab::core::AssertionFailure("the fixture text package would not serialise", std::source_location::current());
+        }
+        packageJson = std::move(*written);
+        packageBytes.assign(std::as_bytes(std::span{packageJson}).begin(), std::as_bytes(std::span{packageJson}).end());
+
+        approval[0] = ms::TextPackageApproval{.locale = localeTag, .packageId = packageId, .packageSha256 = mdux::evidence::sha256(packageBytes)};
+        screen      = ms::ScreenPackage{.id                   = "labelled",
+                                        .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth         = 64,
+                                        .surfaceHeight        = 48,
+                                        .approvedTextPackages = approval,
+                                        .nodes                = nodes,
+                                        .budget               = budget};
+    }
+
+    [[nodiscard]] const ms::CompiledNode& title() const {
+        const ms::CompiledNode* node = screen.find("title");
+        if (node == nullptr) {
+            throw speclab::core::AssertionFailure("the fixture screen lost its label", std::source_location::current());
+        }
+        return *node;
+    }
+
+    /// The binding, proved by the module that owns that proof.
+    [[nodiscard]] ms::TextBinding binding() const {
+        auto made = ms::TextBinding::create(screen, font, text, packageBytes, runs);
+        if (!made.has_value()) {
+            throw speclab::core::AssertionFailure(std::format("the fixture artifacts were refused: {}", ms::describe(made.error())),
+                                                  std::source_location::current());
+        }
+        return *made;
+    }
+};
 
 }  // namespace
 
@@ -187,13 +317,14 @@ const mdux::spec::Register anUnpositionedTextNodeStillGetsBothChecks{
                       mdux::spec::Checks checks;
 
                       const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
                       const std::vector<std::byte>  records = abRun();
-                      const mv::TextExpectation     title   = expect(titleNode(), records, font);
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font, atlas);
 
-                      // The placement rule, restated as the number it produces: the run's ink box
-                      // is fourteen wide and six tall, and its corner is the node's corner.
+                      // The placement rule, restated as the number it produces: the run's ink box is
+                      // fourteen wide and six tall, and its corner is the node's corner.
                       checks.expect(title.ink() == ms::NodeRect{10, 20, 14, 6}, "the ink lands at the node's top-left corner");
-                      checks.expect(title.locale() == "en-US", "the obligation names the approved locale it runs in");
+                      checks.expect(title.locale() == localeTag, "the obligation names the approved locale it runs in");
 
                       Canvas canvas{64, 48, ground};
                       paintRun(canvas, title, tintOf(titleToken));
@@ -205,7 +336,79 @@ const mdux::spec::Register anUnpositionedTextNodeStillGetsBothChecks{
                       checks.expect(presence.held(), std::format("LocalizedTextPresence holds: {}", mv::describe(presence.finding)));
                       checks.expect(containment.check == "InkContainment", "the outcome names its check");
                       checks.expect(presence.check == "LocalizedTextPresence", "and so does the other");
-                      checks.expect(presence.scope == "en-US", "and both name the locale rather than a locale-free scope");
+                      checks.expect(presence.scope == localeTag, "and both name the locale rather than a locale-free scope");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register sparseInkDoesNotSatisfyPresence{
+    "Ink that merely occupies the glyph rectangles does not satisfy LocalizedTextPresence",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-presence-rejects-sparse-ink")
+            .Given("a frame painting one pixel inside each of the run's glyph rectangles", [] {})
+            .When("LocalizedTextPresence runs", [] {})
+            .Then("it fails, because the claim is about the run's shape and not about occupancy",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
+                      const std::vector<std::byte>  records = abRun();
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font, atlas);
+
+                      // Every check that knows only glyph metrics passes this frame: each non-blank
+                      // record's rectangle contains ink, and nothing is painted outside them.
+                      Canvas sparse{64, 48, ground};
+                      for (std::size_t index = 0; index < title.glyphCount(); ++index) {
+                          const std::optional<mv::PlacedGlyph> placed = title.glyph(index);
+                          if (placed.has_value()) {
+                              sparse.set(placed->rect.x, placed->rect.y, tintOf(titleToken));
+                          }
+                      }
+
+                      const mv::CheckOutcome presence = mv::localizedTextPresence(sparse.view(), title);
+                      checks.expect(presence.finding == mv::Finding::CoverageDiffers, std::format("sparse ink is caught: {}", mv::describe(presence.finding)));
+                      checks.expect(presence.foundColorValid && presence.foundColor == ground, "and the outcome names the pixel that was left unpainted");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aDifferentGlyphOfTheSameSizeIsCaught{
+    "A different glyph at the same placement and bounds does not satisfy LocalizedTextPresence",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-presence-rejects-substituted-glyph")
+            .Given("a frame drawing the solid glyph's shape where the sparse one belongs", [] {})
+            .When("LocalizedTextPresence runs", [] {})
+            .Then("the substitution is caught, because the coverage is compared and not the box",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
+                      const std::vector<std::byte>  records = abRun();
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font, atlas);
+
+                      // The second glyph's rectangle, filled the way the *first* glyph is covered.
+                      // Same placement, same bounds, same tint, different letter - which is what a
+                      // run drawn from another package's slots looks like.
+                      Canvas swapped{64, 48, ground};
+                      paintRun(swapped, title, tintOf(titleToken));
+                      const std::optional<mv::PlacedGlyph> second = title.glyph(2);
+                      checks.expect(second.has_value(), "the fixture keeps its second glyph");
+                      if (!second.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      swapped.fill(second->rect, tintOf(titleToken));
+
+                      const mv::CheckOutcome presence = mv::localizedTextPresence(swapped.view(), title);
+                      checks.expect(presence.finding == mv::Finding::CoverageDiffers,
+                                    std::format("the substituted glyph is caught: {}", mv::describe(presence.finding)));
+                      checks.expect(presence.glyphIndex == 2, std::format("and it is the third record, got {}", presence.glyphIndex));
                       checks.raise();
                   })
             .Execute();
@@ -231,8 +434,9 @@ const mdux::spec::Register aRunThatLeavesItsNodeIsCaught{
                       };
 
                       const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
                       const std::vector<std::byte>  records = abRun();
-                      const mv::TextExpectation     title   = expect(narrow, records, font);
+                      const mv::TextExpectation     title   = expect(narrow, records, font, atlas);
 
                       Canvas canvas{64, 48, ground};
                       paintRun(canvas, title, tintOf(titleToken));
@@ -259,8 +463,9 @@ const mdux::spec::Register inkInTheWrongPlaceIsCaught{
                       mdux::spec::Checks checks;
 
                       const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
                       const std::vector<std::byte>  records = abRun();
-                      const mv::TextExpectation     title   = expect(titleNode(), records, font);
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font, atlas);
 
                       Canvas shifted{64, 48, ground};
                       paintRun(shifted, title, tintOf(titleToken), 1);
@@ -289,11 +494,12 @@ const mdux::spec::Register anotherLocalesRunIsNotThisLocalesRun{
                       mdux::spec::Checks checks;
 
                       const mdux::font::FontPackage font     = twoGlyphFont();
+                      const std::vector<std::byte>  atlas    = syntheticAtlas();
                       const std::vector<std::byte>  approved = abRun();
                       const std::vector<std::byte>  shorter  = aOnlyRun();
 
-                      const mv::TextExpectation expected = expect(titleNode(), approved, font);
-                      const mv::TextExpectation other    = expect(titleNode(), shorter, font);
+                      const mv::TextExpectation expected = expect(titleNode(), approved, font, atlas);
+                      const mv::TextExpectation other    = expect(titleNode(), shorter, font, atlas);
 
                       // The frame drew the *other* locale's run. Its single glyph lands where this
                       // locale's first one does, so half of the expectation is satisfied - which is
@@ -312,19 +518,20 @@ const mdux::spec::Register anotherLocalesRunIsNotThisLocalesRun{
     }};
 
 const mdux::spec::Register inkOutsideTheRunIsCaught{
-    "Ink the approved run does not account for fails, and so does ink in a foreign colour",
+    "Ink the approved run does not account for fails, and so does a run in the wrong tint",
     "evidence-unit",
     [] {
         return speclab::Test("verify-text-presence-rejects-stray-ink")
             .Given("a correctly drawn run", [] {})
-            .When("one extra pixel is painted in the gap the space leaves, and then a glyph is recoloured", [] {})
-            .Then("the first is ink outside the run and the second is a foreign colour",
+            .When("one extra pixel is painted in the gap the space leaves, and then the run is recoloured", [] {})
+            .Then("the first is ink outside the run and the second is a coverage disagreement",
                   [] {
                       mdux::spec::Checks checks;
 
                       const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
                       const std::vector<std::byte>  records = abRun();
-                      const mv::TextExpectation     title   = expect(titleNode(), records, font);
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font, atlas);
 
                       // The gap the space leaves is where a run from another package, or a stale
                       // frame, would show through. The atlas slot is exactly the glyph's bitmap, so
@@ -339,61 +546,129 @@ const mdux::spec::Register inkOutsideTheRunIsCaught{
                       Canvas recoloured{64, 48, ground};
                       paintRun(recoloured, title, ColorRgba8{.r = 255, .g = 0, .b = 0, .a = 255});
                       const mv::CheckOutcome wrongTint = mv::localizedTextPresence(recoloured.view(), title);
-                      checks.expect(wrongTint.finding == mv::Finding::ForeignColour,
+                      checks.expect(wrongTint.finding == mv::Finding::CoverageDiffers,
                                     std::format("a run in the wrong tint is caught: {}", mv::describe(wrongTint.finding)));
-                      checks.expect(wrongTint.expectedColor == tintOf(titleToken), "against the tint the node's token resolves to");
+                      checks.expect(wrongTint.foundColorValid && wrongTint.foundColor.r == 255, "and the outcome carries the pixel it found");
                       checks.raise();
                   })
             .Execute();
     }};
 
 const mdux::spec::Register aTextExpectationRefusesWhatItCannotCheck{
-    "A text expectation refuses a node, a scope or a run it could not discharge an obligation over",
+    "A text expectation refuses a node, a scope, a run or a sheet it could not check against",
     "evidence-unit",
     [] {
         return speclab::Test("verify-text-expectation-fails-closed")
-            .Given("a node with no text key, a locale-free scope, a partial run and a blank one", [] {})
+            .Given("a node with no text key, a locale-free scope, a partial run, a blank one and a wrong sheet", [] {})
             .When("an expectation is built from each", [] {})
             .Then("each is refused, rather than leaving an obligation nobody could discharge",
                   [] {
                       mdux::spec::Checks checks;
 
                       const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
                       const std::vector<std::byte>  records = abRun();
 
-                      const auto refusal = [&](const ms::CompiledNode& node, mv::RenderScope scope, std::span<const std::byte> bytes) {
-                          auto made = mv::TextExpectation::create(node, scope, bytes, font, ground);
-                          return made.has_value() ? std::optional<mv::VerifyError>{} : std::optional<mv::VerifyError>{made.error()};
-                      };
+                      const auto refusal =
+                          [&](const ms::CompiledNode& node, mv::RenderScope scope, std::span<const std::byte> bytes, std::span<const std::byte> sheet) {
+                              auto made = mv::TextExpectation::createSynthetic(node, scope, bytes, font, sheet, ground);
+                              return made.has_value() ? std::optional<mv::VerifyError>{} : std::optional<mv::VerifyError>{made.error()};
+                          };
 
                       const ms::CompiledNode* backdropNode = labelledScreen.find("backdrop");
                       checks.expect(backdropNode != nullptr, "the fixture keeps its panel");
                       if (backdropNode != nullptr) {
-                          checks.expect(refusal(*backdropNode, approvedLocale, records) == mv::VerifyError::NodeCarriesNoTextKey,
+                          checks.expect(refusal(*backdropNode, approvedLocale, records, atlas) == mv::VerifyError::NodeCarriesNoTextKey,
                                         "a panel raises no text obligation");
                       }
 
                       // The locale-free scope exists so a textless screen keeps its geometric
                       // obligations, not so a text obligation can lose its locale.
-                      checks.expect(refusal(titleNode(), mv::RenderScope::localeFree(), records) == mv::VerifyError::ScopeIsLocaleFree,
+                      checks.expect(refusal(titleNode(), mv::RenderScope::localeFree(), records, atlas) == mv::VerifyError::ScopeIsLocaleFree,
                                     "a text obligation must name its locale");
 
                       const std::vector<std::byte> truncated{records.begin(), records.end() - 1};
-                      checks.expect(refusal(titleNode(), approvedLocale, truncated) == mv::VerifyError::MalformedRun, "a partial record is refused");
+                      checks.expect(refusal(titleNode(), approvedLocale, truncated, atlas) == mv::VerifyError::MalformedRun, "a partial record is refused");
 
                       const std::vector<std::byte> blank = blankRun();
-                      checks.expect(refusal(titleNode(), approvedLocale, blank) == mv::VerifyError::EmptyRun,
+                      checks.expect(refusal(titleNode(), approvedLocale, blank, atlas) == mv::VerifyError::EmptyRun,
                                     "and a run that paints nothing cannot discharge a rendered-truth obligation");
 
                       const std::array<std::array<std::byte, 6>, 1> unknownGlyph{record(9, 0, 6)};
                       const std::vector<std::byte>                  dangling = runOf(unknownGlyph);
-                      checks.expect(refusal(titleNode(), approvedLocale, dangling) == mv::VerifyError::GlyphIndexOutOfRange,
+                      checks.expect(refusal(titleNode(), approvedLocale, dangling, atlas) == mv::VerifyError::GlyphIndexOutOfRange,
                                     "a record naming a glyph the package does not hold is refused");
 
                       const std::vector<std::byte> tooLong(mdux::text::draw::recordSize * (mdux::medui::maxGlyphsPerRun + 1), std::byte{0});
-                      checks.expect(refusal(titleNode(), approvedLocale, tooLong) == mv::VerifyError::RunTooLong,
+                      checks.expect(refusal(titleNode(), approvedLocale, tooLong, atlas) == mv::VerifyError::RunTooLong,
                                     "and so is a run the runtime itself would refuse to draw");
+
+                      // A sheet of the wrong size is a sheet from another font, and sampling it
+                      // would find the run present in the wrong letters.
+                      const std::vector<std::byte> shortSheet(atlas.size() - 1, std::byte{0});
+                      checks.expect(refusal(titleNode(), approvedLocale, records, shortSheet) == mv::VerifyError::AtlasSizeMismatch,
+                                    "and a coverage sheet that is not the one the font package describes");
                       checks.raise();
                   })
+            .Execute();
+    }};
+
+const mdux::spec::Register aProductionExpectationIsAuthorisedByArtifacts{
+    "A production text expectation comes from an authenticated binding, or not at all",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-expectation-provenance")
+            .Given("a screen, a font package, a text package, its canonical bytes and its sidecar, all agreeing", [] {})
+            .When("expectations are built from the binding, and from things that authorise none", [] {})
+            .Then(
+                "only the authorised one is admitted, and each refusal names what was missing",
+                [] {
+                    mdux::spec::Checks checks;
+
+                    const BoundArtifacts  fixture;
+                    const ms::TextBinding binding = fixture.binding();
+                    const ms::TextBinding unbound;
+
+                    const auto build = [&](const ms::ScreenPackage& screen, const ms::CompiledNode& node, const ms::TextBinding& bound, mv::RenderScope scope) {
+                        return mv::TextExpectation::create(screen, node, bound, fixture.atlas, scope, ground);
+                    };
+
+                    // The authorised case. Nothing about the locale, the run bytes or the font was
+                    // supplied by this scenario: the run was looked up by the node's own textKey in
+                    // the package the screen's manifest approves.
+                    auto authorised = build(fixture.screen, fixture.title(), binding, approvedLocale);
+                    checks.expect(authorised.has_value(),
+                                  authorised.has_value() ? "the authorised expectation is admitted"
+                                                         : std::format("the authorised expectation was refused: {}", mv::describe(authorised.error())));
+                    if (authorised.has_value()) {
+                        checks.expect(authorised->records().size() == fixture.runs.size(), "and it carries the run the package addresses");
+                        checks.expect(authorised->ink() == ms::NodeRect{10, 20, 14, 6}, "placed by the runtime's own rule");
+
+                        Canvas canvas{64, 48, ground};
+                        paintRun(canvas, *authorised, tintOf(titleToken));
+                        checks.expect(mv::localizedTextPresence(canvas.view(), *authorised).held(), "and it discharges its obligation against a correct frame");
+                    }
+
+                    const auto error = [](auto&& made) {
+                        return made.has_value() ? std::optional<mv::VerifyError>{} : std::optional<mv::VerifyError>{made.error()};
+                    };
+
+                    checks.expect(error(build(fixture.screen, fixture.title(), unbound, approvedLocale)) == mv::VerifyError::TextBindingUnbound,
+                                  "a binding carrying no packages authorises nothing");
+
+                    // `labelledScreen` approves the same locale and package id with a digest that
+                    // is not this package's, which is the case a locale-and-id comparison alone
+                    // would wave through.
+                    checks.expect(error(build(labelledScreen, titleNode(), binding, approvedLocale)) == mv::VerifyError::BindingNotApproved,
+                                  "a screen whose manifest does not carry this package's digest");
+
+                    checks.expect(error(build(fixture.screen, titleNode(), binding, approvedLocale)) == mv::VerifyError::NodeNotInScreen,
+                                  "a node that is not this screen's, even with the right id");
+
+                    checks.expect(error(build(fixture.screen, fixture.title(), binding, mv::RenderScope::forLocale("de-DE")))
+                                      == mv::VerifyError::ScopeIsNotTheBoundLocale,
+                                  "and a scope that would report an English frame as a German outcome");
+                    checks.raise();
+                })
             .Execute();
     }};

--- a/tests/verify/TextCheckTests.cpp
+++ b/tests/verify/TextCheckTests.cpp
@@ -190,6 +190,21 @@ constexpr std::uint32_t glyphRows  = 6;
     return runOf(runs);
 }
 
+/// The two glyphs placed two pixels apart, so their four-pixel bitmaps overlap by two columns.
+///
+/// Nothing in `FontPackage::validate()` requires an advance to clear its own bitmap, so a font with
+/// tight advances or negative kerning produces exactly this. The draw path records one quad per
+/// glyph and blends them in turn, so the overlap column holds both coverages composited - which a
+/// check comparing against one glyph at a time would call a defect on a correct frame.
+[[nodiscard]] std::vector<std::byte> overlappingRun() {
+    // The *sparse* glyph twice, not the solid one: where a solid glyph overlaps anything the
+    // composition is 255 and so is either coverage alone, which would let a scenario claim a
+    // composited check while testing nothing. Two half-covered texels compose to 192, a value
+    // neither glyph produces by itself.
+    const std::array<std::array<std::byte, 6>, 2> runs{record(2, 0, 6), record(2, 2, 6)};
+    return runOf(runs);
+}
+
 /// A run of nothing but the space.
 [[nodiscard]] std::vector<std::byte> blankRun() {
     const std::array<std::array<std::byte, 6>, 1> runs{record(0, 0, 6)};
@@ -220,7 +235,12 @@ expect(const ms::CompiledNode& node, std::span<const std::byte> records, const m
     return *made;
 }
 
-/// Paints the run exactly as the coverage draw path would: every texel blended over the ground.
+/// Paints the run the way the coverage draw path does: one quad per glyph, blended in turn.
+///
+/// Deliberately *not* a composited expectation computed in one pass. The frame a scenario hands to
+/// the check has to be built the way the device builds one - each glyph blended over whatever the
+/// previous glyphs left - or an overlap scenario would be comparing the check against a fixture that
+/// shared its assumption instead of against a rendered frame.
 void paintRun(Canvas& canvas, const mv::TextExpectation& expectation, ColorRgba8 tint, Px shiftX = 0) {
     for (std::size_t index = 0; index < expectation.glyphCount(); ++index) {
         const std::optional<mv::PlacedGlyph> placed = expectation.glyph(index);
@@ -229,7 +249,9 @@ void paintRun(Canvas& canvas, const mv::TextExpectation& expectation, ColorRgba8
         }
         for (Px dy = 0; dy < placed->rect.height; ++dy) {
             for (Px dx = 0; dx < placed->rect.width; ++dx) {
-                canvas.set(placed->rect.x + dx + shiftX, placed->rect.y + dy, mv::blend(ground, tint, expectation.coverage(*placed, dx, dy)));
+                const Px x = placed->rect.x + dx + shiftX;
+                const Px y = placed->rect.y + dy;
+                canvas.set(x, y, mv::blend(canvas.at(x, y), tint, expectation.coverage(*placed, dx, dy)));
             }
         }
     }
@@ -371,6 +393,54 @@ const mdux::spec::Register sparseInkDoesNotSatisfyPresence{
                       const mv::CheckOutcome presence = mv::localizedTextPresence(sparse.view(), title);
                       checks.expect(presence.finding == mv::Finding::CoverageDiffers, std::format("sparse ink is caught: {}", mv::describe(presence.finding)));
                       checks.expect(presence.foundColorValid && presence.foundColor == ground, "and the outcome names the pixel that was left unpainted");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register overlappingGlyphsAreComposited{
+    "Two glyphs whose bitmaps overlap are checked against their composited coverage",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-presence-composites-overlap")
+            .Given("a run placing two four-pixel glyphs two pixels apart", [] {})
+            .When("the frame blends each quad over what the previous one left, as the draw path does", [] {})
+            .Then("the check holds, and still fails when the overlap column is painted from one glyph alone",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
+                      const std::vector<std::byte>  records = overlappingRun();
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font, atlas);
+
+                      const std::optional<mv::PlacedGlyph> first  = title.glyph(0);
+                      const std::optional<mv::PlacedGlyph> second = title.glyph(1);
+                      checks.expect(first.has_value() && second.has_value(), "both glyphs are placed");
+                      if (!first.has_value() || !second.has_value()) {
+                          checks.raise();
+                          return;
+                      }
+                      // The overlap is the point of the fixture, so it is asserted rather than
+                      // assumed: two columns of the six the two bitmaps span are shared.
+                      checks.expect(second->rect.x - first->rect.x == 2, "the second glyph starts two pixels into the first");
+                      checks.expect(title.ink() == ms::NodeRect{10, 20, 6, 6}, "and the ink box spans both");
+
+                      Canvas canvas{64, 48, ground};
+                      paintRun(canvas, title, tintOf(titleToken));
+                      const mv::CheckOutcome presence = mv::localizedTextPresence(canvas.view(), title);
+                      checks.expect(presence.held(), std::format("the composited frame holds: {}", mv::describe(presence.finding)));
+
+                      // ...and the check has not simply become permissive. Both glyphs cover the
+                      // last shared column at 128, which composes to 192; painting it from one
+                      // glyph's coverage alone is a value the composition does not produce, and it
+                      // misses by four - twice the two-layer allowance.
+                      Canvas single{64, 48, ground};
+                      paintRun(single, title, tintOf(titleToken));
+                      single.set(first->rect.x + 3, first->rect.y, mv::blend(ground, tintOf(titleToken), 128));
+                      const mv::CheckOutcome partial = mv::localizedTextPresence(single.view(), title);
+                      checks.expect(partial.finding == mv::Finding::CoverageDiffers,
+                                    std::format("one glyph's coverage alone is caught: {}", mv::describe(partial.finding)));
                       checks.raise();
                   })
             .Execute();

--- a/tests/verify/VerifySpecMain.cpp
+++ b/tests/verify/VerifySpecMain.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file VerifySpecMain.cpp
+ * @brief Entry point for the governed `mdux.verify` SpecLab BDD executable.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone)
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ *
+ * Links MduX::Core only, and no GPU is involved anywhere in this binary. That is ADR-014 decision
+ * 1's first consequence made mechanical: a framebuffer is an array, so a check can be built and
+ * proved before a driver exists to produce one. A scenario here that needed Vulkan would mean the
+ * checks had stopped being pure functions over pixels.
+ */
+
+import std;
+import speclab;
+
+#include "../framework/SpecLabBridge.hpp"
+
+int main(int argc, char** argv) {
+    return mdux::spec::main(argc, argv, "MduX Rendered-Truth Verification Spec");
+}

--- a/tools/medui/Goldens.cpp
+++ b/tools/medui/Goldens.cpp
@@ -16,6 +16,7 @@ import mdux.tools.medui.ast;
 import mdux.tools.medui.diagnostics;
 import mdux.tools.medui.layout;
 import mdux.tools.medui.semantic;
+import mdux.verify;
 
 namespace mdux::tools::medui {
 
@@ -317,26 +318,6 @@ private:
 };
 
 }  // namespace
-
-std::string_view spell(CvCheck check) noexcept {
-    switch (check) {
-        case CvCheck::Bounds:
-            return "Bounds";
-        case CvCheck::ColorHash:
-            return "ColorHash";
-    }
-    return "";
-}
-
-std::optional<CvCheck> parseCvCheck(std::string_view name) noexcept {
-    if (name == spell(CvCheck::Bounds)) {
-        return CvCheck::Bounds;
-    }
-    if (name == spell(CvCheck::ColorHash)) {
-        return CvCheck::ColorHash;
-    }
-    return std::nullopt;
-}
 
 SafetyResult validateSafetyAnnotations(const ast::Screen& screen, std::string file) {
     return Validator{std::move(file)}.run(screen);

--- a/tools/medui/Goldens.cppm
+++ b/tools/medui/Goldens.cppm
@@ -111,25 +111,30 @@ import std;
 import mdux.tools.cli;
 import mdux.tools.medui.ast;
 import mdux.tools.medui.layout;
+import mdux.verify;
 
 export namespace mdux::tools::medui {
 
 /**
  * @brief A verification #16's driver performs against a rendered frame.
  *
- * The closed set the shared language defines. Order is the serialisation order: `cvChecks` is
- * sorted by this enumeration so that a screen has one canonical form.
+ * The closed set the shared language defines, named here and *defined* in `mdux.verify` (#252).
+ * Order is the serialisation order: `cvChecks` is sorted by this enumeration so that a screen has
+ * one canonical form.
+ *
+ * An alias rather than a second enumeration, for the reason ADR-012 decision 4 gives about the
+ * golden predicate: the compiler that writes these names and the verifier that reads them back must
+ * not be able to disagree about what the set contains, and two declarations of one closed set agree
+ * until the day they matter. The direction is deliberate too - the governed module owns the type,
+ * because a device-side reader may not depend on a host tool.
  */
-enum class CvCheck : std::uint8_t {
-    Bounds,    ///< the node's content occupies the rectangle the compiler resolved
-    ColorHash  ///< the node's content carries the tint its colour token resolves to
-};
+using mdux::verify::CvCheck;
 
 /// The spelling an author writes and the serialiser emits, e.g. `Bounds`.
-[[nodiscard]] std::string_view spell(CvCheck check) noexcept;
+using mdux::verify::spell;
 
 /// The check `name` spells, or nothing when the name is not one of the closed set.
-[[nodiscard]] std::optional<CvCheck> parseCvCheck(std::string_view name) noexcept;
+using mdux::verify::parseCvCheck;
 
 /**
  * @brief One golden reference: what a verifier must find, and where.


### PR DESCRIPTION
## Summary

ADR-014 (#251) fixed what rendered-truth verification checks and what it cannot, and recorded that
nothing it described ran yet. This is the first of its four implementation children: `mdux.verify`,
a governed module of four pure functions over a CPU framebuffer and an artifact-derived expectation.

- **`goldenBounds()`** — the content inside a golden's declared rectangle *is* that rectangle. An
  equality rather than a containment, because that is ADR-014's own worked example: a rectangle
  moved by one pixel still overlaps its declared box, so only the equality fails on it.
- **`colorHash()`** — every painted pixel is a blend of the ground and the resolved tint, and at
  least one is the tint exactly. No tolerance is needed: a convex combination of two integer
  channels cannot round outside the interval they span, and a fully covered pixel is exactly the
  tint because coverage modulates alpha and never rgb.
- **`inkContainment()`** — the ink the committed run and font metrics predict, placed by the rule
  `mdux.medui.screen` fixes, is inside the node, and is what the frame actually shows there.
- **`localizedTextPresence()`** — per glyph, in both directions: every non-blank record of the
  approved locale's run painted something inside its own rectangle, and every pixel of the node
  outside all of those rectangles is still the ground. The second half is what stops a different
  translation from satisfying the first.

Two expectation views, obtainable only through a `create()` that resolves them against the compiled
screen — which is where ADR-014 decision 2 lives. The golden view fails closed on a dangling node id
and on **every** field the sidecar duplicates disagreeing with the node it names, and on a
`ColorHash` with no tint to compare against. The text view needs no golden entry and no
`position:`: it is raised from the `textKey` alone, in one approved locale.

### Three decisions worth a reviewer's attention

**Both views carry two resolved colours, where ADR-014's prose names one.** The tint is what a check
compares *against*; deciding whether a pixel was painted **at all** needs the value it would have
had otherwise, and no amount of knowing the tint supplies it. Both are resolved through the governed
table and the driver's own fixed clear colour — never read back out of the frame under test, which
would make a check compare a measurement against itself. Documented at length in the module header.

**`GoldenBounds` is an equality, so a component that fills only part of its node does not discharge
it.** Stated in the header rather than discovered later: this matters for #17, and the rule to apply
is that such a component needs a golden that says so, not that the check is loosened.

**Two rules that had one implementation keep having one.** `quantise()` moves out of
`Screen.cpp`'s anonymous namespace into `mdux.medui.schema`, because the runtime turns a token
into the bytes a frame carries and this module compares those bytes back — two copies would agree
until one rounded differently, and the failure would read as a rendering defect. `CvCheck` is
defined in `mdux.verify` and aliased by `mdux.tools.medui.goldens`, in that direction because
ADR-004 does not let a device-side reader depend on a host tool.

**A run that paints no ink is refused, not passed.** A single space is legitimate for the runtime,
which draws nothing; it is not something a rendered-truth obligation can discharge, and a pass would
be indistinguishable from a screen that lost its text.

ADR-014 itself is not amended. Its "nothing described below runs today" is a statement of what was
true when it was accepted, and its Review Date clause already points at #253.

Closes #252

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #252

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked (#251 merged as #272)
- **Merge order:** mergeable now. #253 is blocked by this.

## Shared registries touched

- [x] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [x] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [x] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`
- [ ] None of the above

`tools/medui/Goldens.cppm` and `.cpp` are edited but no host-tool target's source list changes.

## Rebase state

- **Rebased onto:** `bba93abbe946a128742ce869e230b87609fc75c0` (`origin/develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

Local leg is GCC 16.1.0 / CMake 4.2.3 / Ninja 1.13.2, Release, Vulkan 1.4.341 with lavapipe.

- [x] `cmake -S . -B build-252 -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build-252` — clean, no warnings
- [x] `ctest --test-dir build-252` — **647/647 passed**, of which 18 are the new `verify_spec`
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK, 83 files, 0 findings
- [x] Other: `python3 tools/governed-lint/mdux_governed_lint.py` — OK, 34 files, 0 findings;
      `ctest -L governed` — `governed.noThrow.symbolScan` and its negative both pass;
      `offscreen_tests` (the `pixel` label, under lavapipe) — 36/36, including the authored-screen
      panel and label scenarios that exercise the moved `quantise()`;
      `clang-format` clean on every added and edited file.
- Not run locally: MSVC, macOS/Clang 21 and Linux/Clang 21 legs — CI covers them.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** pending — #253 is the successor and must wait for it.
- [ ] That run is green.

## Regulatory impact

This is the mechanism an IEC 62304:2006 §5.7 argument would eventually point at, and it changes no
claim today. Nothing here supplies a software system, system requirements or a representative use
environment, and ADR-014's scope limit is unchanged and restated in the module header: verification
compares a frame against the compiled screen, both come from one source, so what is established is
internal consistency and not that the screen is the right screen.

Artifacts touched: `docs/architecture.md` and `AGENTS.md` module and test-target tables (the
latter's executable counts were already stale by six and are corrected to the tree). No ADR is
amended, no committed artifact under `generated/` changes, and no risk control or traceability
record is claimed. `mdux.medui.screen`'s behaviour is unchanged: `quantise()` moved between
namespaces with its arithmetic intact, and the lavapipe pixel scenarios that compare its output byte
for byte still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rendered-output verification for framebuffer bounds, colors, text placement, and localized text presence.
  - Added validation for malformed or inconsistent rendering expectations and framebuffer data.
  - Centralized color conversion for consistent RGBA rendering.

- **Bug Fixes**
  - Improved detection of misplaced, missing, incorrectly colored, or substituted text and graphics during verification.
  - Prevented invalid rendering metadata from being accepted as valid test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->