### PR TITLE
Make ccache BMI-aware for Clang modules [#280]

### DIFF
--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -108,6 +108,7 @@ jobs:
         sudo apt-get install -y \
           ninja-build \
           build-essential \
+          ccache \
           clang-21 \
           libc++-21-dev \
           libc++abi-21-dev \
@@ -137,6 +138,11 @@ jobs:
         major="$("$clangxx" --version | sed -n 's/.*clang version \([0-9]*\).*/\1/p' | head -1)"
         if [ "$major" != "21" ]; then
           echo "::error::${clangxx} reports major version ${major}, expected 21."
+          exit 1
+        fi
+        ccache_version="$(ccache --version | sed -n 's/^ccache version \([0-9][0-9.]*\).*/\1/p' | head -1)"
+        if ! dpkg --compare-versions "$ccache_version" ge 4.8; then
+          echo "::error::ccache ${ccache_version:-unknown} cannot accept per-compilation BMI inputs; 4.8+ is required."
           exit 1
         fi
 
@@ -181,6 +187,14 @@ jobs:
         export DISPLAY=:99
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         ctest --preset ninja-clang --output-on-failure
+
+    # #280's negative case changes an exported struct without touching its consumer, then proves
+    # that the new BMI invalidates the cached object. The second rebuild also has to be a cache hit:
+    # bypassing every module consumer would be correct but would throw away the compile-time benefit
+    # this launcher exists to preserve. Kept as a named step with --no-tests=error so losing the
+    # registration cannot masquerade as a green run.
+    - name: Verify ccache invalidates named-module consumers
+      run: ctest --preset ninja-clang -R '^build\.cache\.namedModuleIntegrity$' -V --no-tests=error
 
     # The step this workflow's header used to describe as future work. It matches the MSVC and GCC
     # legs in windows-build.yml / linux-gcc16-build.yml: re-derive every committed artifact and

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -1,29 +1,82 @@
-option(ENABLE_CACHE "Enable cache if available" ON)
-if(NOT ENABLE_CACHE)
-  return()
-endif()
-
+option(ENABLE_CACHE "Enable a compiler cache if available" ON)
 set(CACHE_OPTION
     "ccache"
     CACHE STRING "Compiler cache to be used")
+set(CACHE_BINARY "" CACHE FILEPATH
+    "Compiler cache executable override; empty searches for CACHE_OPTION")
 set(CACHE_OPTION_VALUES "ccache" "sccache")
 set_property(CACHE CACHE_OPTION PROPERTY STRINGS ${CACHE_OPTION_VALUES})
-list(
-  FIND
-  CACHE_OPTION_VALUES
-  ${CACHE_OPTION}
-  CACHE_OPTION_INDEX)
+list(FIND CACHE_OPTION_VALUES "${CACHE_OPTION}" CACHE_OPTION_INDEX)
 
-if(${CACHE_OPTION_INDEX} EQUAL -1)
-  message(
-    STATUS
-      "Using custom compiler cache system: '${CACHE_OPTION}', explicitly supported entries are ${CACHE_OPTION_VALUES}")
+# These cache entries are the explicit contract consumed by tests/CMakeLists.txt. Reset them on
+# every configure so normal early-return paths cannot leave stale capability state behind.
+set(MDUX_CACHE_BINARY "" CACHE INTERNAL "Resolved compiler cache executable" FORCE)
+set(MDUX_CACHE_KIND "disabled" CACHE INTERNAL "Resolved compiler cache kind" FORCE)
+set(MDUX_CACHE_CAN_HASH_BMIS OFF CACHE INTERNAL
+    "Whether the compiler cache accepts per-compilation BMI inputs" FORCE)
+
+if(NOT ENABLE_CACHE)
+    return()
 endif()
 
-find_program(CACHE_BINARY ${CACHE_OPTION})
+if(CACHE_OPTION_INDEX EQUAL -1)
+    message(STATUS
+        "Using custom compiler cache system: '${CACHE_OPTION}', explicitly supported entries are ${CACHE_OPTION_VALUES}")
+endif()
+
 if(CACHE_BINARY)
-  message(STATUS "${CACHE_OPTION} found and enabled")
-  set(CMAKE_CXX_COMPILER_LAUNCHER ${CACHE_BINARY})
+    set(mdux_resolved_cache_binary "${CACHE_BINARY}")
 else()
-  message(WARNING "${CACHE_OPTION} is enabled but was not found. Not using it")
+    find_program(mdux_resolved_cache_binary NAMES "${CACHE_OPTION}" NO_CACHE)
+endif()
+if(NOT mdux_resolved_cache_binary)
+    message(WARNING "${CACHE_OPTION} is enabled but was not found. Not using it")
+    return()
+endif()
+set(MDUX_CACHE_BINARY "${mdux_resolved_cache_binary}"
+    CACHE INTERNAL "Resolved compiler cache executable" FORCE)
+
+# Ccache still does not understand C++20 named-module dependency state. In particular, neither
+# depend_mode nor sloppiness=modules adds imported BMIs to an object's key. The launcher below
+# therefore compiles module providers directly and, on Clang, hashes every imported BMI before
+# caching a consumer. Other named-module command formats fail closed to a direct compilation;
+# ordinary translation units remain eligible for the selected cache.
+set(MDUX_CACHE_KIND "other" CACHE INTERNAL "Resolved compiler cache kind" FORCE)
+execute_process(
+    COMMAND "${MDUX_CACHE_BINARY}" --version
+    RESULT_VARIABLE mdux_cache_version_result
+    OUTPUT_VARIABLE mdux_cache_version_stdout
+    ERROR_VARIABLE mdux_cache_version_stderr
+)
+string(CONCAT mdux_cache_version_banner
+    "${mdux_cache_version_stdout}" "\n" "${mdux_cache_version_stderr}")
+if(mdux_cache_version_result EQUAL 0 AND
+   mdux_cache_version_banner MATCHES "(^|\n)ccache version ([0-9]+(\\.[0-9]+)+)")
+    set(MDUX_CACHE_KIND "ccache" CACHE INTERNAL "Resolved compiler cache kind" FORCE)
+    set(mdux_cache_version "${CMAKE_MATCH_2}")
+    # Per-compilation configuration, used for extra_files_to_hash, arrived in ccache 4.8.
+    if(mdux_cache_version VERSION_GREATER_EQUAL "4.8")
+        set(MDUX_CACHE_CAN_HASH_BMIS ON CACHE INTERNAL
+            "Whether the compiler cache accepts per-compilation BMI inputs" FORCE)
+    endif()
+endif()
+
+set(CMAKE_CXX_COMPILER_LAUNCHER
+    "${CMAKE_COMMAND}"
+    "-DMDUX_CACHE_BINARY=${MDUX_CACHE_BINARY}"
+    "-DMDUX_CACHE_KIND=${MDUX_CACHE_KIND}"
+    "-DMDUX_CACHE_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}"
+    "-DMDUX_CACHE_CAN_HASH_BMIS=${MDUX_CACHE_CAN_HASH_BMIS}"
+    -P "${CMAKE_CURRENT_LIST_DIR}/MduXCompilerCacheLauncher.cmake"
+    --
+)
+
+if(MDUX_CACHE_KIND STREQUAL "ccache" AND
+   CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+   MDUX_CACHE_CAN_HASH_BMIS)
+    message(STATUS
+        "ccache ${mdux_cache_version} found: module providers compile directly; Clang module consumers hash imported BMIs; other compilations remain cache-eligible")
+else()
+    message(STATUS
+        "${CACHE_OPTION} found: named-module compilations bypass the cache; other compilations remain cache-eligible")
 endif()

--- a/cmake/MduXCompilerCache.cmake
+++ b/cmake/MduXCompilerCache.cmake
@@ -1,0 +1,98 @@
+include_guard(GLOBAL)
+
+# Classify a Clang CMake module-map response file. Only a list composed entirely of imported BMI
+# arguments is cacheable. Provider output or any syntax this project does not understand fails
+# closed, because a missed cache opportunity is preferable to an object built against a stale BMI.
+function(mdux_analyze_clang_module_map content base_directory out_cacheable out_bmis)
+    string(STRIP "${content}" stripped_content)
+    if(stripped_content STREQUAL "")
+        set("${out_cacheable}" TRUE PARENT_SCOPE)
+        set("${out_bmis}" "" PARENT_SCOPE)
+        return()
+    endif()
+
+    separate_arguments(module_arguments NATIVE_COMMAND "${stripped_content}")
+    set(imported_bmis)
+    foreach(argument IN LISTS module_arguments)
+        if(NOT argument MATCHES "^-fmodule-file=(.+)$")
+            set("${out_cacheable}" FALSE PARENT_SCOPE)
+            set("${out_bmis}" "" PARENT_SCOPE)
+            return()
+        endif()
+
+        set(module_file "${CMAKE_MATCH_1}")
+        if(module_file MATCHES "^[^=]+=(.+)$")
+            set(module_file "${CMAKE_MATCH_1}")
+        endif()
+        if(NOT IS_ABSOLUTE "${module_file}")
+            get_filename_component(module_file
+                "${module_file}" ABSOLUTE BASE_DIR "${base_directory}")
+        endif()
+        cmake_path(NORMAL_PATH module_file)
+
+        if(NOT EXISTS "${module_file}" OR
+           (NOT WIN32 AND module_file MATCHES ":"))
+            set("${out_cacheable}" FALSE PARENT_SCOPE)
+            set("${out_bmis}" "" PARENT_SCOPE)
+            return()
+        endif()
+        list(APPEND imported_bmis "${module_file}")
+    endforeach()
+
+    if(NOT imported_bmis)
+        set("${out_cacheable}" FALSE PARENT_SCOPE)
+        set("${out_bmis}" "" PARENT_SCOPE)
+        return()
+    endif()
+
+    list(REMOVE_DUPLICATES imported_bmis)
+    set("${out_cacheable}" TRUE PARENT_SCOPE)
+    set("${out_bmis}" "${imported_bmis}" PARENT_SCOPE)
+endfunction()
+
+# Encode ccache's platform-specific path list. The launcher bracket-quotes the completed setting,
+# so a Windows semicolon remains inside one process argument rather than becoming a CMake list.
+function(mdux_join_ccache_extra_files paths use_windows_separator out_argument)
+    if(use_windows_separator)
+        set(path_separator ";")
+    else()
+        set(path_separator ":")
+    endif()
+    list(JOIN paths "${path_separator}" extra_files)
+    set("${out_argument}" "${extra_files}" PARENT_SCOPE)
+endfunction()
+
+# Append one exact process argument as a CMake bracket argument. The delimiter grows until its
+# closing token is absent from the value, preserving semicolons, quotes, newlines, and empty argv
+# entries when the resulting execute_process call is evaluated.
+function(mdux_append_bracket_argument code argument out_code)
+    set(equals)
+    while(TRUE)
+        set(terminator "]${equals}]")
+        string(FIND "${argument}" "${terminator}" terminator_index)
+        if(terminator_index EQUAL -1)
+            break()
+        endif()
+        string(APPEND equals "=")
+    endwhile()
+    string(APPEND code " [${equals}[${argument}]${equals}]")
+    set("${out_code}" "${code}" PARENT_SCOPE)
+endfunction()
+
+# Identify arguments that either produce module state or can hide/use module state the launcher
+# cannot safely add to a cache key. A recognized CMake .modmap is parsed separately by the caller.
+function(mdux_argument_requires_cache_bypass argument out_bypass)
+    set(requires_bypass OFF)
+    if(argument MATCHES "\\.(cppm|ixx|mpp)$" OR
+       argument MATCHES "^[-/].*[Mm][Oo][Dd][Uu][Ll][Ee]" OR
+       argument MATCHES "^-working-directory($|=)" OR
+       argument STREQUAL "--precompile" OR
+       argument MATCHES "^[-/]ifc(Output|Only)($|:)" OR
+       argument MATCHES "^[-/]interface$" OR
+       argument MATCHES "^[-/](reference|headerUnit)(:|$)")
+        set(requires_bypass ON)
+    elseif(argument MATCHES "^@" AND NOT argument MATCHES "^@(.+\\.modmap)$")
+        set(requires_bypass ON)
+    endif()
+    set("${out_bypass}" "${requires_bypass}" PARENT_SCOPE)
+endfunction()

--- a/cmake/MduXCompilerCacheLauncher.cmake
+++ b/cmake/MduXCompilerCacheLauncher.cmake
@@ -1,0 +1,103 @@
+include("${CMAKE_CURRENT_LIST_DIR}/MduXCompilerCache.cmake")
+
+foreach(required_variable
+        MDUX_CACHE_BINARY MDUX_CACHE_KIND MDUX_CACHE_COMPILER_ID MDUX_CACHE_CAN_HASH_BMIS)
+    if(NOT DEFINED ${required_variable})
+        message(FATAL_ERROR
+            "MduXCompilerCacheLauncher.cmake: ${required_variable} must be set")
+    endif()
+endforeach()
+
+set(separator_index -1)
+math(EXPR last_argument_index "${CMAKE_ARGC} - 1")
+foreach(index RANGE 0 ${last_argument_index})
+    if(CMAKE_ARGV${index} STREQUAL "--")
+        set(separator_index ${index})
+        break()
+    endif()
+endforeach()
+if(separator_index LESS 0)
+    message(FATAL_ERROR
+        "MduXCompilerCacheLauncher.cmake: missing -- before the compiler command")
+endif()
+
+math(EXPR command_start "${separator_index} + 1")
+if(command_start GREATER last_argument_index)
+    message(FATAL_ERROR
+        "MduXCompilerCacheLauncher.cmake: missing compiler command after --")
+endif()
+
+set(compiler_command_code)
+set(bypass_cache OFF)
+set(imported_bmis)
+foreach(index RANGE ${command_start} ${last_argument_index})
+    set(argument "${CMAKE_ARGV${index}}")
+    mdux_append_bracket_argument("${compiler_command_code}" "${argument}"
+        compiler_command_code)
+
+    mdux_argument_requires_cache_bypass("${argument}" argument_requires_bypass)
+    if(argument_requires_bypass)
+        set(bypass_cache ON)
+    endif()
+
+    if(argument MATCHES "^@(.+\\.modmap)$")
+        set(module_map_path "${CMAKE_MATCH_1}")
+        string(REGEX REPLACE "^\"|\"$" "" module_map_path "${module_map_path}")
+        if(NOT IS_ABSOLUTE "${module_map_path}")
+            get_filename_component(module_map_path
+                "${module_map_path}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+        endif()
+
+        if(NOT EXISTS "${module_map_path}")
+            set(bypass_cache ON)
+            continue()
+        endif()
+
+        file(READ "${module_map_path}" module_map_content)
+        string(STRIP "${module_map_content}" stripped_module_map)
+        if(stripped_module_map STREQUAL "")
+            continue()
+        endif()
+
+        if(MDUX_CACHE_KIND STREQUAL "ccache" AND
+           MDUX_CACHE_COMPILER_ID STREQUAL "Clang" AND
+           MDUX_CACHE_CAN_HASH_BMIS)
+            mdux_analyze_clang_module_map(
+                "${module_map_content}" "${CMAKE_CURRENT_BINARY_DIR}"
+                module_map_cacheable module_map_bmis)
+            if(module_map_cacheable)
+                list(APPEND imported_bmis ${module_map_bmis})
+            else()
+                set(bypass_cache ON)
+            endif()
+        else()
+            set(bypass_cache ON)
+        endif()
+    endif()
+endforeach()
+
+set(command_code "execute_process(COMMAND")
+if(bypass_cache)
+    string(APPEND command_code "${compiler_command_code}")
+else()
+    mdux_append_bracket_argument("${command_code}" "${MDUX_CACHE_BINARY}" command_code)
+    if(imported_bmis)
+        list(REMOVE_DUPLICATES imported_bmis)
+        # Ccache follows the host path-list separator. Bracket quoting preserves the Windows
+        # semicolon inside a single process argument.
+        mdux_join_ccache_extra_files(
+            "${imported_bmis}" "${WIN32}" imported_bmi_argument)
+        mdux_append_bracket_argument("${command_code}"
+            "extra_files_to_hash=${imported_bmi_argument}" command_code)
+    endif()
+    string(APPEND command_code "${compiler_command_code}")
+endif()
+
+string(APPEND command_code " RESULT_VARIABLE command_result)")
+cmake_language(EVAL CODE "${command_code}")
+if(command_result MATCHES "^[0-9]+$" AND command_result LESS_EQUAL 255)
+    cmake_language(EXIT ${command_result})
+else()
+    message(FATAL_ERROR
+        "MduX compiler-cache launcher could not execute the compiler: ${command_result}")
+endif()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,6 +104,29 @@ build and a plain `build/` one do not collide.
 | `MDUX_BUILD_TESTS` | `ON` |
 | `MDUX_BUILD_DOCS` | `OFF` |
 | `MDUX_ENABLE_REGULATORY_DOCS` | `ON` |
+| `ENABLE_CACHE` | `ON` |
+| `CACHE_OPTION` | `ccache` |
+| `CACHE_BINARY` | empty (search `PATH` for `CACHE_OPTION`) |
+
+### Compiler cache
+
+When `ccache` is available, MduX keeps it enabled without trusting it to understand C++20 named
+modules — [upstream still tracks that support as open](https://github.com/ccache/ccache/issues/1252).
+Module interfaces compile directly because a cache hit cannot restore their BMI output.
+On Clang, a module consumer remains cacheable, but the contents of every imported BMI are added to
+its cache key; changing an exported layout therefore invalidates the consumer even when its source
+is unchanged. Module command formats the launcher does not recognize bypass the cache rather than
+risk a stale object. Ordinary translation units remain eligible for the selected cache.
+
+This behavior requires ccache 4.8 or newer for cached Clang module consumers. An older ccache still
+works, but named-module compilations bypass it. `-DENABLE_CACHE=OFF` disables the launcher entirely;
+`-DCACHE_OPTION=<program>` selects another launcher, for which named-module compilations also bypass
+the cache until that program's BMI handling is qualified. `-DCACHE_BINARY=<path>` pins a particular
+cache executable, for example when bisecting a ccache version regression.
+
+`build.cache.namedModuleIntegrity` is the negative check behind this policy: it changes the layout
+of an exported struct without touching its consumer, asserts that the consumer observes the new
+layout, then forces a content-identical rebuild and asserts that it was a real ccache hit.
 
 ### Selecting suites
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,37 @@
 
 include(${CMAKE_SOURCE_DIR}/cmake/MduXTestDiscovery.cmake)
 
+# Issue #280: Ccache does not model C++20 named-module dependencies. The classifier test is always
+# present and pins the fail-closed response-file parser. The integration test needs real ccache and
+# Clang's explicit BMI paths; the Linux Clang workflow installs ccache so this negative layout-change
+# case is continuously exercised rather than left as a local-only reproduction.
+add_test(NAME build.cache.classifier
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -DBINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompilerCacheClassifierTest.cmake)
+set_tests_properties(build.cache.classifier PROPERTIES LABELS "build")
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+   MDUX_CACHE_KIND STREQUAL "ccache" AND
+   MDUX_CACHE_CAN_HASH_BMIS)
+    add_test(NAME build.cache.namedModuleIntegrity
+        COMMAND ${CMAKE_COMMAND}
+            -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+            -DBINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
+            -DCXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DGENERATOR=${CMAKE_GENERATOR}
+            -DCACHE_BINARY=${MDUX_CACHE_BINARY}
+            "-DCXX_FLAGS=${CMAKE_CXX_FLAGS}"
+            "-DEXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}"
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompilerCacheIntegrityTest.cmake)
+    set_tests_properties(build.cache.namedModuleIntegrity PROPERTIES LABELS "build" TIMEOUT 120)
+else()
+    message(STATUS
+        "build.cache.namedModuleIntegrity not registered: it requires Clang and ccache 4.8+; "
+        "build.cache.classifier still verifies fail-closed module-map handling")
+endif()
+
 # Governed-zone module tests. Deliberately links MduX::Core only, not MduX::MduX -
 # this is itself a check that the governed modules are usable without pulling in
 # Vulkan (see ADR-004).

--- a/tests/cmake/CompilerCacheClassifierTest.cmake
+++ b/tests/cmake/CompilerCacheClassifierTest.cmake
@@ -1,0 +1,142 @@
+foreach(required_variable SOURCE_DIR BINARY_DIR)
+    if(NOT DEFINED ${required_variable})
+        message(FATAL_ERROR
+            "CompilerCacheClassifierTest.cmake: ${required_variable} must be set")
+    endif()
+endforeach()
+
+include("${SOURCE_DIR}/cmake/MduXCompilerCache.cmake")
+
+set(fixture_directory "${BINARY_DIR}/compiler-cache-classifier")
+file(REMOVE_RECURSE "${fixture_directory}")
+file(MAKE_DIRECTORY "${fixture_directory}/bmis")
+file(WRITE "${fixture_directory}/bmis/first.pcm" "first-bmi")
+file(WRITE "${fixture_directory}/bmis/second.pcm" "second-bmi")
+
+mdux_analyze_clang_module_map(
+    "" "${fixture_directory}" empty_cacheable empty_bmis)
+if(NOT empty_cacheable OR empty_bmis)
+    message(FATAL_ERROR "An empty module map must remain cacheable without extra files")
+endif()
+
+mdux_analyze_clang_module_map(
+    "-fmodule-file=first=bmis/first.pcm\n-fmodule-file=bmis/second.pcm"
+    "${fixture_directory}" imports_cacheable imported_bmis)
+if(NOT imports_cacheable)
+    message(FATAL_ERROR "A complete Clang import map must be cacheable")
+endif()
+list(LENGTH imported_bmis imported_bmi_count)
+if(NOT imported_bmi_count EQUAL 2)
+    message(FATAL_ERROR
+        "Expected two imported BMIs, found ${imported_bmi_count}: ${imported_bmis}")
+endif()
+foreach(imported_bmi IN LISTS imported_bmis)
+    if(NOT IS_ABSOLUTE "${imported_bmi}" OR NOT EXISTS "${imported_bmi}")
+        message(FATAL_ERROR "Imported BMI was not resolved to an existing absolute path: ${imported_bmi}")
+    endif()
+endforeach()
+
+foreach(unsafe_map
+        "-x c++-module\n-fmodule-output=bmis/provider.pcm"
+        "-fmodule-file=missing=bmis/missing.pcm"
+        "-fmodule-file=first=bmis/first.pcm\n-unknown-module-option")
+    mdux_analyze_clang_module_map(
+        "${unsafe_map}" "${fixture_directory}" unsafe_cacheable unsafe_bmis)
+    if(unsafe_cacheable OR unsafe_bmis)
+        message(FATAL_ERROR
+            "An incomplete, provider, or unknown module map must bypass the cache: ${unsafe_map}")
+    endif()
+endforeach()
+
+set(extra_file_paths "C:/first.pcm" "D:/second.pcm")
+mdux_join_ccache_extra_files("${extra_file_paths}" FALSE unix_extra_files)
+if(NOT unix_extra_files STREQUAL "C:/first.pcm:D:/second.pcm")
+    message(FATAL_ERROR "Unexpected Unix ccache path list: ${unix_extra_files}")
+endif()
+
+mdux_join_ccache_extra_files("${extra_file_paths}" TRUE windows_extra_files)
+if(NOT windows_extra_files STREQUAL "C:/first.pcm;D:/second.pcm")
+    message(FATAL_ERROR "Unexpected Windows ccache path list: ${windows_extra_files}")
+endif()
+
+foreach(unsafe_argument
+        "Api.cppm"
+        "-fprebuilt-module-path=bmis"
+        "-fmodules-cache-path=cache"
+        "-fmodule-map-file=modules.map"
+        "-fno-module-lazy"
+        "/experimental:module"
+        "-working-directory=elsewhere"
+        "-working-directory"
+        "@compile.rsp"
+        "/reference:Api=Api.ifc")
+    mdux_argument_requires_cache_bypass("${unsafe_argument}" requires_bypass)
+    if(NOT requires_bypass)
+        message(FATAL_ERROR "Module-affecting argument did not require bypass: ${unsafe_argument}")
+    endif()
+endforeach()
+foreach(safe_argument "Consumer.cpp" "-Wall" "@Consumer.cpp.o.modmap")
+    mdux_argument_requires_cache_bypass("${safe_argument}" requires_bypass)
+    if(requires_bypass)
+        message(FATAL_ERROR "Cache-neutral argument unexpectedly required bypass: ${safe_argument}")
+    endif()
+endforeach()
+
+set(argument_probe "${fixture_directory}/ArgumentProbe.cmake")
+file(WRITE "${argument_probe}" [=[
+if(NOT CMAKE_ARGC EQUAL 7 OR
+   NOT CMAKE_ARGV3 STREQUAL "a;b" OR
+   NOT CMAKE_ARGV4 STREQUAL "" OR
+   NOT CMAKE_ARGV5 STREQUAL "extra_files_to_hash=C:/first.pcm;D:/second.pcm" OR
+   NOT CMAKE_ARGV6 STREQUAL "x]]y")
+    message(FATAL_ERROR
+        "Argument round-trip failed: argc=${CMAKE_ARGC}, '${CMAKE_ARGV3}', '${CMAKE_ARGV4}', "
+        "'${CMAKE_ARGV5}', '${CMAKE_ARGV6}'")
+endif()
+]=])
+set(argument_probe_code "execute_process(COMMAND")
+mdux_append_bracket_argument("${argument_probe_code}" "${CMAKE_COMMAND}" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}"
+    "-DMDUX_CACHE_BINARY=${CMAKE_COMMAND}" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "-DMDUX_CACHE_KIND=other"
+    argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "-DMDUX_CACHE_COMPILER_ID=Clang"
+    argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "-DMDUX_CACHE_CAN_HASH_BMIS=OFF"
+    argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "-P" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}"
+    "${SOURCE_DIR}/cmake/MduXCompilerCacheLauncher.cmake" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "--" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "-E" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "env" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "${CMAKE_COMMAND}" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "-P" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "${argument_probe}" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "a;b" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}"
+    "extra_files_to_hash=${windows_extra_files}" argument_probe_code)
+mdux_append_bracket_argument("${argument_probe_code}" "x]]y" argument_probe_code)
+string(APPEND argument_probe_code " RESULT_VARIABLE argument_probe_result)")
+cmake_language(EVAL CODE "${argument_probe_code}")
+if(NOT argument_probe_result EQUAL 0)
+    message(FATAL_ERROR "Exact launcher argument round-trip failed: ${argument_probe_result}")
+endif()
+
+set(exit_probe "${fixture_directory}/Exit130.cmake")
+file(WRITE "${exit_probe}" "cmake_language(EXIT 130)\n")
+execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+        "-DMDUX_CACHE_BINARY=${fixture_directory}/must-not-run"
+        -DMDUX_CACHE_KIND=ccache
+        -DMDUX_CACHE_COMPILER_ID=Clang
+        -DMDUX_CACHE_CAN_HASH_BMIS=ON
+        -P "${SOURCE_DIR}/cmake/MduXCompilerCacheLauncher.cmake"
+        -- "${CMAKE_COMMAND}" -P "${exit_probe}" Api.cppm
+    RESULT_VARIABLE exit_probe_result)
+if(NOT exit_probe_result EQUAL 130)
+    message(FATAL_ERROR "Launcher changed child exit code 130 to ${exit_probe_result}")
+endif()
+
+message(STATUS "Compiler cache classifier: OK")

--- a/tests/cmake/CompilerCacheIntegrityTest.cmake
+++ b/tests/cmake/CompilerCacheIntegrityTest.cmake
@@ -1,0 +1,156 @@
+foreach(required_variable
+        SOURCE_DIR BINARY_DIR CXX_COMPILER GENERATOR CACHE_BINARY CXX_FLAGS EXE_LINKER_FLAGS)
+    if(NOT DEFINED ${required_variable})
+        message(FATAL_ERROR
+            "CompilerCacheIntegrityTest.cmake: ${required_variable} must be set")
+    endif()
+endforeach()
+
+function(run_checked description)
+    execute_process(
+        COMMAND ${ARGN}
+        RESULT_VARIABLE command_result
+        OUTPUT_VARIABLE command_stdout
+        ERROR_VARIABLE command_stderr
+    )
+    if(NOT command_result EQUAL 0)
+        message(FATAL_ERROR
+            "${description} failed (${command_result}):\n${command_stdout}\n${command_stderr}")
+    endif()
+endfunction()
+
+function(assert_probe expected fixture_build)
+    execute_process(
+        COMMAND "${fixture_build}/probe"
+        RESULT_VARIABLE probe_result
+        OUTPUT_VARIABLE probe_output
+        ERROR_VARIABLE probe_error
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT probe_result EQUAL 0 OR NOT probe_output STREQUAL "${expected}")
+        message(FATAL_ERROR
+            "Probe reported '${probe_output}' with status ${probe_result}; expected '${expected}'.\n${probe_error}")
+    endif()
+endfunction()
+
+set(fixture_root "${BINARY_DIR}/compiler-cache-integrity")
+set(fixture_source "${fixture_root}/source")
+set(fixture_build "${fixture_root}/build")
+set(fixture_cache "${fixture_root}/cache")
+set(fixture_config "${fixture_root}/ccache.conf")
+file(REMOVE_RECURSE "${fixture_root}")
+file(MAKE_DIRECTORY "${fixture_source}" "${fixture_cache}")
+file(WRITE "${fixture_config}" "max_size = 32M\ndirect_mode = true\n")
+
+set(cache_module "${SOURCE_DIR}/cmake/Cache.cmake")
+string(CONFIGURE [=[
+cmake_minimum_required(VERSION 4.0)
+project(MduXCompilerCacheIntegrity LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_SCAN_FOR_MODULES ON)
+set(ENABLE_CACHE ON CACHE BOOL "" FORCE)
+set(CACHE_OPTION "ccache" CACHE STRING "" FORCE)
+set(CACHE_BINARY "@CACHE_BINARY@" CACHE FILEPATH "" FORCE)
+include("@cache_module@")
+
+add_library(fixture)
+target_sources(fixture
+    PUBLIC FILE_SET CXX_MODULES FILES Api.cppm
+    PRIVATE Consumer.cpp)
+add_executable(probe Main.cpp)
+target_link_libraries(probe PRIVATE fixture)
+]=] fixture_cmakelists @ONLY)
+file(WRITE "${fixture_source}/CMakeLists.txt" "${fixture_cmakelists}")
+file(WRITE "${fixture_source}/Api.cppm" [=[
+export module fixture.api;
+export struct Layout { int first; };
+]=])
+file(WRITE "${fixture_source}/Consumer.cpp" [=[
+import fixture.api;
+int compiledLayoutSize() { return sizeof(Layout); }
+]=])
+file(WRITE "${fixture_source}/Main.cpp" [=[
+#include <cstdio>
+int compiledLayoutSize();
+int main() { std::printf("%d\n", compiledLayoutSize()); }
+]=])
+
+set(cache_environment
+    "${CMAKE_COMMAND}" -E env
+    --unset=CCACHE_DISABLE
+    --unset=CCACHE_RECACHE
+    "CCACHE_DIR=${fixture_cache}"
+    "CCACHE_CONFIGPATH=${fixture_config}")
+
+run_checked("Fixture configure"
+    ${cache_environment} "${CMAKE_COMMAND}"
+    -S "${fixture_source}" -B "${fixture_build}" -G "${GENERATOR}"
+    "-DCMAKE_CXX_COMPILER=${CXX_COMPILER}"
+    "-DCMAKE_CXX_FLAGS=${CXX_FLAGS}"
+    "-DCMAKE_EXE_LINKER_FLAGS=${EXE_LINKER_FLAGS}")
+file(READ "${fixture_build}/CMakeCache.txt" fixture_cache_contents)
+foreach(expected_cache_entry
+        "CACHE_BINARY:FILEPATH=${CACHE_BINARY}"
+        "MDUX_CACHE_BINARY:INTERNAL=${CACHE_BINARY}"
+        "MDUX_CACHE_KIND:INTERNAL=ccache"
+        "MDUX_CACHE_CAN_HASH_BMIS:INTERNAL=ON")
+    string(FIND "${fixture_cache_contents}" "${expected_cache_entry}" cache_entry_index)
+    if(cache_entry_index EQUAL -1)
+        message(FATAL_ERROR
+            "Fixture cache does not contain the expected entry: ${expected_cache_entry}")
+    endif()
+endforeach()
+run_checked("Ccache statistics reset"
+    ${cache_environment} "${CACHE_BINARY}" --zero-stats)
+run_checked("Baseline module build"
+    ${cache_environment} "${CMAKE_COMMAND}" --build "${fixture_build}")
+assert_probe("4" "${fixture_build}")
+
+# This is the negative case from #280: only the provider changes. A cache key that omits the BMI
+# returns the old Consumer.cpp object and the probe still prints 4.
+file(WRITE "${fixture_source}/Api.cppm" [=[
+export module fixture.api;
+export struct Layout { int first; double second; };
+]=])
+run_checked("Build after exported layout change"
+    ${cache_environment} "${CMAKE_COMMAND}" --build "${fixture_build}")
+assert_probe("16" "${fixture_build}")
+
+# A content-identical rebuild must still hit the cache; correctness was not bought by disabling it
+# for consumers. Sleeping makes the timestamp change observable on filesystems with 1 s granularity.
+run_checked("Timestamp separation" "${CMAKE_COMMAND}" -E sleep 1)
+file(TOUCH "${fixture_source}/Consumer.cpp")
+run_checked("Content-identical consumer rebuild"
+    ${cache_environment} "${CMAKE_COMMAND}" --build "${fixture_build}")
+assert_probe("16" "${fixture_build}")
+
+execute_process(
+    COMMAND ${cache_environment} "${CACHE_BINARY}" --print-stats
+    RESULT_VARIABLE stats_result
+    OUTPUT_VARIABLE stats_output
+    ERROR_VARIABLE stats_error
+)
+if(NOT stats_result EQUAL 0)
+    message(FATAL_ERROR "Reading ccache statistics failed: ${stats_error}")
+endif()
+string(REGEX MATCH "direct_cache_hit[	 ]+([0-9]+)" unused "${stats_output}")
+set(direct_hits "${CMAKE_MATCH_1}")
+string(REGEX MATCH "preprocessed_cache_hit[	 ]+([0-9]+)" unused "${stats_output}")
+set(preprocessed_hits "${CMAKE_MATCH_1}")
+if(direct_hits STREQUAL "")
+    set(direct_hits 0)
+endif()
+if(preprocessed_hits STREQUAL "")
+    set(preprocessed_hits 0)
+endif()
+math(EXPR cache_hits "${direct_hits} + ${preprocessed_hits}")
+if(cache_hits LESS 1)
+    message(FATAL_ERROR
+        "The unchanged module consumer did not produce a ccache hit:\n${stats_output}")
+endif()
+
+message(STATUS
+    "Compiler cache integrity: layout change invalidated the consumer and an unchanged rebuild hit ccache")


### PR DESCRIPTION
## Summary

Keep compiler caching enabled while making it sound for MduX's C++20 named-module builds.

The compiler launcher now classifies module commands before invoking the selected cache:

- module providers compile directly because a cache hit cannot restore their BMI side output;
- Clang consumers using ccache 4.8+ remain cacheable, with every imported BMI supplied through
  ccache's per-compilation `extra_files_to_hash` setting;
- unknown module command formats, older ccache versions, and other cache programs fail closed to a
  direct compile, while ordinary translation units remain cache-eligible.

The new negative integration test changes an exported struct layout without touching its consumer
and verifies that the rebuilt executable observes the new layout. It then touches the unchanged
consumer and requires a real ccache hit, proving that correctness was not obtained by disabling
consumer caching. The Linux Clang workflow installs ccache 4.8+ and runs this test explicitly.

This follows ccache's still-open named-module limitation
(https://github.com/ccache/ccache/issues/1252) while retaining safe incremental-build acceleration.

Closes #280

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #280

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [x] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`
- [ ] None of the above

## Rebase state

- **Rebased onto:** `b0b0bbc39bc6df8ae6a81ccafcc13b2ffc321b11`
- **Conflicts resolved as a union:** no conflicts

## Verification

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — used an equivalent fresh out-of-tree
      GCC configuration under `/tmp/mdux-280-gcc`; configure and all 595 build steps passed
- [x] `ctest --test-dir /tmp/mdux-280-gcc --output-on-failure` — 676/676 passed
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 83 files checked, 0 findings
- [x] Other:
  - standalone Clang/ccache layout-change integrity test passed, including the required subsequent
    ccache hit;
  - Clang-configured `build.cache.classifier` and `build.cache.namedModuleIntegrity`: 2/2 passed;
  - GCC-configured `build.cache.classifier`: 1/1 passed;
  - `check_named_mechanisms.py`: 79 documents/workflows checked;
  - `git diff --check` clean;
  - `clang-build.yml` parses as YAML.

The repository's exact `ninja-clang` preset could not configure on this host because its required
`/usr/lib/llvm-21/lib/libc++.modules.json` manifest is absent. An alternate Clang 21/libstdc++
configuration exercised both cache tests successfully. Its wider `MduXCore` build reached step
74/76 before the existing 4096-byte stack-frame guard rejected `Compliance.cpp` under that
unsupported standard-library combination; the supported Clang/libc++ lane remains covered by CI.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green.

## Regulatory impact

None — this changes compiler-cache orchestration, tests, CI, and build documentation only. It does
not alter runtime behaviour, governed APIs, risk controls, compliance metadata, traceability,
generated evidence, or any claim about a medical-device standard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved compiler-cache support for C++20 named modules and imported module artifacts.
  * Added options to enable caching and select a custom cache executable.
  * Added validation for cache availability and ccache version compatibility.
  * Cache bypasses unsafe module-related compilations while continuing to cache eligible translation units.

* **Documentation**
  * Documented compiler-cache configuration, version requirements, and named-module behavior.

* **Tests**
  * Added coverage for cache classification, module integrity, and correct rebuilds after module changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->