### PR TITLE
Give an approved locale tag a grammar [#281]

### DIFF
--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -117,6 +117,14 @@ form without allocation, requires both digests to agree, and then requires an ex
 The binding retains that identity, and `render()` refuses it against a screen whose manifest does not
 contain the same record.
 
+`locale` is constrained to `[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*`, at most 35 characters — a closed
+subset of RFC 5646 rather than the whole of it, checked by `mdux::medui::isLocaleTag()` inside
+`ScreenPackage::validate()` and therefore inside every generated screen's `static_assert` (#281).
+The subset is deliberately smaller than BCP 47: full conformance is a registry and a parser, and the
+subset already covers every locale `mdux-textbake` can produce. Before it the manifest's only rule
+was non-empty, which admitted `en/US`, `(locale-free)` and a kilobyte of text into a field consumers
+had started deriving filenames and identifiers from.
+
 This amends the earlier consequence that adding a locale or changing a translation rewrote no screen
 artifact. It now rewrites `approvedTextPackages` and the screen's digest intentionally. The layout is
 still not duplicated and no glyph bytes move into the screen; the changed digest records that the

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -44,6 +44,12 @@
  * approval manifest, deliberately - otherwise a different, individually valid package could be
  * substituted after review while every local consistency check still passed.
  *
+ * The locale in that record is a *tag*, and `isLocaleTag()` below says what that means (#281).
+ * Until then the only rule was non-empty, so `en/US`, `(locale-free)` and a kilobyte of text were
+ * all legal approved locales - while consumers had begun deriving filenames and identifiers from
+ * the tag. Constraining it here rather than at each consumer makes it a compile error in the
+ * generated screen's own `static_assert`, which is the earliest place it can be one.
+ *
  * The cost, stated as a cost: one rectangle serves every locale, so it must be the one that
  * survives the widest approved translation. That is what #195 measures, and why the budget below
  * cannot be derived from the node count.
@@ -116,6 +122,7 @@ enum class SchemaError : std::uint8_t {
     EmptyBudget,                  ///< a screen with nodes whose budget can hold no primitive
     BudgetExceedsIndexWidth,      ///< more vertices than a 16-bit index can address
     EmptyApprovedLocale,          ///< a text-package approval does not name its locale
+    MalformedApprovedLocale,      ///< a locale tag outside the closed subset `isLocaleTag()` admits
     EmptyApprovedPackageId,       ///< a text-package approval does not name its package
     EmptyApprovedPackageDigest,   ///< a text-package approval carries no package identity
     DuplicateApprovedLocale,      ///< two text-package approvals claim the same locale
@@ -171,6 +178,8 @@ enum class SchemaError : std::uint8_t {
             return "the vertex budget exceeds what a 16-bit index can address";
         case SchemaError::EmptyApprovedLocale:
             return "an approved text package does not name its locale";
+        case SchemaError::MalformedApprovedLocale:
+            return "an approved locale is not a well-formed language tag";
         case SchemaError::EmptyApprovedPackageId:
             return "an approved text package does not name its package id";
         case SchemaError::EmptyApprovedPackageDigest:
@@ -727,6 +736,68 @@ static_assert(std::variant_size_v<NodePayload> == 11, "an alternative was added 
     return {};
 }
 
+/// The longest locale tag an approval may carry. Not a rule of RFC 5646, which sets no maximum -
+/// this repository's bound, chosen because consumers derive filenames and identifiers from the tag
+/// and a name has to be a name. It admits language-script-region plus several variants, which is
+/// past anything `mdux-textbake` can produce, and rejects a tag long enough to be a payload.
+inline constexpr std::size_t maxLocaleTagLength = 35;
+
+/**
+ * @brief Whether `tag` is a locale tag this schema admits: `[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*`.
+ *
+ * A **closed subset** of RFC 5646, not the whole of it. Full BCP 47 is a registry and a parser, and
+ * neither belongs in a `constexpr` device-side check; the subset above covers every locale the text
+ * pipeline can bake today - `en-US`, `de-DE`, `fr-FR` and their script and variant forms - and
+ * rejects everything the permissiveness admitted before: `en/US`, `(locale-free)`, `../etc`, a tag
+ * carrying a newline, and a kilobyte of text.
+ *
+ * Case is not constrained. RFC 5646 declares tags case-insensitive and recommends `en-US` casing
+ * without requiring it, so a schema that refused `en-us` would be inventing a rule; equality between
+ * approvals stays exact, which is what makes duplicate detection a comparison rather than a fold.
+ *
+ * Shape is not existence, the same distinction `isColorToken()` draws: a well-formed tag may name a
+ * locale no text package was ever baked for, which the approval manifest's digest answers and this
+ * predicate does not.
+ */
+[[nodiscard]] constexpr bool isLocaleTag(std::string_view tag) noexcept {
+    if (tag.empty() || tag.size() > maxLocaleTagLength) {
+        return false;
+    }
+
+    // The primary subtag: letters only, two or three of them.
+    std::size_t index = 0;
+    while (index < tag.size() && tag[index] != '-') {
+        const char character = tag[index];
+        if (!((character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z'))) {
+            return false;
+        }
+        ++index;
+    }
+    if (index < 2 || index > 3) {
+        return false;
+    }
+
+    // Everything after it is a `-` and two to eight alphanumerics, repeated. The loop never has to
+    // know whether a subtag is a script, a region or a variant - telling them apart is the registry
+    // half of BCP 47, and dropping it is what makes this subset a check rather than a parser.
+    while (index < tag.size()) {
+        ++index;  // `tag[index]` is the `-` the loop above or below stopped on.
+        const std::size_t start = index;
+        while (index < tag.size() && tag[index] != '-') {
+            const char character = tag[index];
+            const bool admitted  = (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9');
+            if (!admitted) {
+                return false;
+            }
+            ++index;
+        }
+        if (const std::size_t length = index - start; length < 2 || length > 8) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /**
  * @brief One text package this screen was compiled and reviewed against.
  *
@@ -735,7 +806,7 @@ static_assert(std::variant_size_v<NodePayload> == 11, "an alternative was added 
  * when that package is internally valid, uses the same font and carries the same keys.
  */
 struct TextPackageApproval {
-    std::string_view locale;           ///< the package's BCP 47 locale
+    std::string_view locale;           ///< the package's locale; `isLocaleTag()` is the grammar
     std::string_view packageId;        ///< the package header id
     evidence::Digest packageSha256{};  ///< SHA-256 of its canonical `package.json`
 
@@ -1010,6 +1081,11 @@ constexpr mdux::core::ResultVoid<SchemaError> ScreenPackage::validate() const no
         const TextPackageApproval& approval = approvedTextPackages[index];
         if (approval.locale.empty()) {
             return err(SchemaError::EmptyApprovedLocale);
+        }
+        // Empty first, then shape. `isLocaleTag()` refuses an empty tag too, so the order is what
+        // keeps "the field was never filled in" a different diagnosis from "the tag is not a tag".
+        if (!isLocaleTag(approval.locale)) {
+            return err(SchemaError::MalformedApprovedLocale);
         }
         if (approval.packageId.empty()) {
             return err(SchemaError::EmptyApprovedPackageId);

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -357,6 +357,82 @@ const mdux::spec::Register imagePackageApprovalsAreIdentified{
             .Execute();
     }};
 
+// `isLocaleTag()` is `constexpr`, and a generated screen's `static_assert(validate())` is where a
+// malformed tag now becomes a compile error rather than a run-time refusal. These pin the grammar
+// where the device build reads it - the scenario below covers what `validate()` does with it.
+static_assert(ms::isLocaleTag("en"), "a bare two-letter language is a tag");
+static_assert(ms::isLocaleTag("fra"), "and so is a three-letter one");
+static_assert(ms::isLocaleTag("en-US"), "language-region, the form every baked package uses");
+static_assert(ms::isLocaleTag("zh-Hans-CN"), "language-script-region");
+static_assert(ms::isLocaleTag("de-DE-1996"), "a numeric variant subtag");
+static_assert(ms::isLocaleTag("en-us"), "case is not constrained: RFC 5646 tags are case-insensitive");
+static_assert(!ms::isLocaleTag(""), "an empty tag names nothing");
+static_assert(!ms::isLocaleTag("e"), "a one-letter primary subtag is below the grammar");
+static_assert(!ms::isLocaleTag("engl"), "and a four-letter one is above it");
+static_assert(!ms::isLocaleTag("en/US"), "the separator that collided with a filename is not a separator here");
+static_assert(!ms::isLocaleTag("(locale-free)"), "nor is the sentinel a scope may carry outside the manifest");
+static_assert(!ms::isLocaleTag("../etc"), "nor a path");
+static_assert(!ms::isLocaleTag("en\nUS"), "nor a tag carrying a newline");
+static_assert(!ms::isLocaleTag("en-"), "a trailing separator introduces an empty subtag");
+static_assert(!ms::isLocaleTag("en--US"), "and so does a doubled one");
+static_assert(!ms::isLocaleTag("en-U"), "a one-character subtag is below the grammar");
+static_assert(!ms::isLocaleTag("en-ABCDEFGHI"), "and a nine-character one is above it");
+static_assert(!ms::isLocaleTag(std::string_view{"en-US-aaaaaaaa-bbbbbbbb-cccccccc-dddddddd"}), "a tag past maxLocaleTagLength is a payload, not a name");
+static_assert(std::string_view{"en-US-aaaaaaaa-bbbbbbbb-cccccccc-dddddddd"}.size() > ms::maxLocaleTagLength,
+              "and that rejection is the length bound rather than the subtag grammar");
+
+const mdux::spec::Register approvedLocalesHaveAGrammar{
+    "An approved locale is a language tag, not an arbitrary string",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-approved-locale-grammar")
+            .Given("the reference screen, whose one approval names en-US", [] {})
+            .When("that tag is replaced by strings the schema previously admitted", [] {})
+            .Then("each is refused as malformed, while a well-formed tag still validates",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The four from #281, which `validate()` accepted before this rule: a tag whose
+                      // separator is a path separator, the locale-free sentinel a diff-image scope
+                      // carries, a relative path, and a tag with a newline in it. Every one of them
+                      // reached a consumer that derives a filename from it.
+                      for (const std::string_view malformed : {"en/US", "(locale-free)", "../etc", "en\nUS", "e", "engl", "en-", "en--US"}) {
+                          Fixture bad;
+                          bad.approvedTextPackages[0].locale = malformed;
+                          checks.expect(errorOf(bad) == ms::SchemaError::MalformedApprovedLocale,
+                                        std::format("'{}' is refused as malformed, got {}", malformed, describe(errorOf(bad))));
+                      }
+
+                      // A kilobyte of letters satisfies the primary-subtag rule for its first three
+                      // characters and nothing else; the length bound is what refuses it, and it is
+                      // checked here rather than only at compile time because the run-time path is
+                      // the one a parsed artifact takes.
+                      const std::string oversized(1024, 'a');
+
+                      Fixture huge;
+                      huge.approvedTextPackages[0].locale = oversized;
+                      checks.expect(errorOf(huge) == ms::SchemaError::MalformedApprovedLocale,
+                                    std::format("a 1 KB tag is refused, got {}", describe(errorOf(huge))));
+
+                      // Empty stays its own diagnosis. `isLocaleTag()` would refuse it too, so this
+                      // pins the order of the two checks rather than restating the first one.
+                      Fixture empty;
+                      empty.approvedTextPackages[0].locale = {};
+                      checks.expect(errorOf(empty) == ms::SchemaError::EmptyApprovedLocale,
+                                    std::format("an unfilled field is still EmptyApprovedLocale, got {}", describe(errorOf(empty))));
+
+                      // The cost check #281 asked for: every locale the text pipeline bakes today
+                      // still validates. These are the three the fixtures and recipes carry.
+                      for (const std::string_view accepted : {"en-US", "de-DE", "fr-FR"}) {
+                          Fixture good;
+                          good.approvedTextPackages[0].locale = accepted;
+                          checks.expect(!errorOf(good).has_value(), std::format("'{}' still validates", accepted));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register nodesAreAddressable{"Every node must be addressable, and addressable by exactly one id", "evidence-unit", [] {
                                                    return speclab::Test("medui-schema-node-ids")
                                                        .Given("the reference screen", [] {})


### PR DESCRIPTION
## Summary

`ScreenPackage::validate()` required an approved locale to be non-empty, present alongside its
package id and digest, and unique among the approvals. It imposed no shape on the tag, so `en/US`,
`(locale-free)`, `../etc`, a tag carrying a newline and a kilobyte of text were all legal approved
locales — in a field consumers had begun deriving filenames and identifiers from.

This answers the four questions the issue asks:

1. **Should there be a grammar at all?** Yes. The permissiveness is real rather than theoretical:
   nothing rejected a bad tag, and #255's `diffImageName()` is defended at the consumer only.
2. **Which grammar?** `[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*`, at most 35 characters — the closed subset
   the issue proposes, not BCP 47. Full RFC 5646 is a registry and a parser, and neither belongs in
   a `constexpr` device-side check.
3. **Where does it live?** `mdux.medui.schema`, beside the other `validate()` rules, as
   `isLocaleTag()` and `SchemaError::MalformedApprovedLocale`. Being `constexpr` is the point: a
   generated screen's own `static_assert(package.validate().has_value())` makes a malformed tag a
   compile error rather than a run-time refusal.
4. **What does it cost?** Nothing today. `en-US`, `de-DE` and `fr-FR` are the only locales the text
   and font packages, recipes and fixtures carry, and the scenario checks that they still validate
   rather than asserting it.

Two deliberate limits:

- **Case is not constrained.** RFC 5646 declares tags case-insensitive and recommends `en-US` casing
  without requiring it, so refusing `en-us` would invent a rule. Approval equality stays exact,
  which is what keeps duplicate detection a comparison rather than a fold.
- **`EmptyApprovedLocale` survives.** `isLocaleTag()` would refuse an empty tag too, but "the field
  was never filled in" is a different diagnosis from "the tag is not a tag", so the checks stay
  ordered and the scenario pins that order.

The 35-character bound is this repository's, not the RFC's, which sets no maximum. It is stated as
such where it is defined.

**Scope note.** `mdux-textbake` and `mdux-fontbake` still require only non-empty. The producer this
issue is about is the artifact schema, which is where every consumer that derives a name from the
tag reads it. Extending the rule to the text and font packages would need one shared definition
rather than a second grammar — the arrangement ADR-008 decision 1 calls out — so it is not smuggled
in here.

Closes #281

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #281 (maintainer-authored)

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [x] None of the above

<!-- `include/mdux/medui/Schema.cppm` is an existing module interface, already in its FILE_SET; no
     list, schema, index or committed artifact changes. -->

## Rebase state

- **Rebased onto:** `7e7996d9985919860b10ab470f458f08c32e09e3` (develop, after #293 merged)
- **Conflicts resolved as a union:** two, both against #293's image-approval work, and both
  genuine unions rather than overlapping intent:
  - `include/mdux/medui/Schema.cppm` — the `SchemaError` enum. #293 added seven image enumerators,
    this branch adds `MalformedApprovedLocale`. Both are kept; the new enumerator sits after
    `EmptyApprovedLocale`, re-aligned to the comment column `MissingImagePackageApproval` widened.
  - `tests/medui/SchemaTests.cpp` — each side appended a different `spec::Register` at the same
    point and the two shared one trailing `.Execute();`. Both scenarios are kept, the first closed
    explicitly so the existing tail closes the second.

  The rebased diff is 161 insertions / 1 deletion, unchanged from before the rebase, and both
  previously conflicting scenarios pass.

## Verification

- [x] `cmake --preset ninja-gcc && cmake --build build-gcc` — clean, GCC 16.1.0
- [x] `ctest --test-dir build-gcc` — 693/693 passed (692 on `develop` plus this branch's one)
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (83 files, 0 findings)
- [x] Other: `clang-format --dry-run --Werror` clean on both changed sources; the other four
      docs-lint checks (`check_file_headers.py`, `check_named_mechanisms.py`,
      `generate_ai_reference.py --check`, `check_schema_type_drift.py`) and the docs-lint unit
      suite (153 tests) all OK. MSVC, Clang and macOS legs not run locally — CI covers them.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green.

## Regulatory impact

Tightens an artifact contract rather than a safety behaviour, and tightening can only reject a
screen that previously validated — no screen that was refused now passes. ADR-012 decision 1 is
updated in the same diff, since it is the record of what the approval manifest carries. No
traceability, risk-control or compliance-metadata artifact changes, and no claim about a standard is
made: the grammar is described throughout as a closed subset of RFC 5646, explicitly not conformance
to it, and the length bound is labelled as this repository's rather than the RFC's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Approved locale tags are now validated against a consistent format and length limit.
  - Invalid values, including path-like, placeholder, newline-containing, or oversized tags, are rejected with a specific validation error.
  - Empty locale values remain distinct from malformed locale values.

- **Documentation**
  - Updated the screen artifact guidance to document the approved locale tag format and 35-character limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
