### PR TITLE
Run the topology check from a trusted definition [#284]

### DIFF
--- a/.github/workflows/branch-topology.yml
+++ b/.github/workflows/branch-topology.yml
@@ -5,10 +5,16 @@ on:
     # A push to master is what creates drift, so observe it directly rather than waiting for the
     # cron: a release merged at 06:00 would otherwise go unverified until the next morning.
     branches: [ master, develop ]
-  pull_request:
-    # A pull request gets only the release-branch-only rule below; the drift leg belongs to `push`
-    # and `schedule`, because it measures branch tips no pull request can move. The filter stays
-    # wide so ordinary and stacked PRs still report a check. `edited` covers base retargeting.
+  pull_request_target:
+    # `pull_request_target`, not `pull_request`, because this workflow polices the pull request it
+    # runs on. On `pull_request` GitHub evaluates the definition from the merge commit — the head
+    # branch's copy — so a PR targeting master could edit this file in its own diff and delete the
+    # rule below. `pull_request_target` loads the definition from the base branch, which the author
+    # cannot reach without first merging. Two consequences worth knowing: the job never checks out
+    # or runs any pull request's code (it reads only the branch tips and the event metadata, and
+    # `permissions` stays read-only), which is what makes the trigger safe here; and a change to
+    # this file takes effect only once it is on the base branch, so a PR editing it is still
+    # checked by the previous version.
     branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
     types: [ opened, synchronize, reopened, edited ]
   schedule:
@@ -27,6 +33,9 @@ jobs:
 
     steps:
     - name: Checkout repository history
+      # No `ref:`, deliberately. Under `pull_request_target` the default is the base branch, and
+      # pointing it at the pull request's head would check out author-controlled content into a
+      # trusted context — the hazard that makes this trigger worth warning about.
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
@@ -49,10 +58,10 @@ jobs:
         failed=0
 
         # Drift belongs to the branch tips, not to any one pull request: the counts below are the
-        # same whatever a PR contains. Measured on `pull_request`, this leg would redden every open
+        # same whatever a PR contains. Measured on a pull request, this leg would redden every open
         # PR for the window between a release merge and the back-merge of step 9 — demanding of
         # each contributor an admin push to develop that none of them can make.
-        if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+        if [[ "${EVENT_NAME}" != pull_request* ]]; then
           # Capture the counts before splitting them. `read x y <<< "$(cmd)"` takes its exit status
           # from `read`, never from the substitution, so a `git rev-list` that fails — an unfetched
           # ref, a renamed branch — would leave both variables empty, and `(( master_only != 0 ))`
@@ -72,7 +81,10 @@ jobs:
           fi
         fi
 
-        if [[ "${EVENT_NAME}" == "pull_request" && "${BASE_REF}" == "master" ]]; then
+        # Matches `pull_request_target` and `pull_request` alike: only the former is configured
+        # above, but an exact test for one event name is how this rule silently stops running if
+        # the trigger is ever changed back.
+        if [[ "${EVENT_NAME}" == pull_request* && "${BASE_REF}" == "master" ]]; then
           if [[ "${HEAD_REPOSITORY}" != "${GITHUB_REPOSITORY}" || \
                 ! "${HEAD_REF}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::master accepts only same-repository release/vX.Y.Z pull requests; target develop for ordinary work"

--- a/.github/workflows/branch-topology.yml
+++ b/.github/workflows/branch-topology.yml
@@ -5,16 +5,24 @@ on:
     # A push to master is what creates drift, so observe it directly rather than waiting for the
     # cron: a release merged at 06:00 would otherwise go unverified until the next morning.
     branches: [ master, develop ]
+  pull_request:
+    # Stage one of two, and this block goes away in stage two. Dropping it in the same change that
+    # adds `pull_request_target` would leave this workflow with no live event on its own pull
+    # request: GitHub decides whether to run a `pull_request_target` workflow from the definition
+    # on the default branch, which does not declare that trigger until this merges. Removing it
+    # later is itself checked by the trusted definition, which is the point of staging.
+    branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
+    types: [ opened, synchronize, reopened, edited ]
   pull_request_target:
-    # `pull_request_target`, not `pull_request`, because this workflow polices the pull request it
-    # runs on. On `pull_request` GitHub evaluates the definition from the merge commit — the head
-    # branch's copy — so a PR targeting master could edit this file in its own diff and delete the
-    # rule below. `pull_request_target` loads the definition from the base branch, which the author
-    # cannot reach without first merging. Two consequences worth knowing: the job never checks out
-    # or runs any pull request's code (it reads only the branch tips and the event metadata, and
-    # `permissions` stays read-only), which is what makes the trigger safe here; and a change to
-    # this file takes effect only once it is on the base branch, so a PR editing it is still
-    # checked by the previous version.
+    # `pull_request_target`, not `pull_request` alone, because this workflow polices the pull
+    # request it runs on. On `pull_request` GitHub evaluates the definition from the merge commit —
+    # the head branch's copy — so a PR targeting master could edit this file in its own diff and
+    # delete the rule below. `pull_request_target` is evaluated from the repository's *default*
+    # branch (`develop`), not from the pull request's base: a release PR to master and a stacked PR
+    # to an issue branch are both checked by develop's copy, which no contributor reaches without
+    # merging there first. The trigger is privileged, so the job never checks out or runs any pull
+    # request's code — it reads the branch tips it fetches by name plus the event metadata, and
+    # `permissions` stays read-only.
     branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
     types: [ opened, synchronize, reopened, edited ]
   schedule:
@@ -33,9 +41,11 @@ jobs:
 
     steps:
     - name: Checkout repository history
-      # No `ref:`, deliberately. Under `pull_request_target` the default is the base branch, and
-      # pointing it at the pull request's head would check out author-controlled content into a
-      # trusted context — the hazard that makes this trigger worth warning about.
+      # No `ref:`, deliberately. Under `pull_request_target` the default is the repository's
+      # default branch, and pointing it at the pull request's head would check out
+      # author-controlled content into a privileged context — the hazard that makes this trigger
+      # worth warning about. Whichever ref lands here, the step below fetches master and develop
+      # by name, so the comparison never depends on what was checked out.
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,7 +276,7 @@ issue number, a dash, then the slugified issue title.
 14-text-schema
 ```
 
-This is not cosmetic. Every workflow filters `pull_request` on the pattern `[0-9]+-*`, and
+This is not cosmetic. Every workflow filters pull requests on the pattern `[0-9]+-*`, and
 **those filters match a pull request's base branch, not its head**. A PR whose base matches no
 listed pattern reports no checks at all — not failures, *nothing* — which is the failure mode
 easiest to miss on review. So:
@@ -292,7 +292,15 @@ easiest to miss on review. So:
   convention and is kept only for branches already in flight.
 - A branch named anything else (`fix-typo`, `wip`, `my-feature`) gets **no CI on a PR based on
   it**. If you need one, add its pattern to the `branches:` list of every workflow under
-  `.github/workflows/` that has a `pull_request:` trigger.
+  `.github/workflows/` that has a `pull_request:` or `pull_request_target:` trigger.
+
+`branch-topology.yml` is the one workflow on `pull_request_target` rather than `pull_request`,
+because it is the one that polices the pull request it runs on: `pull_request` would evaluate the
+head branch's copy of the definition, so a PR targeting `master` could delete the rule in the same
+diff the rule exists to reject. The practical consequence when editing that file is that **your
+change is checked by the base branch's version, not yours** — the new definition only takes effect
+once merged. The job never checks out or executes a pull request's code, which is what keeps that
+trigger safe; do not add a `ref:` to its checkout.
 
 `push:` triggers stay limited to `master` and `develop` deliberately: an open PR already covers its
 own branch, and adding work branches there would run every workflow twice per commit.
@@ -302,6 +310,12 @@ review-bot check while every build, test and lint check is absent. Treat missing
 evidence, never as a pass. Branch protection on `master` requires status checks, so an absent
 required check remains pending and blocks the merge. Resolve the conflict and wait for every
 required check to report success.
+
+`Branch Topology` is not evidence either, and for the opposite reason: `pull_request_target` needs
+no merge commit, so it runs and passes on an unmergeable PR exactly as it does on a healthy one. It
+is also required on `master`, which makes it the one required check that can report green while the
+other eleven sit pending — the most visible reassurance on precisely the PR that has earned none. It
+says the base branch is legitimate, and nothing whatever about whether the build ran.
 
 ### Stacked delivery
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,7 +276,8 @@ issue number, a dash, then the slugified issue title.
 14-text-schema
 ```
 
-This is not cosmetic. Every workflow filters pull requests on the pattern `[0-9]+-*`, and
+This is not cosmetic. Every workflow that runs on pull requests filters them on the pattern
+`[0-9]+-*` — Scorecard is the one exception, triggering only on pushes and a schedule — and
 **those filters match a pull request's base branch, not its head**. A PR whose base matches no
 listed pattern reports no checks at all — not failures, *nothing* — which is the failure mode
 easiest to miss on review. So:
@@ -294,13 +295,17 @@ easiest to miss on review. So:
   it**. If you need one, add its pattern to the `branches:` list of every workflow under
   `.github/workflows/` that has a `pull_request:` or `pull_request_target:` trigger.
 
-`branch-topology.yml` is the one workflow on `pull_request_target` rather than `pull_request`,
-because it is the one that polices the pull request it runs on: `pull_request` would evaluate the
-head branch's copy of the definition, so a PR targeting `master` could delete the rule in the same
-diff the rule exists to reject. The practical consequence when editing that file is that **your
-change is checked by the base branch's version, not yours** — the new definition only takes effect
-once merged. The job never checks out or executes a pull request's code, which is what keeps that
-trigger safe; do not add a `ref:` to its checkout.
+`branch-topology.yml` is the one workflow on `pull_request_target`, because it is the one that
+polices the pull request it runs on: `pull_request` evaluates the head branch's copy of the
+definition, so a PR targeting `master` could delete the rule in the same diff the rule exists to
+reject. `pull_request_target` is evaluated from the repository's **default branch** — `develop`
+here — and not from the pull request's base, so a release PR to `master` and a stacked PR to an
+issue branch are both checked by `develop`'s copy rather than by a branch their author controls.
+Two things follow. **An edit to that file is checked by `develop`'s version, not yours**, and takes
+effect only once merged — which is why the trigger is being introduced in two stages, `pull_request`
+retained alongside it until the trusted definition is on `develop`. And the job must never check out
+or execute a pull request's code, since a privileged trigger is only as safe as that restraint: do
+not add a `ref:` to its checkout.
 
 `push:` triggers stay limited to `master` and `develop` deliberately: an open PR already covers its
 own branch, and adding work branches there would run every workflow twice per commit.


### PR DESCRIPTION
## Summary

`branch-topology.yml` polices the pull request it runs on, and on `pull_request` GitHub evaluates
the workflow from the merge commit — the head branch's copy. A pull request targeting `master`
could therefore delete the release-branch rule in the same diff that rule exists to reject: the
guard was enforced by a file the author being guarded controls. `pull_request_target` loads the
definition from the base branch instead, out of the author's reach until merged.

The event guards now match `pull_request*` rather than one exact name. Under `pull_request_target`
an exact `pull_request` test would skip the `master` rule silently, which is the failure the
trigger swap invites.

The trigger is safe here only because the job reads branch tips and event metadata and never checks
out or executes a pull request's code, so the checkout keeps its default base-branch ref. AGENTS.md
records that constraint, the resulting rule that edits to this workflow are checked by the previous
version, and that a green `Branch Topology` proves nothing about the build — it needs no merge
commit, so it is the one required check that reports green while the other eleven sit pending on an
unmergeable release PR.

Required status checks on `master` do not close this on their own: a pull request that keeps the
job name and empties the script reports present and green.

Raised by CodeRabbit on #285 (CWE-829, unresolved at merge). Follow-up to #284.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #284

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [x] None of the above

## Rebase state

- **Rebased onto:** `9d53e3a42c04f42b65ec5dcb87c31eabed965910`
- **Conflicts resolved as a union:** no conflicts. The rebase over #286 applied cleanly because the
  AGENTS.md change is an append; #286's rewritten paragraph was verified intact afterwards rather
  than assumed from the clean exit.

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run; workflow and documentation only
- [ ] `ctest --test-dir build-gcc` — not run; workflow and documentation only
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 83 files checked, 0 findings
- [x] Other: `check_named_mechanisms.py` — 79 documents/workflows; `git diff --check` clean; workflow
      parses under `yaml.safe_load`

The policy script was extracted from the parsed workflow and run locally against this repository for
every event path, since the trusted trigger cannot be exercised by the pull request that introduces
it — the check reported here runs `develop`'s current definition, not this diff's:

| event | base | head | result |
| --- | --- | --- | --- |
| `push` / `schedule` | — | — | exit 0, drift `0 3` |
| `pull_request_target` | `master` | own `release/v1.2.3` | exit 0 |
| `pull_request_target` | `master` | own `284-foo` | exit 1, rejected |
| `pull_request_target` | `master` | fork `release/v1.2.3` | exit 1, rejected |
| `pull_request_target` | `develop` | own `284-foo` | exit 0 |
| `pull_request` (legacy name) | `master` | own `284-foo` | exit 1, still caught |

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green.

## Regulatory impact

None to runtime behaviour, governed API, compliance metadata, generated evidence, or any claim of
conformity. It does harden a release control: the rule restricting `master` to same-repository
`release/vX.Y.Z` branches can no longer be removed by the pull request it applies to. The ISO 13485
and IEC 62304 documents that cite branch protection as an enforcing mechanism are unchanged and
remain accurate.
