### PR TITLE
Guard release branch topology [#284]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Invitation / CLA issue: #
 
 ## Dependency
 
-- **Base branch:** <!-- `develop`, or the predecessor branch this is stacked on -->
+- **Base branch:** <!-- `develop`, the predecessor branch this is stacked on, or `master` only for a same-repository `release/vX.Y.Z` branch -->
 - **Predecessor PR:** <!-- #NNN, or "not stacked" -->
 - **Merge order:** <!-- "mergeable now", or "must not merge until #NNN has merged" -->
 

--- a/.github/workflows/branch-topology.yml
+++ b/.github/workflows/branch-topology.yml
@@ -2,14 +2,18 @@ name: Branch Topology
 
 on:
   push:
-    branches: [ develop ]
+    # A push to master is what creates drift, so observe it directly rather than waiting for the
+    # cron: a release merged at 06:00 would otherwise go unverified until the next morning.
+    branches: [ master, develop ]
   pull_request:
-    # Keep the topology check attached to ordinary and stacked PRs too. On a PR to master the
-    # same job also enforces the release-branch-only rule below. `edited` covers base retargeting.
+    # A pull request gets only the release-branch-only rule below; the drift leg belongs to `push`
+    # and `schedule`, because it measures branch tips no pull request can move. The filter stays
+    # wide so ordinary and stacked PRs still report a check. `edited` covers base retargeting.
     branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
     types: [ opened, synchronize, reopened, edited ]
   schedule:
-    # A push to master can create drift without moving develop, so retain an independent backstop.
+    # A backstop for what the push events cannot see: a run cancelled or skipped, or history
+    # rewritten in place by a force-push.
     - cron: '17 5 * * *'
   workflow_dispatch:
 
@@ -41,14 +45,31 @@ jobs:
         HEAD_REF: ${{ github.head_ref }}
         HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
       run: |
+        set -euo pipefail
         failed=0
-        read -r master_only develop_only <<< \
-          "$(git rev-list --left-right --count origin/master...origin/develop)"
 
-        echo "master-only commits: ${master_only}; develop-only commits: ${develop_only}"
-        if (( master_only != 0 )); then
-          echo "::error::master carries ${master_only} commit(s) develop lacks; back-merge master as described in docs/release-process.md step 9"
-          failed=1
+        # Drift belongs to the branch tips, not to any one pull request: the counts below are the
+        # same whatever a PR contains. Measured on `pull_request`, this leg would redden every open
+        # PR for the window between a release merge and the back-merge of step 9 — demanding of
+        # each contributor an admin push to develop that none of them can make.
+        if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+          # Capture the counts before splitting them. `read x y <<< "$(cmd)"` takes its exit status
+          # from `read`, never from the substitution, so a `git rev-list` that fails — an unfetched
+          # ref, a renamed branch — would leave both variables empty, and `(( master_only != 0 ))`
+          # reads an empty variable as zero. The guard would pass precisely when git is broken, so
+          # assert the counts are numbers rather than trusting the arithmetic to notice.
+          counts="$(git rev-list --left-right --count origin/master...origin/develop)"
+          read -r master_only develop_only <<< "${counts}"
+          if [[ ! "${master_only}" =~ ^[0-9]+$ || ! "${develop_only}" =~ ^[0-9]+$ ]]; then
+            echo "::error::git rev-list returned no usable commit counts: '${counts}'"
+            exit 1
+          fi
+
+          echo "master-only commits: ${master_only}; develop-only commits: ${develop_only}"
+          if (( master_only != 0 )); then
+            echo "::error::master carries ${master_only} commit(s) develop lacks; back-merge master as described in docs/release-process.md step 9"
+            failed=1
+          fi
         fi
 
         if [[ "${EVENT_NAME}" == "pull_request" && "${BASE_REF}" == "master" ]]; then

--- a/.github/workflows/branch-topology.yml
+++ b/.github/workflows/branch-topology.yml
@@ -1,0 +1,62 @@
+name: Branch Topology
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    # Keep the topology check attached to ordinary and stacked PRs too. On a PR to master the
+    # same job also enforces the release-branch-only rule below. `edited` covers base retargeting.
+    branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
+    types: [ opened, synchronize, reopened, edited ]
+  schedule:
+    # A push to master can create drift without moving develop, so retain an independent backstop.
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  branch-topology:
+    name: Branch Topology
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository history
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Fetch the authoritative branch tips
+      run: |
+        git fetch --no-tags origin \
+          +refs/heads/master:refs/remotes/origin/master \
+          +refs/heads/develop:refs/remotes/origin/develop
+
+    - name: Enforce the release topology
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        EVENT_NAME: ${{ github.event_name }}
+        HEAD_REF: ${{ github.head_ref }}
+        HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+      run: |
+        failed=0
+        read -r master_only develop_only <<< \
+          "$(git rev-list --left-right --count origin/master...origin/develop)"
+
+        echo "master-only commits: ${master_only}; develop-only commits: ${develop_only}"
+        if (( master_only != 0 )); then
+          echo "::error::master carries ${master_only} commit(s) develop lacks; back-merge master as described in docs/release-process.md step 9"
+          failed=1
+        fi
+
+        if [[ "${EVENT_NAME}" == "pull_request" && "${BASE_REF}" == "master" ]]; then
+          if [[ "${HEAD_REPOSITORY}" != "${GITHUB_REPOSITORY}" || \
+                ! "${HEAD_REF}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::master accepts only same-repository release/vX.Y.Z pull requests; target develop for ordinary work"
+            failed=1
+          fi
+        fi
+
+        exit "${failed}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,17 +282,25 @@ listed pattern reports no checks at all — not failures, *nothing* — which is
 easiest to miss on review. So:
 
 - Create branches from the issue, with that button or by writing the same name by hand.
+- Target `develop`, or the predecessor branch for a stack. The only branches that target `master`
+  are same-repository `release/vX.Y.Z` branches; the `Branch Topology` check rejects every other
+  source.
 - A stacked PR (one targeting its predecessor rather than `develop`, so a reviewer sees one
   issue's diff instead of the cumulative one) is covered automatically, because its base is
   itself an issue branch.
-- `main`, `develop` and the older `feat/**` prefix also match. `feat/**` predates this
+- `master`, `develop` and the older `feat/**` prefix also match. `feat/**` predates this
   convention and is kept only for branches already in flight.
 - A branch named anything else (`fix-typo`, `wip`, `my-feature`) gets **no CI on a PR based on
   it**. If you need one, add its pattern to the `branches:` list of every workflow under
   `.github/workflows/` that has a `pull_request:` trigger.
 
-`push:` triggers stay limited to `main` and `develop` deliberately: an open PR already covers its
+`push:` triggers stay limited to `master` and `develop` deliberately: an open PR already covers its
 own branch, and adding work branches there would run every workflow twice per commit.
+
+**An unmergeable PR does not run GitHub's `pull_request` workflows.** It can therefore show a green
+review-bot check while every build, test and lint check is absent. Treat missing required checks as
+missing evidence, never as a pass. On `master`, branch protection keeps those checks required, so
+they remain pending and block the merge even when GitHub cannot construct the test merge commit.
 
 ### Stacked delivery
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,9 +298,11 @@ easiest to miss on review. So:
 own branch, and adding work branches there would run every workflow twice per commit.
 
 **An unmergeable PR does not run GitHub's `pull_request` workflows.** It can therefore show a green
-review-bot check while every build, test and lint check is absent. Treat missing required checks as
-missing evidence, never as a pass. On `master`, branch protection keeps those checks required, so
-they remain pending and block the merge even when GitHub cannot construct the test merge commit.
+review-bot check while every build, test and lint check is absent. Treat missing checks as missing
+evidence, never as a pass — and note that nothing yet stops you acting otherwise: `master` currently
+configures no required status checks, so GitHub offers an unblocked merge button on a PR whose
+workflows never ran. Until that protection exists, confirming every expected check is present and
+green is a manual step, on you.
 
 ### Stacked delivery
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -187,9 +187,10 @@ $ gh release create vX.Y.Z --verify-tag --title "vX.Y.Z — Wave N: <what it is>
 
 **A green check is not evidence that the CI ran.** GitHub does not run `pull_request` workflows
 when it cannot construct a merge commit, so an unmergeable release PR can display a passing review
-bot while every build, test and lint check is absent. Do not merge or tag from that state. The
-required checks on `master` must all be present and green; an absent check remains pending under
-branch protection. Resolve the conflict and wait for the workflows to run.
+bot while every build, test and lint check is absent. Do not merge or tag from that state. Every
+check `master` expects must be present and green before you merge, and verifying that is manual
+today: the repository configures no required status checks, so nothing holds an absent check
+pending and nothing blocks the merge. Resolve the conflict and wait for the workflows to run.
 
 Four things this spells out because cutting v0.6.0 found each of them the hard way.
 
@@ -226,10 +227,11 @@ unpushed commit, the pull must fail rather than quietly add a merge, because an 
 indistinguishable in the final count from the drift this step exists to measure.
 
 [`branch-topology.yml`](../.github/workflows/branch-topology.yml) enforces that invariant on every
-push to `develop`, on every mergeable pull request covered by the repository's branch convention,
-and once a day. If it reports commits unique to `master`, back-merge `origin/master` into `develop`
-before continuing feature or release work; do not make a duplicate change independently on both
-branches.
+push to `master` or `develop`, and once a day. Deliberately not on a pull request: the counts come
+from the branch tips, which no PR can move, so a PR would report the state of the branches around it
+and stay red until someone with push access to `develop` acted. If the check reports commits unique
+to `master`, back-merge `origin/master` into `develop` before continuing feature or release work; do
+not make a duplicate change independently on both branches.
 
 **Merge the release PR, do not squash it.** A squash gives the release commit a single parent, so no
 release-branch commit is in `master`'s ancestry, and the back-merge falls back to the last common

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -29,7 +29,9 @@ at all**, silently, which is worse than a failing one.
   predecessor rather than on `develop` — see [`AGENTS.md`](../AGENTS.md) and issue `#117`.
 - **`release/vX.Y.Z`** exists so that release-only changes are reviewable as a diff. It is where the
   version moves and the artifacts are re-baked, both of which touch files no feature branch should.
-- **`master`** carries releases and nothing else. Its tip is the most recent tag.
+- **`master`** carries releases and nothing else. Its tip is the most recent tag. Branch protection
+  rejects direct pushes, and the `Branch Topology` check accepts only same-repository
+  `release/vX.Y.Z` pull requests targeting it.
 
 A release branch rather than tagging `develop` directly, for one reason that is specific to this
 repository: **the version bump changes committed artifacts**, so it needs review like any other
@@ -183,6 +185,12 @@ $ git push origin vX.Y.Z
 $ gh release create vX.Y.Z --verify-tag --title "vX.Y.Z — Wave N: <what it is>" --notes-file <notes>
 ```
 
+**A green check is not evidence that the CI ran.** GitHub does not run `pull_request` workflows
+when it cannot construct a merge commit, so an unmergeable release PR can display a passing review
+bot while every build, test and lint check is absent. Do not merge or tag from that state. The
+required checks on `master` must all be present and green; an absent check remains pending under
+branch protection. Resolve the conflict and wait for the workflows to run.
+
 Four things this spells out because cutting v0.6.0 found each of them the hard way.
 
 **Merge with `--merge`, mechanically.** The reason is in step 9, but the choice is made *here*, and
@@ -216,6 +224,12 @@ The left column must be `0`: `master` carries nothing `develop` lacks. Skipping 
 number grows. `--ff-only` is the same guard as step 1 — if local `develop` has drifted or carries an
 unpushed commit, the pull must fail rather than quietly add a merge, because an extra merge here is
 indistinguishable in the final count from the drift this step exists to measure.
+
+[`branch-topology.yml`](../.github/workflows/branch-topology.yml) enforces that invariant on every
+push to `develop`, on every mergeable pull request covered by the repository's branch convention,
+and once a day. If it reports commits unique to `master`, back-merge `origin/master` into `develop`
+before continuing feature or release work; do not make a duplicate change independently on both
+branches.
 
 **Merge the release PR, do not squash it.** A squash gives the release commit a single parent, so no
 release-branch commit is in `master`'s ancestry, and the back-merge falls back to the last common
@@ -256,9 +270,9 @@ whether an epic is genuinely closed, whether an artifact diff that is not only `
 acceptable, and whether the known-limits section is honest. A release button that skipped them would
 be recording a decision nobody made.
 
-What *is* automated is everything mechanical: the byte comparisons, the trust-zone check, the
-governed-source lints, the no-heap scans and the pixel tests all run on every pull request, including
-the release one.
+What *is* automated is everything mechanical: branch containment, the byte comparisons, the
+trust-zone check, the governed-source lints, the no-heap scans and the pixel tests all run on every
+mergeable pull request, including the release one.
 
 ## Two things in this history that will confuse you
 


### PR DESCRIPTION
## Summary

Add a `Branch Topology` workflow that detects master/develop drift, reruns when a PR is retargeted, and rejects non-release PRs targeting `master`. Update repository and release guidance for the release-only master policy and the green-when-unmergeable trap.

Closes #284

## Invitation and contributor agreement

- [x] This change was requested directly by the repository maintainer in issue #284.
- [ ] Independent contributor CLA acceptance is not applicable to this maintainer-directed agent change.

Invitation / CLA issue: #284

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [x] None of the listed shared registries

## Rebase state

- **Rebased onto:** `develop` at `180fc01625c07db37e537fdbd24b2e81649e687b`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [x] Branch policy shell logic: aligned ordinary PR and `release/v1.2.3` pass; ordinary master PR and simulated master-only drift fail.
- [x] Workflow YAML parses locally and `Branch Topology` passes in GitHub Actions.
- [x] `mdux-docs-lint`: 83 files, 0 findings.
- [x] `mdux-named-mechanisms`: 79 documents/workflows, 0 findings.
- [x] AI-reference indexes and schema-drift checks pass.
- [ ] Full docs-lint unit discovery: one unrelated local failure because ignored `examples/build/CMakeFiles/.../CMakeCXXCompilerId.cpp` is scanned as source; the pre-existing build tree was preserved.
- [ ] C++ build not run locally: no product code, module, generated artifact, or rendering path changes. PR CI covers all build legs.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the master protection is changed.
- **Post-merge `develop` run:** pending merge
- [ ] That run is green.

## Regulatory impact

Potentially safety-relevant: this changes release-control auditability and CI enforcement, but no governed runtime behavior, compliance metadata, generated evidence, or product API. `docs/release-process.md` is updated proportionately; no ADR, risk record, or SDF content changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated branch-topology checks to enforce release branch rules and branch containment.
  * Added validation requiring pull requests targeting `master` to originate from same-repository `release/vX.Y.Z` branches.

* **Documentation**
  * Updated branch naming and release process guidance to reflect `master` as the default branch.
  * Documented release branch restrictions, topology checks, and handling of missing checks on unmergeable pull requests.
  * Clarified pull request template guidance for permitted base branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->