### PR TITLE
Document required master checks [#284]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,10 +299,9 @@ own branch, and adding work branches there would run every workflow twice per co
 
 **An unmergeable PR does not run GitHub's `pull_request` workflows.** It can therefore show a green
 review-bot check while every build, test and lint check is absent. Treat missing checks as missing
-evidence, never as a pass. Branch protection on `master` requires `Branch Topology` and the
-repository's build, test, lint, documentation, compliance and security gates, so an absent check
-remains pending and blocks the merge. Resolve the conflict and wait for every required workflow to
-report success.
+evidence, never as a pass. Branch protection on `master` requires status checks, so an absent
+required check remains pending and blocks the merge. Resolve the conflict and wait for every
+required check to report success.
 
 ### Stacked delivery
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,10 +299,10 @@ own branch, and adding work branches there would run every workflow twice per co
 
 **An unmergeable PR does not run GitHub's `pull_request` workflows.** It can therefore show a green
 review-bot check while every build, test and lint check is absent. Treat missing checks as missing
-evidence, never as a pass — and note that nothing yet stops you acting otherwise: `master` currently
-configures no required status checks, so GitHub offers an unblocked merge button on a PR whose
-workflows never ran. Until that protection exists, confirming every expected check is present and
-green is a manual step, on you.
+evidence, never as a pass. Branch protection on `master` requires `Branch Topology` and the
+repository's build, test, lint, documentation, compliance and security gates, so an absent check
+remains pending and blocks the merge. Resolve the conflict and wait for every required workflow to
+report success.
 
 ### Stacked delivery
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -188,9 +188,9 @@ $ gh release create vX.Y.Z --verify-tag --title "vX.Y.Z — Wave N: <what it is>
 **A green check is not evidence that the CI ran.** GitHub does not run `pull_request` workflows
 when it cannot construct a merge commit, so an unmergeable release PR can display a passing review
 bot while every build, test and lint check is absent. Do not merge or tag from that state. Every
-check `master` expects must be present and green before you merge, and verifying that is manual
-today: the repository configures no required status checks, so nothing holds an absent check
-pending and nothing blocks the merge. Resolve the conflict and wait for the workflows to run.
+check `master` expects must be present and green before you merge. Branch protection keeps an
+absent required check pending and blocks the merge. Resolve the conflict and wait for every
+required workflow to report success.
 
 Four things this spells out because cutting v0.6.0 found each of them the hard way.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -190,7 +190,10 @@ when it cannot construct a merge commit, so an unmergeable release PR can displa
 bot while every build, test and lint check is absent. Do not merge or tag from that state. Every
 status check required by `master` must be present and successful before you merge. Branch
 protection keeps an absent required check pending and blocks the merge. Resolve the conflict and
-wait for every required check to report success.
+wait for every required check to report success. That protection is also `strict`, so a release
+branch behind `master` must absorb it before the merge button unblocks — normally moot, because a
+release branch descends from `develop` and `develop` back-merged `master` at step 9, but not on a
+hotfix or a second release opened while one is still in flight.
 
 Four things this spells out because cutting v0.6.0 found each of them the hard way.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -188,9 +188,9 @@ $ gh release create vX.Y.Z --verify-tag --title "vX.Y.Z — Wave N: <what it is>
 **A green check is not evidence that the CI ran.** GitHub does not run `pull_request` workflows
 when it cannot construct a merge commit, so an unmergeable release PR can display a passing review
 bot while every build, test and lint check is absent. Do not merge or tag from that state. Every
-check `master` expects must be present and green before you merge. Branch protection keeps an
-absent required check pending and blocks the merge. Resolve the conflict and wait for every
-required workflow to report success.
+status check required by `master` must be present and successful before you merge. Branch
+protection keeps an absent required check pending and blocks the merge. Resolve the conflict and
+wait for every required check to report success.
 
 Four things this spells out because cutting v0.6.0 found each of them the hard way.
 


### PR DESCRIPTION
## Summary

Synchronize the release documentation with the `master` branch protection enabled after #285 merged. Missing required checks are now described as pending and merge-blocking instead of as a manual-only safeguard.

Follow-up to #284.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #284

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [x] None of the above

## Rebase state

- **Rebased onto:** `0475ae78ea99540e7acbda0f94a0ae76c2170fe4`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run; documentation-only change
- [ ] `ctest --test-dir build-gcc` — not run; documentation-only change
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 83 files checked, 0 findings
- [x] Other: `python3 tools/docs-lint/check_named_mechanisms.py` — 79 documents/workflows checked; `git diff --check` passed

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green.

## Regulatory impact

Release-control and auditability documentation is synchronized with the enforced GitHub branch protection. This changes no runtime behavior, governed API, compliance metadata, generated evidence, or claim of conformity with a medical-device standard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified branch protection requirements for the `master` branch.
  - Documented that every required status check must be present and successful before merging.
  - Noted that unavailable required checks remain pending and block merges until resolved.
  - Updated release guidance to require release branches to incorporate changes from `master` before merging, with exceptions for hotfixes and concurrent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->