### PR TITLE
Remove the untrusted topology trigger [#284]

### DIFF
--- a/.github/workflows/branch-topology.yml
+++ b/.github/workflows/branch-topology.yml
@@ -5,24 +5,18 @@ on:
     # A push to master is what creates drift, so observe it directly rather than waiting for the
     # cron: a release merged at 06:00 would otherwise go unverified until the next morning.
     branches: [ master, develop ]
-  pull_request:
-    # Stage one of two, and this block goes away in stage two. Dropping it in the same change that
-    # adds `pull_request_target` would leave this workflow with no live event on its own pull
-    # request: GitHub decides whether to run a `pull_request_target` workflow from the definition
-    # on the default branch, which does not declare that trigger until this merges. Removing it
-    # later is itself checked by the trusted definition, which is the point of staging.
-    branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
-    types: [ opened, synchronize, reopened, edited ]
   pull_request_target:
-    # `pull_request_target`, not `pull_request` alone, because this workflow polices the pull
-    # request it runs on. On `pull_request` GitHub evaluates the definition from the merge commit —
-    # the head branch's copy — so a PR targeting master could edit this file in its own diff and
-    # delete the rule below. `pull_request_target` is evaluated from the repository's *default*
-    # branch (`develop`), not from the pull request's base: a release PR to master and a stacked PR
-    # to an issue branch are both checked by develop's copy, which no contributor reaches without
-    # merging there first. The trigger is privileged, so the job never checks out or runs any pull
-    # request's code — it reads the branch tips it fetches by name plus the event metadata, and
-    # `permissions` stays read-only.
+    # `pull_request_target`, and deliberately not `pull_request`, because this workflow polices the
+    # pull request it runs on. On `pull_request` GitHub evaluates the definition from the merge
+    # commit — the head branch's copy — so a PR targeting master could edit this file in its own
+    # diff and delete the rule below. `pull_request_target` is evaluated from the repository's
+    # *default* branch (`develop`), not from the pull request's base: a release PR to master and a
+    # stacked PR to an issue branch are both checked by develop's copy, which no contributor
+    # reaches without merging there first. The trigger is privileged, so the job never checks out
+    # or runs any pull request's code — it reads the branch tips it fetches by name plus the event
+    # metadata, and `permissions` stays read-only. Do not add `pull_request` back: running both was
+    # the transition that got this trigger onto develop where it could be trusted, not a
+    # belt-and-braces pairing.
     branches: [ master, develop, '[0-9]+-*', 'feat/**' ]
     types: [ opened, synchronize, reopened, edited ]
   schedule:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,10 +302,10 @@ reject. `pull_request_target` is evaluated from the repository's **default branc
 here — and not from the pull request's base, so a release PR to `master` and a stacked PR to an
 issue branch are both checked by `develop`'s copy rather than by a branch their author controls.
 Two things follow. **An edit to that file is checked by `develop`'s version, not yours**, and takes
-effect only once merged — which is why the trigger is being introduced in two stages, `pull_request`
-retained alongside it until the trusted definition is on `develop`. And the job must never check out
-or execute a pull request's code, since a privileged trigger is only as safe as that restraint: do
-not add a `ref:` to its checkout.
+effect only once merged — which is why the trigger arrived in two stages, `pull_request` retained
+alongside it until the trusted definition was on `develop` and could check its own removal. And the
+job must never check out or execute a pull request's code, since a privileged trigger is only as
+safe as that restraint: do not add a `ref:` to its checkout.
 
 `push:` triggers stay limited to `master` and `develop` deliberately: an open PR already covers its
 own branch, and adding work branches there would run every workflow twice per commit.


### PR DESCRIPTION
## Summary

Stage two of the two-stage migration merged as #287, which retained `pull_request` alongside
`pull_request_target` because a `pull_request_target` workflow is evaluated from the definition on
the repository's default branch — and `develop` did not declare that trigger yet, so removing
`pull_request` in the same change would have left the workflow with no live event on its own pull
request. `develop` declares it now, so this removal is evaluated from the trusted definition rather
than from its own head revision. That is the property staging existed to obtain, and this PR is the
first change to the file to benefit from it.

Running both triggers was the transition, not a redundancy. While both are declared on the default
branch, a pull request whose head still carries `pull_request` fires the workflow twice under one
check-run name, which matters now that the name is a required status check on `master`. That window
opened when #287 merged and closes here. The trigger comment records the point, so that the pairing
is not restored later as an apparent safety measure.

Follow-up to #284, completing #287.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #284

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** #287 (merged)
- **Merge order:** mergeable now

## Shared registries touched

- [x] None of the above

## Rebase state

- **Rebased onto:** `7411d64384947a19efbdb15e70f5b8e7d5c79267`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run; workflow and documentation only
- [ ] `ctest --test-dir build-gcc` — not run; workflow and documentation only
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 83 files checked, 0 findings
- [x] Other: `check_named_mechanisms.py` — 79 documents/workflows; `git diff --check` clean; workflow
      parses under `yaml.safe_load` with triggers `pull_request_target`, `push`, `schedule`,
      `workflow_dispatch`

Policy script extracted from the parsed workflow and run against this repository for every
surviving event path:

| event | base | head | result |
| --- | --- | --- | --- |
| `push` / `schedule` | — | — | exit 0, drift `0 4` |
| `pull_request_target` | `master` | own `release/v1.2.3` | exit 0 |
| `pull_request_target` | `master` | own `284-foo` | exit 1, rejected |
| `pull_request_target` | `master` | fork `release/v1.2.3` | exit 1, rejected |
| `pull_request_target` | `develop` | own `284-foo` | exit 0 |

Unlike #287, the check reported on this pull request is live evidence rather than a local
substitute. Confirmed through the API rather than by name: #287's head produced one `Branch
Topology` run and its event was `pull_request`, since `develop` did not yet declare the trusted
trigger — which is precisely the gap review identified. This PR's head produces one run whose event
is `pull_request_target`, so the rule that governs it now comes from `develop`, not from the diff
under review.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green.

## Regulatory impact

None to runtime behaviour, governed API, compliance metadata, generated evidence, or any claim of
conformity. It completes a release-control hardening: the rule restricting `master` to
same-repository `release/vX.Y.Z` branches is now evaluated only from a definition on `develop`,
which no pull request author can alter without merging there first.
