### PR TITLE
S4 — Emit verification.json as an evidence artifact [#254]

### DIFF
--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -114,6 +114,7 @@ jobs:
           vulkan-tools \
           libvulkan-dev \
           vulkan-utility-libraries-dev \
+          mesa-vulkan-drivers \
           spirv-tools \
           libglfw3-dev \
           xvfb
@@ -153,9 +154,18 @@ jobs:
           echo "$found"
         fi
 
-    - name: Verify Vulkan installation
+    # Asserted rather than tolerated, and that changed with #254. This leg used to accept "Vulkan
+    # driver not available (expected in CI)" because nothing here rendered. The screen bundle's
+    # verification.json is now re-derived during the build by a tool that needs a device, so a leg
+    # without lavapipe does not produce a weaker artifact - it fails to build. Finding that out here,
+    # with the ICD list in the log, beats finding it out as a bake step that could not create an
+    # instance several hundred lines later.
+    - name: Verify a Vulkan device is present
       run: |
-        vulkaninfo --summary || echo "Vulkan driver not available (expected in CI)"
+        set -euo pipefail
+        echo "Available Vulkan ICDs:"
+        ls -1 /usr/share/vulkan/icd.d/ || true
+        vulkaninfo --summary
 
     # The preset, not an equivalent-looking configure line: CMakePresets.json's ninja-clang
     # description exists precisely to keep preset and CI from drifting apart, which a
@@ -181,3 +191,16 @@ jobs:
     # green tick for zero assertions.
     - name: Verify evidence artifacts (Clang)
       run: ctest --preset ninja-clang -L evidence --output-on-failure --no-tests=error
+
+    # A skip here would mean the evidence step above compared a verification.json that this leg did
+    # not really re-derive, which #254 forbids. The same guard the GCC and macOS legs carry.
+    - name: Verify rendered tests ran on lavapipe
+      shell: bash
+      run: |
+        set -euo pipefail
+        pixel_log="$RUNNER_TEMP/clang-pixel.log"
+        ctest --preset ninja-clang -L pixel -V --no-tests=error 2>&1 | tee "$pixel_log"
+        if grep -q 'Skipped' "$pixel_log"; then
+          echo '::error::Pixel tests were skipped - no Vulkan device. They must run on this leg.'
+          exit 1
+        fi

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -132,7 +132,19 @@ jobs:
           -DENABLE_SANITIZER_ADDRESS=ON \
           -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON
 
+    # detect_leaks=0 for the build itself, which became a thing that renders when #254 made
+    # verification.json a bake output: `mdux-verify-bake` runs here, sanitized, against lavapipe,
+    # and LeakSanitizer reports the same driver-owned 240 bytes through `<unknown module>` that the
+    # rendered-truth step below documents at length. It is not suppressible by name for the reason
+    # given there.
+    #
+    # Nothing is lost by scoping it this way. The other bakers that run during this build are driven
+    # as library calls by `medui_tools_spec` and friends in the leak-detecting step below, so an
+    # owner dropped in a baker is still caught - by the step whose job that is, rather than here.
     - name: Build
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
       run: cmake --build build-asan
 
     # Everything except the suites that talk to a GPU driver. Leak detection is on here, which is

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -119,14 +119,24 @@ jobs:
         if (-not $icd) {
           throw "mesa3d $version carries no 64-bit lavapipe ICD manifest"
         }
-        # Both spellings, and the older one is the one that actually works here. `VK_DRIVER_FILES`
-        # arrived in loader 1.3.207; the SDK pinned above is 1.3.204.0, whose loader ignores it
-        # entirely and reports "no usable ICD" with the variable set correctly in the environment.
-        # `VK_ICD_FILENAMES` is what that loader reads. Setting both keeps this working when the SDK
-        # pin moves forward, since the newer loader prefers `VK_DRIVER_FILES`.
-        "VK_DRIVER_FILES=$($icd.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        "VK_ICD_FILENAMES=$($icd.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        Write-Host "lavapipe ICD: $($icd.FullName)"
+        # Registered in the registry rather than pointed at with VK_DRIVER_FILES, and the loader
+        # is emphatic about why. This runner is elevated, and an elevated loader ignores every
+        # driver-path environment variable as a hardening measure - it will not let a planted ICD
+        # into an administrator process. With the variable set correctly it says, in as many words:
+        #
+        #   INFO: Loader is running with elevated permissions.
+        #         Environment variable VK_DRIVER_FILES will be ignored
+        #
+        # and then fails vkCreateInstance with "no usable ICD". The loader it says that with is
+        # C:\Windows\SYSTEM32\vulkan-1.dll version 1.3.301 - the system loader, not the SDK's - so
+        # the variable is new enough to be understood and is discarded anyway. HKLM\...\Khronos\
+        # Vulkan\Drivers is the documented way to install an ICD system-wide, it is what an elevated
+        # loader still reads, and writing it is exactly what being elevated makes possible.
+        $key = 'HKLM:\SOFTWARE\Khronos\Vulkan\Drivers'
+        New-Item -Path $key -Force | Out-Null
+        # A driver entry is a REG_DWORD whose *name* is the manifest path; 0 means enabled.
+        New-ItemProperty -Path $key -Name $icd.FullName -PropertyType DWord -Value 0 -Force | Out-Null
+        Write-Host "registered lavapipe ICD: $($icd.FullName)"
 
     - name: Install Ninja
       run: |
@@ -156,13 +166,6 @@ jobs:
       shell: cmd
 
     - name: Build
-      env:
-        # This leg's Vulkan device is a software rasterizer installed by hand two steps above, and
-        # the build renders through it (#254). When a loader declines an ICD it does so silently and
-        # reports only "no usable ICD" at vkCreateInstance, which says nothing about why. Loader
-        # diagnostics turn that into the loader's own sentence, in the log, next to the bake that
-        # failed.
-        VK_LOADER_DEBUG: all
       run: cmake --build --preset ninja-msvc
       shell: cmd
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -84,6 +84,44 @@ jobs:
           & "$env:VULKAN_SDK\bin\vulkaninfoSDK.exe" --summary
         }
 
+    # Lavapipe, so this leg can execute the rendered-truth producer (#254).
+    #
+    # The component list above installs a loader without a driver, and `windows-latest` has no GPU,
+    # so this runner enumerated zero physical devices until now. That was invisible while nothing
+    # here rendered. It stopped being invisible when `verification.json` joined the screen bundle:
+    # the file is re-derived by `mdux-verify-bake` during the ordinary build, so a leg with no ICD
+    # does not produce a smaller artifact - it fails to build. ADR-007 decision 6 asks all four legs
+    # to re-derive every committed artifact, and #254 forbids reading a missing device as a skip, so
+    # the software rasterizer is what keeps this leg in the claim rather than an exception to it.
+    #
+    # Mesa's own Windows build, pinned by release tag and verified against the SHA-256 GitHub
+    # records for that exact asset. An unpinned "latest" would let a third-party binary change what
+    # this leg renders with between two runs of the same commit, under a byte-identity claim.
+    - name: Install lavapipe (Mesa software Vulkan)
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $version  = '26.2.0'
+        $expected = 'dcb2719ef346dab5b609fcb193a5f13cfc4b0502e3f4de1ad43d349477402f47'
+        $archive  = Join-Path $env:RUNNER_TEMP 'mesa.7z'
+        $target   = Join-Path $env:RUNNER_TEMP 'mesa'
+        $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$version/mesa3d-$version-release-msvc.7z"
+        Invoke-WebRequest -Uri $url -OutFile $archive
+        $actual = (Get-FileHash -Algorithm SHA256 -Path $archive).Hash.ToLower()
+        if ($actual -ne $expected) {
+          throw "mesa3d $version is $actual, not the pinned $expected"
+        }
+        & 7z x $archive "-o$target" -y | Out-Null
+        # Located rather than hardcoded: the archive's internal layout is Mesa's business, and a
+        # moved file should fail here by name instead of as a device that silently never appears.
+        # The manifest's library_path is relative, so the DLL has to stay beside it.
+        $icd = Get-ChildItem -Path $target -Recurse -Filter 'lvp_icd*64*.json' | Select-Object -First 1
+        if (-not $icd) {
+          throw "mesa3d $version carries no 64-bit lavapipe ICD manifest"
+        }
+        "VK_DRIVER_FILES=$($icd.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        Write-Host "VK_DRIVER_FILES=$($icd.FullName)"
+
     - name: Install Ninja
       run: |
         $NINJA_URL = "https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-win.zip"
@@ -126,6 +164,19 @@ jobs:
     - name: Verify evidence artifacts (MSVC)
       run: ctest --preset ninja-msvc -L evidence
       shell: cmd
+
+    # A skip here would mean the evidence step above compared a verification.json this leg did not
+    # really re-derive, which #254 forbids. The same guard the GCC, Clang and macOS legs carry.
+    - name: Verify rendered tests ran on lavapipe
+      shell: bash
+      run: |
+        set -euo pipefail
+        pixel_log="$RUNNER_TEMP/msvc-pixel.log"
+        ctest --preset ninja-msvc -L pixel -V --no-tests=error 2>&1 | tee "$pixel_log"
+        if grep -q 'Skipped' "$pixel_log"; then
+          echo '::error::Pixel tests were skipped - no Vulkan device. They must run on this leg.'
+          exit 1
+        fi
 
     # Floating-point determinism (ADR-008, issue #59). The frozen bit patterns in
     # tests/ml/DeterminismTests.cpp are the contract, and this step is one half of what makes it a

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -156,6 +156,13 @@ jobs:
       shell: cmd
 
     - name: Build
+      env:
+        # This leg's Vulkan device is a software rasterizer installed by hand two steps above, and
+        # the build renders through it (#254). When a loader declines an ICD it does so silently and
+        # reports only "no usable ICD" at vkCreateInstance, which says nothing about why. Loader
+        # diagnostics turn that into the loader's own sentence, in the log, next to the bake that
+        # failed.
+        VK_LOADER_DEBUG: all
       run: cmake --build --preset ninja-msvc
       shell: cmd
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -119,8 +119,14 @@ jobs:
         if (-not $icd) {
           throw "mesa3d $version carries no 64-bit lavapipe ICD manifest"
         }
+        # Both spellings, and the older one is the one that actually works here. `VK_DRIVER_FILES`
+        # arrived in loader 1.3.207; the SDK pinned above is 1.3.204.0, whose loader ignores it
+        # entirely and reports "no usable ICD" with the variable set correctly in the environment.
+        # `VK_ICD_FILENAMES` is what that loader reads. Setting both keeps this working when the SDK
+        # pin moves forward, since the newer loader prefers `VK_DRIVER_FILES`.
         "VK_DRIVER_FILES=$($icd.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        Write-Host "VK_DRIVER_FILES=$($icd.FullName)"
+        "VK_ICD_FILENAMES=$($icd.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        Write-Host "lavapipe ICD: $($icd.FullName)"
 
     - name: Install Ninja
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,12 @@ mdux_compile_screen(
         # but every file a custom command reads is a dependency in its own right; otherwise an
         # independently changed or damaged sidecar would not even ask the screen bake to validate it.
         generated/text/endoscope-monitor-en-us/runs.bin
+        # The atlas, for the same reason applied to the second stage (#254): `loadLocale()` reads
+        # the file the font package names and checks its digest, so the glyphs the verification
+        # renders come from these bytes. Without the edge, an atlas changed on its own leaves all
+        # four outputs newer than their inputs, ninja skips the bake, and evidence.screen.<id>
+        # compares a bundle no producer re-derived - a pass that means nothing.
+        generated/font/dejavu-ui/atlas.bin
 )
 
 # ...and the generated C++ for it (issue #201). Build-tree only, never committed. This is the last

--- a/cmake/MduXBake.cmake
+++ b/cmake/MduXBake.cmake
@@ -76,6 +76,15 @@
 #
 # TOOL is always a `MduX::<tool>` target. A cross-compiling build substitutes an imported
 # executable for the same name without any call site changing.
+#
+# ## A bake that takes more than one tool
+#
+# THEN_TOOLS names further tools run over the same output directory, in order, after TOOL. The
+# screen bundle is the case that needed it (#254): compiling a screen and rendering it are different
+# jobs with different dependencies - one reads a `.medui` file, the other needs a Vulkan device - and
+# fusing them would make a GPU a prerequisite of every compile. What they are not is two artifacts.
+# They produce one bundle, under one registration, compared by one `evidence.<kind>.<id>` test, which
+# is what keeps a later stage from acquiring weaker evidence than the stage before it.
 
 set(_MDUX_COMPARE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/MduXCompareArtifacts.cmake")
 set(_MDUX_UPDATE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/MduXUpdateArtifacts.cmake")
@@ -97,7 +106,7 @@ endfunction()
 function(mdux_bake_artifact)
     set(options "")
     set(single KIND ID TOOL RECIPE)
-    set(multi SOURCES OUTPUTS)
+    set(multi SOURCES OUTPUTS THEN_TOOLS)
     cmake_parse_arguments(ARG "${options}" "${single}" "${multi}" ${ARGN})
 
     foreach(required KIND ID TOOL RECIPE OUTPUTS)
@@ -112,12 +121,14 @@ function(mdux_bake_artifact)
         message(FATAL_ERROR
             "mdux_bake_artifact: call mdux_declare_bake_targets() before registering artifacts")
     endif()
-    if(NOT TARGET ${ARG_TOOL})
-        message(FATAL_ERROR
-            "mdux_bake_artifact: TOOL '${ARG_TOOL}' is not a target. Host tools are resolved "
-            "through a MduX::<tool> target so a cross-compiling build can substitute an "
-            "imported executable; declare it before registering this artifact.")
-    endif()
+    foreach(tool ${ARG_TOOL} ${ARG_THEN_TOOLS})
+        if(NOT TARGET ${tool})
+            message(FATAL_ERROR
+                "mdux_bake_artifact: TOOL '${tool}' is not a target. Host tools are resolved "
+                "through a MduX::<tool> target so a cross-compiling build can substitute an "
+                "imported executable; declare it before registering this artifact.")
+        endif()
+    endforeach()
 
     foreach(component KIND ID)
         if(NOT ARG_${component} MATCHES "^[a-z0-9][a-z0-9-]*$")
@@ -166,11 +177,19 @@ function(mdux_bake_artifact)
     # The baker runs with the source directory as its working directory, so every path it reads
     # from the recipe and every path it records in report.json is repository-relative. That is
     # what keeps a report free of absolute paths, which BakeReport::validate() rejects.
+    # THEN_TOOLS extends this one command into a sequence, each stage invoked the same way. It is
+    # not a second registration: one custom command, one OUTPUT set, one evidence test. A stage that
+    # exits non-zero fails the build, so a bundle is never half-produced.
+    set(bake_commands COMMAND ${ARG_TOOL} bake "${ARG_RECIPE}" "${baked_dir}")
+    foreach(tool ${ARG_THEN_TOOLS})
+        list(APPEND bake_commands COMMAND ${tool} bake "${ARG_RECIPE}" "${baked_dir}")
+    endforeach()
+
     add_custom_command(
         OUTPUT ${baked_outputs}
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${baked_dir}"
-        COMMAND ${ARG_TOOL} bake "${ARG_RECIPE}" "${baked_dir}"
-        DEPENDS ${ARG_TOOL} "${recipe_path}" ${source_paths}
+        ${bake_commands}
+        DEPENDS ${ARG_TOOL} ${ARG_THEN_TOOLS} "${recipe_path}" ${source_paths}
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         COMMENT "Baking ${label}"
         VERBATIM

--- a/cmake/MduXCompileScreen.cmake
+++ b/cmake/MduXCompileScreen.cmake
@@ -9,10 +9,11 @@
 # What this wrapper adds over calling `mdux_bake_artifact()` directly is the two things a caller
 # could otherwise get wrong silently:
 #
-#   - **The three outputs are fixed here**, not per call site. ADR-012 makes `package.json`,
-#     `goldens.json` and `report.json` unconditional, so a screen that pins nothing writes `[]`
-#     rather than one fewer file. A call site listing its own OUTPUTS could drop one and produce a
-#     smaller artifact that still passed its own comparison.
+#   - **The four outputs are fixed here**, not per call site. ADR-012 makes `package.json`,
+#     `goldens.json` and `report.json` unconditional and ADR-014 decision 4 adds `verification.json`,
+#     so a screen that pins nothing writes `[]` rather than one fewer file. A call site listing its
+#     own OUTPUTS could drop one and produce a smaller artifact that still passed its own
+#     comparison.
 #   - **The `.medui` source becomes a dependency automatically**, read out of the recipe. A
 #     forgotten SOURCES entry does not fail: it makes edits to the screen stop triggering a rebake,
 #     so the committed artifact quietly stops matching its source until someone runs the update
@@ -133,14 +134,26 @@ function(mdux_compile_screen)
         KIND screen
         ID ${ARG_ID}
         TOOL mdux-meduic
+        # The second half of the one production sequence (#254): mdux-meduic compiles the screen,
+        # then this renders it and writes verification.json plus the report members naming it. Still
+        # one mdux_bake_artifact() registration for screen/<id>, which ADR-014 decision 4 requires -
+        # a second one would collide in its generated target, its test and its output directory.
+        THEN_TOOLS mdux-verify-bake
         RECIPE ${ARG_RECIPE}
         SOURCES
             ${screen_source}
             ${ARG_SOURCES}
-        # Fixed here rather than per call site: all three are unconditional (ADR-012, decision 1).
+            # The committed artifacts the render reads. They are already dependencies of the compile
+            # for the text packages; the shader package is new here, and it is a real edge: re-baking
+            # mdux-ui changes the frame this screen is verified against.
+            generated/shader/mdux-ui/package.json
+            generated/shader/mdux-ui/shaders.spv
+        # Fixed here rather than per call site: all four are unconditional (ADR-012 decision 1,
+        # ADR-014 decision 4).
         OUTPUTS
             package.json
             goldens.json
             report.json
+            verification.json
     )
 endfunction()

--- a/docs/adr/ADR-007-evidence-pipeline-doctrine.md
+++ b/docs/adr/ADR-007-evidence-pipeline-doctrine.md
@@ -138,6 +138,20 @@ lane. That is what separates "a different toolchain produced identical bytes" fr
 This is written down here specifically so that a future change cannot "simplify" CI to one leg
 without knowingly discarding the claim.
 
+**Since #254, each leg must also provide a Vulkan device, and that is a new obligation rather than
+an incidental one.** The screen bundle's `verification.json` is re-derived by rendering the screen,
+so a leg without an ICD cannot produce the artifact at all - and #254 forbids treating that as a
+skip, because a leg that copied the committed file would satisfy the byte comparison while providing
+no rendered evidence. Two legs had no device when that landed: Linux/Clang installed the loader
+without `mesa-vulkan-drivers`, and Windows/MSVC installed `Vulkan-Loader` with no ICD behind it, so
+both enumerated zero physical devices while nothing here rendered. Both now carry a software
+rasterizer - lavapipe from the distribution on Linux, and Mesa's own Windows build pinned by release
+tag and SHA-256 on Windows - joining the lavapipe and MoltenVK the GCC and macOS legs already had.
+
+The byte-identity claim survives the addition because the artifact records outcomes rather than
+samples: four drivers agreeing that a check held produce identical bytes, which is exactly the
+property decision 4 of ADR-014 protects by keeping measurements out of the file.
+
 **A correction, kept rather than silently overwritten.** This paragraph previously read "Windows/MSVC
 **and** Linux/GCC (and Clang, now that issue #48 re-enabled that leg)". Issue #48 did not re-enable
 that leg: it added the GCC 16 leg and left the Clang half of its own title open, and

--- a/docs/adr/ADR-007-evidence-pipeline-doctrine.md
+++ b/docs/adr/ADR-007-evidence-pipeline-doctrine.md
@@ -96,6 +96,35 @@ Not the recipe's literal contents — the resolved set with every default expand
 a default silently changes every output while every report still looks unchanged, which is precisely
 the failure a byte-verified pipeline exists to prevent.
 
+### 4b. A report names every tool that produced an output, not only the one it is registered to
+
+`tool` and `toolVersion` name the tool a bake is *registered to*. For five of the seven committed
+artifacts that is the whole story, because one tool writes every file. The screen bundle is not:
+`mdux-meduic` compiles it and `mdux-verify-bake` then renders it and writes `verification.json`
+(ADR-014 decision 4), under one `mdux_bake_artifact()` registration and one report, because a second
+report at the same path is forbidden and a reader holding two would have to decide which is
+authoritative.
+
+So the single report carries a `stages` array, one record per output that a tool other than `tool`
+produced:
+
+```json
+"stages": [
+  { "output": "verification.json", "tool": "mdux-verify-bake", "toolVersion": "0.6.0" }
+]
+```
+
+Absent entirely when a bake has one tool, which is why adding it left the other six artifacts byte
+for byte as they were. `validate()` rejects a stage naming an output the report does not list, and
+two stages claiming one output — an answer naming a file nobody wrote, or two tools for one file, is
+worse than no answer.
+
+This is not a cosmetic field. The purpose stated at the top of this record is to answer "which tool,
+at which version, from which input, produced this binary artifact". Without `stages`, the screen's
+report answers that wrongly for one of its four outputs: it attributes a rendered frame's evidence
+to a compiler that never created a Vulkan device. A digest says what was produced and `options` says
+how it was configured; neither says by whom.
+
 ### 5. No commit SHA in a byte-compared report — it cannot be made to work
 An earlier draft of this ADR had `BakeReport` carry `toolGitSha`, a configure-time `git rev-parse
 HEAD` baked in as a compile definition, with CI rejecting `"unknown"` in a committed report.

--- a/docs/adr/ADR-014-rendered-truth-verification.md
+++ b/docs/adr/ADR-014-rendered-truth-verification.md
@@ -20,7 +20,7 @@ Epic #16 renders a compiled screen offscreen, checks that the content a golden r
 appears where the compiled screen said it would and that every localized text run appears inside its
 node, across every approved locale, then emits that as an evidence artifact. Its implementation
 children build the checks (#252), the driver (#253), the artifact (#254) and the CI leg (#255).
-Issues #252 and #253 now implement the first two; #254 and #255 remain. This record preceded all four so
+Issues #252, #253 and #254 now implement the first three; #255 remains. This record preceded all four so
 that they apply a recorded decision rather than reconstructing one from whatever they produced —
 the same reason #190 preceded the rest of #15.
 
@@ -54,10 +54,12 @@ What is genuinely open, and what this ADR therefore has to decide rather than in
 4. what the mechanism is worth to an IEC 62304:2006 §5.7 Software system testing argument, and
    where that worth stops.
 
-**Implementation status.** Issues #252 and #253 implement `mdux.verify` and the host-only
-`mdux-verify-ui` driver. The driver loads committed screen, golden, shader, text and font artifacts,
-enumerates the complete obligation set, renders once per scope and reports owning outcomes.
-`verification.json` does not yet exist; #254 owns that artifact and #255 owns its automatic CI gate.
+**Implementation status.** Issues #252, #253 and #254 implement `mdux.verify`, the host-only
+`mdux-verify-ui` driver and the artifact. The driver loads committed screen, golden, shader, text and
+font artifacts, enumerates the complete obligation set, renders once per scope and reports owning
+outcomes; `mdux-verify-bake` serializes those same outcomes as
+`generated/screen/<id>/verification.json` inside the screen's one bake registration. #255 still owns
+the automatic CI gate and the failure diff.
 
 ### The contradiction this record has to settle
 
@@ -421,4 +423,6 @@ the frame.
 - **Decision Date**: 2026-08-31
 - **Approved By**: Project maintainer
 - **Review Date**: reviewed 2026-09-02 when #253 first ran against a drawn, golden-eligible
-  textless fixture; review again when #254 commits the first `verification.json`
+  textless fixture, and again the same day when #254 committed the first `verification.json` - which
+  records three `NothingPainted` findings, exactly the consequence this record predicted for the
+  current screen. Review again when #17 draws the deferred golden nodes and #255 gates on them.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,7 +158,7 @@ Seven artifacts are committed today:
 | `generated/model/ecg-demo-alt/` | `mdux-mlbake` | `weights.bin` |
 | `generated/font/dejavu-ui/` | `mdux-textbake` | `atlas.bin` |
 | `generated/text/endoscope-monitor-en-us/` | `mdux-textbake` | `runs.bin` |
-| `generated/screen/endoscope-monitor/` | `mdux-meduic` | `package.json` + `goldens.json` |
+| `generated/screen/endoscope-monitor/` | `mdux-meduic`, then `mdux-verify-bake` | `package.json` + `goldens.json` + `verification.json` |
 
 The screen is the one entry whose payload is not opaque bytes, and ADR-012 explains why: a screen
 cannot bake vertices, because four of the eleven components in the dictionary — `NumericDisplay`,
@@ -177,8 +177,21 @@ it. It derives render scopes only from the screen manifest, rejects locale subse
 obligations, and distinguishes a completed check failure from a run that Vulkan or an artifact
 problem made impossible. The committed endoscope screen currently reports failed golden checks
 because `NumericDisplay` and `SignalTrace` remain deferred until #17; this is a failed verification,
-not a skipped or successful one. #254 will serialize the same outcomes rather than reimplementing
-the predicates or the producer.
+not a skipped or successful one.
+
+The screen is also the one entry baked by a *sequence* rather than a single tool (#254).
+`mdux-meduic` compiles it, then `mdux-verify-bake` renders the result and writes `verification.json`
+beside it, extending the same `report.json` with the new output's digest and the locale set the run
+resolved. Both stages are one `mdux_bake_artifact()` registration and one `evidence.screen.<id>`
+comparison, so the rendered half cannot end up with weaker evidence than the compiled half. The two
+are separate tools because their dependencies differ: reading a `.medui` file needs no GPU, and
+fusing them would make a Vulkan device a prerequisite of every screen compile.
+
+That artifact records one outcome per enumerated obligation and nothing else — no measured pixel, no
+path, no duration. What it says is that the frame agreed with the compiled screen, which is internal
+consistency rather than truth: the expectation and the frame come from one source. It is also why
+the committed file currently records three `NothingPainted` findings; an artifact that hid them
+would be worse than none.
 
 Every baker registers through `mdux_bake_artifact()`
 ([`cmake/MduXBake.cmake`](../cmake/MduXBake.cmake)), which creates the bake target, an

--- a/docs/governance/soup-register.toml
+++ b/docs/governance/soup-register.toml
@@ -111,6 +111,28 @@ risk_controls = [
 known_anomaly_tracking = "A defect found in this dependency is recorded as a ProblemReport (mdux.governance.compliance, issue #35) with this component_id in its description; none open as of this entry. Note this dependency is also why the project's GCC floor is 16: GCC 15 cannot build it, and upstream dropped GCC 15 support before v0.1.0. One toolchain anomaly is known and shared: GCC 16.2.0 corrupts the module BMIs for speclab.core.testsuite and speclab.runners.testrunner, which turned this repository's develop red (MduX #205) and upstream's CI too (ambroise-leclerc/SpecLab#15). Both projects pin gcc:16.1.0; a working 16.2.x is tracked as ambroise-leclerc/SpecLab#17. Upstream issue numbers are written in full here because a bare #15 or #17 in this repository names the .medui compiler and Content components epics."
 
 [[entries]]
+component_id = "mesa-lavapipe-win"
+name = "Mesa lavapipe (Windows binaries, mesa-dist-win)"
+version = "26.2.0 (asset mesa3d-26.2.0-release-msvc.7z, sha256 dcb2719ef346dab5b609fcb193a5f13cfc4b0502e3f4de1ad43d349477402f47)"
+classification = "build-tool"
+supplier = "Mesa3D project; Windows binaries built and published by pal1000 (mesa-dist-win), not by Mesa itself"
+repository = "https://github.com/pal1000/mesa-dist-win"
+license = "MIT (Mesa); the distribution also bundles LLVM components under Apache-2.0-with-LLVM-exception"
+usage = "The Vulkan software rasterizer the Windows CI leg renders through, so that leg can re-derive generated/screen/<id>/verification.json rather than copy it (#254). CI only: it is downloaded onto the GitHub-hosted runner, is never committed, never linked into any target, and never reaches a developer machine or a built binary. The Linux legs use the distribution's own lavapipe and macOS uses MoltenVK, so this entry covers one leg of four."
+trust_zone = "build"
+integration_path = ".github/workflows/windows-build.yml (Install lavapipe step: pinned download, SHA-256 check, registration in HKLM\\SOFTWARE\\Khronos\\Vulkan\\Drivers)"
+pinned_by = [".github/workflows/windows-build.yml"]
+runtime_deployment = false
+support_model = "Community-maintained project, redistributed by a third party who is not the upstream vendor. No medical-device qualification and no support agreement. The redistribution step is itself part of the trust chain and is why the digest below is pinned rather than the release tag alone."
+boundary_rationale = "A CI-host tool. It renders the frame a verification check is evaluated against, so unlike CMake it does influence committed evidence - but only through pass/fail outcomes, never through bytes it produces: ADR-014 decision 4 keeps every measured sample out of verification.json precisely so the artifact is a property of its declared inputs rather than of the driver that drew the frame."
+risk_controls = [
+    "Pinned by release tag *and* by SHA-256 of the exact asset, verified on the runner before extraction; a substituted or re-cut upload fails the step rather than silently changing what this leg renders with.",
+    "Four-leg byte comparison is the control that matters: the same verification.json is re-derived under lavapipe on two Linux legs, this distribution on Windows, and MoltenVK on macOS. A lavapipe-specific misrender that changed an outcome would disagree with three other drivers and fail evidence.screen.<id>, rather than being committed.",
+    "The Windows leg fails its build outright when no device is present, and its pixel-labelled step fails on a skip, so a silently absent rasterizer cannot become a green run over an artifact nobody re-derived.",
+]
+known_anomaly_tracking = "A defect found in this dependency is recorded as a ProblemReport (mdux.governance.compliance, issue #35) with this component_id in its description; none open as of this entry."
+
+[[entries]]
 name = "DejaVu Sans"
 supplier = "DejaVu fonts project (from Bitstream Vera, Bitstream Inc.)"
 license = "Bitstream-Vera (with the Arev additions; DejaVu changes public domain)"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,7 +58,7 @@ the whole of Track C.
 |---|---|---|
 | UI authoring | Partly closed, and moving. The HTML path is deleted (#127) and `mdux.draw` now describes a frame in governed code. The compiler is complete front to back — lexer, parser, AST, semantic analysis, bounded layout, per-locale text budgets and safety-critical goldens, all host-only and conformance-tested against the shared MedUI spec, then the canonical package, the two C++ emitters, `mdux-meduic` and a committed screen artifact. The governed runtime draws one without allocating. `mdux-medui-check` validates one file without a build, and an authored screen reaches pixels through the governed runtime in `ScreenPixelTests` (#201). A text package is baked, the committed screen carries a `t("STR-KEY")` measured against it (#235), the governed runtime draws it (#242), and the screen is bound to the packages it was compiled against by digest (#244) - so a label authored in `.medui` reaches pixels through every stage, and a substituted translation is refused rather than drawn. What is still ahead is content rather than path: the rest of the components' own geometry (#17). | `.medui` compiled at build time to a `CompiledScreenPackage`. The runtime never parses, never solves layout, never shapes text. |
 | Rendering | Closed (#13). A real Vulkan renderer, an offscreen target with readback, and the project's first pixel test running under lavapipe in CI. | A real Vulkan renderer, plus offscreen verification of rendered truth. |
-| Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Seven artifacts committed under `generated/`, re-derived and byte-compared on all four CI legs - MSVC, GCC 16, macOS/Clang 21 (#222) and Linux/Clang 21 (#246). | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
+| Evidence | Closed (#12). SHA-256, canonical JSON, bake reports and `mdux_bake_artifact()`. Seven artifacts committed under `generated/`, re-derived and byte-compared on all four CI legs - MSVC, GCC 16, macOS/Clang 21 (#222) and Linux/Clang 21 (#246), each of which now also provides a Vulkan device so the screen bundle's rendered `verification.json` is re-derived rather than copied (#254). | Every asset baked by a host tool into committed `package.json` / `report.json`, byte-verified in CI. |
 | ML | Closed (#18). Governed f32 kernels shared by host and device, a fail-closed golden self-test, no heap in `predict` verified three ways, and a committed ECG demonstrator whose weights swap with zero source change. | Zero-SOUP deterministic f32 inference with a golden-vector, fail-closed self-test. |
 | Trust zones | Closed (#11). `MduXCore` is governed and never receives Vulkan's include directories; `mdux_verify_trust_zones()` walks the link graph at configure time, `mdux-governed-lint` rejects the banned construct at source level, and `governed.noThrow.symbolScan` rejects it in the emitted objects (#116). | `crates/` / `adapters/` / `tools/` with enforced dependency rules. |
 | Docs | Closed (#8, #10). Five standards on real clause structure with per-clause indexes and JSON Schemas, plus the documentation architecture — README derived from real targets, a contiguous ADR index, and a CI lint for internal links and retired paths. | Five standards, clause-accurate modules, per-clause index, JSON Schemas, CI-linted. |
@@ -384,8 +384,8 @@ and colour checks are exercisable before a single glyph exists.
 
 - #251 S1 ADR: automated UI verification · _closed_
 - #252 S2 Bounds, ink containment, colour hash · _closed_
-- #253 S3 The verify driver · _implemented by this change_
-- #254 S4 Evidence report emission
+- #253 S3 The verify driver · _closed_
+- #254 S4 Evidence report emission · _implemented by this change_
 - #255 S5 CI across all locales
 
 Sequential: each child is blocked by its predecessor. Two things landed after the epic was written

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -33,7 +33,6 @@
       "generated/text/endoscope-monitor-en-us/package.json"
     ],
     "verification": {
-      "artifactRoot": "generated",
       "locales": [
         "en-US"
       ]

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -57,6 +57,13 @@
     "sha256": "ce8676090fb3355b9d16b4ef2b7dadaa640593997b54141eaa0b55e945bac328"
   },
   "schemaVersion": 1,
+  "stages": [
+    {
+      "output": "verification.json",
+      "tool": "mdux-verify-bake",
+      "toolVersion": "0.6.0"
+    }
+  ],
   "tool": "mdux-meduic",
   "toolVersion": "0.6.0"
 }

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -31,7 +31,13 @@
     "surfaceWidth": 1280,
     "textPackages": [
       "generated/text/endoscope-monitor-en-us/package.json"
-    ]
+    ],
+    "verification": {
+      "artifactRoot": "generated",
+      "locales": [
+        "en-US"
+      ]
+    }
   },
   "outputs": [
     {
@@ -41,6 +47,10 @@
     {
       "path": "package.json",
       "sha256": "79bb460bbf10e51b69eeddde9782e3ef99c464a2c8d9e71cc0601623703fde07"
+    },
+    {
+      "path": "verification.json",
+      "sha256": "d8419fd85a48b0e6b6b7a796452fc774253923937b91079a820fb0cef4e2dfee"
     }
   ],
   "recipe": {

--- a/generated/screen/endoscope-monitor/verification.json
+++ b/generated/screen/endoscope-monitor/verification.json
@@ -1,0 +1,69 @@
+{
+  "id": "endoscope-monitor",
+  "inputs": [
+    {
+      "id": "endoscope-monitor",
+      "role": "screenPackage",
+      "sha256": "79bb460bbf10e51b69eeddde9782e3ef99c464a2c8d9e71cc0601623703fde07"
+    },
+    {
+      "id": "endoscope-monitor",
+      "role": "goldens",
+      "sha256": "60c555cbeceb4e897e5a4302c0d667aaca84dd72d28ef2c13d96178d86eb1a2a"
+    },
+    {
+      "id": "mdux-ui",
+      "role": "shaderPackage",
+      "sha256": "d3a6531a26084f559fe514b190ce3b06bdfb7452be90a45a1b5b7fd35464c105"
+    },
+    {
+      "id": "endoscope-monitor-en-us",
+      "locale": "en-US",
+      "role": "textPackage",
+      "sha256": "f8ed5dda0711eaa721fb63f2fc2054b8563849f2bbe38df43913d733cdeeb87b"
+    },
+    {
+      "id": "dejavu-ui",
+      "locale": "en-US",
+      "role": "fontPackage",
+      "sha256": "34bff16611756b163fc7fbedcfa4935d614d23e4b35c705ccab75f1814f28873"
+    }
+  ],
+  "kind": "screen",
+  "outcomes": [
+    {
+      "check": "Bounds",
+      "finding": "NothingPainted",
+      "nodeId": "insufflation-pressure",
+      "scope": "en-US"
+    },
+    {
+      "check": "ColorHash",
+      "finding": "NothingPainted",
+      "nodeId": "insufflation-pressure",
+      "scope": "en-US"
+    },
+    {
+      "check": "Bounds",
+      "finding": "NothingPainted",
+      "nodeId": "ecg-lead-ii",
+      "scope": "en-US"
+    },
+    {
+      "check": "InkContainment",
+      "finding": "Held",
+      "nodeId": "screen-title",
+      "scope": "en-US"
+    },
+    {
+      "check": "LocalizedTextPresence",
+      "finding": "Held",
+      "nodeId": "screen-title",
+      "scope": "en-US"
+    }
+  ],
+  "renderScopes": [
+    "en-US"
+  ],
+  "schemaVersion": 1
+}

--- a/include/mdux/evidence/Report.cppm
+++ b/include/mdux/evidence/Report.cppm
@@ -25,6 +25,10 @@
  * }
  * ```
  *
+ * An artifact produced by more than one tool carries one further member, `stages`, naming the tool
+ * and version behind each output the registered `tool` did not write. See `ToolStage` and ADR-007
+ * decision 4b; it is absent from a single-tool report.
+ *
  * ## Two rules that are easy to get wrong
  *
  * **`options` is the fully resolved set, with defaults expanded** - not the recipe's literal
@@ -76,7 +80,9 @@ enum class ReportError : std::uint8_t {
     NoOutputs,
     DuplicateOutputPath,
     UnsupportedSchemaVersion,
-    MalformedReport,        ///< parsed JSON did not have the expected shape
+    MalformedReport,       ///< parsed JSON did not have the expected shape
+    UnknownStageOutput,    ///< a stage claims an output the report does not list
+    DuplicateStageOutput,  ///< two stages claim to have produced the same file
 };
 
 [[nodiscard]] std::string_view describe(ReportError error) noexcept;
@@ -84,7 +90,7 @@ enum class ReportError : std::uint8_t {
 /// A file the baker read or wrote, identified by a repository-relative path and its digest.
 struct FileRecord {
     std::string path;
-    Digest sha256{};
+    Digest      sha256{};
 };
 
 /**
@@ -93,8 +99,8 @@ struct FileRecord {
  */
 struct PackageHeader {
     std::uint64_t schemaVersion{kSchemaVersion};
-    std::string id;    ///< the `<id>` in `generated/<kind>/<id>/`, e.g. "roboto-ui"
-    std::string kind;  ///< the `<kind>`, e.g. "font", "shader", "model"
+    std::string   id;    ///< the `<id>` in `generated/<kind>/<id>/`, e.g. "roboto-ui"
+    std::string   kind;  ///< the `<kind>`, e.g. "font", "shader", "model"
 
     [[nodiscard]] mdux::core::ResultVoid<ReportError> validate() const noexcept;
 
@@ -102,21 +108,52 @@ struct PackageHeader {
     /// rather than nesting them, so a package's header fields sit at its top level.
     [[nodiscard]] mdux::core::ResultVoid<json::Error> writeInto(json::Value& object) const noexcept;
 
-    [[nodiscard]] static mdux::core::Result<PackageHeader, ReportError> readFrom(
-        const json::Value& object) noexcept;
+    [[nodiscard]] static mdux::core::Result<PackageHeader, ReportError> readFrom(const json::Value& object) noexcept;
+};
+
+/**
+ * @brief Which tool produced one output, when more than one tool produced the artifact.
+ *
+ * Most artifacts are baked by one tool, and for those there are no stage records and the member is
+ * absent from the file. A screen is not: `mdux-meduic` compiles it and `mdux-verify-bake` then
+ * renders it and writes `verification.json` (ADR-014 decision 4). One artifact, one registration,
+ * one report - so the report is where the chain has to be legible.
+ *
+ * Without this, a reader holding the screen's report sees `tool: "mdux-meduic"` and no mention of
+ * the second executable, and attributes every output to the compiler. That is not a cosmetic
+ * imprecision: ADR-007 exists to answer "which tool, at which version, from which input, produced
+ * this artifact", and for one of the four outputs the unextended report answers it wrongly. A
+ * digest says what was produced and a resolved option set says how it was configured; neither says
+ * by whom.
+ *
+ * One record per output rather than one per tool with a list of outputs. It reads the same way
+ * `outputs` does - a flat row per file - and it sidesteps a GCC 16 defect that corrupts this
+ * module's BMI when an exported struct carries a `std::vector<std::string>`; `mdux-textbake` then
+ * fails to read the module with "Bad file data". Verified by isolation: adding an otherwise unused
+ * struct with such a member to this file reproduces it, and this shape does not.
+ */
+struct ToolStage {
+    std::string tool;         ///< e.g. "mdux-verify-bake"
+    std::string toolVersion;  ///< the project version that tool was built from
+    std::string output;       ///< the output path it wrote, which `outputs` must also list
 };
 
 /**
  * @brief The audit record a baker writes alongside every artifact.
  */
 struct BakeReport {
-    std::uint64_t schemaVersion{kSchemaVersion};
-    std::string tool;         ///< e.g. "mdux-fontbake"
-    std::string toolVersion;  ///< the project version the tool was built from
-    FileRecord recipe;
+    std::uint64_t           schemaVersion{kSchemaVersion};
+    std::string             tool;         ///< e.g. "mdux-fontbake"; the tool the bake is registered to
+    std::string             toolVersion;  ///< the project version the tool was built from
+    FileRecord              recipe;
     std::vector<FileRecord> inputs;
-    json::Value options;  ///< fully resolved, defaults expanded - see the module comment
+    json::Value             options;  ///< fully resolved, defaults expanded - see the module comment
     std::vector<FileRecord> outputs;
+
+    /// Further tools in the production sequence, one record per output they wrote. Empty for a
+    /// single-tool bake, and omitted from the file when empty - which is what let this member be
+    /// added without re-baking six artifacts that have nothing to say about it.
+    std::vector<ToolStage> stages;
 
     /// Checks the invariants that would otherwise break byte-identity or auditability.
     [[nodiscard]] mdux::core::ResultVoid<ReportError> validate() const noexcept;
@@ -128,8 +165,7 @@ struct BakeReport {
 
     /// Parses canonical `report.json` text. Strict: rejects a malformed shape and an
     /// unsupported schemaVersion, and validates the result.
-    [[nodiscard]] static mdux::core::Result<BakeReport, ReportError> parse(
-        std::string_view text) noexcept;
+    [[nodiscard]] static mdux::core::Result<BakeReport, ReportError> parse(std::string_view text) noexcept;
 };
 
 /// Lowercase-hex helper shared by report readers: parses 64 hex digits into a Digest.

--- a/include/mdux/verify/Verify.cppm
+++ b/include/mdux/verify/Verify.cppm
@@ -828,6 +828,44 @@ enum class Finding : std::uint8_t {
 [[nodiscard]] std::string_view describe(Finding finding) noexcept;
 
 /**
+ * @brief The enumerator's own name, e.g. `NothingPainted` - the spelling a serialiser emits.
+ *
+ * Distinct from `describe()`, and the distinction is the point. `describe()` returns the sentence a
+ * driver prints for a human, and improving that wording should stay free; #254 commits findings into
+ * a byte-compared artifact, where a reworded sentence would fail an evidence comparison on every leg
+ * while nothing about the verification had changed. The same split `spell(CvCheck)` already makes.
+ */
+[[nodiscard]] constexpr std::string_view spell(Finding finding) noexcept {
+    switch (finding) {
+        case Finding::Held:
+            return "Held";
+        case Finding::RegionOutsideFrame:
+            return "RegionOutsideFrame";
+        case Finding::NoTintToCompare:
+            return "NoTintToCompare";
+        case Finding::NothingPainted:
+            return "NothingPainted";
+        case Finding::BoundsDiffer:
+            return "BoundsDiffer";
+        case Finding::TintAbsent:
+            return "TintAbsent";
+        case Finding::ForeignColour:
+            return "ForeignColour";
+        case Finding::InkLeftItsNode:
+            return "InkLeftItsNode";
+        case Finding::InkExtentDiffers:
+            return "InkExtentDiffers";
+        case Finding::GlyphMissing:
+            return "GlyphMissing";
+        case Finding::CoverageDiffers:
+            return "CoverageDiffers";
+        case Finding::InkOutsideTheRun:
+            return "InkOutsideTheRun";
+    }
+    return {};
+}
+
+/**
  * @brief One obligation's result: what was expected, what was found, and where.
  *
  * Structured rather than a formatted string, because this module allocates nothing and a governed

--- a/src/evidence/Report.cpp
+++ b/src/evidence/Report.cpp
@@ -52,7 +52,7 @@ namespace {
     std::size_t start = 0;
     while (start <= path.size()) {
         const std::size_t slash = path.find('/', start);
-        const std::size_t end = (slash == std::string_view::npos) ? path.size() : slash;
+        const std::size_t end   = (slash == std::string_view::npos) ? path.size() : slash;
         if (path.substr(start, end - start) == "..") {
             return err(ReportError::ParentDirectoryInPath);
         }
@@ -75,8 +75,7 @@ namespace {
         return err(set.error());
     }
     const std::array<char, 64> hex = toHex(record.sha256);
-    if (auto set = object.set("sha256", json::Value::string(std::string{hex.data(), hex.size()}));
-        !set.has_value()) {
+    if (auto set = object.set("sha256", json::Value::string(std::string{hex.data(), hex.size()})); !set.has_value()) {
         return err(set.error());
     }
     return object;
@@ -106,8 +105,7 @@ namespace {
     return FileRecord{.path = std::string{*pathText}, .sha256 = *digest};
 }
 
-[[nodiscard]] Result<json::Value, json::Error> fileRecordsToJson(
-    std::span<const FileRecord> records) noexcept {
+[[nodiscard]] Result<json::Value, json::Error> fileRecordsToJson(std::span<const FileRecord> records) noexcept {
     json::Value array = json::Value::array({});
     for (const FileRecord& record : records) {
         auto object = fileRecordToJson(record);
@@ -121,8 +119,7 @@ namespace {
     return array;
 }
 
-[[nodiscard]] Result<std::vector<FileRecord>, ReportError> fileRecordsFromJson(
-    const json::Value& array) noexcept {
+[[nodiscard]] Result<std::vector<FileRecord>, ReportError> fileRecordsFromJson(const json::Value& array) noexcept {
     if (array.kind() != json::Value::Kind::Array) {
         return err(ReportError::MalformedReport);
     }
@@ -139,8 +136,7 @@ namespace {
 }
 
 /// Reads a required non-empty string member.
-[[nodiscard]] Result<std::string, ReportError> requireString(const json::Value& object,
-                                                              std::string_view key) noexcept {
+[[nodiscard]] Result<std::string, ReportError> requireString(const json::Value& object, std::string_view key) noexcept {
     const auto member = object.require(key);
     if (!member.has_value()) {
         return err(ReportError::MalformedReport);
@@ -160,18 +156,34 @@ namespace {
 
 std::string_view describe(ReportError error) noexcept {
     switch (error) {
-    case ReportError::EmptyToolName:            return "tool name is empty";
-    case ReportError::EmptyToolVersion:         return "tool version is empty";
-    case ReportError::EmptyPath:                return "path is empty";
-    case ReportError::AbsolutePath:             return "path is absolute";
-    case ReportError::BackslashInPath:          return "path contains a backslash";
-    case ReportError::ParentDirectoryInPath:    return "path contains a '..' component";
-    case ReportError::EmptyId:                  return "package id is empty";
-    case ReportError::EmptyKind:                return "package kind is empty";
-    case ReportError::NoOutputs:                return "report lists no outputs";
-    case ReportError::DuplicateOutputPath:      return "report lists an output path twice";
-    case ReportError::UnsupportedSchemaVersion: return "unsupported schema version";
-    case ReportError::MalformedReport:          return "report JSON has an unexpected shape";
+        case ReportError::EmptyToolName:
+            return "tool name is empty";
+        case ReportError::EmptyToolVersion:
+            return "tool version is empty";
+        case ReportError::EmptyPath:
+            return "path is empty";
+        case ReportError::AbsolutePath:
+            return "path is absolute";
+        case ReportError::BackslashInPath:
+            return "path contains a backslash";
+        case ReportError::ParentDirectoryInPath:
+            return "path contains a '..' component";
+        case ReportError::EmptyId:
+            return "package id is empty";
+        case ReportError::EmptyKind:
+            return "package kind is empty";
+        case ReportError::NoOutputs:
+            return "report lists no outputs";
+        case ReportError::DuplicateOutputPath:
+            return "report lists an output path twice";
+        case ReportError::UnsupportedSchemaVersion:
+            return "unsupported schema version";
+        case ReportError::MalformedReport:
+            return "report JSON has an unexpected shape";
+        case ReportError::UnknownStageOutput:
+            return "a production stage names an output the report does not list";
+        case ReportError::DuplicateStageOutput:
+            return "two production stages claim the same output";
     }
     return "unrecognized report error";
 }
@@ -188,7 +200,7 @@ Result<Digest, ReportError> digestFromHex(std::string_view hex) noexcept {
     for (std::size_t i = 0; i < 32; ++i) {
         std::uint8_t byte = 0;
         for (std::size_t nibble = 0; nibble < 2; ++nibble) {
-            const char c = hex[i * 2 + nibble];
+            const char   c     = hex[i * 2 + nibble];
             std::uint8_t value = 0;
             if (c >= '0' && c <= '9') {
                 value = static_cast<std::uint8_t>(c - '0');
@@ -224,8 +236,7 @@ ResultVoid<ReportError> PackageHeader::validate() const noexcept {
 }
 
 ResultVoid<json::Error> PackageHeader::writeInto(json::Value& object) const noexcept {
-    if (auto set = object.set("schemaVersion", json::Value::unsignedInteger(schemaVersion));
-        !set.has_value()) {
+    if (auto set = object.set("schemaVersion", json::Value::unsignedInteger(schemaVersion)); !set.has_value()) {
         return set;
     }
     if (auto set = object.set("id", json::Value::string(id)); !set.has_value()) {
@@ -259,8 +270,7 @@ Result<PackageHeader, ReportError> PackageHeader::readFrom(const json::Value& ob
         return err(kind.error());
     }
 
-    PackageHeader header{
-        .schemaVersion = *versionValue, .id = std::move(*id), .kind = std::move(*kind)};
+    PackageHeader header{.schemaVersion = *versionValue, .id = std::move(*id), .kind = std::move(*kind)};
     if (auto valid = header.validate(); !valid.has_value()) {
         return err(valid.error());
     }
@@ -308,6 +318,29 @@ ResultVoid<ReportError> BakeReport::validate() const noexcept {
             }
         }
     }
+    // A stage may only claim a file the artifact actually has, and no file may have two producers:
+    // the point of recording a stage is to answer "which tool wrote this output", and an answer
+    // naming a file nobody wrote, or naming two tools for one file, is worse than none.
+    for (std::size_t i = 0; i < stages.size(); ++i) {
+        const ToolStage& stage = stages[i];
+        if (stage.tool.empty()) {
+            return err(ReportError::EmptyToolName);
+        }
+        if (stage.toolVersion.empty()) {
+            return err(ReportError::EmptyToolVersion);
+        }
+        const bool listed = std::ranges::any_of(outputs, [&stage](const FileRecord& output) {
+            return output.path == stage.output;
+        });
+        if (!listed) {
+            return err(ReportError::UnknownStageOutput);
+        }
+        for (std::size_t k = 0; k < i; ++k) {
+            if (stages[k].output == stage.output) {
+                return err(ReportError::DuplicateStageOutput);
+            }
+        }
+    }
     return {};
 }
 
@@ -325,9 +358,8 @@ Result<json::Value, ReportError> BakeReport::toJson() const noexcept {
         return object.set(std::move(key), std::move(value)).has_value();
     };
 
-    if (!setMember("schemaVersion", json::Value::unsignedInteger(schemaVersion)) ||
-        !setMember("tool", json::Value::string(tool)) ||
-        !setMember("toolVersion", json::Value::string(toolVersion))) {
+    if (!setMember("schemaVersion", json::Value::unsignedInteger(schemaVersion)) || !setMember("tool", json::Value::string(tool))
+        || !setMember("toolVersion", json::Value::string(toolVersion))) {
         return err(ReportError::MalformedReport);
     }
 
@@ -343,8 +375,7 @@ Result<json::Value, ReportError> BakeReport::toJson() const noexcept {
 
     // An options object the baker never populated is written as {} rather than as null, so the
     // member is always present and always the same kind - a reader needs no special case.
-    json::Value resolvedOptions =
-        options.kind() == json::Value::Kind::Object ? options : json::Value::emptyObject();
+    json::Value resolvedOptions = options.kind() == json::Value::Kind::Object ? options : json::Value::emptyObject();
     if (!setMember("options", std::move(resolvedOptions))) {
         return err(ReportError::MalformedReport);
     }
@@ -352,6 +383,24 @@ Result<json::Value, ReportError> BakeReport::toJson() const noexcept {
     auto outputsJson = fileRecordsToJson(outputs);
     if (!outputsJson.has_value() || !setMember("outputs", std::move(*outputsJson))) {
         return err(ReportError::MalformedReport);
+    }
+
+    // Omitted entirely when empty, which is what let this member be added without re-baking six
+    // artifacts that have one tool and nothing to say about it.
+    if (!stages.empty()) {
+        std::vector<json::Value> stageValues;
+        stageValues.reserve(stages.size());
+        for (const ToolStage& stage : stages) {
+            json::Value entry = json::Value::emptyObject();
+            if (!entry.set("output", json::Value::string(stage.output)).has_value() || !entry.set("tool", json::Value::string(stage.tool)).has_value()
+                || !entry.set("toolVersion", json::Value::string(stage.toolVersion)).has_value()) {
+                return err(ReportError::MalformedReport);
+            }
+            stageValues.push_back(std::move(entry));
+        }
+        if (!setMember("stages", json::Value::array(std::move(stageValues)))) {
+            return err(ReportError::MalformedReport);
+        }
     }
 
     return object;
@@ -393,9 +442,10 @@ Result<BakeReport, ReportError> BakeReport::parse(std::string_view text) noexcep
     BakeReport report;
     report.schemaVersion = *versionValue;
 
-    for (const auto& [key, target] : std::initializer_list<
-             std::pair<std::string_view, std::string*>>{{"tool", &report.tool},
-                                                         {"toolVersion", &report.toolVersion}}) {
+    for (const auto& [key, target] : std::initializer_list<std::pair<std::string_view, std::string*>>{
+             {       "tool",        &report.tool},
+             {"toolVersion", &report.toolVersion}
+    }) {
         auto value = requireString(*document, key);
         if (!value.has_value()) {
             return err(value.error());
@@ -441,6 +491,31 @@ Result<BakeReport, ReportError> BakeReport::parse(std::string_view text) noexcep
         return err(outputs.error());
     }
     report.outputs = std::move(*outputs);
+
+    // Optional: a single-tool report carries no `stages` member at all and must keep parsing.
+    if (const json::Value* stagesJson = document->find("stages"); stagesJson != nullptr) {
+        if (stagesJson->kind() != json::Value::Kind::Array) {
+            return err(ReportError::MalformedReport);
+        }
+        for (const json::Value& entry : stagesJson->elements()) {
+            if (entry.kind() != json::Value::Kind::Object) {
+                return err(ReportError::MalformedReport);
+            }
+            ToolStage stage;
+            for (const auto& [key, target] : std::initializer_list<std::pair<std::string_view, std::string*>>{
+                     {       "tool",        &stage.tool},
+                     {"toolVersion", &stage.toolVersion},
+                     {     "output",      &stage.output}
+            }) {
+                auto value = requireString(entry, key);
+                if (!value.has_value()) {
+                    return err(value.error());
+                }
+                *target = std::move(*value);
+            }
+            report.stages.push_back(std::move(stage));
+        }
+    }
 
     if (auto valid = report.validate(); !valid.has_value()) {
         return err(valid.error());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -842,6 +842,7 @@ mdux_discover_tests(verify_spec)
 add_executable(verify_ui_spec
     verify_ui/VerifyUiSpecMain.cpp
     verify_ui/DriverTests.cpp
+    verify_ui/ArtifactTests.cpp
 )
 target_link_libraries(verify_ui_spec PRIVATE MduX::VerifyUiLib speclab::speclab)
 target_include_directories(verify_ui_spec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/verify_ui/ArtifactTests.cpp
+++ b/tests/verify_ui/ArtifactTests.cpp
@@ -146,6 +146,23 @@ const mdux::spec::Register aRunThatCouldNotBeMadeIsNotWritable{
                       vu::RunResult mismatched = completedRun();
                       mismatched.outcomes.pop_back();
                       checks.expect(!vu::writeVerification(mismatched, "demo").has_value(), "and neither is a run whose outcomes do not cover its obligations");
+
+                      // Equal counts are not coverage. An outcome recorded against an obligation
+                      // the run never enumerated is evidence for a claim nobody made, and it is
+                      // invisible to a size check.
+                      vu::RunResult mispaired      = completedRun();
+                      mispaired.outcomes[1].nodeId = "a-node-no-obligation-named";
+                      const auto refusedMispaired  = vu::writeVerification(mispaired, "demo");
+                      checks.expect(!refusedMispaired.has_value() && refusedMispaired.error() == vu::ArtifactError::OutcomeMismatch,
+                                    "an outcome that does not pair with its obligation is refused, not serialized");
+
+                      vu::RunResult wrongScope     = completedRun();
+                      wrongScope.outcomes[0].scope = "de-DE";
+                      checks.expect(!vu::writeVerification(wrongScope, "demo").has_value(), "and so is one attributed to a scope the run did not render");
+
+                      vu::RunResult wrongCheck     = completedRun();
+                      wrongCheck.outcomes[0].check = "ColorHash";
+                      checks.expect(!vu::writeVerification(wrongCheck, "demo").has_value(), "and one that would turn a bounds obligation into a tint claim");
                       checks.raise();
                   })
             .Execute();
@@ -178,7 +195,7 @@ const mdux::spec::Register theReportGainsTheOutputAndItsOptions{
                           checks.raise();
                           return;
                       }
-                      const auto options = vu::verificationOptions(result, "generated");
+                      const auto options = vu::verificationOptions(result);
                       if (!options.has_value()) {
                           checks.expect(false, "the resolved options are built");
                           checks.raise();
@@ -201,6 +218,10 @@ const mdux::spec::Register theReportGainsTheOutputAndItsOptions{
                       // The resolved set, not the `all` that asked for it: ADR-007 decision 4 exists
                       // so a narrowed run cannot look like a full one in the report.
                       checks.expect(extended->contains("\"verification\"") && extended->contains("en-US"), "and records the locales the run actually covered");
+                      // BakeReport::validate() does not look inside `options`, so a path placed
+                      // there is one nothing rejects. The locale set is the resolved option; the
+                      // tree it was read from is not.
+                      checks.expect(!extended->contains("artifactRoot"), "and no path smuggled in through the options object");
                       checks.raise();
                   })
             .Execute();

--- a/tests/verify_ui/ArtifactTests.cpp
+++ b/tests/verify_ui/ArtifactTests.cpp
@@ -1,0 +1,209 @@
+/**
+ * @file ArtifactTests.cpp
+ * @brief What `verification.json` records, and the three things it must never record.
+ *
+ * Direct-library tests over a synthesized `RunResult`, so what a check asserts is the writer's
+ * behaviour and not a rendered frame's. The end-to-end path - compile, render, serialize, compare -
+ * is `evidence.screen.<id>`, which runs the real producer on every ADR-007 leg.
+ */
+import std;
+import speclab;
+import mdux.evidence.json;
+import mdux.evidence.report;
+import mdux.tools.verify.artifact;
+import mdux.tools.verify.driver;
+import mdux.verify;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+namespace evj = mdux::evidence::json;
+namespace mv  = mdux::verify;
+namespace vu  = mdux::tools::verify;
+
+/// A run that discharged one `Bounds` obligation and one text obligation, in one locale.
+[[nodiscard]] vu::RunResult completedRun() {
+    vu::RunResult result;
+    result.state       = vu::RunState::ChecksFailed;
+    result.renderCount = 1;
+    result.obligations = {
+        {.kind = vu::ObligationKind::Golden,  .nodeId = "dial", .scope = "en-US",         .check = "Bounds"},
+        {  .kind = vu::ObligationKind::Text, .nodeId = "title", .scope = "en-US", .check = "InkContainment"}
+    };
+    result.outcomes = {
+        {.finding = mv::Finding::NothingPainted,  .nodeId = "dial", .scope = "en-US",         .check = "Bounds"},
+        {          .finding = mv::Finding::Held, .nodeId = "title", .scope = "en-US", .check = "InkContainment"}
+    };
+    result.inputs = {
+        {.role = "screenPackage",       .id = "demo",      .locale = {}, .sha256 = std::string(64, 'a')},
+        {  .role = "textPackage", .id = "demo-en-us", .locale = "en-US", .sha256 = std::string(64, 'b')}
+    };
+    return result;
+}
+
+const mdux::spec::Register outcomesAreScopedToOneObligation{
+    "Each recorded outcome makes only its own obligation's claim",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-artifact-outcome-scope")
+            .Given("a run over a node checked for bounds but not for tint", [] {})
+            .When("the artifact is written", [] {})
+            .Then("the node appears once, as a Bounds outcome, and nothing claims its tint was checked",
+                  [] {
+                      mdux::spec::Checks checks;
+                      const auto         text = vu::writeVerification(completedRun(), "demo");
+                      if (!text.has_value()) {
+                          checks.expect(false, "the artifact is written for a completed run");
+                          checks.raise();
+                          return;
+                      }
+                      const auto document = evj::parse(*text);
+                      if (!document.has_value()) {
+                          checks.expect(false, "the artifact is canonical JSON");
+                          checks.raise();
+                          return;
+                      }
+                      const evj::Value* outcomes = document->find("outcomes");
+                      checks.expect(outcomes != nullptr && outcomes->kind() == evj::Value::Kind::Array, "it carries an outcomes array");
+                      if (outcomes == nullptr || outcomes->kind() != evj::Value::Kind::Array) {
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(outcomes->elements().size() == 2, "one outcome per enumerated obligation, and no more");
+                      // The claim that matters: a node carrying only Bounds must not appear as a
+                      // tint check anywhere in the file, whatever else the writer adds later.
+                      checks.expect(!text->contains("ColorHash"), "a node checked only for bounds is never described as tint-checked");
+                      checks.expect(text->contains("NothingPainted") && text->contains("Held"),
+                                    "each outcome carries its own finding rather than a shared summary");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register noMeasurementReachesTheArtifact{
+    "No measurement, path or timestamp reaches the committed artifact",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-artifact-no-measurements")
+            .Given("a run whose outcomes carry found rectangles and sampled colours", [] {})
+            .When("the artifact is written", [] {})
+            .Then("none of that appears, because a byte-compared file may not depend on the driver that produced the frame",
+                  [] {
+                      mdux::spec::Checks checks;
+                      vu::RunResult      result = completedRun();
+                      // The driver fills these so it can print a sentence a reader can act on.
+                      // ADR-014 decision 4 keeps every one of them out of the file.
+                      result.outcomes[0].foundValid      = true;
+                      result.outcomes[0].found           = {.x = 3, .y = 4, .width = 5, .height = 6};
+                      result.outcomes[0].foundColorValid = true;
+                      result.outcomes[0].foundColor      = {.r = 12, .g = 34, .b = 56, .a = 255};
+
+                      const auto text = vu::writeVerification(result, "demo");
+                      if (!text.has_value()) {
+                          checks.expect(false, "the artifact is written");
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(!text->contains("found"), "no measured rectangle or colour is recorded");
+                      checks.expect(!text->contains("expected"), "not even the expectation's own numbers, which goldens.json already carries");
+                      checks.expect(!text->contains("/") && !text->contains("\\\\"), "no path, absolute or otherwise");
+                      checks.expect(!text->contains("duration") && !text->contains("elapsed"), "no duration");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aRunThatCouldNotBeMadeIsNotWritable{
+    "A run that could not be made produces no artifact at all",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-artifact-refuses-impossible-run")
+            .Given("a run that never rendered, and one that rendered nothing", [] {})
+            .When("each is offered to the writer", [] {})
+            .Then("both are refused, so no committed file can claim a verification that did not happen",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      vu::RunResult absentDevice = completedRun();
+                      absentDevice.state         = vu::RunState::NoRenderDevice;
+                      const auto refusedDevice   = vu::writeVerification(absentDevice, "demo");
+                      checks.expect(!refusedDevice.has_value() && refusedDevice.error() == vu::ArtifactError::NotRun,
+                                    "an absent render device fails production rather than committing an empty verification");
+
+                      vu::RunResult couldNotRun = completedRun();
+                      couldNotRun.state         = vu::RunState::CouldNotRun;
+                      checks.expect(!vu::writeVerification(couldNotRun, "demo").has_value(), "and so does every other inability to run");
+
+                      // Distinct from the above: this run *did* execute. ADR-014 decision 3 makes a
+                      // verification of nothing a failure in its own right.
+                      vu::RunResult empty = completedRun();
+                      empty.obligations.clear();
+                      empty.outcomes.clear();
+                      const auto refusedEmpty = vu::writeVerification(empty, "demo");
+                      checks.expect(!refusedEmpty.has_value() && refusedEmpty.error() == vu::ArtifactError::NoObligations,
+                                    "a run that discharged nothing is not evidence");
+
+                      vu::RunResult mismatched = completedRun();
+                      mismatched.outcomes.pop_back();
+                      checks.expect(!vu::writeVerification(mismatched, "demo").has_value(), "and neither is a run whose outcomes do not cover its obligations");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theReportGainsTheOutputAndItsOptions{
+    "The screen's one report gains the new output and the resolved locale set",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-artifact-extends-report")
+            .Given("the report mdux-meduic wrote for the two files it produced", [] {})
+            .When("the verification artifact is added to the bundle", [] {})
+            .Then("the same report names three outputs and records the locales the run resolved",
+                  [] {
+                      mdux::spec::Checks         checks;
+                      const vu::RunResult        result = completedRun();
+                      mdux::evidence::BakeReport compiled;
+                      compiled.tool        = "mdux-meduic";
+                      compiled.toolVersion = "0.6.0";
+                      compiled.recipe      = {.path = "recipes/screen/demo.toml", .sha256 = {}};
+                      compiled.options     = evj::Value::emptyObject();
+                      compiled.outputs     = {
+                          {.path = "goldens.json", .sha256 = {}},
+                          {.path = "package.json", .sha256 = {}}
+                      };
+
+                      const auto compiledText = compiled.write();
+                      if (!compiledText.has_value()) {
+                          checks.expect(false, "the compiler's own report is valid");
+                          checks.raise();
+                          return;
+                      }
+                      const auto options = vu::verificationOptions(result, "generated");
+                      if (!options.has_value()) {
+                          checks.expect(false, "the resolved options are built");
+                          checks.raise();
+                          return;
+                      }
+                      const auto extended = vu::extendReport(*compiledText, "{}\n", *options);
+                      if (!extended.has_value()) {
+                          checks.expect(false, "the report is extended");
+                          checks.raise();
+                          return;
+                      }
+                      const auto reread = mdux::evidence::BakeReport::parse(*extended);
+                      if (!reread.has_value()) {
+                          checks.expect(false, "and the result is still a bake report");
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(reread->outputs.size() == 3, "the one report names three outputs");
+                      checks.expect(reread->outputs.back().path == "verification.json", "the new one last, keeping the list sorted");
+                      // The resolved set, not the `all` that asked for it: ADR-007 decision 4 exists
+                      // so a narrowed run cannot look like a full one in the report.
+                      checks.expect(extended->contains("\"verification\"") && extended->contains("en-US"), "and records the locales the run actually covered");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+}  // namespace

--- a/tests/verify_ui/ArtifactTests.cpp
+++ b/tests/verify_ui/ArtifactTests.cpp
@@ -15,6 +15,7 @@ import mdux.tools.verify.driver;
 import mdux.verify;
 
 #include "../framework/SpecLabBridge.hpp"
+#include "../framework/TemporaryDirectory.hpp"
 
 namespace {
 namespace evj = mdux::evidence::json;
@@ -201,7 +202,7 @@ const mdux::spec::Register theReportGainsTheOutputAndItsOptions{
                           checks.raise();
                           return;
                       }
-                      const auto extended = vu::extendReport(*compiledText, "{}\n", *options);
+                      const auto extended = vu::extendReport(*compiledText, "{}\n", *options, "9.9.9");
                       if (!extended.has_value()) {
                           checks.expect(false, "the report is extended");
                           checks.raise();
@@ -222,9 +223,114 @@ const mdux::spec::Register theReportGainsTheOutputAndItsOptions{
                       // there is one nothing rejects. The locale set is the resolved option; the
                       // tree it was read from is not.
                       checks.expect(!extended->contains("artifactRoot"), "and no path smuggled in through the options object");
+                      // The point of the stage record: the report's own `tool` is the compiler, so
+                      // without this a reader attributes verification.json to a tool that never saw
+                      // a frame - which is the one question ADR-007 exists to answer.
+                      checks.expect(reread->tool == "mdux-meduic", "the report still names the tool the bake is registered to");
+                      checks.expect(reread->stages.size() == 1 && reread->stages.front().tool == "mdux-verify-bake"
+                                        && reread->stages.front().output == "verification.json" && reread->stages.front().toolVersion == "9.9.9",
+                                    "and names the second tool, its version, and the one output it wrote");
                       checks.raise();
                   })
             .Execute();
     }};
+
+const mdux::spec::Register aFailedPromotionLeavesTheBundleAlone{
+    "A bundle that cannot be published completely is not published at all",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-artifact-publish-rollback")
+            .Given("a bundle whose second file cannot be promoted", [] {})
+            .When("it is published", [] {})
+            .Then("both files still hold exactly what they held before",
+                  [] {
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory scratch{"mdux-verify-publish"};
+                      const std::filesystem::path    first  = scratch.path() / "verification.json";
+                      const std::filesystem::path    second = scratch.path() / "report.json";
+
+                      const auto put = [](const std::filesystem::path& path, std::string_view text) {
+                          std::ofstream out{path, std::ios::binary | std::ios::trunc};
+                          out.write(text.data(), static_cast<std::streamsize>(text.size()));
+                      };
+                      const auto contents = [](const std::filesystem::path& path) {
+                          std::ifstream      in{path, std::ios::binary};
+                          std::ostringstream buffer;
+                          buffer << in.rdbuf();
+                          return buffer.str();
+                      };
+                      put(first, "old verification\n");
+                      put(second, "old report\n");
+
+                      const std::array files{
+                          vu::BundleFile{ .path = first, .text = "new verification\n"},
+                          vu::BundleFile{.path = second,       .text = "new report\n"}
+                      };
+
+                      // The failure is injected on the *second* promotion, after the first has
+                      // already succeeded. That ordering is the whole point: it is the state in
+                      // which a naive implementation leaves a new file beside a stale one.
+                      std::size_t promotions   = 0;
+                      const auto  refuseSecond = [&promotions](const std::filesystem::path& from, const std::filesystem::path& to) -> std::error_code {
+                          if (++promotions == 3) {
+                              return std::make_error_code(std::errc::io_error);
+                          }
+                          std::error_code failure;
+                          std::filesystem::rename(from, to, failure);
+                          return failure;
+                      };
+
+                      const auto published = vu::publishBundle(files, refuseSecond);
+                      checks.expect(!published.has_value() && published.error() == vu::ArtifactError::PublishFailed,
+                                    "publication fails rather than reporting a bundle it did not write");
+                      checks.expect(contents(first) == "old verification\n", "the first file is back to what it held");
+                      checks.expect(contents(second) == "old report\n", "and so is the second, which never changed");
+                      checks.expect(!std::filesystem::exists(first.string() + ".staged") && !std::filesystem::exists(second.string() + ".staged"),
+                                    "and no staged leftovers remain");
+                      checks.expect(!std::filesystem::exists(first.string() + ".previous") && !std::filesystem::exists(second.string() + ".previous"),
+                                    "nor any displaced originals");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aCompletePublicationReplacesBoth{"A bundle that publishes completely replaces every file", "evidence-unit", [] {
+                                                                return speclab::Test("verify-artifact-publish-success")
+                                                                    .Given("a bundle over files that already exist", [] {})
+                                                                    .When("it is published with nothing failing", [] {})
+                                                                    .Then("both hold the new bytes and nothing is left beside them",
+                                                                          [] {
+                                                                              mdux::spec::Checks             checks;
+                                                                              mdux::test::TemporaryDirectory scratch{"mdux-verify-publish-ok"};
+                                                                              const std::filesystem::path    first  = scratch.path() / "verification.json";
+                                                                              const std::filesystem::path    second = scratch.path() / "report.json";
+                                                                              {
+                                                                                  std::ofstream out{second, std::ios::binary};
+                                                                                  out << "old report\n";
+                                                                              }
+
+                                                                              const std::array files{
+                                                                                  vu::BundleFile{ .path = first, .text = "new verification\n"},
+                                                                                  vu::BundleFile{.path = second,       .text = "new report\n"}
+                                                                              };
+                                                                              checks.expect(vu::publishBundle(files).has_value(), "publication succeeds");
+
+                                                                              const auto contents = [](const std::filesystem::path& path) {
+                                                                                  std::ifstream      in{path, std::ios::binary};
+                                                                                  std::ostringstream buffer;
+                                                                                  buffer << in.rdbuf();
+                                                                                  return buffer.str();
+                                                                              };
+                                                                              // The first file did not exist beforehand and the second did, so this covers
+                                                                              // both branches of the displacement bookkeeping in one pass.
+                                                                              checks.expect(contents(first) == "new verification\n",
+                                                                                            "a file that did not exist is created");
+                                                                              checks.expect(contents(second) == "new report\n", "and one that did is replaced");
+                                                                              checks.expect(!std::filesystem::exists(second.string() + ".previous"),
+                                                                                            "with no displaced original left behind");
+                                                                              checks.raise();
+                                                                          })
+                                                                    .Execute();
+                                                            }};
 
 }  // namespace

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -453,8 +453,12 @@ target_sources(MduXVerifyUiLib
     PUBLIC
         FILE_SET CXX_MODULES
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
-        FILES verify/Driver.cppm
-    PRIVATE verify/Driver.cpp
+        FILES
+            verify/Driver.cppm
+            verify/Artifact.cppm
+    PRIVATE
+        verify/Driver.cpp
+        verify/Artifact.cpp
 )
 
 target_compile_features(MduXVerifyUiLib PUBLIC cxx_std_23)
@@ -490,4 +494,28 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(mdux-verify-ui PRIVATE /experimental:module /std:c++latest)
+endif()
+
+# mdux-verify-bake (issue #254) - the artifact half of the same library.
+#
+# A separate executable from mdux-verify-ui rather than a subcommand on it: one is the driver a
+# person or a CI leg runs over a committed bundle, the other is a build step that writes into the
+# build tree. Sharing MduXVerifyUiLib is what matters - both reach verification through the one
+# obligation enumeration, so the committed artifact and the CI run cannot disagree about what was
+# checked. Never installed or exported, and no example links it.
+add_executable(mdux-verify-bake verify/VerifyBakeMain.cpp)
+target_link_libraries(mdux-verify-bake PRIVATE MduX::VerifyUiLib MduX_warnings)
+
+set_target_properties(mdux-verify-bake PROPERTIES
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
+
+if(TARGET __CMAKE::CXX23)
+    set_target_properties(mdux-verify-bake PROPERTIES CXX_MODULE_STD ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(mdux-verify-bake PRIVATE /experimental:module /std:c++latest)
 endif()

--- a/tools/verify/Artifact.cpp
+++ b/tools/verify/Artifact.cpp
@@ -1,0 +1,187 @@
+/**
+ * @file Artifact.cpp
+ * @brief Implementation of `verification.json` and the report members it adds.
+ */
+module;
+
+module mdux.tools.verify.artifact;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.digest;
+import mdux.evidence.json;
+import mdux.evidence.report;
+import mdux.tools.verify.driver;
+import mdux.verify;
+
+namespace mdux::tools::verify {
+namespace {
+
+namespace evj = mdux::evidence::json;
+
+using mdux::core::err;
+
+/// Sets a member on a freshly built object, turning canonical JSON's refusal into this module's
+/// error rather than dropping the field. Every key here is a distinct literal, so a duplicate is
+/// impossible today; it is still checked, so a future edit that repeats one fails loudly.
+[[nodiscard]] bool put(evj::Value& object, std::string key, evj::Value value) {
+    return object.set(std::move(key), std::move(value)).has_value();
+}
+
+/// One bound artifact as the file records it: what it was to this run, which artifact it is, and
+/// its digest. `locale` appears only where it means something, so a shader package does not carry
+/// an empty locale that reads as "no locale was approved".
+[[nodiscard]] std::optional<evj::Value> inputToJson(const BoundArtifact& input) {
+    evj::Value entry = evj::Value::emptyObject();
+    if (!put(entry, "id", evj::Value::string(input.id)) || !put(entry, "role", evj::Value::string(input.role))
+        || !put(entry, "sha256", evj::Value::string(input.sha256))) {
+        return std::nullopt;
+    }
+    if (!input.locale.empty() && !put(entry, "locale", evj::Value::string(input.locale))) {
+        return std::nullopt;
+    }
+    return entry;
+}
+
+/**
+ * @brief One outcome as the file records it: the obligation, and whether it held.
+ *
+ * Four members and no fifth. `check` and `scope` are what keep a claim scoped to the obligation it
+ * came from - a node verified in `en-US` and not in `de-DE` shows up as two entries with different
+ * findings rather than as one summary - and `finding` is a named reason rather than a boolean so
+ * that "nothing was drawn there" and "it was drawn in the wrong colour" stay distinguishable.
+ */
+[[nodiscard]] std::optional<evj::Value> outcomeToJson(const Outcome& outcome) {
+    evj::Value entry = evj::Value::emptyObject();
+    if (!put(entry, "check", evj::Value::string(outcome.check)) || !put(entry, "finding", evj::Value::string(std::string{mdux::verify::spell(outcome.finding)}))
+        || !put(entry, "nodeId", evj::Value::string(outcome.nodeId)) || !put(entry, "scope", evj::Value::string(outcome.scope))) {
+        return std::nullopt;
+    }
+    return entry;
+}
+
+}  // namespace
+
+std::string_view describe(ArtifactError error) noexcept {
+    switch (error) {
+        case ArtifactError::NotRun:
+            return "the verification run could not be made, so there are no outcomes to record";
+        case ArtifactError::NoObligations:
+            return "the run discharged no obligations, and a verification of nothing is not evidence";
+        case ArtifactError::OutcomeMismatch:
+            return "the run produced a different number of outcomes than it enumerated obligations";
+        case ArtifactError::MalformedReport:
+            return "the screen bundle's report.json is not a bake report";
+        case ArtifactError::ReportRewriteFailed:
+            return "the extended bake report failed its own validation";
+        case ArtifactError::SerializationFailed:
+            return "canonical JSON refused a verification member";
+    }
+    return "unknown verification artifact error";
+}
+
+mdux::core::Result<std::string, ArtifactError> writeVerification(const RunResult& result, std::string_view screenId) {
+    // Only a run that actually rendered and evaluated may be serialized. ADR-014 decision 3 makes a
+    // skipped check a failure; #254 adds that a run which could not be made must fail artifact
+    // production rather than commit a file that looks like a verification of nothing.
+    if (result.state != RunState::Passed && result.state != RunState::ChecksFailed) {
+        return err(ArtifactError::NotRun);
+    }
+    if (result.obligations.empty()) {
+        return err(ArtifactError::NoObligations);
+    }
+    if (result.outcomes.size() != result.obligations.size()) {
+        return err(ArtifactError::OutcomeMismatch);
+    }
+
+    std::vector<evj::Value> inputs;
+    inputs.reserve(result.inputs.size());
+    for (const BoundArtifact& input : result.inputs) {
+        auto entry = inputToJson(input);
+        if (!entry.has_value())
+            return err(ArtifactError::SerializationFailed);
+        inputs.push_back(std::move(*entry));
+    }
+
+    std::vector<evj::Value> outcomes;
+    outcomes.reserve(result.outcomes.size());
+    for (const Outcome& outcome : result.outcomes) {
+        auto entry = outcomeToJson(outcome);
+        if (!entry.has_value())
+            return err(ArtifactError::SerializationFailed);
+        outcomes.push_back(std::move(*entry));
+    }
+
+    // The render scopes, in the order the run rendered them, so a reader can see that every
+    // approved locale was covered rather than inferring it from the outcome list.
+    std::vector<evj::Value> scopes;
+    for (const Obligation& obligation : result.obligations) {
+        const bool seen = std::ranges::any_of(scopes, [&obligation](const evj::Value& scope) {
+            const auto text = scope.asString();
+            return text.has_value() && *text == obligation.scope;
+        });
+        if (!seen)
+            scopes.push_back(evj::Value::string(obligation.scope));
+    }
+
+    const evidence::PackageHeader header{.schemaVersion = evidence::kSchemaVersion, .id = std::string{screenId}, .kind = "screen"};
+    evj::Value                    document = evj::Value::emptyObject();
+    if (!header.writeInto(document).has_value()) {
+        return err(ArtifactError::SerializationFailed);
+    }
+    if (!put(document, "inputs", evj::Value::array(std::move(inputs))) || !put(document, "outcomes", evj::Value::array(std::move(outcomes)))
+        || !put(document, "renderScopes", evj::Value::array(std::move(scopes)))) {
+        return err(ArtifactError::SerializationFailed);
+    }
+
+    auto text = evj::write(document);
+    if (!text.has_value()) {
+        return err(ArtifactError::SerializationFailed);
+    }
+    return *text;
+}
+
+mdux::core::Result<evj::Value, ArtifactError> verificationOptions(const RunResult& result, std::string_view artifactRoot) {
+    std::vector<evj::Value> locales;
+    for (const Obligation& obligation : result.obligations) {
+        const bool seen = std::ranges::any_of(locales, [&obligation](const evj::Value& locale) {
+            const auto text = locale.asString();
+            return text.has_value() && *text == obligation.scope;
+        });
+        if (!seen)
+            locales.push_back(evj::Value::string(obligation.scope));
+    }
+
+    evj::Value options = evj::Value::emptyObject();
+    if (!put(options, "artifactRoot", evj::Value::string(std::string{artifactRoot})) || !put(options, "locales", evj::Value::array(std::move(locales)))) {
+        return err(ArtifactError::SerializationFailed);
+    }
+    return options;
+}
+
+mdux::core::Result<std::string, ArtifactError> extendReport(std::string_view reportText, std::string_view verificationJson, const evj::Value& options) {
+    auto report = evidence::BakeReport::parse(reportText);
+    if (!report.has_value()) {
+        return err(ArtifactError::MalformedReport);
+    }
+
+    // Appended rather than inserted: `mdux-meduic` writes `goldens.json` then `package.json`, so
+    // appending `verification.json` keeps the list in the sorted order a reader expects. report.json
+    // stays absent from its own outputs - a file cannot carry its own digest.
+    const auto bytes = std::as_bytes(std::span{verificationJson.data(), verificationJson.size()});
+    report->outputs.push_back({.path = std::string{verificationFileName}, .sha256 = evidence::sha256(bytes)});
+
+    evj::Value resolved = report->options.kind() == evj::Value::Kind::Object ? report->options : evj::Value::emptyObject();
+    if (!put(resolved, "verification", options)) {
+        return err(ArtifactError::SerializationFailed);
+    }
+    report->options = std::move(resolved);
+
+    auto text = report->write();
+    if (!text.has_value()) {
+        return err(ArtifactError::ReportRewriteFailed);
+    }
+    return *text;
+}
+
+}  // namespace mdux::tools::verify

--- a/tools/verify/Artifact.cpp
+++ b/tools/verify/Artifact.cpp
@@ -93,6 +93,17 @@ mdux::core::Result<std::string, ArtifactError> writeVerification(const RunResult
     if (result.outcomes.size() != result.obligations.size()) {
         return err(ArtifactError::OutcomeMismatch);
     }
+    // Equal counts are not coverage. The driver appends an outcome per obligation in one pass, so
+    // these agree today - but this writer is what turns them into committed evidence, and an
+    // outcome recorded against an obligation the run did not enumerate is exactly the claim the
+    // artifact must not be able to make. Checking the pairing costs one comparison per obligation.
+    for (std::size_t index = 0; index < result.obligations.size(); ++index) {
+        const Obligation& obligation = result.obligations[index];
+        const Outcome&    outcome    = result.outcomes[index];
+        if (outcome.nodeId != obligation.nodeId || outcome.scope != obligation.scope || outcome.check != obligation.check) {
+            return err(ArtifactError::OutcomeMismatch);
+        }
+    }
 
     std::vector<evj::Value> inputs;
     inputs.reserve(result.inputs.size());
@@ -141,7 +152,7 @@ mdux::core::Result<std::string, ArtifactError> writeVerification(const RunResult
     return *text;
 }
 
-mdux::core::Result<evj::Value, ArtifactError> verificationOptions(const RunResult& result, std::string_view artifactRoot) {
+mdux::core::Result<evj::Value, ArtifactError> verificationOptions(const RunResult& result) {
     std::vector<evj::Value> locales;
     for (const Obligation& obligation : result.obligations) {
         const bool seen = std::ranges::any_of(locales, [&obligation](const evj::Value& locale) {
@@ -153,7 +164,7 @@ mdux::core::Result<evj::Value, ArtifactError> verificationOptions(const RunResul
     }
 
     evj::Value options = evj::Value::emptyObject();
-    if (!put(options, "artifactRoot", evj::Value::string(std::string{artifactRoot})) || !put(options, "locales", evj::Value::array(std::move(locales)))) {
+    if (!put(options, "locales", evj::Value::array(std::move(locales)))) {
         return err(ArtifactError::SerializationFailed);
     }
     return options;

--- a/tools/verify/Artifact.cpp
+++ b/tools/verify/Artifact.cpp
@@ -62,6 +62,23 @@ using mdux::core::err;
 
 }  // namespace
 
+namespace {
+
+/// Writes `text` to `path`, whole. Returns false on any stream failure.
+[[nodiscard]] bool writeWhole(const std::filesystem::path& path, std::string_view text) {
+    std::ofstream out{path, std::ios::binary | std::ios::trunc};
+    out.write(text.data(), static_cast<std::streamsize>(text.size()));
+    out.close();
+    return static_cast<bool>(out);
+}
+
+void removeQuietly(const std::filesystem::path& path) {
+    std::error_code ignored;
+    std::filesystem::remove(path, ignored);
+}
+
+}  // namespace
+
 std::string_view describe(ArtifactError error) noexcept {
     switch (error) {
         case ArtifactError::NotRun:
@@ -76,6 +93,8 @@ std::string_view describe(ArtifactError error) noexcept {
             return "the extended bake report failed its own validation";
         case ArtifactError::SerializationFailed:
             return "canonical JSON refused a verification member";
+        case ArtifactError::PublishFailed:
+            return "the bundle could not be written; it has been left as it was";
     }
     return "unknown verification artifact error";
 }
@@ -170,7 +189,8 @@ mdux::core::Result<evj::Value, ArtifactError> verificationOptions(const RunResul
     return options;
 }
 
-mdux::core::Result<std::string, ArtifactError> extendReport(std::string_view reportText, std::string_view verificationJson, const evj::Value& options) {
+mdux::core::Result<std::string, ArtifactError>
+extendReport(std::string_view reportText, std::string_view verificationJson, const evj::Value& options, std::string_view toolVersion) {
     auto report = evidence::BakeReport::parse(reportText);
     if (!report.has_value()) {
         return err(ArtifactError::MalformedReport);
@@ -188,11 +208,97 @@ mdux::core::Result<std::string, ArtifactError> extendReport(std::string_view rep
     }
     report->options = std::move(resolved);
 
+    // The stage that says who wrote the file just added. The report's `tool` names the compiler
+    // this bake is registered to and stays that way; this is the rest of the chain.
+    report->stages.push_back({.tool = std::string{artifactToolName}, .toolVersion = std::string{toolVersion}, .output = std::string{verificationFileName}});
+
     auto text = report->write();
     if (!text.has_value()) {
         return err(ArtifactError::ReportRewriteFailed);
     }
     return *text;
+}
+
+mdux::core::ResultVoid<ArtifactError> publishBundle(std::span<const BundleFile> files, const PromoteStep& promote) {
+    const auto move = [&promote](const std::filesystem::path& from, const std::filesystem::path& to) -> std::error_code {
+        if (promote) {
+            return promote(from, to);
+        }
+        std::error_code failure;
+        std::filesystem::rename(from, to, failure);
+        return failure;
+    };
+
+    std::vector<std::filesystem::path>                staged;
+    std::vector<std::optional<std::filesystem::path>> displaced(files.size());
+    staged.reserve(files.size());
+
+    const auto abandonStaged = [&staged] {
+        for (const std::filesystem::path& path : staged) {
+            removeQuietly(path);
+        }
+    };
+
+    // 1. Every file lands beside its target first, so a serialization or disk failure happens
+    //    before anything the bundle consists of has been touched.
+    for (const BundleFile& file : files) {
+        std::filesystem::path temporary = file.path;
+        temporary                      += ".staged";
+        if (!writeWhole(temporary, file.text)) {
+            removeQuietly(temporary);
+            abandonStaged();
+            return err(ArtifactError::PublishFailed);
+        }
+        staged.push_back(std::move(temporary));
+    }
+
+    // 2. Existing targets move aside rather than being overwritten, so there is something to
+    //    restore. A file that did not exist stays recorded as absent.
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        if (!std::filesystem::exists(files[index].path)) {
+            continue;
+        }
+        std::filesystem::path previous = files[index].path;
+        previous                      += ".previous";
+        if (const std::error_code failure = move(files[index].path, previous); failure) {
+            for (std::size_t done = 0; done < index; ++done) {
+                if (displaced[done].has_value()) {
+                    static_cast<void>(move(*displaced[done], files[done].path));
+                }
+            }
+            abandonStaged();
+            return err(ArtifactError::PublishFailed);
+        }
+        displaced[index] = std::move(previous);
+    }
+
+    // 3. Promote. A failure here is the case this whole dance exists for: everything already
+    //    promoted goes back to what it was, and a target that had no previous version is removed
+    //    rather than left holding a file the bundle never had.
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        if (const std::error_code failure = move(staged[index], files[index].path); failure) {
+            for (std::size_t done = 0; done < index; ++done) {
+                removeQuietly(files[done].path);
+                if (displaced[done].has_value()) {
+                    static_cast<void>(move(*displaced[done], files[done].path));
+                }
+            }
+            for (std::size_t rest = index; rest < files.size(); ++rest) {
+                removeQuietly(staged[rest]);
+                if (displaced[rest].has_value()) {
+                    static_cast<void>(move(*displaced[rest], files[rest].path));
+                }
+            }
+            return err(ArtifactError::PublishFailed);
+        }
+    }
+
+    for (const auto& previous : displaced) {
+        if (previous.has_value()) {
+            removeQuietly(*previous);
+        }
+    }
+    return {};
 }
 
 }  // namespace mdux::tools::verify

--- a/tools/verify/Artifact.cppm
+++ b/tools/verify/Artifact.cppm
@@ -1,0 +1,99 @@
+/**
+ * @file Artifact.cppm
+ * @brief `verification.json`, and the two members it adds to the screen bundle's existing report.
+ *
+ * @compliance ADR-004 Trust zones in C++ (host-tools zone)
+ * @compliance ADR-007 Evidence pipeline doctrine
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ *
+ * This is #254's half of the screen bundle: #253's driver renders and evaluates, and this turns the
+ * `RunResult` it returns into the fourth committed file. It enumerates nothing, resolves nothing and
+ * re-applies no predicate - it serializes outcomes it was handed. ADR-014 decision 2's rule about
+ * expectations is a rule about implementations, and a writer that recomputed any part of a run
+ * would be the second implementation that rule exists to prevent.
+ *
+ * ## What the artifact says, and the sentence it must survive
+ *
+ * Each outcome names exactly one obligation and makes only that obligation's claim. A node carrying
+ * only `Bounds` appears once, as a `Bounds` outcome, and nothing in the file can be read as saying
+ * its tint was checked. The file names the screen package, the goldens sidecar, the shader package
+ * and the per-locale font and text packages it used, by digest.
+ *
+ * What it does not say is that the screen is correct. The expectation and the frame come from one
+ * source, so what holds is that the render agrees with the compiled screen - internal consistency,
+ * not truth. ADR-014 decision 4 states this as a constraint on wording rather than a caveat, which
+ * is why nothing here is named `passed`, `valid` or `correct`.
+ *
+ * ## Why there is no measurement in it
+ *
+ * `Outcome` carries `found` rectangles and `foundColor` samples so a driver can print a sentence a
+ * reader can act on. None of that reaches this file. A measured pixel makes a byte-compared
+ * artifact a property of the driver tuple that produced the frame rather than of its declared
+ * inputs, so a rendering change would fail an evidence comparison while every check still held -
+ * the same structural argument ADR-007 decision 5 makes about commit SHAs. The failure diff #255
+ * attaches is a measurement for a human, and it lives outside this file.
+ */
+module;
+
+export module mdux.tools.verify.artifact;
+
+import std;
+import mdux.core.result;
+import mdux.evidence.json;
+import mdux.evidence.report;
+import mdux.tools.verify.driver;
+
+export namespace mdux::tools::verify {
+
+/// The file name this writer owns, fixed here so the CMake `OUTPUTS` entry and the writer cannot
+/// drift into naming two different files.
+inline constexpr std::string_view verificationFileName = "verification.json";
+
+/// The tool name that appears in diagnostics from the bake front end.
+inline constexpr std::string_view artifactToolName = "mdux-verify-bake";
+
+enum class ArtifactError : std::uint8_t {
+    NotRun,               ///< the run could not be made, so there is no outcome set to serialize
+    NoObligations,        ///< a run that verified nothing is not evidence (ADR-014 decision 3)
+    OutcomeMismatch,      ///< outcomes and obligations disagree; the driver's own invariant broke
+    MalformedReport,      ///< the bundle's `report.json` did not parse as a bake report
+    ReportRewriteFailed,  ///< the extended report failed its own validation
+    SerializationFailed,  ///< canonical JSON refused a member this writer built
+};
+
+[[nodiscard]] std::string_view describe(ArtifactError error) noexcept;
+
+/**
+ * @brief The canonical `verification.json` text for a completed run, trailing newline included.
+ *
+ * Fails rather than writing a file for a run that could not be made: an artifact recording zero
+ * outcomes because no device existed is indistinguishable, once committed, from one recording zero
+ * outcomes because the screen had nothing to verify. ADR-014 decision 3 makes both a failure, and
+ * this is where the first of them stops being writable.
+ */
+[[nodiscard]] mdux::core::Result<std::string, ArtifactError> writeVerification(const RunResult& result, std::string_view screenId);
+
+/**
+ * @brief The fully resolved verification options, as the screen's `report.json` records them.
+ *
+ * `--locales=all` resolved to the manifest's actual set is the option worth recording: it is the
+ * one knob a caller could otherwise use to narrow what was verified, and ADR-007 decision 4 exists
+ * so that a resolved set appears in the report rather than the name of one.
+ */
+[[nodiscard]] mdux::core::Result<evidence::json::Value, ArtifactError> verificationOptions(const RunResult& result, std::string_view artifactRoot);
+
+/**
+ * @brief Re-emits the bundle's `report.json` with the verification output and its resolved options.
+ *
+ * The screen bundle has one report, and this extends it rather than adding a second at the same
+ * path - ADR-014 decision 4 forbids the second, and a reader holding two reports for one artifact
+ * has to decide which is authoritative. `mdux-meduic` writes the report first, naming the two files
+ * it produced; this adds the third, which cannot exist until a frame has been rendered.
+ *
+ * `verificationJson` is the exact text `writeVerification()` returned, so the digest recorded is of
+ * the bytes that get committed rather than of a re-serialization that might differ.
+ */
+[[nodiscard]] mdux::core::Result<std::string, ArtifactError>
+extendReport(std::string_view reportText, std::string_view verificationJson, const evidence::json::Value& options);
+
+}  // namespace mdux::tools::verify

--- a/tools/verify/Artifact.cppm
+++ b/tools/verify/Artifact.cppm
@@ -79,8 +79,14 @@ enum class ArtifactError : std::uint8_t {
  * `--locales=all` resolved to the manifest's actual set is the option worth recording: it is the
  * one knob a caller could otherwise use to narrow what was verified, and ADR-007 decision 4 exists
  * so that a resolved set appears in the report rather than the name of one.
+ *
+ * The artifact root the run read from is deliberately *not* here. `BakeReport::validate()` checks
+ * the paths in `inputs`, `outputs` and `recipe`, and does not look inside `options` - so a path
+ * placed here is a path in a byte-compared file that nothing rejects. It also adds no verification
+ * semantics: the report already names every input by repository-relative path, and the locale set
+ * is what says the run was not narrowed.
  */
-[[nodiscard]] mdux::core::Result<evidence::json::Value, ArtifactError> verificationOptions(const RunResult& result, std::string_view artifactRoot);
+[[nodiscard]] mdux::core::Result<evidence::json::Value, ArtifactError> verificationOptions(const RunResult& result);
 
 /**
  * @brief Re-emits the bundle's `report.json` with the verification output and its resolved options.

--- a/tools/verify/Artifact.cppm
+++ b/tools/verify/Artifact.cppm
@@ -59,6 +59,7 @@ enum class ArtifactError : std::uint8_t {
     MalformedReport,      ///< the bundle's `report.json` did not parse as a bake report
     ReportRewriteFailed,  ///< the extended report failed its own validation
     SerializationFailed,  ///< canonical JSON refused a member this writer built
+    PublishFailed,        ///< a bundle file could not be staged or promoted; the bundle is unchanged
 };
 
 [[nodiscard]] std::string_view describe(ArtifactError error) noexcept;
@@ -89,17 +90,51 @@ enum class ArtifactError : std::uint8_t {
 [[nodiscard]] mdux::core::Result<evidence::json::Value, ArtifactError> verificationOptions(const RunResult& result);
 
 /**
- * @brief Re-emits the bundle's `report.json` with the verification output and its resolved options.
+ * @brief Re-emits the bundle's `report.json` with the verification output, options and producer.
  *
  * The screen bundle has one report, and this extends it rather than adding a second at the same
  * path - ADR-014 decision 4 forbids the second, and a reader holding two reports for one artifact
  * has to decide which is authoritative. `mdux-meduic` writes the report first, naming the two files
  * it produced; this adds the third, which cannot exist until a frame has been rendered.
  *
+ * It also adds the stage record naming *this* tool and its version. The report's top-level `tool`
+ * stays `mdux-meduic`, because that is the tool the bake is registered to - so without the stage a
+ * reader would attribute `verification.json` to the screen compiler, which never saw a frame.
+ * ADR-007 exists to answer which tool at which version produced an artifact; for one of the four
+ * outputs, the unextended report answers it wrongly.
+ *
  * `verificationJson` is the exact text `writeVerification()` returned, so the digest recorded is of
  * the bytes that get committed rather than of a re-serialization that might differ.
  */
 [[nodiscard]] mdux::core::Result<std::string, ArtifactError>
-extendReport(std::string_view reportText, std::string_view verificationJson, const evidence::json::Value& options);
+extendReport(std::string_view reportText, std::string_view verificationJson, const evidence::json::Value& options, std::string_view toolVersion);
+
+/// One file of a bundle to publish, with the exact bytes it should end up holding.
+struct BundleFile {
+    std::filesystem::path path;
+    std::string           text;
+};
+
+/**
+ * @brief The promotion step, injectable so a test can fail the second one.
+ *
+ * Production passes nothing and gets `std::filesystem::rename`. The seam exists because the
+ * property worth testing here - that a failure part way through leaves the bundle exactly as it
+ * was - cannot be provoked from outside: every filesystem state that makes a rename fail also
+ * makes the preceding backup fail, so the interesting ordering never arises by itself.
+ */
+using PromoteStep = std::function<std::error_code(const std::filesystem::path& from, const std::filesystem::path& to)>;
+
+/**
+ * @brief Writes every file, or leaves all of them exactly as they were.
+ *
+ * A bundle has to stay coherent: a `verification.json` whose `report.json` does not name it would
+ * pass its own byte comparison while the report stopped describing the artifact beside it. Two
+ * renames are not one transaction, so this does not claim atomicity - what it guarantees is that
+ * every partial outcome is undone. Each file is staged beside its target, each existing target is
+ * moved aside first, and a failure at any point restores what was there: previous contents where a
+ * file existed, absence where it did not.
+ */
+[[nodiscard]] mdux::core::ResultVoid<ArtifactError> publishBundle(std::span<const BundleFile> files, const PromoteStep& promote = {});
 
 }  // namespace mdux::tools::verify

--- a/tools/verify/Driver.cpp
+++ b/tools/verify/Driver.cpp
@@ -82,6 +82,15 @@ void report(std::vector<cli::Diagnostic>& diagnostics, const std::filesystem::pa
     return std::string{reinterpret_cast<const char*>(bytes->data()), bytes->size()};
 }
 
+/// The lowercase-hex digest of already-read artifact text, spelled the way every other evidence
+/// record spells one. Taken from the bytes the run actually parsed rather than by re-reading the
+/// file, so what the artifact names is what the verification used.
+[[nodiscard]] std::string hexDigest(std::string_view text) {
+    const auto bytes  = std::as_bytes(std::span{text.data(), text.size()});
+    const auto digest = mdux::evidence::toHex(mdux::evidence::sha256(bytes));
+    return std::string{digest.data(), digest.size()};
+}
+
 [[nodiscard]] bool exactMembers(const json::Value& value, std::initializer_list<std::string_view> expected) {
     if (value.kind() != json::Value::Kind::Object || value.members().size() != expected.size()) {
         return false;
@@ -134,12 +143,14 @@ struct OwnedGolden {
     }
 };
 
-[[nodiscard]] std::optional<std::vector<OwnedGolden>> readGoldens(const std::filesystem::path& path, std::vector<cli::Diagnostic>& diagnostics) {
+[[nodiscard]] std::optional<std::vector<OwnedGolden>>
+readGoldens(const std::filesystem::path& path, std::string& digestOut, std::vector<cli::Diagnostic>& diagnostics) {
     const auto text = readText(path);
     if (!text.has_value()) {
         report(diagnostics, path, "VUI002", "cannot read goldens.json");
         return std::nullopt;
     }
+    digestOut = hexDigest(*text);
     auto root = json::parse(*text);
     if (!root.has_value() || root->kind() != json::Value::Kind::Array) {
         report(diagnostics, path, "VUI003", "goldens.json is not a canonical JSON array");
@@ -262,6 +273,7 @@ struct ShaderAssets {
     mdux::shader::ShaderPackage           package;
     std::vector<std::byte>                sidecar;
     std::vector<mdux::shader::ModuleView> modules;
+    std::string                           sha256;  ///< of package.json, for #254's artifact
 
     [[nodiscard]] mdux::shader::PackageView view() const noexcept {
         return {.id = package.header.id, .spirv = sidecar, .modules = modules, .descriptors = package.descriptors, .pushConstants = package.pushConstants};
@@ -291,7 +303,7 @@ struct ShaderAssets {
         report(diagnostics, sidecarPath, "VUI005", "the mdux-ui shader sidecar does not match package.json");
         return std::nullopt;
     }
-    ShaderAssets assets{.package = std::move(*package), .sidecar = std::move(*sidecar), .modules = {}};
+    ShaderAssets assets{.package = std::move(*package), .sidecar = std::move(*sidecar), .modules = {}, .sha256 = hexDigest(*text)};
     assets.modules.reserve(assets.package.modules.size());
     for (const auto& module : assets.package.modules) {
         if (module.byteOffset > std::numeric_limits<std::size_t>::max() || module.byteLength > std::numeric_limits<std::size_t>::max()) {
@@ -654,9 +666,15 @@ RunResult run(const std::filesystem::path& requestedScreenDirectory, const std::
         report(result.diagnostics, packagePath, "VUI001", "screen package is non-canonical or its id does not match its directory");
         return result;
     }
-    auto ownedGoldens = readGoldens(screenDirectory / "goldens.json", result.diagnostics);
+    std::string goldensDigest;
+    auto        ownedGoldens = readGoldens(screenDirectory / "goldens.json", goldensDigest, result.diagnostics);
     if (!ownedGoldens)
         return result;
+
+    // Recorded as the run binds them, in one fixed order, because #254 commits this list and a
+    // byte-compared file cannot depend on the order a container happened to yield.
+    result.inputs.push_back({.role = "screenPackage", .id = std::string{screen.id}, .locale = {}, .sha256 = hexDigest(*packageText)});
+    result.inputs.push_back({.role = "goldens", .id = std::string{screen.id}, .locale = {}, .sha256 = std::move(goldensDigest)});
     std::vector<mv::GoldenEntry> goldens;
     goldens.reserve(ownedGoldens->size());
     for (const auto& golden : *ownedGoldens)
@@ -677,6 +695,7 @@ RunResult run(const std::filesystem::path& requestedScreenDirectory, const std::
     auto shader = loadShader(artifactRoot, result.diagnostics);
     if (!shader)
         return result;
+    result.inputs.push_back({.role = "shaderPackage", .id = std::string{shader->package.header.id}, .locale = {}, .sha256 = shader->sha256});
 
     const bool                hasText = std::ranges::any_of(screen.nodes, [](const auto& node) {
         return !mv::textKeyOf(node).empty();
@@ -688,6 +707,12 @@ RunResult run(const std::filesystem::path& requestedScreenDirectory, const std::
             auto assets = loadLocale(approval, artifactRoot, result.diagnostics);
             if (!assets)
                 return result;
+            // In manifest order, which `ScreenPackage::validate()` already fixes, so the same screen
+            // yields the same list on every leg.
+            result.inputs.push_back(
+                {.role = "textPackage", .id = std::string{assets->text.header.id}, .locale = assets->locale, .sha256 = hexDigest(assets->textJson)});
+            result.inputs.push_back(
+                {.role = "fontPackage", .id = std::string{assets->font.id}, .locale = assets->locale, .sha256 = hexDigest(assets->fontJson)});
             locales.push_back(std::move(*assets));
         }
     }

--- a/tools/verify/Driver.cppm
+++ b/tools/verify/Driver.cppm
@@ -96,7 +96,7 @@ struct Outcome {
  */
 struct BoundArtifact {
     std::string role;    ///< `screenPackage`, `goldens`, `shaderPackage`, `fontPackage`, `textPackage`
-    std::string id;      ///< the artifact id; empty for the screen's own two bundle files
+    std::string id;      ///< the artifact id; the screen's own id for its package and goldens
     std::string locale;  ///< the approved locale a text package carries; empty otherwise
     std::string sha256;  ///< lowercase hex, as every other evidence record spells a digest
 

--- a/tools/verify/Driver.cppm
+++ b/tools/verify/Driver.cppm
@@ -82,11 +82,33 @@ struct Outcome {
     }
 };
 
+/**
+ * @brief One committed artifact the run bound, named by role rather than by filesystem path.
+ *
+ * #254 writes these into `verification.json`, which is byte-compared, and a path is exactly what
+ * ADR-007 decision 5 keeps out of such a file: during a bake the screen bundle is read from
+ * `${CMAKE_BINARY_DIR}/mdux_bake/screen/<id>/`, so a recorded path would name the machine that
+ * produced the artifact. A role, an id and a digest identify the same input without that.
+ *
+ * The driver fills these where it already resolves and digests each artifact, so the writer has no
+ * second resolution path to disagree with - the rule ADR-014 decision 2 states for expectations
+ * applies just as much to the inputs the artifact names.
+ */
+struct BoundArtifact {
+    std::string role;    ///< `screenPackage`, `goldens`, `shaderPackage`, `fontPackage`, `textPackage`
+    std::string id;      ///< the artifact id; empty for the screen's own two bundle files
+    std::string locale;  ///< the approved locale a text package carries; empty otherwise
+    std::string sha256;  ///< lowercase hex, as every other evidence record spells a digest
+
+    [[nodiscard]] bool operator==(const BoundArtifact&) const = default;
+};
+
 struct RunResult {
     RunState                                  state{RunState::CouldNotRun};
     std::size_t                               renderCount{0};
     std::vector<Obligation>                   obligations;
     std::vector<Outcome>                      outcomes;
+    std::vector<BoundArtifact>                inputs;
     std::vector<mdux::tools::cli::Diagnostic> diagnostics;
 };
 

--- a/tools/verify/VerifyBakeMain.cpp
+++ b/tools/verify/VerifyBakeMain.cpp
@@ -47,59 +47,6 @@ void fail(std::string_view message) {
     std::println(std::cerr, "{}: error: {}", vu::artifactToolName, message);
 }
 
-[[nodiscard]] bool writeText(const std::filesystem::path& path, std::string_view text) {
-    std::ofstream out{path, std::ios::binary | std::ios::trunc};
-    out.write(text.data(), static_cast<std::streamsize>(text.size()));
-    out.close();
-    if (!out) {
-        fail(std::format("cannot write {}", path.generic_string()));
-        return false;
-    }
-    return true;
-}
-
-/**
- * @brief Writes both files, or leaves the bundle as it found it.
- *
- * The bundle has to stay coherent: a `verification.json` whose `report.json` does not name it would
- * pass its own byte comparison while the report stopped describing the artifact beside it. Both
- * texts are already built before anything is written, so the remaining risk is an I/O failure part
- * way through - which is why each lands in a sibling temporary first and is renamed only once both
- * are on disk. Renaming within one directory is the cheapest step available; two renames are not
- * one transaction, but the failure window shrinks from "a serialization died half way" to "a rename
- * syscall failed after both files were written whole".
- */
-[[nodiscard]] bool publish(const std::vector<std::pair<std::filesystem::path, std::string>>& files) {
-    std::vector<std::filesystem::path> staged;
-    const auto                         discard = [&staged] {
-        for (const std::filesystem::path& path : staged) {
-            std::error_code ignored;
-            std::filesystem::remove(path, ignored);
-        }
-    };
-
-    for (const auto& [path, text] : files) {
-        std::filesystem::path temporary = path;
-        temporary                      += ".staged";
-        if (!writeText(temporary, text)) {
-            discard();
-            return false;
-        }
-        staged.push_back(std::move(temporary));
-    }
-
-    for (std::size_t index = 0; index < files.size(); ++index) {
-        std::error_code failure;
-        std::filesystem::rename(staged[index], files[index].first, failure);
-        if (failure) {
-            fail(std::format("cannot publish {}: {}", files[index].first.generic_string(), failure.message()));
-            discard();
-            return false;
-        }
-    }
-    return true;
-}
-
 [[nodiscard]] std::optional<std::string> readText(const std::filesystem::path& path) {
     std::ifstream in{path, std::ios::binary};
     if (!in)
@@ -160,16 +107,18 @@ int main(int argc, char** argv) {
         fail(std::format("cannot resolve verification options: {}", vu::describe(options.error())));
         return 1;
     }
-    auto extended = vu::extendReport(*reportText, *verification, *options);
+    auto extended = vu::extendReport(*reportText, *verification, *options, MDUX_TOOL_VERSION);
     if (!extended.has_value()) {
         fail(std::format("cannot extend report.json: {}", vu::describe(extended.error())));
         return 1;
     }
 
-    if (!publish({
-            {bundle / std::filesystem::path{vu::verificationFileName}, *verification},
-            {                                              reportPath,     *extended}
-    })) {
+    const std::array bundleFiles{
+        vu::BundleFile{.path = bundle / std::filesystem::path{vu::verificationFileName}, .text = *verification},
+        vu::BundleFile{                                              .path = reportPath,     .text = *extended}
+    };
+    if (const auto published = vu::publishBundle(bundleFiles); !published.has_value()) {
+        fail(std::string{vu::describe(published.error())});
         return 1;
     }
 

--- a/tools/verify/VerifyBakeMain.cpp
+++ b/tools/verify/VerifyBakeMain.cpp
@@ -1,0 +1,136 @@
+/**
+ * @file VerifyBakeMain.cpp
+ * @brief The second command in the screen bundle's production sequence: render, then serialize.
+ *
+ * `mdux-meduic bake <recipe> <dir>` compiles the screen and writes `package.json`, `goldens.json`
+ * and the report naming those two. This runs next, over the bundle that command just produced, and
+ * adds the fourth file plus the report members that name it. The argument shape is deliberately the
+ * baker's own - `bake <recipe> <output-dir>` - so `mdux_bake_artifact()` invokes both tools the same
+ * way and the sequence stays one registration rather than two.
+ *
+ * ## Why this is a separate process rather than a stage inside the compiler
+ *
+ * The compiler is what every screen goes through, and a screen compile that required a Vulkan
+ * device would make a GPU a prerequisite of reading a `.medui` file. Verification needs one; the
+ * compile does not, and fusing them would spread that requirement over `mdux-medui-check`, the
+ * emit path and every test that drives a compile as a call.
+ *
+ * ## Why a failed check is not a failed bake
+ *
+ * A node in the wrong place and a missing Vulkan loader are different facts, and #254 requires the
+ * artifact to distinguish them. An inability to run - no device, an unreadable input, a digest that
+ * drifted - exits non-zero and writes nothing, so no committed file can claim a verification that
+ * did not happen. A check that ran and did not hold is recorded as the finding it produced and the
+ * bundle is written: that is evidence, and suppressing it would leave the tree with no record that
+ * the screen fails. The gate that turns such an artifact red belongs to #255.
+ */
+import std;
+import mdux.evidence.json;
+import mdux.tools.cli;
+import mdux.tools.verify.artifact;
+import mdux.tools.verify.driver;
+
+namespace {
+
+namespace cli = mdux::tools::cli;
+namespace vu  = mdux::tools::verify;
+
+[[nodiscard]] std::string usage() {
+    return std::format("usage:\n  {} bake <recipe.toml> <output-dir>\n\n"
+                       "Renders the screen bundle in <output-dir>, writes verification.json beside it and\n"
+                       "extends its report.json. The recipe is accepted for symmetry with the compiler and\n"
+                       "is not re-read: what is verified is the bundle that was just produced.\n",
+                       vu::artifactToolName);
+}
+
+void fail(std::string_view message) {
+    std::println(std::cerr, "{}: error: {}", vu::artifactToolName, message);
+}
+
+[[nodiscard]] bool writeText(const std::filesystem::path& path, std::string_view text) {
+    std::ofstream out{path, std::ios::binary | std::ios::trunc};
+    out.write(text.data(), static_cast<std::streamsize>(text.size()));
+    out.close();
+    if (!out) {
+        fail(std::format("cannot write {}", path.generic_string()));
+        return false;
+    }
+    return true;
+}
+
+[[nodiscard]] std::optional<std::string> readText(const std::filesystem::path& path) {
+    std::ifstream in{path, std::ios::binary};
+    if (!in)
+        return std::nullopt;
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    if (!in && !in.eof())
+        return std::nullopt;
+    return buffer.str();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const std::vector<std::string_view> arguments{argv + (argc > 0 ? 1 : 0), argv + std::max(argc, 1)};
+    if (arguments.size() == 1 && (arguments[0] == "--help" || arguments[0] == "-h")) {
+        std::print(std::cout, "{}", usage());
+        return 2;
+    }
+    if (arguments.size() != 3 || arguments[0] != "bake") {
+        std::print(std::cerr, "{}", usage());
+        return 2;
+    }
+
+    const std::filesystem::path bundle = arguments[2];
+
+    // The artifact root is the committed `generated/` tree: the screen bundle being verified is the
+    // freshly baked one in the build tree, while the shader, font and text packages it renders
+    // against are the committed artifacts every other consumer reads. Passing it explicitly is what
+    // keeps those two apart - the single-argument overload would look for all of them beside the
+    // bundle, which during a bake is a build directory.
+    const vu::RunResult result = vu::run(bundle, std::filesystem::path{"generated"});
+
+    const std::string rendered = cli::render(result.diagnostics, cli::Format::Text, vu::toolName);
+    if (!rendered.empty()) {
+        std::print(std::cerr, "{}", rendered);
+    }
+
+    auto verification = vu::writeVerification(result, bundle.filename().generic_string());
+    if (!verification.has_value()) {
+        fail(std::format("cannot produce {}: {}", vu::verificationFileName, vu::describe(verification.error())));
+        return 1;
+    }
+
+    const std::filesystem::path reportPath = bundle / "report.json";
+    const auto                  reportText = readText(reportPath);
+    if (!reportText.has_value()) {
+        fail(std::format("cannot read {}", reportPath.generic_string()));
+        return 1;
+    }
+
+    auto options = vu::verificationOptions(result, "generated");
+    if (!options.has_value()) {
+        fail(std::format("cannot resolve verification options: {}", vu::describe(options.error())));
+        return 1;
+    }
+    auto extended = vu::extendReport(*reportText, *verification, *options);
+    if (!extended.has_value()) {
+        fail(std::format("cannot extend report.json: {}", vu::describe(extended.error())));
+        return 1;
+    }
+
+    // Both files or neither: a bundle carrying verification.json whose report does not name it would
+    // pass its own byte comparison while the report stopped describing the artifact beside it.
+    if (!writeText(bundle / std::filesystem::path{vu::verificationFileName}, *verification) || !writeText(reportPath, *extended)) {
+        return 1;
+    }
+
+    std::println(std::cout,
+                 "{}: {} obligations recorded in {} render scope{}",
+                 vu::artifactToolName,
+                 result.outcomes.size(),
+                 result.renderCount,
+                 result.renderCount == 1 ? "" : "s");
+    return 0;
+}

--- a/tools/verify/VerifyBakeMain.cpp
+++ b/tools/verify/VerifyBakeMain.cpp
@@ -58,6 +58,48 @@ void fail(std::string_view message) {
     return true;
 }
 
+/**
+ * @brief Writes both files, or leaves the bundle as it found it.
+ *
+ * The bundle has to stay coherent: a `verification.json` whose `report.json` does not name it would
+ * pass its own byte comparison while the report stopped describing the artifact beside it. Both
+ * texts are already built before anything is written, so the remaining risk is an I/O failure part
+ * way through - which is why each lands in a sibling temporary first and is renamed only once both
+ * are on disk. Renaming within one directory is the cheapest step available; two renames are not
+ * one transaction, but the failure window shrinks from "a serialization died half way" to "a rename
+ * syscall failed after both files were written whole".
+ */
+[[nodiscard]] bool publish(const std::vector<std::pair<std::filesystem::path, std::string>>& files) {
+    std::vector<std::filesystem::path> staged;
+    const auto                         discard = [&staged] {
+        for (const std::filesystem::path& path : staged) {
+            std::error_code ignored;
+            std::filesystem::remove(path, ignored);
+        }
+    };
+
+    for (const auto& [path, text] : files) {
+        std::filesystem::path temporary = path;
+        temporary                      += ".staged";
+        if (!writeText(temporary, text)) {
+            discard();
+            return false;
+        }
+        staged.push_back(std::move(temporary));
+    }
+
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        std::error_code failure;
+        std::filesystem::rename(staged[index], files[index].first, failure);
+        if (failure) {
+            fail(std::format("cannot publish {}: {}", files[index].first.generic_string(), failure.message()));
+            discard();
+            return false;
+        }
+    }
+    return true;
+}
+
 [[nodiscard]] std::optional<std::string> readText(const std::filesystem::path& path) {
     std::ifstream in{path, std::ios::binary};
     if (!in)
@@ -91,7 +133,11 @@ int main(int argc, char** argv) {
     // bundle, which during a bake is a build directory.
     const vu::RunResult result = vu::run(bundle, std::filesystem::path{"generated"});
 
-    const std::string rendered = cli::render(result.diagnostics, cli::Format::Text, vu::toolName);
+    // Attributed to the process that printed them, not to the library that produced them. The VUI
+    // codes stay the driver's. Only the JSON envelope carries the tool name today, so this changes
+    // nothing a reader sees from a bake - which is the reason to get it right now rather than when
+    // something starts asking this tool for `--format=json` and gets another tool's name back.
+    const std::string rendered = cli::render(result.diagnostics, cli::Format::Text, vu::artifactToolName);
     if (!rendered.empty()) {
         std::print(std::cerr, "{}", rendered);
     }
@@ -109,7 +155,7 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    auto options = vu::verificationOptions(result, "generated");
+    auto options = vu::verificationOptions(result);
     if (!options.has_value()) {
         fail(std::format("cannot resolve verification options: {}", vu::describe(options.error())));
         return 1;
@@ -120,9 +166,10 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    // Both files or neither: a bundle carrying verification.json whose report does not name it would
-    // pass its own byte comparison while the report stopped describing the artifact beside it.
-    if (!writeText(bundle / std::filesystem::path{vu::verificationFileName}, *verification) || !writeText(reportPath, *extended)) {
+    if (!publish({
+            {bundle / std::filesystem::path{vu::verificationFileName}, *verification},
+            {                                              reportPath,     *extended}
+    })) {
         return 1;
     }
 


### PR DESCRIPTION
Closes #254.

`mdux-verify-ui` rendered and evaluated every obligation and then threw the result away at the
process boundary. This serializes it as the screen bundle's fourth committed file.

## The shape

`mdux_compile_screen()` remains the one `screen/<id>` registration. What it gains is a second
stage: `mdux_bake_artifact()` learns `THEN_TOOLS`, so a single custom command runs `mdux-meduic`
and then the new `mdux-verify-bake` over the same output directory, under one `OUTPUTS` set and one
`evidence.screen.<id>` comparison. The rendered half therefore cannot end up with weaker evidence
than the compiled half.

Two tools rather than one because their dependencies differ. Reading a `.medui` file needs no GPU,
and fusing them would make a Vulkan device a prerequisite of every screen compile, of
`mdux-medui-check`, and of every test that drives a compile as a call.

The writer consumes `RunResult` and enumerates nothing itself — no second obligation predicate, no
synthetic production path. Findings serialize through a new `spell(Finding)` rather than
`describe()`, so improving a diagnostic's wording cannot fail an evidence comparison on four legs.

## What the artifact says

One outcome per enumerated obligation, each making only that obligation's claim. A node carrying
only `Bounds` appears once, as a `Bounds` outcome, and nothing in the file reads as saying its tint
was checked. The file names the screen package, goldens sidecar, shader package and per-locale font
and text packages by digest.

No measurement reaches it — no found rectangle, no sampled colour, no path, no duration. A
measurement would make a byte-compared file a property of the driver tuple that produced the frame
rather than of its declared inputs, which is ADR-007 decision 5's argument about commit SHAs applied
to pixels.

An inability to run fails production and writes nothing. A check that ran and did not hold is
recorded as the finding it produced. The committed `endoscope-monitor` artifact therefore carries
three `NothingPainted` findings today — exactly what ADR-014 predicted for a screen whose
`NumericDisplay` and `SignalTrace` the runtime still defers to #17. An artifact that hid them would
be worse than none; #255 owns the gate.

## The four-leg constraint

Two of the four evidence legs could not have re-derived this file, and that was invisible while
nothing there rendered:

| Leg | Before | Now |
|---|---|---|
| Linux/GCC 16 | lavapipe | unchanged |
| macOS/Clang 21 | MoltenVK | unchanged |
| Linux/Clang 21 libc++ | loader, no `mesa-vulkan-drivers` — **zero devices** | lavapipe from the distribution |
| Windows/MSVC | `Vulkan-Loader` with no ICD — **zero devices** | Mesa's Windows build, pinned by tag and SHA-256 |

Since the bake now renders, a leg without a device fails to build rather than producing a smaller
artifact, so neither can satisfy the byte comparison without having actually verified the screen.
Both legs also gain the `-L pixel` skip guard the other two already carry. ADR-007 decision 6 records
that the device is now an obligation of each leg rather than an accident of two.

## Verified

- Two independent bakes produce byte-identical `package.json`, `goldens.json`, `report.json` and
  `verification.json`.
- `VK_DRIVER_FILES=/nonexistent.json` exits 1, writes nothing and leaves `report.json` untouched —
  distinct from a failed check, which exits 0 and records the finding.
- `generated/` is unchanged in digest across a build; only `mdux-bake-update` stages it.
- 666/666 tests including the `evidence` label; evidence-lint, docs-lint and the governed no-throw
  scans are clean.

Not verified locally: the device here is radv, not lavapipe or MoltenVK. The artifact holds outcomes
rather than samples, so byte-identity should survive four drivers — but this PR's own CI is what
proves it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Screen bundles now include a `verification.json` artifact summarizing verification outcomes, resolved locales, and input integrity data.
  - Screen generation now performs verification automatically after rendering and updates the bundle report with verification stages.
  - Bundle updates are published atomically, preventing partial output when generation fails.

- **Bug Fixes**
  - Linux Clang and Windows CI now provide software Vulkan rendering and fail when rendered tests are skipped, improving test reliability.

- **Documentation**
  - Updated architecture, roadmap, and decision records to document the rendered verification workflow and CI coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->