### PR TITLE
S2 — SignalTrace: ring-buffer binding and CPU polyline expansion [#257]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -41,9 +41,21 @@ The runtime draws a `Panel` and, given a `TextBinding`, a `Label` (#242) — the
 compiled screen needs to reach glyphs: the font package, the text package for the locale the device
 is running, and its sidecar. Without one, a label is deferred rather than refused.
 
+It also draws the **field** a `NumericDisplay` or a `SignalTrace` reserves (#255): that node's whole
+rectangle, in the single token it carries, which is exactly the pair its golden entry pins.
+
+A `SignalTrace` draws its **waveform** as well, given a `SignalBinding` (#257) — the second join, and
+the one whose inputs no artifact carries. A slot names the node's `stream_source`, a caller-owned
+ring of samples, and the range those samples are read against; that range is the host's because what
+a sample means in millivolts is a property of an amplifier rather than of a layout. Two things to
+know before you write one: a ring past `maxSamplesPerTrace` (256) is **refused rather than
+truncated**, and a bound trace dims its field so the full-tint stroke over it is visible — an unbound
+one is the opaque field #255 draws, unchanged.
+
 One limit is worth knowing before you write a screen: every other component is visited, counted in
 `FrameStats::deferred` and left undrawn. A `Button` is more than its text — it has a face nothing in
-this project has decided — and live-data components have no geometry until the frame does. Both are
+this project has decided — an `Image` needs a package this repository does not yet bake, and a
+`Clock` or `StatusIndicator` has no single tint a field could be painted in. All of them are
 [#17](https://github.com/ambroise-leclerc/MduX/issues/17).
 
 The HTML/CSS path that used to stand in for all of this - `UiFileWatcher::loadContent()`, which

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,9 @@ twelve of its children have landed: a screen goes from source to a bounded, budg
 golden-annotated set of rectangles, to a committed byte-compared artifact, to `constexpr` C++, to
 draw commands recorded without allocating, to a pixel compared under lavapipe. What the wave leaves
 behind is component content rather than path: a baked text package now lets the governed runtime
-draw a `Label`, while live-data and composite components such as `NumericDisplay` and `SignalTrace`
-remain deferred (`#17`).
+draw a `Label`, and `#257` has since given a `SignalTrace` its waveform, expanded on the device from
+a caller-owned ring buffer into the screen's pre-sized vertex budget. The rest of `#17` - `Image`,
+`NumericDisplay`'s digits, `StatusIndicator`, `TextInput`, `Button` - is still deferred.
 
 Treat any AGENTS.md section below that describes current architecture as authoritative for *today's
 code*; treat this subsection as the direction that code is moving in.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ target_sources(MduXCore
             include/mdux/text/Schema.cppm
             include/mdux/medui/Schema.cppm
             include/mdux/medui/Screen.cppm
+            include/mdux/medui/Trace.cppm
             include/mdux/verify/Verify.cppm
     PRIVATE
         src/evidence/Digest.cpp
@@ -282,6 +283,7 @@ target_sources(MduXCore
         src/text/Draw.cpp
         src/text/Schema.cpp
         src/medui/Screen.cpp
+        src/medui/Trace.cpp
         src/verify/Verify.cpp
         src/governance/Governance.cpp
         src/governance/Justification.cpp

--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ Derived from the targets and tests that build on `develop`.
 | `MduXMeduiLib` | Implemented | The `.medui` compiler end to end: parsing, semantic validation, integer-only bounded layout, per-locale text budgets, golden references, the canonical package, two C++ emitters, and the `mdux-meduic` / `mdux-medui-check` tools ([#15](https://github.com/ambroise-leclerc/MduX/issues/15)) |
 | `MduXVerifyUiLib`, `mdux-verify-ui` | Implemented | host-only rendered-truth driver: artifact-derived obligations across every approved locale, offscreen Vulkan execution, and distinct failed-check / impossible-run outcomes ([#253](https://github.com/ambroise-leclerc/MduX/issues/253)). Gated in CI as `verify.screen.<id>` on the three render legs, with a PNG diff image uploaded on failure ([#255](https://github.com/ambroise-leclerc/MduX/issues/255)) |
 | Text and glyph rendering | Implemented | host-side shaping into baked runs, an R8 coverage atlas, and a governed draw path; a compiled screen's `Label` is joined to a text package at run time and drawn ([#14](https://github.com/ambroise-leclerc/MduX/issues/14), [#242](https://github.com/ambroise-leclerc/MduX/issues/242)). A `Button`'s text is not drawn, because a button is more than its text ([#17](https://github.com/ambroise-leclerc/MduX/issues/17)) |
-| Live-data components | Partial | a `NumericDisplay` and a `SignalTrace` paint the field they reserve, which is what their golden entry pins ([#255](https://github.com/ambroise-leclerc/MduX/issues/255)); the reading inside it — expanded digits, an expanded waveform — is still deferred ([#257](https://github.com/ambroise-leclerc/MduX/issues/257), [#258](https://github.com/ambroise-leclerc/MduX/issues/258)) |
+| Live-data components | Partial | a `NumericDisplay` and a `SignalTrace` paint the field they reserve, which is what their golden entry pins ([#255](https://github.com/ambroise-leclerc/MduX/issues/255)). A `SignalTrace` also draws the **waveform** inside it, expanded on the CPU from a caller-owned ring buffer into the screen's pre-sized vertex budget, refused rather than truncated past its cap ([#257](https://github.com/ambroise-leclerc/MduX/issues/257)); a `NumericDisplay`'s expanded digits are still deferred ([#258](https://github.com/ambroise-leclerc/MduX/issues/258)) |
 | `mdux-docs-lint`, `mdux-evidence-lint` | Implemented | run in CI |
 | **Regulatory material** | | |
 | Standards corpus under `docs/` | Documentation only | five clause-structured references with generated indexes and schemas |
 | Software Development File | Documentation only | templates and records under `software_development_file/` |
 | Risk management, QMS, lifecycle *code* | **Not started** | no `mdux::risk`, `mdux::qms` or `mdux::lifecycle` exists |
 | **Not started** | | |
-| Content components (`SignalTrace`, `StatusIndicator`, …) | Planned | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) |
+| Content components (`Image`, `StatusIndicator`, `TextInput`, …) | Planned | [#17](https://github.com/ambroise-leclerc/MduX/issues/17). `SignalTrace` has landed ([#257](https://github.com/ambroise-leclerc/MduX/issues/257)) and is in the Partial row above |
 
 `.medui` reaches pixels today, and the path is built rather than planned. An authored screen is
 compiled by `mdux-meduic` into `generated/screen/<id>/` — a package, a golden sidecar and a bake

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,7 @@ are ordinary `PRIVATE` sources.
 | `mdux.ml.runtime` | `include/mdux/ml/Runtime.cppm` | `src/ml/Runtime.cpp` |
 | `mdux.medui.schema` | `include/mdux/medui/Schema.cppm` | header-only |
 | `mdux.medui.screen` | `include/mdux/medui/Screen.cppm` | `src/medui/Screen.cpp` |
+| `mdux.medui.trace` | `include/mdux/medui/Trace.cppm` | `src/medui/Trace.cpp` |
 | `mdux.verify` | `include/mdux/verify/Verify.cppm` | `src/verify/Verify.cpp` |
 
 `mdux.core.result` is a naming alias over `std::expected`, not a reimplementation
@@ -181,6 +182,22 @@ Two of those four have one part that *is* in the artifact, and since #255 the ru
 exactly the pair their golden entry pins. ADR-014 decision 5 is why that is read off the golden
 sidecar rather than invented in the renderer, and why a `Clock` (no token) and a `StatusIndicator`
 (one per state) are not in it.
+
+One of the two now draws the live part as well. `mdux.medui.trace` expands a **caller-owned ring
+buffer** into stroke quads — segments as quads with square joint caps rather than mitred joins, which
+have no unbounded spike as an angle closes — and `SignalBinding` is what joins a stream name the
+screen carries to the samples and the scale only the host knows. The samples never enter the
+artifact and never could: what a sample of `ECG_LEAD_II` means in millivolts is a property of the
+amplifier, not of the layout.
+
+Three properties are worth naming because they are what makes that safe rather than merely working.
+The expansion writes into the vertex budget the screen already declares, sized once and never grown.
+A ring past `maxSamplesPerTrace` is **refused**, not truncated — a waveform silently showing a
+different window is indistinguishable on a monitor from a correct reading of different data. And a
+bound trace paints its field at reduced coverage under a full-tint stroke, which is the one
+composition an additive draw list and a `ColorHash` golden both admit; an *unbound* trace is
+unchanged, which is why the committed screen's pixel and `verify` legs are unchanged too — both
+render it without signals.
 
 `goldens.json` is a sidecar with a different consumer — #16's frame verifier, not the runtime — and a
 different rule. ADR-011 puts **every `@safety_critical` node and every node with an explicit
@@ -330,7 +347,7 @@ tracking issue; the issue is authoritative for what remains.
 |---|---|---|
 | `.medui` compiler | [#15](https://github.com/ambroise-leclerc/MduX/issues/15) | complete front to back: parsing, semantic validation, bounded layout, text budgets, golden references, the canonical package, both C++ emitters, `mdux-meduic`, `mdux-medui-check`, and a governed runtime that draws a compiled screen. One committed screen reaches pixels in `ScreenPixelTests`, carrying text (#242), fields (#255), and a baked QOI-derived Image (#256); live and interactive component content remains under #17 |
 | Rendered-truth verification | [#16](https://github.com/ambroise-leclerc/MduX/issues/16) | beyond the current pixel test |
-| Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `SignalTrace`, `StatusIndicator`, `NumericDisplay` and the rest |
+| Content components | [#17](https://github.com/ambroise-leclerc/MduX/issues/17) | `Image`, `StatusIndicator`, `TextInput`, `Button` and the rest. `SignalTrace` has shipped (#257): it draws a live waveform from a caller-owned ring, and the `EcgClassifierExample` binds the same ring its classifier reads |
 
 ### The HTML/CSS path is gone, not planned
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -124,8 +124,20 @@ target_sources(EcgClassifierExample
             TYPE CXX_MODULES
             BASE_DIRS ${MDUX_GENERATED_MODEL_DIR}
             FILES ${MDUX_ECG_MODEL_MODULE}
+        # The committed endoscope screen as generated `constexpr` C++ (issue #257). Its own file
+        # set, because the two emitted modules live under different generated directories and a
+        # file set has one set of base dirs. Build-tree only, like the model module beside it.
+        #
+        # This is what makes the demonstrator a *consumer* of the screen rather than a program that
+        # prints numbers: `EndoscopeMonitor` carries a `SignalTrace` named `ECG_LEAD_II`, and the
+        # ring this example already had is bound to it. Still no Vulkan and no window - a draw list
+        # is geometry, and building one needs neither.
+        FILE_SET generated_screen_modules
+            TYPE CXX_MODULES
+            BASE_DIRS ${MDUX_GENERATED_SCREEN_DIR}
+            FILES ${MDUX_ENDOSCOPE_SCREEN_MODULE}
 )
-add_dependencies(EcgClassifierExample emit-model-${MDUX_ECG_MODEL_ID})
+add_dependencies(EcgClassifierExample emit-model-${MDUX_ECG_MODEL_ID} emit-screen-endoscope-monitor)
 target_link_libraries(EcgClassifierExample PRIVATE MduX::Core)
 
 mdux_embed_blob(EcgClassifierExample

--- a/examples/EcgClassifierExample.cpp
+++ b/examples/EcgClassifierExample.cpp
@@ -235,7 +235,7 @@ int main() {
     std::println("");
     std::println("Frame from the committed screen '{}' ({}x{}):", endoscopeMonitor.id, endoscopeMonitor.surfaceWidth, endoscopeMonitor.surfaceHeight);
 
-    const medui::SampleRing view = ring.view();
+    const medui::SampleRing                view = ring.view();
     const std::array<medui::SignalSlot, 1> slots{
         medui::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &view, .style = ecgTrace}
     };

--- a/examples/EcgClassifierExample.cpp
+++ b/examples/EcgClassifierExample.cpp
@@ -24,14 +24,28 @@
  *    model id. The weight-swap test (tests/ml/WeightSwapTests.cpp) exercises the two committed
  *    packages dynamically without changing this device example.
  *
- * ## Two things it deliberately does not do yet
+ * ## 5. One ring, two readers - which is what #257 came here to demonstrate
  *
- * The `.medui` screen and the `SignalTrace` widget issue #64 describes do not exist yet - they are
- * issue #15 and epic #11's S2. When they land, this classifier's output drives a `StatusIndicator`
- * and reads from the same sample ring buffer the trace renders. The ring buffer below is written
- * with that in mind: the classifier reads a window out of it rather than owning the samples, so
- * the eventual demonstration that the trace and the classifier are provably looking at identical
- * data is a matter of giving them the same buffer.
+ * This file used to say that "the `.medui` screen and the `SignalTrace` widget issue #64 describes
+ * do not exist yet", and that when they landed the demonstration "is a matter of giving them the
+ * same buffer". It landed, and that is exactly what happens below: `EndoscopeMonitor` - the
+ * committed screen this repository compiles, whose `SignalTrace` is named `ECG_LEAD_II` - is bound
+ * to the same `SampleRing` the classifier reads its window out of, and a frame is recorded from it.
+ *
+ * The demonstration is the *identity*, not the picture. Nothing copies the samples on the way to
+ * either reader: `readWindow()` hands the classifier a contiguous ordered window and `view()` hands
+ * the trace a description of the same storage, so there is no second buffer that could drift from
+ * the first. A monitor showing a waveform beside a classification derived from different samples is
+ * a specific and very bad failure, and this arrangement makes it unspellable rather than unlikely.
+ *
+ * Still no Vulkan and no window. A draw list is geometry - the vertices, indices and commands a
+ * renderer would consume - and building one needs neither a device nor a surface, which is the
+ * same thing `MedicalUiExample` demonstrates from the other end.
+ *
+ * ## One thing it deliberately does not do yet
+ *
+ * The classifier's output does not drive a `StatusIndicator`: that component is still deferred by
+ * the runtime and arrives with #259.
  *
  * The package emitter is the equivalent of the shader pipeline's issue #121: the committed JSON is
  * mechanically rendered into build-tree source and validated by `static_assert`. Only the weight
@@ -39,6 +53,12 @@
  */
 
 import std;
+import mdux.core.units;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.medui.screen;
+import mdux.medui.trace;
+import mdux.medui.generated.screen_endoscope_monitor;
 import mdux.ml.schema;
 import mdux.ml.runtime;
 import mdux.ml.generated.model_ecg_demo;
@@ -47,7 +67,9 @@ import mdux.ml.generated.model_ecg_demo;
 
 namespace {
 
-namespace ml = mdux::ml;
+namespace ml    = mdux::ml;
+namespace medui = mdux::medui;
+namespace draw  = mdux::draw;
 
 /// Sampling rate the demonstrator's 180-sample window corresponds to.
 constexpr std::size_t sampleRateHz = 180;
@@ -84,6 +106,17 @@ public:
         }
     }
 
+    /// The same samples as the governed trace expansion reads them: a description, not a copy.
+    ///
+    /// `head_` is where the *next* sample goes, which is also the oldest live one once the ring has
+    /// wrapped - and is not the oldest before it has, when the samples start at zero and stop at
+    /// `filled_`. Both cases are spelled out rather than left to the full() path alone, because a
+    /// trace is drawn from the first frame of a device's life and the classifier only from the
+    /// moment its window is complete.
+    [[nodiscard]] medui::SampleRing view() const noexcept {
+        return medui::SampleRing{.storage = samples_, .oldest = full() ? head_ : 0, .count = filled_};
+    }
+
 private:
     std::array<float, Capacity> samples_{};
     std::size_t                 head_{0};
@@ -102,6 +135,27 @@ private:
     }
     return 0.05f * static_cast<float>((index % 7)) - 0.15f;
 }
+
+/// The committed screen, as generated code holds it: read-only data its own emitter `static_assert`ed.
+constexpr medui::ScreenPackage endoscopeMonitor = medui::generated::screen_endoscope_monitor::package();
+static_assert(endoscopeMonitor.validate().has_value(), "the committed screen's generated form validates");
+
+/// Storage for one frame, sized once from the screen's own budget - and by it, so the two cannot
+/// drift. This is the "pre-sized vertex budget" #257 writes into: made here, never grown, and large
+/// enough for the trace because the budget the product declared says so.
+struct Frame {
+    std::array<draw::UiVertex, endoscopeMonitor.budget.maxVertices>    vertices{};
+    std::array<draw::Index, endoscopeMonitor.budget.maxIndices>        indices{};
+    std::array<draw::DrawCommand, endoscopeMonitor.budget.maxCommands> commands{};
+};
+
+/// The scale this demonstrator's synthetic samples are read against.
+///
+/// The screen cannot carry these numbers and should not: what a sample of `ECG_LEAD_II` means is a
+/// property of the amplifier the host owns, not of the layout. Here the "amplifier" is
+/// `syntheticSample()`, whose output lies in [-0.5, 1.0], and the band is widened a little either
+/// side so an excursion is visible as an excursion rather than as a reading against the rail.
+constexpr medui::TraceStyle ecgTrace{.minimum = -1.0F, .maximum = 1.5F, .strokeWidth = 2};
 
 }  // namespace
 
@@ -172,6 +226,58 @@ int main() {
         std::println(")");
         ++classified;
     }
+
+    // 4. The same ring, read as a waveform by the governed screen runtime (#257).
+    //
+    // Nothing is copied between step 3 and this one. `ring` is the object the loop above pushed
+    // samples into and `readWindow()` classified out of; `ring.view()` describes that same storage
+    // to the trace expansion. Whatever the classifier just said, it said about these samples.
+    std::println("");
+    std::println("Frame from the committed screen '{}' ({}x{}):", endoscopeMonitor.id, endoscopeMonitor.surfaceWidth, endoscopeMonitor.surfaceHeight);
+
+    const medui::SampleRing view = ring.view();
+    const std::array<medui::SignalSlot, 1> slots{
+        medui::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &view, .style = ecgTrace}
+    };
+
+    auto binding = medui::SignalBinding::create(endoscopeMonitor, slots);
+    if (!binding.has_value()) {
+        // Fail-closed here too, and for the same class of reason `Classifier1D::create()` is: a
+        // stream name this screen does not carry is a trace that would silently stay empty.
+        std::println(std::cerr, "signal binding refused: {}", medui::describe(binding.error()));
+        return 1;
+    }
+
+    // Sized once, from the screen's own budget, and never grown - which is what makes the no-heap
+    // property true of the frame rather than of an intention. Heap-allocated because a demonstrator
+    // on a desktop has a heap; on a device this is a static object, and either way `render()` never
+    // touches an allocator. See tests/medui/ScreenNoHeapTests.cpp.
+    auto frame = std::make_unique<Frame>();
+    auto list  = draw::DrawList::create(frame->vertices, frame->indices, frame->commands, endoscopeMonitor.budget);
+    if (!list.has_value()) {
+        std::println(std::cerr, "draw list refused: {}", draw::describe(list.error()));
+        return 1;
+    }
+
+    const auto recorded = medui::render(endoscopeMonitor, *list, {}, {}, *binding);
+    if (!recorded.has_value()) {
+        std::println(std::cerr, "frame refused: {}", medui::describe(recorded.error()));
+        return 1;
+    }
+
+    std::println("  samples bound  : {} (the window the classifier read, not a copy of it)", view.count);
+    std::println("  traces expanded: {}", recorded->traces);
+    std::println("  nodes / drawn  : {} visited, {} rectangles, {} deferred", recorded->nodes, recorded->rects, recorded->deferred);
+    std::println("  budget used    : {}/{} vertices, {}/{} indices, {}/{} commands",
+                 list->vertices().size(),
+                 endoscopeMonitor.budget.maxVertices,
+                 list->indices().size(),
+                 endoscopeMonitor.budget.maxIndices,
+                 list->commands().size(),
+                 endoscopeMonitor.budget.maxCommands);
+    std::println("");
+    std::println("  The label, the image and the video surface are deferred: they need a bound text");
+    std::println("  package and packages this repository does not yet bake. The waveform does not.");
 
     std::println("");
     std::println("Swapping these weights is a re-bake of the recipe and a change to the configured");

--- a/include/mdux/draw/Draw.cppm
+++ b/include/mdux/draw/Draw.cppm
@@ -77,6 +77,27 @@ struct UvRect {
     constexpr bool operator==(const UvRect&) const = default;
 };
 
+/**
+ * @brief A position in surface pixels, with a fractional part.
+ *
+ * `core::Rect` is integer, which is the right choice everywhere a rectangle is axis-aligned: an
+ * integer coordinate cannot be rounded two ways by two toolchains. A polyline segment is the first
+ * primitive in this project that is *not* axis-aligned - its quad's corners are the segment's
+ * endpoints displaced along a normal, and that displacement is irrational for all but a handful of
+ * slopes. Rounding it to whole pixels would make a 1px stroke jump between one and two pixels wide
+ * as the slope changed, which is exactly the artefact a stroke width exists to prevent.
+ *
+ * So this type exists to carry the one quantity that cannot be integral, and nothing else. It is
+ * deliberately not a general "float point": no arithmetic operators, because every computation that
+ * produces one belongs to the module that knows what the numbers mean.
+ */
+struct Point2F {
+    float x{0.0F};
+    float y{0.0F};
+
+    constexpr bool operator==(const Point2F&) const = default;
+};
+
 struct UiVertex {
     float x{0.0F};              ///< offset 0
     float y{0.0F};              ///< offset 4
@@ -138,6 +159,7 @@ enum class DrawError : std::uint8_t {
     CommandBudgetExceeded,
     DegenerateRect,          ///< zero or negative width or height
     WrongList,               ///< a rollback marker names a position in a different list, or none
+    DegenerateQuad,          ///< a quad's corners enclose no area, or one of them is not finite
 };
 
 [[nodiscard]] std::string_view describe(DrawError error) noexcept;
@@ -202,6 +224,28 @@ public:
     /// Records an untextured rectangle. The common case, and the only one #124 needs.
     [[nodiscard]] mdux::core::ResultVoid<DrawError> addSolidRect(
         const mdux::core::Rect& rect, mdux::core::ColorRgba8 color) noexcept;
+
+    /**
+     * @brief Records an untextured quadrilateral from four corners, in order.
+     *
+     * The primitive `addSolidRect()` cannot express: a stroke segment between two arbitrary points
+     * is a rectangle rotated by the segment's slope, and an axis-aligned type has no way to say so.
+     * Added for `mdux.medui.trace` (#257) and kept as narrow as that need - `Solid` only, uv zero,
+     * because a *textured* rotated quad would additionally have to decide how the atlas maps onto a
+     * shape whose edges are not axis-aligned, and nothing asks that question yet.
+     *
+     * `corners` are joined in the order given and split into two triangles across the 0-2 diagonal,
+     * exactly as a rectangle is - so a caller must pass them in ring order (each adjacent to the
+     * next), not in a diagonal-first order that would fold the shape into a bowtie.
+     *
+     * Refused as `DegenerateQuad` when any coordinate is not finite, or when the corners enclose no
+     * area. Both are the same defect from a frame's point of view - nothing is drawn - and both are
+     * worth refusing rather than recording: a NaN vertex is undefined behaviour in a rasteriser
+     * rather than an invisible primitive, and it reaches this call the moment a caller normalises a
+     * sample against a zero-width range.
+     */
+    [[nodiscard]] mdux::core::ResultVoid<DrawError> addSolidQuad(
+        const std::array<Point2F, 4>& corners, mdux::core::ColorRgba8 color) noexcept;
 
     /// Sets the clip rectangle applied to subsequent primitives. A change starts a new command.
     void setClip(const mdux::core::Rect& clip) noexcept;
@@ -274,6 +318,15 @@ public:
 
 private:
     DrawList() noexcept = default;
+
+    /// Appends four already-computed vertices as two triangles, or refuses on a budget.
+    ///
+    /// Everything `addRect()` and `addSolidQuad()` do once their own geometry is settled: the three
+    /// budget checks, the fixed 0-1-2 / 0-2-3 split, and extending the current command or starting a
+    /// new one. Shared rather than written twice because the property that matters here is "past the
+    /// checks nothing can fail, so the list never holds a half-recorded primitive" - and a second
+    /// copy of it would be a second place for that to stop being true.
+    [[nodiscard]] mdux::core::ResultVoid<DrawError> appendQuad(const std::array<UiVertex, 4>& corners) noexcept;
 
     std::span<UiVertex> vertices_;
     std::span<Index> indices_;

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -25,9 +25,14 @@
  *   `textKey`, not glyphs (ADR-011), so drawing one is a join with a baked text package for the
  *   locale the device is running. Without a binding there is nothing to join to and the node is
  *   deferred exactly as before, which is also what a screen with no text costs: nothing.
- * - `NumericDisplay` and `SignalTrace` draw their field, and the **reading inside it** is still
- *   deferred: the digits a template expands to and the excursion a waveform makes are functions of a
- *   sample this module is not given, and they arrive with #258 and #257.
+ * - `NumericDisplay` draws its field, and the **reading inside it** is still deferred: the digits a
+ *   template expands to are a function of a sample this module is not given, and they arrive with
+ *   #258.
+ * - `SignalTrace` draws its field, and since #257 the **waveform inside it** as well, when the
+ *   caller supplies a `SignalBinding` naming that node's stream. Without one the node is exactly
+ *   what it was after #255: the opaque field it reserves. The expansion itself is
+ *   `mdux.medui.trace`'s, split out for the reason `mdux.text.draw` is - geometry that can be tested
+ *   against numbers rather than only against a rendered frame.
  * - `Button`, `CriticalButton`, `TextInput` carry text keys or live sources as well, and are still
  *   deferred whole. Their text is not the whole of their appearance - a button has a face, a text
  *   input has a caret and a selection - and this module will not invent those. They arrive with #17.
@@ -68,6 +73,22 @@
  * colour fails the golden its own screen was compiled with. A component whose field a golden pins
  * with `ColorHash` therefore has two ways to show a reading and no others: in the field's own tint,
  * or knocked out of it back to the ground.
+ *
+ * #257 met that constraint head on and neither option was available as written. An additive draw
+ * list cannot knock a stroke back to the ground - there is no erase - and a stroke in the field's
+ * own tint over an opaque field of that tint is invisible. What was available is the *third* reading
+ * of the same rule, which the sentence above did not have to spell out because nothing had needed it
+ * yet: one tint at **two coverages**. A bound trace paints its field at `boundTraceFieldCoverage`
+ * and its stroke at full tint, so every pixel is still a blend of ground and tint at one coverage -
+ * what `ColorHash` asks - the stroke supplies the fully covered pixels `ColorHash` additionally
+ * requires, and the field keeps `goldenBounds()` seeing the node's whole rectangle as painted, which
+ * a stroke alone would not. An unbound trace is unchanged, which is why the committed screen's
+ * pixels and its `verify` leg are unchanged too: both render it without signals.
+ *
+ * That paragraph is an argument, and arguments about what a check admits belong to the check. So it
+ * is also a scenario: `verify-golden-two-coverage-composition` in `tests/verify/GoldenCheckTests.cpp`
+ * paints exactly this composition and asserts that `goldenBounds()` and `colorHash()` both hold -
+ * and that the field alone, without the stroke, is the `TintAbsent` the stroke exists to answer.
  *
  * ## Where a label's glyphs go, and why that is not an invention
  *
@@ -147,6 +168,7 @@ import mdux.evidence.digest;
 import mdux.font.schema;
 import mdux.image.schema;
 import mdux.medui.schema;
+import mdux.medui.trace;
 import mdux.text.draw;
 import mdux.text.schema;
 
@@ -200,6 +222,14 @@ enum class ScreenError : std::uint8_t {
     TextOverflowsNode,     ///< a run's ink is wider or taller than the node that names it
     ImageSidecarMismatch,  ///< RGBA bytes differ from the baked image package
     ImageNotApproved,      ///< the screen did not approve this image id/digest/extent
+    UnknownStreamSource,   ///< a signal slot names a stream no `SignalTrace` on this screen carries
+    DuplicateStream,       ///< two signal slots name the same stream
+    MalformedTraceStyle,   ///< a slot's sample range is empty or not finite, or its stroke is not 1-3px
+    MalformedSampleRing,   ///< a bound ring's oldest index or live count is not a position in it
+    NonFiniteSample,       ///< a live sample is a NaN or an infinity
+    TraceTooLong,          ///< a bound ring holds more than `maxSamplesPerTrace` samples
+    TraceBandTooSmall,     ///< a bound trace's node is too small to hold its stroke
+    ScreenNotApproved,     ///< a signal binding built for one screen was offered to another
 };
 
 // The two token failures are kept apart because the schema keeps them apart, and for its reason: a
@@ -385,6 +415,127 @@ private:
 static_assert(!std::is_aggregate_v<ImageBinding>, "an ImageBinding must only be obtainable through create()");
 
 /**
+ * @brief The coverage a `SignalTrace`'s field is painted at once its samples are on screen.
+ *
+ * The field is opaque while a trace is unbound - that is #255's rule and nothing here changes it -
+ * and drops to this coverage of the same tint the moment a waveform is drawn over it. The reason is
+ * arithmetic rather than taste: a `SignalTraceSpec` carries **one** colour token, so a stroke drawn
+ * over an opaque field of that token is the field, pixel for pixel, and the component would have
+ * gained a feature nobody could see.
+ *
+ * The module comment above states the constraint this has to live inside: a reading drawn in a third
+ * colour fails a `ColorHash` golden, so the only tints available are the node's own and the ground
+ * it sits on, and an additive draw list cannot knock a stroke back to the ground. What is left is
+ * one tint at two coverages - which is exactly what `ColorHash` admits, since it asks that every
+ * pixel be a blend of ground and tint at *some* single coverage, and that a fully covered pixel be
+ * the tint exactly. The stroke supplies the second; the field supplies the first and keeps
+ * `goldenBounds()` seeing the node's whole rectangle as painted, which a stroke alone would not.
+ *
+ * A quarter, then, and not a value chosen by eye: low enough that a 1px stroke at full tint is
+ * unambiguous against it, and high enough to stay clear of the ground at every quantisation. The
+ * number itself is this module's; nothing in the artifacts or the shared contract fixes it, and it is
+ * recorded here rather than inlined so a screen's appearance has one place to be argued about.
+ */
+inline constexpr float boundTraceFieldCoverage = 0.25F;
+
+/**
+ * @brief One live waveform the caller offers this screen: which stream, whose samples, at what scale.
+ *
+ * `streamSource` is matched against the name a `SignalTrace` node carries - `stream_source:` in the
+ * source, `streamSource` in the compiled artifact - so the screen decides *where* the waveform goes
+ * and the caller supplies only *what* it is.
+ *
+ * `ring` is a pointer rather than a value because the producer writes into it between frames: the
+ * binding is made once and reads the ring's current `oldest` and `count` on every frame. Nothing is
+ * owned; the ring and its storage outlive the frame, exactly as the text packages do.
+ */
+struct SignalSlot {
+    std::string_view  streamSource{};  ///< the stream name the compiled node carries
+    const SampleRing* ring{nullptr};   ///< the caller's ring, read afresh each frame
+    TraceStyle        style{};         ///< the range those samples are read against, and the stroke
+};
+
+/**
+ * @brief The live waveforms a screen's `SignalTrace` nodes are joined to, once the join is proved.
+ *
+ * `TextBinding`'s counterpart for signals, and deliberately a much cheaper object: what it proves is
+ * that the caller and the screen agree about *names*, not that four artifacts hash to each other.
+ * There is nothing to hash - samples are produced at run time and no committed artifact describes
+ * them - so the checks are the ones that are actually available:
+ *
+ * - every slot names a stream some `SignalTrace` on this screen carries, because a typo in a stream
+ *   name is otherwise a trace that silently stays empty, and an empty waveform on a monitor is a
+ *   flat line rather than a missing feature;
+ * - no two slots name the same stream, because which of them would win is arbitrary and the wrong
+ *   answer is undetectable from the frame;
+ * - every slot has a ring and a style the expansion can use, checked once here rather than
+ *   rediscovered on the first frame of a device's life.
+ *
+ * A screen need **not** have a slot for every trace. A stream that has not started yet is a normal
+ * state, not a broken one, and its node draws the opaque field it reserved - which is exactly what
+ * this runtime did for every trace before #257.
+ *
+ * A default-constructed binding is *unbound* and means "this caller has no live signals": every
+ * trace draws its field, which is the behaviour every existing caller already has. That is what
+ * keeps `render(screen, list)` and `render(screen, list, text)` meaning what they meant.
+ *
+ * Nothing here is owned, and the slot span is the caller's storage, so `render()` allocates nothing
+ * by construction rather than by discipline.
+ */
+class SignalBinding {
+public:
+    /// An unbound binding: no live signals, every trace drawing the field it reserves.
+    constexpr SignalBinding() noexcept = default;
+
+    /// Proves every slot names a distinct `SignalTrace` on `screen` and carries a usable ring.
+    [[nodiscard]] static mdux::core::Result<SignalBinding, ScreenError> create(const ScreenPackage& screen, std::span<const SignalSlot> slots) noexcept;
+
+    /// Whether this binding carries slots. False for a default-constructed one.
+    [[nodiscard]] constexpr bool bound() const noexcept {
+        return !slots_.empty();
+    }
+
+    [[nodiscard]] constexpr std::span<const SignalSlot> slots() const noexcept {
+        return slots_;
+    }
+
+    /// The slot for `streamSource`, or nullptr when this caller offers none.
+    ///
+    /// Linear, for `ScreenPackage::find()`'s reason: a screen holds a handful of traces, and a map
+    /// would cost more to build than every lookup it could serve.
+    [[nodiscard]] constexpr const SignalSlot* find(std::string_view streamSource) const noexcept {
+        for (const SignalSlot& slot : slots_) {
+            if (slot.streamSource == streamSource) {
+                return &slot;
+            }
+        }
+        return nullptr;
+    }
+
+    /// Whether this binding was built for `screen`.
+    ///
+    /// The identity is the screen's id, which is what an artifact is addressed by: it names a
+    /// directory under `generated/`, a CTest entry and a generated C++ identifier, so two screens in
+    /// one build cannot share it. Retaining it closes the substitution path `TextBinding::approvedBy()`
+    /// closes with a digest - weaker, because there is no digest to hold, and worth having anyway: a
+    /// binding whose slots were validated against screen A says nothing about screen B's traces.
+    [[nodiscard]] constexpr bool approvedBy(const ScreenPackage& screen) const noexcept {
+        return !bound() || screen.id == screenId_;
+    }
+
+private:
+    constexpr SignalBinding(std::string_view screenId, std::span<const SignalSlot> slots) noexcept : slots_{slots}, screenId_{screenId} {}
+
+    std::span<const SignalSlot> slots_{};
+    std::string_view            screenId_{};
+};
+
+// The guarantee `create()` is documented to give, held by the language rather than by discipline -
+// `TextBinding`'s static_assert, for its reason. A class with private data members is not an
+// aggregate, so `SignalBinding{...}` cannot brace-elide its way past the checks.
+static_assert(!std::is_aggregate_v<SignalBinding>, "a SignalBinding must only be obtainable through create()");
+
+/**
  * @brief What one frame did, and what it left undone.
  *
  * `deferred` is the honest half: it counts nodes this runtime visited and could not paint at all,
@@ -403,6 +554,7 @@ struct FrameStats {
     std::uint32_t rects{0};     ///< rectangles recorded
     std::uint32_t deferred{0};  ///< nodes visited and left undrawn
     std::uint32_t steps{0};     ///< units of per-node work, for the bounded-work tests
+    std::uint32_t traces{0};    ///< `SignalTrace` nodes whose samples were expanded
 
     [[nodiscard]] constexpr bool operator==(const FrameStats&) const noexcept = default;
 };
@@ -410,10 +562,14 @@ struct FrameStats {
 /**
  * @brief Records one frame of `screen` into `list`.
  *
- * @param screen a compiled screen, normally the `constexpr` one a generated translation unit holds
- * @param list   a draw list the caller created over storage sized from `screen.budget`
- * @param text   the packages this screen's text keys resolve against; default means "no text", and
- *               every text node is then deferred rather than refused
+ * @param screen  a compiled screen, normally the `constexpr` one a generated translation unit holds
+ * @param list    a draw list the caller created over storage sized from `screen.budget`
+ * @param text    the packages this screen's text keys resolve against; default means "no text", and
+ *                every text node is then deferred rather than refused
+ * @param image   the authenticated baked image this screen's `Image` nodes resolve against;
+ *                default means "no image", and every `Image` node is then deferred
+ * @param signals the live rings this screen's stream sources resolve against; default means "no
+ *                signals", and every trace then draws the opaque field it reserves
  *
  * Allocation-free and `noexcept`: the list is the only storage written, and it was sized before the
  * first frame. On any error the list is restored to its state at entry.
@@ -425,6 +581,10 @@ struct FrameStats {
  * decorative, and a mistake in a baked budget would be bypassed rather than observed.
  */
 [[nodiscard]] mdux::core::Result<FrameStats, ScreenError>
-render(const ScreenPackage& screen, mdux::draw::DrawList& list, const TextBinding& text = {}, const ImageBinding& image = {}) noexcept;
+render(const ScreenPackage& screen,
+       mdux::draw::DrawList&  list,
+       const TextBinding&     text    = {},
+       const ImageBinding&    image   = {},
+       const SignalBinding&   signals = {}) noexcept;
 
 }  // namespace mdux::medui

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -224,6 +224,7 @@ enum class ScreenError : std::uint8_t {
     ImageNotApproved,      ///< the screen did not approve this image id/digest/extent
     UnknownStreamSource,   ///< a signal slot names a stream no `SignalTrace` on this screen carries
     DuplicateStream,       ///< two signal slots name the same stream
+    MissingSampleRing,     ///< a signal slot carries no ring, so its trace could never draw a sample
     MalformedTraceStyle,   ///< a slot's sample range is empty or not finite, or its stroke is not 1-3px
     MalformedSampleRing,   ///< a bound ring's oldest index or live count is not a position in it
     NonFiniteSample,       ///< a live sample is a NaN or an infinity
@@ -580,11 +581,10 @@ struct FrameStats {
  * list can carry several screens; without the second check the screen's declared budget would be
  * decorative, and a mistake in a baked budget would be bypassed rather than observed.
  */
-[[nodiscard]] mdux::core::Result<FrameStats, ScreenError>
-render(const ScreenPackage& screen,
-       mdux::draw::DrawList&  list,
-       const TextBinding&     text    = {},
-       const ImageBinding&    image   = {},
-       const SignalBinding&   signals = {}) noexcept;
+[[nodiscard]] mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage&  screen,
+                                                                 mdux::draw::DrawList& list,
+                                                                 const TextBinding&    text    = {},
+                                                                 const ImageBinding&   image   = {},
+                                                                 const SignalBinding&  signals = {}) noexcept;
 
 }  // namespace mdux::medui

--- a/include/mdux/medui/Trace.cppm
+++ b/include/mdux/medui/Trace.cppm
@@ -1,0 +1,225 @@
+/**
+ * @file Trace.cppm
+ * @brief Governed-zone waveform expansion: a caller-owned ring of samples into stroke quads.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
+ * @compliance ADR-005 Error handling and exceptions policy (Result-returning, noexcept)
+ * @compliance ADR-011 The deterministic `.medui` compile boundary
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Part of MduXCore, which is what puts it under `mdux-governed-lint`, `governed.noThrow.symbolScan`
+ * and `screen.noheap.symbolScan` without any of the three being told about it.
+ *
+ * This module is to `SignalTrace` what `mdux.text.draw` is to `Label`: the expansion step, split out
+ * from the screen runtime that decides *whether* to call it. `mdux.medui.screen` owns the binding
+ * and the composition; this owns the geometry, so the geometry can be tested against numbers rather
+ * than only against a rendered frame.
+ *
+ * ## The samples are the caller's, and stay the caller's
+ *
+ * A waveform's producer is a device driver on a timer, not a UI. `SampleRing` is therefore a view of
+ * storage the caller allocated once and writes into forever - this module never owns it, never
+ * copies it into a scratch buffer, and never asks it to be contiguous or ordered. What it does is
+ * read `count` samples starting at `oldest`, wrapping, which is the shape a ring already has.
+ *
+ * The consequence worth stating is that the ring is **mutable between frames and validated on every
+ * one**. A `create()` that proved `oldest` and `count` consistent once, as `TextBinding` proves its
+ * packages, would be proving it of a snapshot the producer has since moved. So the validation is
+ * per-frame and bounded: three comparisons before the walk, plus one finiteness test per sample.
+ *
+ * ## Segments as quads, joints as caps
+ *
+ * Each pair of consecutive samples becomes one quad: the segment displaced by half the stroke width
+ * along its normal. Each sample additionally becomes a small square quad centred on it.
+ *
+ * Both are built from one value - the centre of the pixel the sample quantised onto, which is the
+ * pixel's corner plus half a pixel. That half is not a detail: a stroke through a pixel *corner*
+ * covers half of each of two rows, so a 1px trace drawn that way is two rows of 50% coverage rather
+ * than one row of the tint, and `ColorHash`'s "a fully covered pixel is exactly the tint" would find
+ * no such pixel anywhere in the node. Building the cap as a quad rather than as the `core::Rect` an
+ * axis-aligned square would naturally be is what lets both primitives share that one centre: a
+ * rect's edges are integers, and an even stroke width centred on a pixel centre has half-integer
+ * edges.
+ *
+ * That square is the "round-cap overdraw" the epic's design note asks for, and it is worth being
+ * exact about what it is rather than letting the name carry a claim the code does not make. A true
+ * round join is a disc; this is the disc's bounding square. At the stroke widths this module admits
+ * - 1 to 3 pixels - a disc and its bounding square differ by at most the four corner pixels of a 3x3
+ * block, and at 1px they are the same pixel. That is the whole reason the width is capped at 3
+ * (`maxStrokeWidth`): past it the approximation starts to be visible as a squared-off join, and a
+ * component that quietly stopped looking like what its documentation says is worse than one that
+ * refuses a width it cannot draw honestly.
+ *
+ * The alternative - mitred joins - needs the intersection of two offset lines, which is unbounded as
+ * the angle between segments closes: a near-reversal produces a spike whose length has no limit, and
+ * a spike is exactly the artefact a waveform must not invent. Overdraw has no such failure mode, and
+ * costs one extra quad per sample.
+ *
+ * ## Integer positions, and the one float this cannot avoid
+ *
+ * Which *pixel* a sample lands on is decided in integers. x is a whole column computed by integer
+ * division, so two toolchains cannot disagree about which column a sample is in; y is a whole row,
+ * the sample normalised against the caller's declared range and quantised exactly as
+ * `medui::quantise()` turns a channel into a byte, with the multiply and the add kept as separate
+ * statements so the rounding cannot depend on whether the compiler fuses them. The half-pixel that
+ * turns that pixel into a centre is a literal, added last.
+ *
+ * What stays floating point is the **normal**: the perpendicular offset that gives a segment its
+ * width is `half / length` along a direction, and `length` is a square root that is irrational for
+ * all but a handful of slopes. Rounding it to whole pixels would make a 1px stroke alternate between
+ * one and two pixels wide as the slope changed. `std::sqrt` is safe to depend on here in a way
+ * `std::exp` was not for ADR-008: IEEE 754 requires it to be correctly rounded, so every conforming
+ * implementation returns the same bits for the same input, which is the property a frame compared
+ * across toolchains needs.
+ *
+ * ## Refused, never truncated
+ *
+ * A ring holding more than `maxSamplesPerTrace` samples is `TooManySamples`. It is not the last *n*
+ * of them, and it is not the first: a waveform silently showing a window other than the one the
+ * caller believes it is showing is the failure this refusal exists to prevent, and on a medical
+ * display it is indistinguishable from a correct reading of different data.
+ *
+ * The second refusal is the budget's, and it belongs to `DrawList` rather than to this module: an
+ * expansion that does not fit rolls back to where the trace began and reports `ListRejected`, so a
+ * frame never carries half a waveform. Both bounds are knowable before a device runs - the cap is a
+ * constant and the budget is baked into the compiled screen - which is what makes "the storage is
+ * sized once and never grown" a property rather than an intention.
+ */
+module;
+
+export module mdux.medui.trace;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+
+export namespace mdux::medui {
+
+/**
+ * @brief The largest trace this module will expand, in samples.
+ *
+ * The type-level cap `maxGlyphsPerRun` is for a `Label`, and it exists for the same reason: per-node
+ * work has to be a constant a device can multiply by its node count before it runs, rather than a
+ * number that moves when a driver changes its sampling rate.
+ *
+ * 256, the same number, and chosen the same way - large enough for the window a demonstrator
+ * classifies (180 samples at 180 Hz is one second of ECG) and small enough that a reviewer can
+ * multiply it against a `DrawBudget` in their head. A trace costs `2n - 1` quads, so 256 samples is
+ * 511 quads, 2044 vertices and 3066 indices: comfortably inside the 4096/6144 the committed
+ * endoscope screen declares, and visibly so rather than by a margin nobody checked.
+ */
+inline constexpr std::size_t maxSamplesPerTrace = 256;
+
+/**
+ * @brief The widest stroke the cap approximation stays honest at, in pixels.
+ *
+ * See the module comment: the joint cap is a square standing in for a disc, and the two are
+ * indistinguishable only while the disc is small. Three pixels is where that stops being true.
+ */
+inline constexpr mdux::core::Px maxStrokeWidth = 3;
+
+/**
+ * @brief A caller-owned ring of samples, as this module reads it.
+ *
+ * An aggregate rather than a `create()`-guarded class, and deliberately so. `TextBinding` is guarded
+ * because what it proves - four artifacts agreeing - is expensive and decided once. This proves
+ * three comparisons about numbers a producer changes between every frame, so a guard would be
+ * proving them of a state that has already moved. See the module comment.
+ *
+ * `storage` is the ring's fixed allocation, made once. `oldest` is the index in it of the oldest
+ * live sample and `count` how many there are; a producer that has not yet filled the ring has
+ * `oldest == 0` and a growing `count`, and one that has wrapped has a moving `oldest` and
+ * `count == storage.size()`.
+ */
+struct SampleRing {
+    std::span<const float> storage{};  ///< the ring's storage, owned by the caller
+    std::size_t            oldest{0};  ///< index of the oldest live sample
+    std::size_t            count{0};   ///< live samples, at most `storage.size()`
+
+    /// The `index`-th sample counting from the oldest, or nothing when `index` is past `count`.
+    ///
+    /// Bounds-checked rather than a raw subscript: the walk below could be written to be provably in
+    /// range, but this type is exported and a caller reading its own ring back deserves the same
+    /// refusal the expansion gets.
+    [[nodiscard]] constexpr std::optional<float> at(std::size_t index) const noexcept {
+        if (index >= count || storage.empty()) {
+            return std::nullopt;
+        }
+        return storage[(oldest + index) % storage.size()];
+    }
+};
+
+/**
+ * @brief How a trace is drawn, and against what range its samples are read.
+ *
+ * These are the device's numbers, not the screen's, and that split is the point. A compiled screen
+ * says *where* a waveform goes and *in what tint* - both validated names, both in an artifact four
+ * CI legs byte-compare. It cannot say what a sample of `ECG_LEAD_II` means in millivolts, because
+ * that is a property of the amplifier the host owns and not of the layout. So the range arrives with
+ * the samples, from the caller that produces them.
+ *
+ * `minimum` maps to the bottom edge of the node's band and `maximum` to the top - value up, the
+ * convention every physiological trace is read with. A sample outside the range is **clamped to the
+ * band, not refused**: an excursion past the display range is a real reading that a monitor shows
+ * pinned to its rail, and refusing the frame would blank the screen at the moment the waveform
+ * became most interesting. A range that is empty or not finite *is* refused, because it makes every
+ * sample's position undefined rather than extreme.
+ */
+struct TraceStyle {
+    float          minimum{0.0F};   ///< the sample value the band's bottom edge represents
+    float          maximum{1.0F};   ///< the sample value the band's top edge represents
+    mdux::core::Px strokeWidth{1};  ///< 1 to `maxStrokeWidth` pixels
+
+    [[nodiscard]] constexpr bool operator==(const TraceStyle&) const noexcept = default;
+};
+
+/// Why a trace was refused. Every one leaves the draw list exactly as it was found.
+enum class TraceError : std::uint8_t {
+    MalformedRing,    ///< `oldest` or `count` does not describe a position in `storage`
+    TooManySamples,   ///< the ring holds more than `maxSamplesPerTrace`
+    NonFiniteSample,  ///< a live sample is a NaN or an infinity
+    MalformedStyle,   ///< the range is empty or not finite, or the stroke width is out of range
+    BandTooSmall,     ///< the node's rectangle cannot hold a band of this stroke width
+    ListRejected,     ///< `DrawList` refused a primitive - budget, or a degenerate quad
+};
+
+[[nodiscard]] std::string_view describe(TraceError error) noexcept;
+
+/// The quads one trace of `samples` costs at worst: one cap per sample, one quad per segment.
+///
+/// Exposed so a caller sizing storage, or a reviewer checking a budget, reads the cost model rather
+/// than reconstructing it. An upper bound rather than an exact count: a segment between two samples
+/// that land on the same pixel is skipped, because the caps at its endpoints already cover every
+/// pixel it would have. A budget is a ceiling, so the bound is the number that belongs in one.
+///
+/// Zero for a ring too short to have a segment, which is not an error - a trace with one sample or
+/// none draws nothing and says so by recording nothing.
+[[nodiscard]] constexpr std::size_t quadsForSamples(std::size_t samples) noexcept {
+    return samples < 2 ? 0 : (2 * samples) - 1;
+}
+
+/**
+ * @brief Records one trace of `ring` into `list`, inside `band`.
+ *
+ * @param list  the destination; the trace is appended as `Solid` quads
+ * @param band  the node's resolved rectangle, in surface pixels
+ * @param ring  the caller's samples, read oldest-first, left to right
+ * @param style the range the samples are normalised against, and the stroke width
+ * @param color the tint the stroke is drawn in
+ *
+ * Allocation-free and `noexcept`. The path is inset so that the stroke - half its width either side
+ * of a pixel centre - stays inside `band`: every vertex this records lies within the rectangle, so a
+ * trace cannot spill onto its neighbour and the runtime needs no clip rectangle to promise it. The
+ * cost is that the band a trace can reach is `strokeWidth / 2` pixels narrower and shorter than the
+ * node on each side, which is why a node too small to hold its own stroke is `BandTooSmall` rather
+ * than a trace drawn slightly outside it.
+ *
+ * All-or-nothing, as `mdux::text::draw::recordRun()` is: on any refusal the list is rolled back to
+ * where it stood on entry, so a frame never carries a partial waveform. A fragment of a trace reads
+ * as a flat line, which on a medical display is a reading rather than an absence.
+ */
+[[nodiscard]] mdux::core::ResultVoid<TraceError>
+recordTrace(mdux::draw::DrawList& list, const mdux::core::Rect& band, const SampleRing& ring, const TraceStyle& style, mdux::core::ColorRgba8 color) noexcept;
+
+}  // namespace mdux::medui

--- a/src/draw/Draw.cpp
+++ b/src/draw/Draw.cpp
@@ -158,13 +158,28 @@ ResultVoid<DrawError> DrawList::addSolidQuad(const std::array<Point2F, 4>& corne
     // collinear or coincident, which is `addRect()`'s DegenerateRect in the shape a quad has it.
     // The sign is not checked: a caller may wind either way, and the fixed 0-1-2 / 0-2-3 split
     // draws both - the pipeline disables face culling, so winding is not a visibility question.
-    float doubledArea = 0.0F;
+    //
+    // Measured relative to the first corner, and accumulated in double. Both matter, and neither is
+    // caution for its own sake: over absolute coordinates the two products are of similar magnitude
+    // and their difference is the area, so a small quad far from the origin loses that difference to
+    // rounding. A 1px cap at (4096, 4096) cancels to exactly zero in float and reads as collinear -
+    // which is a trace refusing to draw because of where it was placed. Translating first is exact
+    // (a float minus a float is exact in double) and makes the products small; the double
+    // accumulation then keeps a unit area from vanishing under coordinates a surface can reach.
+    // Translation does not change an area, so this is the same test, computed where it survives.
+    const double originX     = static_cast<double>(corners[0].x);
+    const double originY     = static_cast<double>(corners[0].y);
+    double       doubledArea = 0.0;
     for (std::size_t i = 0; i < corners.size(); ++i) {
-        const Point2F& a = corners[i];
-        const Point2F& b = corners[(i + 1) % corners.size()];
-        doubledArea += (a.x * b.y) - (b.x * a.y);
+        const Point2F& a  = corners[i];
+        const Point2F& b  = corners[(i + 1) % corners.size()];
+        const double   ax = static_cast<double>(a.x) - originX;
+        const double   ay = static_cast<double>(a.y) - originY;
+        const double   bx = static_cast<double>(b.x) - originX;
+        const double   by = static_cast<double>(b.y) - originY;
+        doubledArea += (ax * by) - (bx * ay);
     }
-    if (!(doubledArea > 0.0F) && !(doubledArea < 0.0F)) {
+    if (!(doubledArea > 0.0) && !(doubledArea < 0.0)) {
         return err(DrawError::DegenerateQuad);
     }
 

--- a/src/draw/Draw.cpp
+++ b/src/draw/Draw.cpp
@@ -49,6 +49,8 @@ std::string_view describe(DrawError error) noexcept {
         return "rectangle has zero or negative width or height";
     case DrawError::WrongList:
         return "a rollback marker names a position in a different list, or in none";
+    case DrawError::DegenerateQuad:
+        return "a quad's corners enclose no area, or one of them is not finite";
     }
     return "unknown draw error";
 }
@@ -139,6 +141,49 @@ ResultVoid<DrawError> DrawList::addSolidRect(const mdux::core::Rect& rect,
     return addRect(rect, color, DrawMode::Solid, mdux::core::Rect{});
 }
 
+ResultVoid<DrawError> DrawList::addSolidQuad(const std::array<Point2F, 4>& corners,
+                                             mdux::core::ColorRgba8 color) noexcept {
+    // Finiteness first, because every test below it is a comparison and a NaN compares false
+    // against all of them - so an unchecked NaN would fall through the area test as "not
+    // degenerate" and reach the rasteriser, where it is undefined behaviour rather than an
+    // invisible primitive. Same reasoning as `medui::quantise()`'s NaN clause, different remedy:
+    // there the value has a defensible zero, here it does not.
+    for (const Point2F& corner : corners) {
+        if (!std::isfinite(corner.x) || !std::isfinite(corner.y)) {
+            return err(DrawError::DegenerateQuad);
+        }
+    }
+
+    // Twice the signed area, by the shoelace formula over the ring. Zero means the four corners are
+    // collinear or coincident, which is `addRect()`'s DegenerateRect in the shape a quad has it.
+    // The sign is not checked: a caller may wind either way, and the fixed 0-1-2 / 0-2-3 split
+    // draws both - the pipeline disables face culling, so winding is not a visibility question.
+    float doubledArea = 0.0F;
+    for (std::size_t i = 0; i < corners.size(); ++i) {
+        const Point2F& a = corners[i];
+        const Point2F& b = corners[(i + 1) % corners.size()];
+        doubledArea += (a.x * b.y) - (b.x * a.y);
+    }
+    if (!(doubledArea > 0.0F) && !(doubledArea < 0.0F)) {
+        return err(DrawError::DegenerateQuad);
+    }
+
+    const std::uint32_t packed = packColor(color);
+    const auto modeValue = static_cast<std::uint32_t>(DrawMode::Solid);
+    std::array<UiVertex, 4> vertices{};
+    for (std::size_t i = 0; i < corners.size(); ++i) {
+        // uv is zero rather than left alone, for addSolidRect()'s reason: the vertex layout is
+        // fixed and an uninitialised float in a buffer that is compared makes a frame irreproducible.
+        vertices[i] = UiVertex{.x = corners[i].x,
+                               .y = corners[i].y,
+                               .u = 0.0F,
+                               .v = 0.0F,
+                               .color = packed,
+                               .mode = modeValue};
+    }
+    return appendQuad(vertices);
+}
+
 ResultVoid<DrawError> DrawList::addRect(const mdux::core::Rect& rect, mdux::core::ColorRgba8 color,
                                         DrawMode mode, const mdux::core::Rect& uv) noexcept {
     // Widening only - the integer overload cannot express a fractional coordinate, which is
@@ -156,6 +201,28 @@ ResultVoid<DrawError> DrawList::addRect(const mdux::core::Rect& rect, mdux::core
         return err(DrawError::DegenerateRect);
     }
 
+    const auto left = static_cast<float>(rect.x);
+    const auto top = static_cast<float>(rect.y);
+    const auto right = static_cast<float>(rect.right());
+    const auto bottom = static_cast<float>(rect.bottom());
+    const auto u0 = uv.u0;
+    const auto v0 = uv.v0;
+    const auto u1 = uv.u1;
+    const auto v1 = uv.v1;
+    const std::uint32_t packed = packColor(color);
+    const auto modeValue = static_cast<std::uint32_t>(mode);
+
+    // Corner order is fixed: top-left, top-right, bottom-right, bottom-left. Two frames built
+    // from the same primitives must produce byte-identical buffers, which a varying order would
+    // break for no benefit.
+    return appendQuad(std::array<UiVertex, 4>{
+        UiVertex{.x = left, .y = top, .u = u0, .v = v0, .color = packed, .mode = modeValue},
+        UiVertex{.x = right, .y = top, .u = u1, .v = v0, .color = packed, .mode = modeValue},
+        UiVertex{.x = right, .y = bottom, .u = u1, .v = v1, .color = packed, .mode = modeValue},
+        UiVertex{.x = left, .y = bottom, .u = u0, .v = v1, .color = packed, .mode = modeValue}});
+}
+
+ResultVoid<DrawError> DrawList::appendQuad(const std::array<UiVertex, 4>& corners) noexcept {
     // Subtraction against remaining capacity, never addition against the limit: with counts near
     // the top of their range an addition could wrap and read as acceptable.
     if (budget_.maxVertices - vertexCount_ < verticesPerRect) {
@@ -175,28 +242,9 @@ ResultVoid<DrawError> DrawList::addRect(const mdux::core::Rect& rect, mdux::core
 
     // Past this point nothing can fail, so the list never holds a half-recorded primitive.
     const auto baseVertex = static_cast<Index>(vertexCount_);
-    const auto left = static_cast<float>(rect.x);
-    const auto top = static_cast<float>(rect.y);
-    const auto right = static_cast<float>(rect.right());
-    const auto bottom = static_cast<float>(rect.bottom());
-    const auto u0 = uv.u0;
-    const auto v0 = uv.v0;
-    const auto u1 = uv.u1;
-    const auto v1 = uv.v1;
-    const std::uint32_t packed = packColor(color);
-    const auto modeValue = static_cast<std::uint32_t>(mode);
-
-    // Corner order is fixed: top-left, top-right, bottom-right, bottom-left. Two frames built
-    // from the same primitives must produce byte-identical buffers, which a varying order would
-    // break for no benefit.
-    vertices_[vertexCount_ + 0] = UiVertex{
-        .x = left, .y = top, .u = u0, .v = v0, .color = packed, .mode = modeValue};
-    vertices_[vertexCount_ + 1] = UiVertex{
-        .x = right, .y = top, .u = u1, .v = v0, .color = packed, .mode = modeValue};
-    vertices_[vertexCount_ + 2] = UiVertex{
-        .x = right, .y = bottom, .u = u1, .v = v1, .color = packed, .mode = modeValue};
-    vertices_[vertexCount_ + 3] = UiVertex{
-        .x = left, .y = bottom, .u = u0, .v = v1, .color = packed, .mode = modeValue};
+    for (std::size_t i = 0; i < corners.size(); ++i) {
+        vertices_[vertexCount_ + i] = corners[i];
+    }
 
     indices_[indexCount_ + 0] = static_cast<Index>(baseVertex + 0);
     indices_[indexCount_ + 1] = static_cast<Index>(baseVertex + 1);

--- a/src/medui/.clang-tidy
+++ b/src/medui/.clang-tidy
@@ -1,0 +1,30 @@
+# Layer 3 of issue #63, applied to the screen-runtime implementation sources (issue #257).
+#
+# #199 gave the screen runtime layers 1 and 2 - the interposition binary `medui_noheap_spec` and the
+# `screen.noheap.symbolScan` object scan, which reuses the `ml-noheap` profile over every MduXCore
+# object under /medui/. This file is the third, and it was the one missing: layers 1 and 2 catch an
+# allocation that is *reachable* and one that is *linked*, and this catches the source construct with
+# a message pointing at the line, which is the fastest of the three to act on.
+#
+# The file is a copy of src/ml/.clang-tidy rather than a shared one, because the two zones are
+# configured independently and a single file would have to live somewhere neither owns. The checks
+# are the same because the property is the same, and the reason it belongs here rather than at the
+# root is unchanged: the root configuration governs style for the whole tree, and mdux.evidence.json
+# and mdux.governance allocate by design, so a check that is an error here would fail on correct code
+# there.
+#
+# -Wframe-larger-than=4096 belongs with these and lives in cmake/MduXDeterminism.cmake, applied to
+# MduXCore as a whole - so it already covers these sources: "no heap" must not quietly become
+# "enormous stack", which on a device is the same bug wearing a different hat.
+
+InheritParentConfig: true
+
+Checks: >
+  cppcoreguidelines-no-malloc,
+  cppcoreguidelines-owning-memory,
+  cppcoreguidelines-pro-type-vararg,
+  cppcoreguidelines-prefer-member-initializer
+
+WarningsAsErrors: >
+  cppcoreguidelines-no-malloc,
+  cppcoreguidelines-owning-memory

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -15,6 +15,7 @@ import mdux.evidence.digest;
 import mdux.font.schema;
 import mdux.image.schema;
 import mdux.medui.schema;
+import mdux.medui.trace;
 import mdux.text.draw;
 import mdux.text.schema;
 
@@ -197,6 +198,47 @@ mdux::core::Result<ImageBinding, ScreenError> ImageBinding::create(const ScreenP
     return ImageBinding{packageSha256, image.width, image.height};
 }
 
+mdux::core::Result<SignalBinding, ScreenError> SignalBinding::create(const ScreenPackage& screen, std::span<const SignalSlot> slots) noexcept {
+    for (std::size_t index = 0; index < slots.size(); ++index) {
+        const SignalSlot& slot = slots[index];
+
+        if (slot.ring == nullptr) {
+            // A slot with no ring is a trace that would draw a dimmed field and nothing in it -
+            // indistinguishable, on a monitor, from a flat line. Refused here rather than deferred
+            // per frame, because it is a defect in how the caller assembled its slots.
+            return mdux::core::err(ScreenError::MalformedTraceStyle);
+        }
+        if (slot.style.strokeWidth < 1 || slot.style.strokeWidth > maxStrokeWidth) {
+            return mdux::core::err(ScreenError::MalformedTraceStyle);
+        }
+        if (!std::isfinite(slot.style.minimum) || !std::isfinite(slot.style.maximum) || !(slot.style.maximum > slot.style.minimum)) {
+            return mdux::core::err(ScreenError::MalformedTraceStyle);
+        }
+
+        // Quadratic in the slot count, which is a handful: a screen holds tens of nodes and rather
+        // fewer traces, and a set would allocate. `ScreenPackage::find()` makes the same trade.
+        for (std::size_t earlier = 0; earlier < index; ++earlier) {
+            if (slots[earlier].streamSource == slot.streamSource) {
+                return mdux::core::err(ScreenError::DuplicateStream);
+            }
+        }
+
+        const bool named = std::ranges::any_of(screen.nodes, [&](const CompiledNode& node) {
+            const NodePayload payload = node.payload;
+            const auto*       trace   = std::get_if<SignalTraceSpec>(&payload);
+            return trace != nullptr && trace->streamSource == slot.streamSource;
+        });
+        if (!named) {
+            // The check that earns this type. A mistyped stream name would otherwise leave the trace
+            // drawing its reserved field forever, and the caller with no way to tell that from a
+            // stream that has simply not started.
+            return mdux::core::err(ScreenError::UnknownStreamSource);
+        }
+    }
+
+    return SignalBinding{screen.id, slots};
+}
+
 std::string_view describe(ScreenError error) noexcept {
     switch (error) {
         case ScreenError::MalformedColorToken:
@@ -223,14 +265,64 @@ std::string_view describe(ScreenError error) noexcept {
             return "the RGBA sidecar is not the one the image package describes";
         case ScreenError::ImageNotApproved:
             return "the screen was not compiled against this image package";
+        case ScreenError::UnknownStreamSource:
+            return "a signal slot names a stream no SignalTrace on this screen carries";
+        case ScreenError::DuplicateStream:
+            return "two signal slots name the same stream";
+        case ScreenError::MalformedTraceStyle:
+            return "a signal slot's sample range is empty or not finite, or its stroke width is out of range";
+        case ScreenError::MalformedSampleRing:
+            return "a bound ring's oldest index or live count is not a position in its storage";
+        case ScreenError::NonFiniteSample:
+            return "a live sample is not a finite number";
+        case ScreenError::TraceTooLong:
+            return "a bound ring holds more samples than this runtime will expand in one trace";
+        case ScreenError::TraceBandTooSmall:
+            return "a bound trace's node is too small to hold its stroke";
+        case ScreenError::ScreenNotApproved:
+            return "the signal binding was built for a different screen";
     }
     // Unreachable for a value of the enumeration, and named rather than defaulted so that adding an
     // enumerator without a case here is a warning at this switch instead of a blank string later.
     return "unknown screen error";
 }
 
+namespace {
+
+/// A `TraceError` as the screen runtime's caller sees it.
+///
+/// One-for-one rather than collapsed to a single "the trace was refused", for the reason the two
+/// colour-token failures are kept apart: a malformed ring is the producer's defect, a too-long one is
+/// a caller asking for more than the cap admits, and a non-finite sample is a driver fault. Sending
+/// all three to the same integrator would send two of them to the wrong person.
+[[nodiscard]] ScreenError asScreenError(mdux::medui::TraceError error) noexcept {
+    switch (error) {
+        case TraceError::MalformedRing:
+            return ScreenError::MalformedSampleRing;
+        case TraceError::TooManySamples:
+            return ScreenError::TraceTooLong;
+        case TraceError::NonFiniteSample:
+            return ScreenError::NonFiniteSample;
+        case TraceError::MalformedStyle:
+            return ScreenError::MalformedTraceStyle;
+        case TraceError::BandTooSmall:
+            return ScreenError::TraceBandTooSmall;
+        case TraceError::ListRejected:
+            return ScreenError::BudgetExhausted;
+    }
+    // Named rather than defaulted, so a new TraceError is a warning here rather than a frame refused
+    // with a reason that names the wrong thing.
+    return ScreenError::BudgetExhausted;
+}
+
+}  // namespace
+
 mdux::core::Result<FrameStats, ScreenError>
-render(const ScreenPackage& screen, mdux::draw::DrawList& list, const TextBinding& text, const ImageBinding& image) noexcept {
+render(const ScreenPackage& screen,
+       mdux::draw::DrawList&  list,
+       const TextBinding&     text,
+       const ImageBinding&    image,
+       const SignalBinding&   signals) noexcept {
     // Taken before anything is recorded: every refusal below rolls back to here, so a frame is
     // whole or absent. A half-drawn frame on a medical display is the worst outcome available,
     // because it looks like a reading.
@@ -251,6 +343,13 @@ render(const ScreenPackage& screen, mdux::draw::DrawList& list, const TextBindin
     }
     if (!image.approvedBy(screen)) {
         return refuse(ScreenError::ImageNotApproved);
+    }
+
+    // The same closure for signals, and the same reason: slots validated against screen A's traces
+    // say nothing about screen B's. Weaker than the text binding's check by exactly as much as the
+    // available evidence is weaker - an id rather than a digest - which `approvedBy()` says.
+    if (!signals.approvedBy(screen)) {
+        return refuse(ScreenError::ScreenNotApproved);
     }
 
     // Where the list stood before this frame. The screen's own budget bounds what *this screen*
@@ -365,6 +464,49 @@ render(const ScreenPackage& screen, mdux::draw::DrawList& list, const TextBindin
             // arithmetic `DrawList` owns. Blank glyphs record nothing, so this counts the inked ones.
             stats.rects += static_cast<std::uint32_t>((list.vertices().size() - verticesBefore) / 4);
             continue;
+        }
+
+        // A `SignalTrace` the caller has samples for. Everything else about the node - where it is,
+        // which token it draws with - is still the artifact's; what the binding adds is the samples
+        // and the scale, which no compiled screen can carry (see `SignalSlot`).
+        if (const auto* trace = std::get_if<SignalTraceSpec>(&node.payload); trace != nullptr) {
+            if (const SignalSlot* slot = signals.find(trace->streamSource); slot != nullptr) {
+                const auto colour = resolveColorToken(trace->colorToken);
+                if (!colour.has_value()) {
+                    return refuse(colour.error() == ThemeError::MalformedToken ? ScreenError::MalformedColorToken : ScreenError::UnknownColorToken);
+                }
+
+                // The field at reduced coverage, then the stroke at full tint. See Screen.cppm,
+                // `boundTraceFieldCoverage`, for why one tint at two coverages is the only
+                // composition a `ColorHash` golden and an additive draw list both admit.
+                mdux::core::ColorRgba8 fieldColour = quantise(*colour);
+                fieldColour.a                      = quantise((*colour)[3] * boundTraceFieldCoverage);
+                if (const auto recorded = list.addSolidRect(toRect(node.bounds), fieldColour); !recorded.has_value()) {
+                    return refuse(ScreenError::BudgetExhausted);
+                }
+                ++stats.rects;
+
+                const std::size_t verticesBefore = list.vertices().size();
+                if (const auto recorded = mdux::medui::recordTrace(list, toRect(node.bounds), *slot->ring, slot->style, quantise(*colour));
+                    !recorded.has_value()) {
+                    // `recordTrace()` rolls its own trace back and this rolls the whole frame back.
+                    // Its error *is* forwarded, unlike the label path's: every way it fails is a
+                    // distinct thing the caller can act on, and none of them was already refused here.
+                    return refuse(asScreenError(recorded.error()));
+                }
+                if (!withinScreenBudget()) {
+                    return refuse(ScreenError::BudgetExhausted);
+                }
+
+                // Payload-proportional work, bounded by `maxSamplesPerTrace` exactly as a label's is
+                // by `maxGlyphsPerRun`. Counted here so the bounded-work tests keep reporting a
+                // number that is still a function of what this frame actually did.
+                stats.steps += static_cast<std::uint32_t>(slot->ring->count);
+                stats.rects += static_cast<std::uint32_t>((list.vertices().size() - verticesBefore) / 4);
+                ++stats.traces;
+                ++stats.steps;
+                continue;
+            }
         }
 
         const std::optional<std::string_view> field = fieldColorToken(node.payload);

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -206,7 +206,12 @@ mdux::core::Result<SignalBinding, ScreenError> SignalBinding::create(const Scree
             // A slot with no ring is a trace that would draw a dimmed field and nothing in it -
             // indistinguishable, on a monitor, from a flat line. Refused here rather than deferred
             // per frame, because it is a defect in how the caller assembled its slots.
-            return mdux::core::err(ScreenError::MalformedTraceStyle);
+            //
+            // Its own error rather than `MalformedTraceStyle`, for the reason stated where the two
+            // colour-token failures are kept apart: an absent ring is a slot the caller never
+            // finished filling in, while a malformed style is a slot filled in wrongly. They send an
+            // integrator to different places.
+            return mdux::core::err(ScreenError::MissingSampleRing);
         }
         if (slot.style.strokeWidth < 1 || slot.style.strokeWidth > maxStrokeWidth) {
             return mdux::core::err(ScreenError::MalformedTraceStyle);
@@ -269,6 +274,8 @@ std::string_view describe(ScreenError error) noexcept {
             return "a signal slot names a stream no SignalTrace on this screen carries";
         case ScreenError::DuplicateStream:
             return "two signal slots name the same stream";
+        case ScreenError::MissingSampleRing:
+            return "a signal slot names a stream but carries no ring to read samples from";
         case ScreenError::MalformedTraceStyle:
             return "a signal slot's sample range is empty or not finite, or its stroke width is out of range";
         case ScreenError::MalformedSampleRing:
@@ -318,11 +325,7 @@ namespace {
 }  // namespace
 
 mdux::core::Result<FrameStats, ScreenError>
-render(const ScreenPackage& screen,
-       mdux::draw::DrawList&  list,
-       const TextBinding&     text,
-       const ImageBinding&    image,
-       const SignalBinding&   signals) noexcept {
+render(const ScreenPackage& screen, mdux::draw::DrawList& list, const TextBinding& text, const ImageBinding& image, const SignalBinding& signals) noexcept {
     // Taken before anything is recorded: every refusal below rolls back to here, so a frame is
     // whole or absent. A half-drawn frame on a medical display is the worst outcome available,
     // because it looks like a reading.

--- a/src/medui/Trace.cpp
+++ b/src/medui/Trace.cpp
@@ -61,9 +61,21 @@ struct SamplePoint {
  * range is a real reading a monitor pins to its rail.
  */
 [[nodiscard]] Px rowFor(float sample, const TraceStyle& style, Px rows) noexcept {
-    const float span       = style.maximum - style.minimum;
-    const float offset     = sample - style.minimum;
-    const float normalised = offset / span;
+    // Widened before subtracting, not afterwards. `create()` checks that the minimum, the maximum
+    // and every sample are finite, which does not make their *differences* finite: a range of
+    // [-FLT_MAX, FLT_MAX] passes every one of those checks and still overflows to an infinite span,
+    // and at the top of that range `sample - minimum` overflows too. The float path then divided one
+    // infinity by another, and the NaN fell into the `!(t > 0.0F)` branch below - so the largest
+    // sample a screen can carry drew on the bottom rail, indistinguishable from the smallest. A
+    // full-scale transition rendered as a flat line, which is the one failure a monitor must not
+    // have.
+    //
+    // The difference of two floats is exact in double, so nothing is rounded here that was not
+    // rounded before, and the division is exactly rounded once on the way back to float. Rail
+    // clamping below is unchanged and still does the work for finite excursions.
+    const double span       = static_cast<double>(style.maximum) - static_cast<double>(style.minimum);
+    const double offset     = static_cast<double>(sample) - static_cast<double>(style.minimum);
+    const auto   normalised = static_cast<float>(offset / span);
 
     float t = normalised;
     // `!(t > 0.0F)` rather than `t < 0.0F`, so a NaN lands on the bottom rail instead of falling

--- a/src/medui/Trace.cpp
+++ b/src/medui/Trace.cpp
@@ -1,0 +1,242 @@
+/**
+ * @file Trace.cpp
+ * @brief Implementation of the governed waveform expansion.
+ */
+
+module;
+
+module mdux.medui.trace;
+
+import std;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.draw;
+
+namespace mdux::medui {
+
+namespace {
+
+using mdux::core::Px;
+
+/**
+ * @brief One sample's position: the centre of the pixel it was quantised onto.
+ *
+ * Half a pixel, added once, and it is the difference between a stroke that lands on the pixels its
+ * width says and one that straddles two rows. Surface coordinates address a pixel's top-left corner,
+ * so pixel (px, py) covers the square from (px, py) to (px + 1, py + 1) and its centre is at
+ * (px + 0.5, py + 0.5). A 1px stroke through that centre covers exactly that pixel; a 1px stroke
+ * through the *corner* covers half of each of two.
+ *
+ * Both the cap and the segment are built from this one value, which is why the cap is a quad rather
+ * than the `core::Rect` an axis-aligned square would naturally be: a rect's edges are integers, and
+ * an even stroke width centred on a pixel centre has half-integer edges. Two primitives built from
+ * one float centre cannot disagree about where the path is; a rect and a quad would disagree by half
+ * a pixel at every even width.
+ */
+struct SamplePoint {
+    float x{0.0F};
+    float y{0.0F};
+};
+
+/// The square quad a joint cap occupies: the bounding square of the disc a round join would draw.
+[[nodiscard]] std::array<mdux::draw::Point2F, 4> capQuad(SamplePoint at, float halfWidth) noexcept {
+    return std::array<mdux::draw::Point2F, 4>{
+        mdux::draw::Point2F{.x = at.x - halfWidth, .y = at.y - halfWidth},
+        mdux::draw::Point2F{.x = at.x + halfWidth, .y = at.y - halfWidth},
+        mdux::draw::Point2F{.x = at.x + halfWidth, .y = at.y + halfWidth},
+        mdux::draw::Point2F{.x = at.x - halfWidth, .y = at.y + halfWidth}
+    };
+}
+
+/**
+ * @brief The row a sample lands on inside a band of `rows` rows, counting down from the top.
+ *
+ * The same shape as `medui::quantise()`, and for the same reason: the multiply and the add are
+ * separate statements so neither the rounding nor the result depends on whether the compiler fuses
+ * them. `mdux_enforce_fp_determinism(MduXCore)` already turns contraction off for this target; this
+ * is the belt to that pair of braces, because a waveform compared across toolchains cannot afford a
+ * last-bit difference in a vertex.
+ *
+ * Clamping rather than refusing is `TraceStyle`'s documented decision: an excursion past the display
+ * range is a real reading a monitor pins to its rail.
+ */
+[[nodiscard]] Px rowFor(float sample, const TraceStyle& style, Px rows) noexcept {
+    const float span       = style.maximum - style.minimum;
+    const float offset     = sample - style.minimum;
+    const float normalised = offset / span;
+
+    float t = normalised;
+    // `!(t > 0.0F)` rather than `t < 0.0F`, so a NaN lands on the bottom rail instead of falling
+    // through both comparisons - the caller has already refused those, and being total is one test.
+    if (!(t > 0.0F)) {
+        t = 0.0F;
+    } else if (t > 1.0F) {
+        t = 1.0F;
+    }
+
+    const float scaled     = t * static_cast<float>(rows - 1);
+    const float rounded    = scaled + 0.5F;
+    const auto  fromBottom = static_cast<Px>(rounded);
+
+    // Value up: the largest sample is at the smallest y. Clamped again on the integer, because the
+    // cast above truncates a value that is at most `rows - 1 + 0.5` and could reach `rows - 1`
+    // exactly - which is in range - but would not be if the arithmetic above ever changed.
+    const Px clamped = fromBottom > rows - 1 ? rows - 1 : fromBottom;
+    return (rows - 1) - clamped;
+}
+
+/// The x column sample `index` of `count` occupies inside a band `columns` wide.
+///
+/// Integer division in 64-bit, so the endpoints are exact - sample 0 is column 0 and sample
+/// `count - 1` is column `columns - 1` - and no toolchain can round the interior differently.
+[[nodiscard]] Px columnFor(std::size_t index, std::size_t count, Px columns) noexcept {
+    if (count < 2) {
+        return 0;
+    }
+    const auto scaled = static_cast<std::int64_t>(index) * static_cast<std::int64_t>(columns - 1);
+    return static_cast<Px>(scaled / static_cast<std::int64_t>(count - 1));
+}
+
+/**
+ * @brief The quad a segment from `from` to `to` occupies at `halfWidth` either side of it.
+ *
+ * Nothing but the offset normal, in ring order: both corners on one side, then both on the other,
+ * so `addSolidQuad()`'s fixed 0-1-2 / 0-2-3 split covers the whole rectangle rather than folding it.
+ *
+ * `std::nullopt` for a zero-length segment, which is not an error: two consecutive samples land on
+ * the same pixel whenever a ring holds more samples than the band has columns, and the caps drawn at
+ * both endpoints already cover exactly the pixels the empty segment would have.
+ */
+[[nodiscard]] std::optional<std::array<mdux::draw::Point2F, 4>> segmentQuad(SamplePoint from, SamplePoint to, float halfWidth) noexcept {
+    const float dx = to.x - from.x;
+    const float dy = to.y - from.y;
+
+    const float lengthSquared = (dx * dx) + (dy * dy);
+    if (!(lengthSquared > 0.0F)) {
+        return std::nullopt;
+    }
+    // IEEE 754 requires sqrt to be correctly rounded, so this is the one transcendental-looking
+    // call a byte-compared frame may depend on. See Trace.cppm for why `std::exp` was not.
+    const float length  = std::sqrt(lengthSquared);
+    const float scale   = halfWidth / length;
+    const float normalX = -dy * scale;
+    const float normalY = dx * scale;
+
+    return std::array<mdux::draw::Point2F, 4>{
+        mdux::draw::Point2F{.x = from.x + normalX, .y = from.y + normalY},
+        mdux::draw::Point2F{  .x = to.x + normalX,   .y = to.y + normalY},
+        mdux::draw::Point2F{  .x = to.x - normalX,   .y = to.y - normalY},
+        mdux::draw::Point2F{.x = from.x - normalX, .y = from.y - normalY}
+    };
+}
+
+}  // namespace
+
+std::string_view describe(TraceError error) noexcept {
+    switch (error) {
+        case TraceError::MalformedRing:
+            return "a ring's oldest index or live count does not describe a position in its storage";
+        case TraceError::TooManySamples:
+            return "a ring holds more samples than this runtime will expand in one trace";
+        case TraceError::NonFiniteSample:
+            return "a live sample is not a finite number";
+        case TraceError::MalformedStyle:
+            return "the sample range is empty or not finite, or the stroke width is out of range";
+        case TraceError::BandTooSmall:
+            return "the node's rectangle cannot hold a band of this stroke width";
+        case TraceError::ListRejected:
+            return "the draw list refused a primitive - budget, or a degenerate quad";
+    }
+    // Named rather than defaulted so that adding an enumerator without a case here is a warning at
+    // this switch instead of a blank string later.
+    return "unknown trace error";
+}
+
+mdux::core::ResultVoid<TraceError>
+recordTrace(mdux::draw::DrawList& list, const mdux::core::Rect& band, const SampleRing& ring, const TraceStyle& style, mdux::core::ColorRgba8 color) noexcept {
+    if (style.strokeWidth < 1 || style.strokeWidth > maxStrokeWidth) {
+        return mdux::core::err(TraceError::MalformedStyle);
+    }
+    if (!std::isfinite(style.minimum) || !std::isfinite(style.maximum) || !(style.maximum > style.minimum)) {
+        return mdux::core::err(TraceError::MalformedStyle);
+    }
+
+    if (ring.count > ring.storage.size() || (ring.count > 0 && ring.oldest >= ring.storage.size())) {
+        return mdux::core::err(TraceError::MalformedRing);
+    }
+    if (ring.count > maxSamplesPerTrace) {
+        // Refused, never truncated. Showing the newest 256 of 300 samples would be a waveform the
+        // caller did not ask for, drawn in the tint that says it is the one it did.
+        return mdux::core::err(TraceError::TooManySamples);
+    }
+
+    // The path is inset so that the stroke - half its width either side of a pixel *centre* - stays
+    // inside the band. The condition is `inset + 0.5 >= strokeWidth / 2`, and integer division
+    // satisfies it exactly at each admitted width: 0 for a 1px stroke, 1 for 2px and 1 for 3px. The
+    // half-pixel that makes those numbers work is `SamplePoint`'s, and is why this is not simply
+    // `strokeWidth / 2` rounded up.
+    const Px inset   = style.strokeWidth / 2;
+    const Px columns = band.width - (2 * inset);
+    const Px rows    = band.height - (2 * inset);
+    if (columns < 1 || rows < 1) {
+        return mdux::core::err(TraceError::BandTooSmall);
+    }
+
+    if (ring.count < 2) {
+        // One sample is a point, not a trace, and no sample is an empty band. Neither is an error -
+        // a ring fills up over the first frames of a device's life - and neither records anything,
+        // so there is nothing to roll back either.
+        return {};
+    }
+
+    const mdux::draw::DrawList::Marker start  = list.mark();
+    const auto                         refuse = [&list, &start](TraceError error) {
+        // Cannot fail for a marker taken from this list moments ago; discarded rather than checked
+        // because there is no second recovery to attempt.
+        static_cast<void>(list.rollback(start));
+        return mdux::core::err(error);
+    };
+
+    const float halfWidth = static_cast<float>(style.strokeWidth) / 2.0F;
+    const Px    originX   = band.x + inset;
+    const Px    originY   = band.y + inset;
+
+    // One cap per sample and one segment behind it, in sample order. Fixed rather than incidental:
+    // two frames built from the same samples must produce byte-identical buffers.
+    SamplePoint previous{};
+    for (std::size_t index = 0; index < ring.count; ++index) {
+        const std::optional<float> sample = ring.at(index);
+        if (!sample.has_value()) {
+            // Unreachable given the bounds checked above, and checked anyway: `at()` is the only
+            // reader, and a bound it enforces that this ignored would be a silent zero sample.
+            return refuse(TraceError::MalformedRing);
+        }
+        if (!std::isfinite(*sample)) {
+            // Before any arithmetic touches it. A NaN sample normalises to a NaN position and
+            // reaches the rasteriser as undefined behaviour rather than as an invisible primitive.
+            return refuse(TraceError::NonFiniteSample);
+        }
+
+        const SamplePoint point{.x = static_cast<float>(originX + columnFor(index, ring.count, columns)) + 0.5F,
+                                .y = static_cast<float>(originY + rowFor(*sample, style, rows)) + 0.5F};
+
+        // The cap: the bounding square of the disc a round join would draw. See Trace.cppm for why
+        // that substitution is honest at these widths and refused past them.
+        if (const auto recorded = list.addSolidQuad(capQuad(point, halfWidth), color); !recorded.has_value()) {
+            return refuse(TraceError::ListRejected);
+        }
+
+        if (index > 0) {
+            if (const std::optional quad = segmentQuad(previous, point, halfWidth); quad.has_value()) {
+                if (const auto recorded = list.addSolidQuad(*quad, color); !recorded.has_value()) {
+                    return refuse(TraceError::ListRejected);
+                }
+            }
+        }
+        previous = point;
+    }
+
+    return {};
+}
+
+}  // namespace mdux::medui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -806,6 +806,7 @@ add_executable(medui_spec
     medui/MeduiSpecMain.cpp
     medui/SchemaTests.cpp
     medui/ScreenRuntimeTests.cpp
+    medui/TraceTests.cpp
     medui/GeneratedScreenTests.cpp
     medui/GeneratedScreenModuleConsumer.cpp
     medui/GeneratedScreenHeaderConsumer.cpp

--- a/tests/draw/DrawTests.cpp
+++ b/tests/draw/DrawTests.cpp
@@ -991,7 +991,11 @@ const mdux::spec::Register drawErrorDescriptions{
             .When("each is described", [] {})
             .Then("each has a unique, non-empty description",
                   [] {
-                      constexpr std::array<DrawError, 7> all{
+                      // Every enumerator, not a subset. WrongList was absent from this list until
+                      // #257 added DegenerateQuad beside it and the omission became visible - which
+                      // is the failure mode a hand-maintained "all" array has, and the reason the
+                      // scenario below counts them against the enumeration's own size.
+                      constexpr std::array<DrawError, 9> all{
                           DrawError::EmptyBudget,
                           DrawError::BudgetExceedsIndexWidth,
                           DrawError::StorageTooSmall,
@@ -999,6 +1003,8 @@ const mdux::spec::Register drawErrorDescriptions{
                           DrawError::IndexBudgetExceeded,
                           DrawError::CommandBudgetExceeded,
                           DrawError::DegenerateRect,
+                          DrawError::WrongList,
+                          DrawError::DegenerateQuad,
                       };
                       std::vector<std::string_view> seen;
                       mdux::spec::Checks checks;
@@ -1008,6 +1014,183 @@ const mdux::spec::Register drawErrorDescriptions{
                           checks.expect(std::ranges::find(seen, text) == seen.end(),
                                         "the description is unique");
                           seen.push_back(text);
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// addSolidQuad() - the rotated primitive a polyline segment needs (#257)
+// ---------------------------------------------------------------------------
+
+/// The four corners of a unit-ish quad, wound as a ring. Not axis-aligned, so an implementation
+/// that quietly took a bounding box would be visible in the vertices.
+constexpr std::array<Point2F, 4> slantedQuad{
+    Point2F{ .x = 10.5F, .y = 20.0F},
+    Point2F{.x = 40.25F, .y = 24.0F},
+    Point2F{.x = 40.25F, .y = 26.0F},
+    Point2F{ .x = 10.5F, .y = 22.0F}
+};
+
+const mdux::spec::Register quadKeepsItsCorners{
+    "A solid quad records its four corners unrounded", "evidence-unit", [] {
+        struct State {
+            SmallStorage storage;
+            std::optional<DrawList> list;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("draw-quad-keeps-corners")
+            .Given("a list and a quad whose corners are not whole pixels",
+                   [state] {
+                       state->list = requireCreated(state->storage.list(), "the list");
+                       requireAdded(state->list->addSolidQuad(slantedQuad, red), "the quad");
+                   })
+            .When("its vertices are read back", [] {})
+            .Then("each corner survives exactly, in the order it was given",
+                  [state] {
+                      // The whole reason Point2F exists: an integer type would have rounded 10.5 and
+                      // 40.25, and a 1px stroke would alternate between one and two pixels wide as
+                      // its slope changed. Compared exactly rather than within a tolerance - these
+                      // are copies, not computations.
+                      const std::span<const UiVertex> vertices = state->list->vertices();
+                      mdux::spec::Checks checks;
+                      checks.expect(vertices.size() == 4, "a quad costs four vertices");
+                      if (vertices.size() != 4) {
+                          checks.raise();
+                          return;
+                      }
+                      for (std::size_t i = 0; i < 4; ++i) {
+                          checks.expect(vertices[i].x == slantedQuad[i].x,
+                                        std::format("corner {} keeps its x", i));
+                          checks.expect(vertices[i].y == slantedQuad[i].y,
+                                        std::format("corner {} keeps its y", i));
+                          checks.expect(vertices[i].mode == static_cast<std::uint32_t>(DrawMode::Solid),
+                                        std::format("corner {} is Solid", i));
+                          checks.expect(vertices[i].u == 0.0F && vertices[i].v == 0.0F,
+                                        std::format("corner {} carries a zeroed uv", i));
+                      }
+                      checks.expect(state->list->indices().size() == 6, "a quad costs six indices");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register quadRefusesDegenerate{
+    "A quad enclosing no area, or carrying a non-finite corner, is refused", "evidence-unit", [] {
+        struct State {
+            SmallStorage storage;
+            std::optional<DrawList> list;
+            std::optional<DrawError> collinear;
+            std::optional<DrawError> notANumber;
+            std::optional<DrawError> infinite;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("draw-quad-refuses-degenerate")
+            .Given("a list",
+                   [state] { state->list = requireCreated(state->storage.list(), "the list"); })
+            .When("degenerate quads are offered",
+                  [state] {
+                      constexpr std::array<Point2F, 4> collinear{
+                          Point2F{.x = 0.0F, .y = 0.0F},
+                          Point2F{.x = 1.0F, .y = 1.0F},
+                          Point2F{.x = 2.0F, .y = 2.0F},
+                          Point2F{.x = 3.0F, .y = 3.0F}
+                      };
+                      state->collinear = requireRejectedAdd(state->list->addSolidQuad(collinear, red),
+                                                            "a collinear quad");
+
+                      std::array<Point2F, 4> withNan = slantedQuad;
+                      withNan[2].y = std::numeric_limits<float>::quiet_NaN();
+                      state->notANumber = requireRejectedAdd(state->list->addSolidQuad(withNan, red),
+                                                              "a quad with a NaN corner");
+
+                      std::array<Point2F, 4> withInf = slantedQuad;
+                      withInf[0].x = std::numeric_limits<float>::infinity();
+                      state->infinite = requireRejectedAdd(state->list->addSolidQuad(withInf, red),
+                                                            "a quad with an infinite corner");
+                  })
+            .Then("each is DegenerateQuad and nothing was recorded",
+                  [state] {
+                      // The NaN case is the one that earns the finiteness test being first: every
+                      // check after it is a comparison, and a NaN compares false against all of
+                      // them - so an unchecked NaN would fall through the area test as "not
+                      // degenerate" and reach the rasteriser, where it is undefined behaviour.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->collinear == DrawError::DegenerateQuad,
+                                    "a collinear quad is DegenerateQuad");
+                      checks.expect(state->notANumber == DrawError::DegenerateQuad,
+                                    "a NaN corner is DegenerateQuad");
+                      checks.expect(state->infinite == DrawError::DegenerateQuad,
+                                    "an infinite corner is DegenerateQuad");
+                      checks.expect(state->list->vertices().empty(), "no vertex was recorded");
+                      checks.expect(state->list->indices().empty(), "no index was recorded");
+                      checks.expect(state->list->commands().empty(), "no command was started");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register quadSharesTheBudget{
+    "A quad is held to the same budget a rectangle is", "evidence-unit", [] {
+        struct State {
+            Storage<8, 12, 2> storage;
+            std::optional<DrawList> list;
+            std::optional<DrawError> refused;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("draw-quad-shares-budget")
+            .Given("a list with room for exactly two primitives",
+                   [state] { state->list = requireCreated(state->storage.list(), "the list"); })
+            .When("a rectangle, a quad and one more quad are offered",
+                  [state] {
+                      requireAdded(state->list->addSolidRect(rect, red), "the rectangle");
+                      requireAdded(state->list->addSolidQuad(slantedQuad, red), "the first quad");
+                      state->refused = requireRejectedAdd(state->list->addSolidQuad(slantedQuad, red),
+                                                          "the third primitive");
+                  })
+            .Then("the third is refused on the vertex budget and the list is intact",
+                  [state] {
+                      // A quad that bypassed the budget would be the whole fixed-budget property
+                      // gone, since #257 makes a trace the primitive a screen records most of.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->refused == DrawError::VertexBudgetExceeded,
+                                    "the third primitive exceeds the vertex budget");
+                      checks.expect(state->list->vertices().size() == 8, "two primitives were kept");
+                      checks.expect(state->list->indices().size() == 12, "their indices were kept");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register quadExtendsTheCurrentCommand{
+    "A quad under an unchanged clip extends the current command", "evidence-unit", [] {
+        struct State {
+            SmallStorage storage;
+            std::optional<DrawList> list;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("draw-quad-extends-command")
+            .Given("a list holding one rectangle",
+                   [state] {
+                       state->list = requireCreated(state->storage.list(), "the list");
+                       requireAdded(state->list->addSolidRect(rect, red), "the rectangle");
+                   })
+            .When("a quad is added under the same clip",
+                  [state] { requireAdded(state->list->addSolidQuad(slantedQuad, red), "the quad"); })
+            .Then("one command covers both",
+                  [state] {
+                      // The property that keeps a command budget meaningful: a trace of 256 samples
+                      // is 511 primitives and must not be 511 commands.
+                      const std::span<const DrawCommand> commands = state->list->commands();
+                      mdux::spec::Checks checks;
+                      checks.expect(commands.size() == 1, "one command");
+                      if (!commands.empty()) {
+                          checks.expect(commands[0].indexCount == 12, "it claims both primitives' indices");
                       }
                       checks.raise();
                   })

--- a/tests/draw/DrawTests.cpp
+++ b/tests/draw/DrawTests.cpp
@@ -1033,6 +1033,62 @@ constexpr std::array<Point2F, 4> slantedQuad{
     Point2F{ .x = 10.5F, .y = 22.0F}
 };
 
+const mdux::spec::Register aSmallQuadSurvivesLargeCoordinates{
+    "A small quad is admitted just as far from the origin as beside it",
+    "evidence-unit",
+    [] {
+        struct State {
+            SmallStorage             storage;
+            std::optional<DrawList>  list;
+            std::optional<DrawError> nearOrigin;
+            std::optional<DrawError> farFromOrigin;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("draw-quad-large-coordinates")
+            .Given("one unit square, offered at the origin and again at a large offset", [] {})
+            .When("each is added to a list with budget to spare",
+                  [state] {
+                      // The degeneracy test is a shoelace sum, and a shoelace sum over *absolute*
+                      // coordinates subtracts two products of similar magnitude. At 4096 those
+                      // products are near 2^24, where a float's ulp is larger than this square's
+                      // area, so the area cancels to zero and a perfectly good quad reads as
+                      // collinear. A trace drawn on a large surface emits one small cap per sample,
+                      // so this is the arithmetic every one of them lands on.
+                      //
+                      // (4096, 4096) rather than an arbitrary large offset: whether the cancellation
+                      // reaches exactly zero depends on the corner values, and this pair is one that
+                      // does. Nearby offsets survive with a wrong-but-nonzero area, which the
+                      // zero-check cannot see - the reason to fix the arithmetic rather than the
+                      // threshold.
+                      const auto square = [](float x, float y) {
+                          return std::array<Point2F, 4>{
+                              Point2F{    .x = x,     .y = y},
+                              Point2F{.x = x + 1,     .y = y},
+                              Point2F{.x = x + 1, .y = y + 1},
+                              Point2F{    .x = x, .y = y + 1}
+                          };
+                      };
+                      state->list = requireCreated(state->storage.list(), "the list");
+
+                      const auto near   = state->list->addSolidQuad(square(0.0F, 0.0F), red);
+                      state->nearOrigin = near.has_value() ? std::nullopt : std::optional{near.error()};
+
+                      const auto far       = state->list->addSolidQuad(square(4096.0F, 4096.0F), red);
+                      state->farFromOrigin = far.has_value() ? std::nullopt : std::optional{far.error()};
+                  })
+            .Then("both are admitted, because area does not depend on where a shape sits",
+                  [state] {
+                      mdux::spec::Checks checks;
+                      checks.expect(!state->nearOrigin.has_value(), "the unit square at the origin is admitted");
+                      checks.expect(!state->farFromOrigin.has_value(),
+                                    std::format("the same square at (4096, 4096) is admitted, got {}",
+                                                state->farFromOrigin.has_value() ? describe(*state->farFromOrigin) : "no error"));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register quadKeepsItsCorners{
     "A solid quad records its four corners unrounded", "evidence-unit", [] {
         struct State {

--- a/tests/medui/ScreenNoHeapTests.cpp
+++ b/tests/medui/ScreenNoHeapTests.cpp
@@ -22,6 +22,7 @@ import mdux.draw;
 import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.medui.screen;
+import mdux.medui.trace;
 import mdux.text.schema;
 
 #include "../framework/SpecLabBridge.hpp"
@@ -309,6 +310,95 @@ const mdux::spec::Register drawingTextAllocatesNothing{
                     // The label is drawn rather than deferred, so this scenario measures the text
                     // path rather than the same deferred walk the case above measures.
                     checks.expect(lastRects == 2, std::format("the panel and the glyph, got {}", lastRects));
+                    checks.expect(after == before, std::format("no allocation across eight frames, counter went {} to {}", before, after));
+                    checks.raise();
+                })
+            .Execute();
+    }};
+
+const mdux::spec::Register expandingATraceAllocatesNothing{
+    "Expanding a bound waveform allocates nothing either",
+    "noheap",
+    [] {
+        return speclab::Test("medui-screen-noheap-render-trace")
+            .Given("a screen whose SignalTrace is bound to a caller-owned ring", [] {})
+            .When("frames are recorded while the producer writes into the ring", [] {})
+            .Then(
+                "the allocation counter does not move",
+                [] {
+                    mdux::spec::Checks checks;
+
+                    // The path #257 adds, and the one with the most ways to allocate quietly: a
+                    // per-frame scratch for the expanded polyline is the obvious implementation of a
+                    // waveform, and it is the implementation this measurement exists to refuse. The
+                    // ring, the slots and the storage are all the caller's, made once, outside the
+                    // counter.
+                    constexpr ms::SignalTraceSpec            trace{.streamSource = "ECG_LEAD_II", .colorToken = "Theme.Colors.Nominal"};
+                    static constexpr std::array<ms::CompiledNode, 1> traceNodes{
+                        ms::CompiledNode{.id = "ecg", .bounds = {0, 0, 200, 60}, .payload = trace}
+                    };
+                    static constexpr mdux::draw::DrawBudget traceBudget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
+                    static constexpr ms::ScreenPackage      traceScreen{.id                   = "noheap-trace",
+                                                                        .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                                        .surfaceWidth         = 200,
+                                                                        .surfaceHeight        = 60,
+                                                                        .approvedTextPackages = {},
+                                                                        .nodes                = traceNodes,
+                                                                        .budget               = traceBudget};
+                    static_assert(traceScreen.validate().has_value(), "the screen under measurement must be one a device could hold");
+
+                    static std::array<float, 24> samples{};
+                    static ms::SampleRing        ring{.storage = samples, .oldest = 0, .count = samples.size()};
+                    static const std::array<ms::SignalSlot, 1> slots{
+                        ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &ring, .style = ms::TraceStyle{.minimum = -1.0F, .maximum = 1.0F, .strokeWidth = 2}}
+                    };
+
+                    const auto made = ms::SignalBinding::create(traceScreen, slots);
+                    if (!made.has_value()) {
+                        checks.expect(false, "the fixture binding is valid");
+                        checks.raise();
+                        return;
+                    }
+                    const ms::SignalBinding binding = *made;
+
+                    static std::array<mdux::draw::UiVertex, 512>   vertices{};
+                    static std::array<mdux::draw::Index, 768>      indices{};
+                    static std::array<mdux::draw::DrawCommand, 16> commands{};
+
+                    auto created = mdux::draw::DrawList::create(vertices, indices, commands, traceBudget);
+                    if (!created.has_value()) {
+                        checks.expect(false, "the storage satisfies the budget");
+                        checks.raise();
+                        return;
+                    }
+                    mdux::draw::DrawList list = std::move(*created);
+
+                    // Nothing inside the measured loop may format a message: `std::format`
+                    // allocates, and a per-frame assertion carrying one would report the test's own
+                    // allocation as the runtime's.
+                    std::uint32_t lastTraces  = 0;
+                    bool          allRecorded = true;
+
+                    const std::size_t before = allocations();
+                    for (int frame = 0; frame < 8; ++frame) {
+                        // The producer, doing what a producer does between frames: writing one new
+                        // sample and moving the ring's oldest index. A per-frame allocation hidden
+                        // behind "the samples changed" would show up as eight.
+                        samples[static_cast<std::size_t>(frame) % samples.size()] = 0.25F * static_cast<float>(frame % 5);
+                        ring.oldest                                               = (ring.oldest + 1) % samples.size();
+
+                        list.reset();
+                        const auto recorded = ms::render(traceScreen, list, {}, {}, binding);
+                        if (!recorded.has_value()) {
+                            allRecorded = false;
+                            continue;
+                        }
+                        lastTraces = recorded->traces;
+                    }
+                    const std::size_t after = allocations();
+
+                    checks.expect(allRecorded, "each frame is recorded");
+                    checks.expect(lastTraces == 1, std::format("the trace was expanded rather than left as a field, got {}", lastTraces));
                     checks.expect(after == before, std::format("no allocation across eight frames, counter went {} to {}", before, after));
                     checks.raise();
                 })

--- a/tests/medui/ScreenNoHeapTests.cpp
+++ b/tests/medui/ScreenNoHeapTests.cpp
@@ -323,84 +323,85 @@ const mdux::spec::Register expandingATraceAllocatesNothing{
         return speclab::Test("medui-screen-noheap-render-trace")
             .Given("a screen whose SignalTrace is bound to a caller-owned ring", [] {})
             .When("frames are recorded while the producer writes into the ring", [] {})
-            .Then(
-                "the allocation counter does not move",
-                [] {
-                    mdux::spec::Checks checks;
+            .Then("the allocation counter does not move",
+                  [] {
+                      mdux::spec::Checks checks;
 
-                    // The path #257 adds, and the one with the most ways to allocate quietly: a
-                    // per-frame scratch for the expanded polyline is the obvious implementation of a
-                    // waveform, and it is the implementation this measurement exists to refuse. The
-                    // ring, the slots and the storage are all the caller's, made once, outside the
-                    // counter.
-                    constexpr ms::SignalTraceSpec            trace{.streamSource = "ECG_LEAD_II", .colorToken = "Theme.Colors.Nominal"};
-                    static constexpr std::array<ms::CompiledNode, 1> traceNodes{
-                        ms::CompiledNode{.id = "ecg", .bounds = {0, 0, 200, 60}, .payload = trace}
-                    };
-                    static constexpr mdux::draw::DrawBudget traceBudget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
-                    static constexpr ms::ScreenPackage      traceScreen{.id                   = "noheap-trace",
-                                                                        .schemaVersion        = mdux::evidence::kSchemaVersion,
-                                                                        .surfaceWidth         = 200,
-                                                                        .surfaceHeight        = 60,
-                                                                        .approvedTextPackages = {},
-                                                                        .nodes                = traceNodes,
-                                                                        .budget               = traceBudget};
-                    static_assert(traceScreen.validate().has_value(), "the screen under measurement must be one a device could hold");
+                      // The path #257 adds, and the one with the most ways to allocate quietly: a
+                      // per-frame scratch for the expanded polyline is the obvious implementation of a
+                      // waveform, and it is the implementation this measurement exists to refuse. The
+                      // ring, the slots and the storage are all the caller's, made once, outside the
+                      // counter.
+                      constexpr ms::SignalTraceSpec                    trace{.streamSource = "ECG_LEAD_II", .colorToken = "Theme.Colors.Nominal"};
+                      static constexpr std::array<ms::CompiledNode, 1> traceNodes{
+                          ms::CompiledNode{.id = "ecg", .bounds = {0, 0, 200, 60}, .payload = trace}
+                      };
+                      static constexpr mdux::draw::DrawBudget traceBudget{.maxVertices = 512, .maxIndices = 768, .maxCommands = 16};
+                      static constexpr ms::ScreenPackage      traceScreen{.id                   = "noheap-trace",
+                                                                          .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                                          .surfaceWidth         = 200,
+                                                                          .surfaceHeight        = 60,
+                                                                          .approvedTextPackages = {},
+                                                                          .nodes                = traceNodes,
+                                                                          .budget               = traceBudget};
+                      static_assert(traceScreen.validate().has_value(), "the screen under measurement must be one a device could hold");
 
-                    static std::array<float, 24> samples{};
-                    static ms::SampleRing        ring{.storage = samples, .oldest = 0, .count = samples.size()};
-                    static const std::array<ms::SignalSlot, 1> slots{
-                        ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &ring, .style = ms::TraceStyle{.minimum = -1.0F, .maximum = 1.0F, .strokeWidth = 2}}
-                    };
+                      static std::array<float, 24>               samples{};
+                      static ms::SampleRing                      ring{.storage = samples, .oldest = 0, .count = samples.size()};
+                      static const std::array<ms::SignalSlot, 1> slots{
+                          ms::SignalSlot{.streamSource = "ECG_LEAD_II",
+                                         .ring         = &ring,
+                                         .style        = ms::TraceStyle{.minimum = -1.0F, .maximum = 1.0F, .strokeWidth = 2}}
+                      };
 
-                    const auto made = ms::SignalBinding::create(traceScreen, slots);
-                    if (!made.has_value()) {
-                        checks.expect(false, "the fixture binding is valid");
-                        checks.raise();
-                        return;
-                    }
-                    const ms::SignalBinding binding = *made;
+                      const auto made = ms::SignalBinding::create(traceScreen, slots);
+                      if (!made.has_value()) {
+                          checks.expect(false, "the fixture binding is valid");
+                          checks.raise();
+                          return;
+                      }
+                      const ms::SignalBinding binding = *made;
 
-                    static std::array<mdux::draw::UiVertex, 512>   vertices{};
-                    static std::array<mdux::draw::Index, 768>      indices{};
-                    static std::array<mdux::draw::DrawCommand, 16> commands{};
+                      static std::array<mdux::draw::UiVertex, 512>   vertices{};
+                      static std::array<mdux::draw::Index, 768>      indices{};
+                      static std::array<mdux::draw::DrawCommand, 16> commands{};
 
-                    auto created = mdux::draw::DrawList::create(vertices, indices, commands, traceBudget);
-                    if (!created.has_value()) {
-                        checks.expect(false, "the storage satisfies the budget");
-                        checks.raise();
-                        return;
-                    }
-                    mdux::draw::DrawList list = std::move(*created);
+                      auto created = mdux::draw::DrawList::create(vertices, indices, commands, traceBudget);
+                      if (!created.has_value()) {
+                          checks.expect(false, "the storage satisfies the budget");
+                          checks.raise();
+                          return;
+                      }
+                      mdux::draw::DrawList list = std::move(*created);
 
-                    // Nothing inside the measured loop may format a message: `std::format`
-                    // allocates, and a per-frame assertion carrying one would report the test's own
-                    // allocation as the runtime's.
-                    std::uint32_t lastTraces  = 0;
-                    bool          allRecorded = true;
+                      // Nothing inside the measured loop may format a message: `std::format`
+                      // allocates, and a per-frame assertion carrying one would report the test's own
+                      // allocation as the runtime's.
+                      std::uint32_t lastTraces  = 0;
+                      bool          allRecorded = true;
 
-                    const std::size_t before = allocations();
-                    for (int frame = 0; frame < 8; ++frame) {
-                        // The producer, doing what a producer does between frames: writing one new
-                        // sample and moving the ring's oldest index. A per-frame allocation hidden
-                        // behind "the samples changed" would show up as eight.
-                        samples[static_cast<std::size_t>(frame) % samples.size()] = 0.25F * static_cast<float>(frame % 5);
-                        ring.oldest                                               = (ring.oldest + 1) % samples.size();
+                      const std::size_t before = allocations();
+                      for (int frame = 0; frame < 8; ++frame) {
+                          // The producer, doing what a producer does between frames: writing one new
+                          // sample and moving the ring's oldest index. A per-frame allocation hidden
+                          // behind "the samples changed" would show up as eight.
+                          samples[static_cast<std::size_t>(frame) % samples.size()] = 0.25F * static_cast<float>(frame % 5);
+                          ring.oldest                                               = (ring.oldest + 1) % samples.size();
 
-                        list.reset();
-                        const auto recorded = ms::render(traceScreen, list, {}, {}, binding);
-                        if (!recorded.has_value()) {
-                            allRecorded = false;
-                            continue;
-                        }
-                        lastTraces = recorded->traces;
-                    }
-                    const std::size_t after = allocations();
+                          list.reset();
+                          const auto recorded = ms::render(traceScreen, list, {}, {}, binding);
+                          if (!recorded.has_value()) {
+                              allRecorded = false;
+                              continue;
+                          }
+                          lastTraces = recorded->traces;
+                      }
+                      const std::size_t after = allocations();
 
-                    checks.expect(allRecorded, "each frame is recorded");
-                    checks.expect(lastTraces == 1, std::format("the trace was expanded rather than left as a field, got {}", lastTraces));
-                    checks.expect(after == before, std::format("no allocation across eight frames, counter went {} to {}", before, after));
-                    checks.raise();
-                })
+                      checks.expect(allRecorded, "each frame is recorded");
+                      checks.expect(lastTraces == 1, std::format("the trace was expanded rather than left as a field, got {}", lastTraces));
+                      checks.expect(after == before, std::format("no allocation across eight frames, counter went {} to {}", before, after));
+                      checks.raise();
+                  })
             .Execute();
     }};

--- a/tests/medui/TraceTests.cpp
+++ b/tests/medui/TraceTests.cpp
@@ -1,0 +1,929 @@
+/**
+ * @file TraceTests.cpp
+ * @brief BDD scenarios for `mdux.medui.trace` and the screen runtime's signal binding (issue #257).
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
+ * @compliance ADR-005 Error handling and exceptions policy
+ * @compliance ADR-012 What a compiled screen emits, and which parts are committed
+ *
+ * Two halves, and they are tested apart for the reason the module is split apart. The geometry half
+ * reads vertices back and checks numbers - where a sample landed, whether the stroke stayed inside
+ * its band, what a second identical expansion produced. The binding half checks the join: which
+ * refusals `SignalBinding::create()` makes once, and what `render()` composes for a trace that has
+ * samples versus one that does not.
+ *
+ * The scenario this issue is judged on is `trace-refuses-an-oversized-ring`: a trace whose sample
+ * count exceeds the cap must be **refused**, not truncated. A truncating implementation passes every
+ * other scenario in this file, draws a plausible waveform, and is wrong in the one way a monitor
+ * cannot show.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.evidence.digest;
+import mdux.evidence.report;
+import mdux.draw;
+import mdux.medui.schema;
+import mdux.medui.screen;
+import mdux.medui.trace;
+
+#include "../framework/SpecLabBridge.hpp"
+
+namespace {
+
+namespace ms   = mdux::medui;
+namespace core = mdux::core;
+namespace draw = mdux::draw;
+
+/// Storage a caller sizes once, exactly as a device would - and never grows.
+///
+/// Generous enough for a full-cap trace (511 quads is 2044 vertices) so that a scenario about
+/// geometry fails on geometry rather than on a budget it did not mean to test. The budget-refusal
+/// scenarios build their own deliberately small list.
+struct Scratch {
+    std::array<draw::UiVertex, 2560>  vertices{};
+    std::array<draw::Index, 3840>     indices{};
+    std::array<draw::DrawCommand, 32> commands{};
+
+    [[nodiscard]] static constexpr draw::DrawBudget budget() noexcept {
+        return draw::DrawBudget{.maxVertices = 2560, .maxIndices = 3840, .maxCommands = 32};
+    }
+
+    [[nodiscard]] draw::DrawList list() {
+        auto created = draw::DrawList::create(vertices, indices, commands, budget());
+        if (!created.has_value()) {
+            throw speclab::core::AssertionFailure("the scratch does not satisfy its own budget", std::source_location::current());
+        }
+        return std::move(*created);
+    }
+};
+
+constexpr core::Rect       band{.x = 10, .y = 20, .width = 100, .height = 50};
+constexpr core::ColorRgba8 nominal{.r = 33, .g = 184, .b = 107, .a = 255};
+constexpr ms::TraceStyle   unitStyle{.minimum = 0.0F, .maximum = 1.0F, .strokeWidth = 1};
+
+/// A ring over `storage`, unwrapped: the caller has not filled it yet, so the oldest sample is at 0.
+[[nodiscard]] ms::SampleRing ringOver(std::span<const float> storage) noexcept {
+    return ms::SampleRing{.storage = storage, .oldest = 0, .count = storage.size()};
+}
+
+/// The box every recorded vertex lies in. Floats, because a stroke's corners are not whole pixels.
+struct VertexBox {
+    float left{0.0F};
+    float top{0.0F};
+    float right{0.0F};
+    float bottom{0.0F};
+};
+
+[[nodiscard]] std::optional<VertexBox> boxOf(std::span<const draw::UiVertex> vertices) noexcept {
+    if (vertices.empty()) {
+        return std::nullopt;
+    }
+    VertexBox box{.left = vertices[0].x, .top = vertices[0].y, .right = vertices[0].x, .bottom = vertices[0].y};
+    for (const draw::UiVertex& vertex : vertices) {
+        box.left   = std::min(box.left, vertex.x);
+        box.top    = std::min(box.top, vertex.y);
+        box.right  = std::max(box.right, vertex.x);
+        box.bottom = std::max(box.bottom, vertex.y);
+    }
+    return box;
+}
+
+/// Hard failure (REQUIRE-equivalent): an expansion that was expected to succeed must have.
+void requireRecorded(core::ResultVoid<ms::TraceError> result, std::string_view what, std::source_location where = std::source_location::current()) {
+    if (!result.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("{}: {}", what, ms::describe(result.error())), where);
+    }
+}
+
+/// Hard failure (REQUIRE-equivalent): an expansion that was expected to be refused must be refused.
+[[nodiscard]] ms::TraceError
+requireRefused(core::ResultVoid<ms::TraceError> result, std::string_view what, std::source_location where = std::source_location::current()) {
+    if (result.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("{}: expected a refusal but the trace was recorded", what), where);
+    }
+    return result.error();
+}
+
+// ---------------------------------------------------------------------------
+// Geometry
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register samplesSpanTheBand{
+    "A trace's first and last samples reach the band's edges, and its extremes reach its rows",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                       scratch;
+            std::optional<draw::DrawList> list;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("trace-spans-the-band")
+            .Given("five samples alternating between the range's ends",
+                   [state] {
+                       static constexpr std::array<float, 5> samples{0.0F, 1.0F, 0.0F, 1.0F, 0.0F};
+                       state->list = state->scratch.list();
+                       requireRecorded(ms::recordTrace(*state->list, band, ringOver(samples), unitStyle, nominal), "the trace");
+                   })
+            .When("the recorded vertices are read back", [] {})
+            .Then("they fill the band exactly and leave none of it",
+                  [state] {
+                      // Both directions in one scenario, deliberately. "Inside the band" alone is
+                      // satisfied by a trace drawn in one corner, and "reaches the edges" alone is
+                      // satisfied by one that spills - and the pair is what the inset arithmetic and
+                      // the pixel-centre convention exist to make simultaneously true.
+                      const std::optional<VertexBox> box = boxOf(state->list->vertices());
+                      mdux::spec::Checks             checks;
+                      if (!box.has_value()) {
+                          checks.expect(false, "the trace recorded something");
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(box->left == static_cast<float>(band.x), std::format("the left edge is {}, expected {}", box->left, band.x));
+                      checks.expect(box->right == static_cast<float>(band.right()), std::format("the right edge is {}, expected {}", box->right, band.right()));
+                      checks.expect(box->top == static_cast<float>(band.y), std::format("the top edge is {}, expected {}", box->top, band.y));
+                      checks.expect(box->bottom == static_cast<float>(band.bottom()),
+                                    std::format("the bottom edge is {}, expected {}", box->bottom, band.bottom()));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register valueIsUp{"The larger sample is the higher one on screen", "evidence-unit", [] {
+                                         struct State {
+                                             Scratch                       scratch;
+                                             std::optional<draw::DrawList> list;
+                                         };
+                                         auto state = std::make_shared<State>();
+
+                                         return speclab::Test("trace-value-is-up")
+                                             .Given("two samples, the second larger than the first",
+                                                    [state] {
+                                                        static constexpr std::array<float, 2> samples{0.0F, 1.0F};
+                                                        state->list = state->scratch.list();
+                                                        requireRecorded(ms::recordTrace(*state->list, band, ringOver(samples), unitStyle, nominal),
+                                                                        "the trace");
+                                                    })
+                                             .When("the two caps are compared", [] {})
+                                             .Then("the larger sample sits at the smaller y",
+                                                   [state] {
+                                                       // The convention every physiological trace is read with, and the one an inverted
+                                                       // y axis makes easy to get backwards. Record order is cap, then cap and the
+                                                       // segment behind it - so the two caps are the first and second quads, four
+                                                       // vertices apart, and each quad's first vertex is its top-left corner.
+                                                       const std::span<const draw::UiVertex> vertices = state->list->vertices();
+                                                       mdux::spec::Checks                    checks;
+                                                       checks.expect(vertices.size() == 12,
+                                                                     std::format("two caps and one segment is twelve vertices, got {}", vertices.size()));
+                                                       if (vertices.size() != 12) {
+                                                           checks.raise();
+                                                           return;
+                                                       }
+                                                       checks.expect(vertices[4].y < vertices[0].y,
+                                                                     std::format("the larger sample is higher: y {} against {}", vertices[4].y, vertices[0].y));
+                                                       checks.raise();
+                                                   })
+                                             .Execute();
+                                     }};
+
+const mdux::spec::Register everyStrokeWidthStaysInside{
+    "Every admitted stroke width stays inside the node",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                                 scratch;
+            std::array<std::optional<VertexBox>, 3> boxes{};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("trace-stroke-widths-stay-inside")
+            .Given("a sawtooth expanded at one, two and three pixels",
+                   [state] {
+                       static constexpr std::array<float, 7> samples{0.0F, 1.0F, 0.25F, 0.75F, 0.0F, 0.5F, 1.0F};
+                       for (core::Px width = 1; width <= ms::maxStrokeWidth; ++width) {
+                           draw::DrawList       list = state->scratch.list();
+                           const ms::TraceStyle style{.minimum = 0.0F, .maximum = 1.0F, .strokeWidth = width};
+                           requireRecorded(ms::recordTrace(list, band, ringOver(samples), style, nominal), std::format("the {}px trace", width));
+                           state->boxes[static_cast<std::size_t>(width - 1)] = boxOf(list.vertices());
+                       }
+                   })
+            .When("each expansion's extent is compared against the node", [] {})
+            .Then(
+                "none of them leaves it",
+                [state] {
+                    // A stroke is drawn half its width either side of the path, so an inset that
+                    // was merely "about right" would spill by half a pixel at exactly one of the
+                    // three widths - which is the kind of defect a single-width test misses and a
+                    // neighbouring node discovers.
+                    mdux::spec::Checks checks;
+                    for (std::size_t index = 0; index < state->boxes.size(); ++index) {
+                        const std::optional<VertexBox>& box = state->boxes[index];
+                        if (!box.has_value()) {
+                            checks.expect(false, std::format("the {}px trace recorded something", index + 1));
+                            continue;
+                        }
+                        checks.expect(box->left >= static_cast<float>(band.x) && box->right <= static_cast<float>(band.right()),
+                                      std::format("the {}px trace stays within x {}..{}, got {}..{}", index + 1, band.x, band.right(), box->left, box->right));
+                        checks.expect(box->top >= static_cast<float>(band.y) && box->bottom <= static_cast<float>(band.bottom()),
+                                      std::format("the {}px trace stays within y {}..{}, got {}..{}", index + 1, band.y, band.bottom(), box->top, box->bottom));
+                    }
+                    checks.raise();
+                })
+            .Execute();
+    }};
+
+const mdux::spec::Register excursionsAreClamped{"A sample outside the display range is pinned to the rail, not refused", "evidence-unit", [] {
+                                                    struct State {
+                                                        Scratch                       scratch;
+                                                        std::optional<draw::DrawList> list;
+                                                        std::optional<VertexBox>      box;
+                                                    };
+                                                    auto state = std::make_shared<State>();
+
+                                                    return speclab::Test("trace-clamps-excursions")
+                                                        .Given("samples far outside the declared range",
+                                                               [state] {
+                                                                   static constexpr std::array<float, 3> samples{-40.0F, 0.5F, 90.0F};
+                                                                   state->list = state->scratch.list();
+                                                                   requireRecorded(ms::recordTrace(*state->list, band, ringOver(samples), unitStyle, nominal),
+                                                                                   "the trace");
+                                                                   state->box = boxOf(state->list->vertices());
+                                                               })
+                                                        .When("the recorded extent is measured", [] {})
+                                                        .Then("the trace is drawn against the band's rails and stays inside it",
+                                                              [state] {
+                                                                  // An excursion past the display range is a real reading a monitor shows pinned
+                                                                  // to its rail. Refusing the frame would blank the display at the moment the
+                                                                  // waveform became most interesting, which is the opposite of fail-safe here.
+                                                                  mdux::spec::Checks checks;
+                                                                  if (!state->box.has_value()) {
+                                                                      checks.expect(false, "the trace recorded something");
+                                                                      checks.raise();
+                                                                      return;
+                                                                  }
+                                                                  checks.expect(state->box->top == static_cast<float>(band.y),
+                                                                                "the high excursion is pinned to the top rail");
+                                                                  checks.expect(state->box->bottom == static_cast<float>(band.bottom()),
+                                                                                "the low excursion is pinned to the bottom rail");
+                                                                  checks.raise();
+                                                              })
+                                                        .Execute();
+                                                }};
+
+const mdux::spec::Register aShortRingDrawsNothing{
+    "A ring with fewer than two samples draws nothing and is not an error",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                       scratch;
+            std::optional<draw::DrawList> list;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("trace-short-ring-draws-nothing")
+            .Given("an empty ring and a one-sample ring",
+                   [state] {
+                       static constexpr std::array<float, 4> storage{0.5F, 0.5F, 0.5F, 0.5F};
+                       state->list = state->scratch.list();
+                       requireRecorded(ms::recordTrace(*state->list, band, ms::SampleRing{.storage = storage, .oldest = 0, .count = 0}, unitStyle, nominal),
+                                       "the empty ring");
+                       requireRecorded(ms::recordTrace(*state->list, band, ms::SampleRing{.storage = storage, .oldest = 2, .count = 1}, unitStyle, nominal),
+                                       "the one-sample ring");
+                   })
+            .When("the list is inspected", [] {})
+            .Then("nothing was recorded and neither call failed",
+                  [state] {
+                      // A ring fills over the first frames of a device's life. Refusing then would
+                      // make a monitor's start-up an error state, and drawing a single point would
+                      // put a dot on screen that reads as a signal.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->list->vertices().empty(), "no vertex was recorded");
+                      checks.expect(ms::quadsForSamples(0) == 0 && ms::quadsForSamples(1) == 0, "the cost model agrees that both are free");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aWrappedRingReadsOldestFirst{"A wrapped ring is read oldest-first from its own oldest index", "evidence-unit", [] {
+                                                            struct State {
+                                                                std::array<std::optional<float>, 4> read{};
+                                                            };
+                                                            auto state = std::make_shared<State>();
+
+                                                            return speclab::Test("trace-wrapped-ring-order")
+                                                                .Given("a ring whose producer has wrapped past the end of its storage",
+                                                                       [state] {
+                                                                           static constexpr std::array<float, 4> storage{0.3F, 0.4F, 0.1F, 0.2F};
+                                                                           const ms::SampleRing ring{.storage = storage, .oldest = 2, .count = 4};
+                                                                           for (std::size_t index = 0; index < 4; ++index) {
+                                                                               state->read[index] = ring.at(index);
+                                                                           }
+                                                                       })
+                                                                .When("its samples are read by position", [] {})
+                                                                .Then("they come back in the order the producer wrote them",
+                                                                      [state] {
+                                                                          // The property the whole binding rests on: the caller never reorders anything
+                                                                          // for this module, so a ring read from the wrong end would draw a waveform
+                                                                          // made of the right samples in the wrong order - which looks like a signal.
+                                                                          constexpr std::array<float, 4> expected{0.1F, 0.2F, 0.3F, 0.4F};
+                                                                          mdux::spec::Checks             checks;
+                                                                          for (std::size_t index = 0; index < expected.size(); ++index) {
+                                                                              checks.expect(state->read[index] == expected[index],
+                                                                                            std::format("sample {} is {}", index, expected[index]));
+                                                                          }
+                                                                          checks.raise();
+                                                                      })
+                                                                .Execute();
+                                                        }};
+
+const mdux::spec::Register expansionIsDeterministic{
+    "The same samples expand to byte-identical buffers",
+    "determinism",
+    [] {
+        struct State {
+            Scratch                       first;
+            Scratch                       second;
+            std::optional<draw::DrawList> a;
+            std::optional<draw::DrawList> b;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("trace-expansion-is-deterministic")
+            .Given("one sample set expanded twice into separate storage",
+                   [state] {
+                       static constexpr std::array<float, 9> samples{0.0F, 0.9F, 0.15F, 0.62F, 0.33F, 1.0F, 0.05F, 0.48F, 0.71F};
+                       state->a = state->first.list();
+                       state->b = state->second.list();
+                       requireRecorded(ms::recordTrace(*state->a, band, ringOver(samples), unitStyle, nominal), "the first expansion");
+                       requireRecorded(ms::recordTrace(*state->b, band, ringOver(samples), unitStyle, nominal), "the second expansion");
+                   })
+            .When("the two buffers are compared", [] {})
+            .Then("they are identical",
+                  [state] {
+                      // A frame is byte-compared across toolchains, and this module is the first in
+                      // the tree whose geometry passes through a square root. `std::sqrt` is
+                      // correctly rounded by IEEE 754, which is what makes that safe; this is the
+                      // scenario that would notice if something less well-behaved crept in beside it.
+                      mdux::spec::Checks checks;
+                      checks.expect(std::ranges::equal(state->a->vertices(), state->b->vertices()), "the vertex buffers match");
+                      checks.expect(std::ranges::equal(state->a->indices(), state->b->indices()), "the index buffers match");
+                      checks.expect(std::ranges::equal(state->a->commands(), state->b->commands()), "the command buffers match");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register costModelBoundsTheExpansion{
+    "quadsForSamples() bounds what an expansion actually records",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch     scratch;
+            std::size_t recorded{0};
+            std::size_t predicted{0};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("trace-cost-model-bounds-expansion")
+            .Given("a full-cap ring of distinct samples",
+                   [state] {
+                       static std::array<float, ms::maxSamplesPerTrace> samples{};
+                       for (std::size_t index = 0; index < samples.size(); ++index) {
+                           samples[index] = static_cast<float>(index % 17) / 16.0F;
+                       }
+                       draw::DrawList list = state->scratch.list();
+                       requireRecorded(ms::recordTrace(list, band, ringOver(samples), unitStyle, nominal), "the full-cap trace");
+                       state->recorded  = list.vertices().size() / 4;
+                       state->predicted = ms::quadsForSamples(samples.size());
+                   })
+            .When("the quads recorded are compared against the cost model", [] {})
+            .Then("the model is an upper bound, and a budget sized from it holds",
+                  [state] {
+                      // The number a reviewer multiplies against a DrawBudget. It is a bound rather
+                      // than an equality because a segment between two samples that land on the same
+                      // column is skipped - which is what a 256-sample ring in a 100px band does a
+                      // great deal of, and exactly why the bound is the number that belongs in a
+                      // budget.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->recorded <= state->predicted,
+                                    std::format("{} quads recorded, at most {} predicted", state->recorded, state->predicted));
+                      checks.expect(state->predicted == (2 * ms::maxSamplesPerTrace) - 1, "the model is one cap per sample and one quad per segment");
+                      checks.expect(4 * state->predicted <= 2560, "a full-cap trace fits the storage this suite sizes once");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+// ---------------------------------------------------------------------------
+// Refusals
+// ---------------------------------------------------------------------------
+
+const mdux::spec::Register refusesAnOversizedRing{"A ring past the cap is refused, not truncated", "evidence-unit", [] {
+                                                      struct State {
+                                                          Scratch                       scratch;
+                                                          std::optional<draw::DrawList> list;
+                                                          std::optional<ms::TraceError> error;
+                                                      };
+                                                      auto state = std::make_shared<State>();
+
+                                                      return speclab::Test("trace-refuses-an-oversized-ring")
+                                                          .Given("a ring holding one sample more than the cap admits",
+                                                                 [state] {
+                                                                     static std::array<float, ms::maxSamplesPerTrace + 1> samples{};
+                                                                     samples.fill(0.5F);
+                                                                     state->list  = state->scratch.list();
+                                                                     state->error = requireRefused(
+                                                                         ms::recordTrace(*state->list, band, ringOver(samples), unitStyle, nominal),
+                                                                         "the oversized ring");
+                                                                 })
+                                                          .When("the list is inspected", [] {})
+                                                          .Then("the expansion is TooManySamples and nothing was drawn",
+                                                                [state] {
+                                                                    // This issue's acceptance criterion. A truncating implementation would draw a
+                                                                    // perfectly plausible waveform of the newest 256 samples, in the tint that says
+                                                                    // it is the window the caller asked for - and there is nothing on a monitor
+                                                                    // that distinguishes that from a correct reading of different data.
+                                                                    mdux::spec::Checks checks;
+                                                                    checks.expect(state->error == ms::TraceError::TooManySamples, "the refusal names the cap");
+                                                                    checks.expect(state->list->vertices().empty(), "no vertex was recorded");
+                                                                    checks.expect(state->list->commands().empty(), "no command was started");
+                                                                    checks.raise();
+                                                                })
+                                                          .Execute();
+                                                  }};
+
+const mdux::spec::Register refusesMalformedInputs{
+    "A malformed ring, sample, style or band is refused",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                                      scratch;
+            std::optional<draw::DrawList>                list;
+            std::array<std::optional<ms::TraceError>, 6> errors{};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("trace-refuses-malformed-inputs")
+            .Given("a valid ring and a list",
+                   [state] {
+                       state->list = state->scratch.list();
+                   })
+            .When("each malformed input is offered in turn",
+                  [state] {
+                      static constexpr std::array<float, 4> storage{0.1F, 0.2F, 0.3F, 0.4F};
+                      static const std::array<float, 3>     withNan{0.1F, std::numeric_limits<float>::quiet_NaN(), 0.3F};
+
+                      state->errors[0] = requireRefused(
+                          ms::recordTrace(*state->list, band, ms::SampleRing{.storage = storage, .oldest = 0, .count = 9}, unitStyle, nominal),
+                          "a live count past the storage");
+                      state->errors[1] = requireRefused(
+                          ms::recordTrace(*state->list, band, ms::SampleRing{.storage = storage, .oldest = 4, .count = 4}, unitStyle, nominal),
+                          "an oldest index past the storage");
+                      state->errors[2] = requireRefused(ms::recordTrace(*state->list, band, ringOver(withNan), unitStyle, nominal), "a NaN sample");
+                      state->errors[3] = requireRefused(
+                          ms::recordTrace(*state->list, band, ringOver(storage), ms::TraceStyle{.minimum = 1.0F, .maximum = 1.0F, .strokeWidth = 1}, nominal),
+                          "an empty range");
+                      state->errors[4] = requireRefused(ms::recordTrace(*state->list,
+                                                                        band,
+                                                                        ringOver(storage),
+                                                                        ms::TraceStyle{.minimum = 0.0F, .maximum = 1.0F, .strokeWidth = ms::maxStrokeWidth + 1},
+                                                                        nominal),
+                                                        "a stroke wider than the cap approximation admits");
+                      state->errors[5] = requireRefused(ms::recordTrace(*state->list,
+                                                                        core::Rect{.x = 0, .y = 0, .width = 2, .height = 2},
+                                                                        ringOver(storage),
+                                                                        ms::TraceStyle{.minimum = 0.0F, .maximum = 1.0F, .strokeWidth = 3},
+                                                                        nominal),
+                                                        "a node too small for its stroke");
+                  })
+            .Then("each names its own cause and the list is untouched",
+                  [state] {
+                      // Distinct causes rather than one "the trace was refused": a malformed ring is
+                      // the producer's defect, a NaN sample is a driver fault, an out-of-range stroke
+                      // is the integrator's - and one shared error would send two of the three to
+                      // the wrong person.
+                      constexpr std::array<ms::TraceError, 6> expected{ms::TraceError::MalformedRing,
+                                                                       ms::TraceError::MalformedRing,
+                                                                       ms::TraceError::NonFiniteSample,
+                                                                       ms::TraceError::MalformedStyle,
+                                                                       ms::TraceError::MalformedStyle,
+                                                                       ms::TraceError::BandTooSmall};
+                      mdux::spec::Checks                      checks;
+                      for (std::size_t index = 0; index < expected.size(); ++index) {
+                          checks.expect(state->errors[index] == expected[index], std::format("refusal {} is {}", index, ms::describe(expected[index])));
+                      }
+                      checks.expect(state->list->vertices().empty(), "no refusal left a vertex behind");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aBudgetRefusalRollsBack{
+    "An expansion that does not fit its budget leaves no partial waveform",
+    "evidence-unit",
+    [] {
+        struct State {
+            std::array<draw::UiVertex, 32>   vertices{};
+            std::array<draw::Index, 48>      indices{};
+            std::array<draw::DrawCommand, 4> commands{};
+            std::optional<draw::DrawList>    list;
+            std::optional<ms::TraceError>    error;
+            std::size_t                      keptVertices{0};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("trace-budget-refusal-rolls-back")
+            .Given("a list with room for eight quads and one rectangle already in it",
+                   [state] {
+                       auto created = draw::DrawList::create(state->vertices,
+                                                             state->indices,
+                                                             state->commands,
+                                                             draw::DrawBudget{.maxVertices = 32, .maxIndices = 48, .maxCommands = 4});
+                       if (!created.has_value()) {
+                           throw speclab::core::AssertionFailure("the small list was not created", std::source_location::current());
+                       }
+                       state->list = std::move(*created);
+                       if (!state->list->addSolidRect(band, nominal).has_value()) {
+                           throw speclab::core::AssertionFailure("the prior rectangle was refused", std::source_location::current());
+                       }
+                   })
+            .When("a trace far larger than the remaining budget is expanded",
+                  [state] {
+                      static constexpr std::array<float, 40> samples{};
+                      state->error        = requireRefused(ms::recordTrace(*state->list, band, ringOver(samples), unitStyle, nominal), "the oversized trace");
+                      state->keptVertices = state->list->vertices().size();
+                  })
+            .Then("the trace is rolled back and what was there before it survives",
+                  [state] {
+                      // All-or-nothing, and the "nothing" has to stop at the trace: a fragment of a
+                      // waveform reads as a flat line, and a rollback that went too far would take
+                      // the caller's own rectangle with it.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->error == ms::TraceError::ListRejected, "the refusal names the list");
+                      checks.expect(state->keptVertices == 4, std::format("only the prior rectangle survives, got {} vertices", state->keptVertices));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyTraceErrorDescribesItself{"Every TraceError has its own description", "evidence-unit", [] {
+                                                              return speclab::Test("trace-error-descriptions")
+                                                                  .Given("every TraceError enumerator", [] {})
+                                                                  .When("each is described", [] {})
+                                                                  .Then("each has a unique, non-empty description",
+                                                                        [] {
+                                                                            constexpr std::array<ms::TraceError, 6> all{ms::TraceError::MalformedRing,
+                                                                                                                        ms::TraceError::TooManySamples,
+                                                                                                                        ms::TraceError::NonFiniteSample,
+                                                                                                                        ms::TraceError::MalformedStyle,
+                                                                                                                        ms::TraceError::BandTooSmall,
+                                                                                                                        ms::TraceError::ListRejected};
+                                                                            std::vector<std::string_view>           seen;
+                                                                            mdux::spec::Checks                      checks;
+                                                                            for (const ms::TraceError error : all) {
+                                                                                const std::string_view text = ms::describe(error);
+                                                                                checks.expect(!text.empty(), "a description exists");
+                                                                                checks.expect(std::ranges::find(seen, text) == seen.end(),
+                                                                                              "the description is unique");
+                                                                                seen.push_back(text);
+                                                                            }
+                                                                            checks.raise();
+                                                                        })
+                                                                  .Execute();
+                                                          }};
+
+// ---------------------------------------------------------------------------
+// The binding, and what render() composes with it
+// ---------------------------------------------------------------------------
+
+constexpr ms::SignalTraceSpec ecg{.streamSource = "ECG_LEAD_II", .colorToken = "Theme.Colors.Nominal"};
+constexpr ms::SignalTraceSpec pleth{.streamSource = "PLETH", .colorToken = "Theme.Colors.Alert"};
+
+constexpr std::array<ms::CompiledNode, 2> traceNodes{
+    ms::CompiledNode{  .id = "ecg",  .bounds = {0, 0, 200, 60},   .payload = ecg},
+    ms::CompiledNode{.id = "pleth", .bounds = {0, 60, 200, 60}, .payload = pleth}
+};
+
+constexpr draw::DrawBudget traceBudget{.maxVertices = 2560, .maxIndices = 3840, .maxCommands = 32};
+
+constexpr ms::ScreenPackage traceScreen{.id                   = "traces",
+                                        .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                        .surfaceWidth         = 200,
+                                        .surfaceHeight        = 120,
+                                        .approvedTextPackages = {},
+                                        .nodes                = traceNodes,
+                                        .budget               = traceBudget};
+
+static_assert(traceScreen.validate().has_value(), "the screen under test must be one a device could hold");
+
+/// Hard failure (REQUIRE-equivalent): a binding that was expected to be made must exist.
+[[nodiscard]] ms::SignalBinding
+requireBound(core::Result<ms::SignalBinding, ms::ScreenError> result, std::string_view what, std::source_location where = std::source_location::current()) {
+    if (!result.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("{}: {}", what, ms::describe(result.error())), where);
+    }
+    return *result;
+}
+
+/// Hard failure (REQUIRE-equivalent): a binding that was expected to be refused must be refused.
+[[nodiscard]] ms::ScreenError
+requireUnbound(core::Result<ms::SignalBinding, ms::ScreenError> result, std::string_view what, std::source_location where = std::source_location::current()) {
+    if (result.has_value()) {
+        throw speclab::core::AssertionFailure(std::format("{}: expected a refusal but a binding was made", what), where);
+    }
+    return result.error();
+}
+
+const mdux::spec::Register anUnboundTraceIsUnchanged{
+    "A screen rendered without signals draws the fields it always drew",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                       scratch;
+            std::optional<ms::FrameStats> stats;
+            std::vector<draw::UiVertex>   vertices;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("screen-unbound-trace-unchanged")
+            .Given("a screen of two traces and no signal binding",
+                   [state] {
+                       draw::DrawList list  = state->scratch.list();
+                       const auto     frame = ms::render(traceScreen, list);
+                       if (!frame.has_value()) {
+                           throw speclab::core::AssertionFailure(std::format("the frame was refused: {}", ms::describe(frame.error())),
+                                                                 std::source_location::current());
+                       }
+                       state->stats = *frame;
+                       state->vertices.assign(list.vertices().begin(), list.vertices().end());
+                   })
+            .When("the frame is inspected", [] {})
+            .Then("each trace is one opaque rectangle, exactly as it was before #257",
+                  [state] {
+                      // The unbound path is the one every existing caller takes - the committed
+                      // screen's pixel test and its `verify` leg among them - so it is a tested
+                      // contract rather than a code path nobody exercises now that a binding exists.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->stats->rects == 2, std::format("two rectangles, got {}", state->stats->rects));
+                      checks.expect(state->stats->traces == 0, "no trace was expanded");
+                      checks.expect(state->stats->deferred == 0, "a reserved field is drawn, not deferred");
+                      checks.expect(state->vertices.size() == 8, std::format("two rectangles is eight vertices, got {}", state->vertices.size()));
+                      const bool opaque = std::ranges::all_of(state->vertices, [](const draw::UiVertex& vertex) {
+                          const auto bytes = std::bit_cast<std::array<std::uint8_t, 4>>(vertex.color);
+                          return bytes[3] == 255;
+                      });
+                      checks.expect(opaque, "an unbound field is opaque");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aBoundTraceDimsItsField{
+    "A bound trace dims its field and strokes at full tint",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                       scratch;
+            std::optional<ms::FrameStats> stats;
+            std::vector<draw::UiVertex>   vertices;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("screen-bound-trace-dims-its-field")
+            .Given("a screen whose first trace is bound to a ring",
+                   [state] {
+                       static constexpr std::array<float, 6>      samples{0.0F, 1.0F, 0.4F, 0.6F, 0.2F, 0.8F};
+                       static const ms::SampleRing                ring = ringOver(samples);
+                       static const std::array<ms::SignalSlot, 1> slots{
+                           ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &ring, .style = unitStyle}
+                       };
+                       const ms::SignalBinding binding = requireBound(ms::SignalBinding::create(traceScreen, slots), "the binding");
+
+                       draw::DrawList list  = state->scratch.list();
+                       const auto     frame = ms::render(traceScreen, list, {}, {}, binding);
+                       if (!frame.has_value()) {
+                           throw speclab::core::AssertionFailure(std::format("the frame was refused: {}", ms::describe(frame.error())),
+                                                                 std::source_location::current());
+                       }
+                       state->stats = *frame;
+                       state->vertices.assign(list.vertices().begin(), list.vertices().end());
+                   })
+            .When("the alpha of every recorded vertex is read", [] {})
+            .Then("exactly one primitive is dimmed and the rest carry the full tint",
+                  [state] {
+                      // One tint at two coverages, which is the composition Screen.cppm argues is the
+                      // only one an additive draw list and a `ColorHash` golden both admit. The
+                      // stroke has to reach full coverage somewhere or `colorHash()` would report
+                      // TintAbsent for the node; the field has to differ from the ground or
+                      // `goldenBounds()` would stop seeing the node's whole rectangle as painted.
+                      const auto  expectedDim = static_cast<std::uint8_t>((255.0F * ms::boundTraceFieldCoverage) + 0.5F);
+                      std::size_t dimmed      = 0;
+                      std::size_t solid       = 0;
+                      for (const draw::UiVertex& vertex : state->vertices) {
+                          const auto bytes = std::bit_cast<std::array<std::uint8_t, 4>>(vertex.color);
+                          if (bytes[3] == 255) {
+                              ++solid;
+                          } else if (bytes[3] == expectedDim) {
+                              ++dimmed;
+                          }
+                      }
+                      mdux::spec::Checks checks;
+                      checks.expect(state->stats->traces == 1, std::format("one trace was expanded, got {}", state->stats->traces));
+                      checks.expect(dimmed == 4, std::format("exactly one dimmed rectangle, got {} vertices at alpha {}", dimmed, expectedDim));
+                      checks.expect(solid + dimmed == state->vertices.size(), "every vertex is either the dimmed field or the full tint");
+                      checks.expect(solid >= 4 * ms::quadsForSamples(6) - 8, "the stroke's quads carry the full tint");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anUnboundStreamStillReservesItsField{
+    "A trace the caller has no samples for still draws its reserved field",
+    "evidence-unit",
+    [] {
+        struct State {
+            std::optional<ms::FrameStats> stats;
+            Scratch                       scratch;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("screen-partially-bound-screen")
+            .Given("a screen of two traces with only the first bound",
+                   [state] {
+                       static constexpr std::array<float, 4>      samples{0.0F, 1.0F, 0.5F, 0.25F};
+                       static const ms::SampleRing                ring = ringOver(samples);
+                       static const std::array<ms::SignalSlot, 1> slots{
+                           ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &ring, .style = unitStyle}
+                       };
+                       const ms::SignalBinding binding = requireBound(ms::SignalBinding::create(traceScreen, slots), "the binding");
+
+                       draw::DrawList list  = state->scratch.list();
+                       const auto     frame = ms::render(traceScreen, list, {}, {}, binding);
+                       if (!frame.has_value()) {
+                           throw speclab::core::AssertionFailure(std::format("the frame was refused: {}", ms::describe(frame.error())),
+                                                                 std::source_location::current());
+                       }
+                       state->stats = *frame;
+                   })
+            .When("the frame's statistics are read", [] {})
+            .Then("one trace is expanded and the other is a reserved field, not a deferral",
+                  [state] {
+                      // A stream that has not started is a normal state, not a broken one. Binding
+                      // every trace a screen carries is not a precondition of rendering it.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->stats->traces == 1, "one trace was expanded");
+                      checks.expect(state->stats->deferred == 0, "the unbound trace is drawn as a field, not deferred");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register bindingRefusesWhatItCanCheck{
+    "A binding refuses an unknown stream, a duplicate, a missing ring and a bad style",
+    "evidence-unit",
+    [] {
+        struct State {
+            std::array<std::optional<ms::ScreenError>, 4> errors{};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("screen-signal-binding-refusals")
+            .Given("a screen carrying two named streams", [] {})
+            .When("each malformed slot set is offered",
+                  [state] {
+                      static constexpr std::array<float, 4> samples{0.0F, 1.0F, 0.5F, 0.25F};
+                      static const ms::SampleRing           ring = ringOver(samples);
+
+                      const std::array<ms::SignalSlot, 1> unknown{
+                          ms::SignalSlot{.streamSource = "ECG_LEAD_III", .ring = &ring, .style = unitStyle}
+                      };
+                      state->errors[0] = requireUnbound(ms::SignalBinding::create(traceScreen, unknown), "an unknown stream");
+
+                      const std::array<ms::SignalSlot, 2> duplicated{
+                          ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &ring, .style = unitStyle},
+                          ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &ring, .style = unitStyle}
+                      };
+                      state->errors[1] = requireUnbound(ms::SignalBinding::create(traceScreen, duplicated), "a duplicated stream");
+
+                      const std::array<ms::SignalSlot, 1> ringless{
+                          ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = nullptr, .style = unitStyle}
+                      };
+                      state->errors[2] = requireUnbound(ms::SignalBinding::create(traceScreen, ringless), "a slot with no ring");
+
+                      const std::array<ms::SignalSlot, 1> badStyle{
+                          ms::SignalSlot{.streamSource = "PLETH", .ring = &ring, .style = ms::TraceStyle{.minimum = 5.0F, .maximum = 1.0F, .strokeWidth = 1}}
+                      };
+                      state->errors[3] = requireUnbound(ms::SignalBinding::create(traceScreen, badStyle), "an inverted range");
+                  })
+            .Then("each refusal names its own cause",
+                  [state] {
+                      // The unknown-stream check is the one that earns this type. A mistyped stream
+                      // name would otherwise leave that trace drawing its reserved field forever,
+                      // with nothing to distinguish it from a stream that has not started.
+                      constexpr std::array<ms::ScreenError, 4> expected{ms::ScreenError::UnknownStreamSource,
+                                                                        ms::ScreenError::DuplicateStream,
+                                                                        ms::ScreenError::MalformedTraceStyle,
+                                                                        ms::ScreenError::MalformedTraceStyle};
+                      mdux::spec::Checks                       checks;
+                      for (std::size_t index = 0; index < expected.size(); ++index) {
+                          checks.expect(state->errors[index] == expected[index], std::format("refusal {} is {}", index, ms::describe(expected[index])));
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aBindingIsNotPortableBetweenScreens{
+    "A binding built for one screen is refused by another",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                        scratch;
+            std::optional<ms::ScreenError> error;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("screen-signal-binding-is-not-portable")
+            .Given("a binding validated against one screen",
+                   [state] {
+                       static constexpr std::array<float, 4>      samples{0.0F, 1.0F, 0.5F, 0.25F};
+                       static const ms::SampleRing                ring = ringOver(samples);
+                       static const std::array<ms::SignalSlot, 1> slots{
+                           ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &ring, .style = unitStyle}
+                       };
+                       const ms::SignalBinding binding = requireBound(ms::SignalBinding::create(traceScreen, slots), "the binding");
+
+                       // The same nodes under a different id: everything about this screen would let
+                       // the binding work, and it is refused anyway, because what was validated was
+                       // the pairing rather than the shape.
+                       ms::ScreenPackage other = traceScreen;
+                       other.id                = "other-traces";
+
+                       draw::DrawList list  = state->scratch.list();
+                       const auto     frame = ms::render(other, list, {}, {}, binding);
+                       if (frame.has_value()) {
+                           throw speclab::core::AssertionFailure("the foreign screen accepted the binding", std::source_location::current());
+                       }
+                       state->error = frame.error();
+                   })
+            .When("the refusal is read", [] {})
+            .Then("it names the screen rather than the samples",
+                  [state] {
+                      // TextBinding closes this path with a digest. There is no digest to hold for a
+                      // signal - samples are produced at run time and no artifact describes them -
+                      // so the identity is the screen's id, and `approvedBy()` says as much.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->error == ms::ScreenError::ScreenNotApproved, "the frame is refused as ScreenNotApproved");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anOversizedRingRefusesTheWholeFrame{
+    "A trace past the cap refuses the frame and leaves nothing behind",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                        scratch;
+            std::optional<ms::ScreenError> error;
+            std::size_t                    kept{0};
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("screen-oversized-trace-refuses-the-frame")
+            .Given("a screen whose bound ring holds more samples than the cap admits",
+                   [state] {
+                       static std::array<float, ms::maxSamplesPerTrace + 1> samples{};
+                       samples.fill(0.5F);
+                       static const ms::SampleRing                ring = ringOver(samples);
+                       static const std::array<ms::SignalSlot, 1> slots{
+                           ms::SignalSlot{.streamSource = "ECG_LEAD_II", .ring = &ring, .style = unitStyle}
+                       };
+                       const ms::SignalBinding binding = requireBound(ms::SignalBinding::create(traceScreen, slots), "the binding");
+
+                       draw::DrawList list  = state->scratch.list();
+                       const auto     frame = ms::render(traceScreen, list, {}, {}, binding);
+                       if (frame.has_value()) {
+                           throw speclab::core::AssertionFailure("the oversized trace was accepted", std::source_location::current());
+                       }
+                       state->error = frame.error();
+                       state->kept  = list.vertices().size();
+                   })
+            .When("the list is inspected", [] {})
+            .Then("the frame is TraceTooLong and whole rather than partial",
+                  [state] {
+                      // The cap refusal, seen from the caller rather than from the expansion - and
+                      // the rollback that makes it a *frame* property. A partial frame on a medical
+                      // display is the worst outcome available, because it looks like a reading.
+                      mdux::spec::Checks checks;
+                      checks.expect(state->error == ms::ScreenError::TraceTooLong, "the refusal names the cap");
+                      checks.expect(state->kept == 0, std::format("the frame was rolled back whole, got {} vertices", state->kept));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+}  // namespace

--- a/tests/medui/TraceTests.cpp
+++ b/tests/medui/TraceTests.cpp
@@ -825,7 +825,7 @@ const mdux::spec::Register bindingRefusesWhatItCanCheck{
                       // with nothing to distinguish it from a stream that has not started.
                       constexpr std::array<ms::ScreenError, 4> expected{ms::ScreenError::UnknownStreamSource,
                                                                         ms::ScreenError::DuplicateStream,
-                                                                        ms::ScreenError::MalformedTraceStyle,
+                                                                        ms::ScreenError::MissingSampleRing,
                                                                         ms::ScreenError::MalformedTraceStyle};
                       mdux::spec::Checks                       checks;
                       for (std::size_t index = 0; index < expected.size(); ++index) {

--- a/tests/medui/TraceTests.cpp
+++ b/tests/medui/TraceTests.cpp
@@ -189,6 +189,53 @@ const mdux::spec::Register valueIsUp{"The larger sample is the higher one on scr
                                              .Execute();
                                      }};
 
+const mdux::spec::Register anExtremeRangeStillSeparatesItsRails{
+    "A full-scale range maps its endpoints to opposite rails",
+    "evidence-unit",
+    [] {
+        struct State {
+            Scratch                       scratch;
+            std::optional<draw::DrawList> list;
+        };
+        auto state = std::make_shared<State>();
+
+        return speclab::Test("trace-extreme-range-separates-rails")
+            .Given("a range spanning the whole float line, and a sample at each end",
+                   [state] {
+                       // Every value here is finite, so `create()`'s checks pass - and the span
+                       // between them is not: `maximum - minimum` overflows in float, and so does
+                       // `sample - minimum` at the top. The float path divided one infinity by
+                       // another and sent the resulting NaN to the bottom rail, so a transition from
+                       // the smallest sample to the largest drew a flat line rather than a step.
+                       // The one failure a monitor must not have, from a range that is merely wide.
+                       static constexpr float                extreme = std::numeric_limits<float>::max();
+                       static constexpr std::array<float, 2> samples{-extreme, extreme};
+                       static constexpr ms::TraceStyle       wide{.minimum = -extreme, .maximum = extreme, .strokeWidth = 1};
+                       state->list = state->scratch.list();
+                       requireRecorded(ms::recordTrace(*state->list, band, ringOver(samples), wide, nominal), "the full-scale trace");
+                   })
+            .When("the two caps are compared", [] {})
+            .Then("they sit on opposite rails, the larger sample higher",
+                  [state] {
+                      // Record order and vertex layout as in `trace-value-is-up`: cap, then cap and
+                      // the segment behind it, each quad's first vertex its top-left corner.
+                      const std::span<const draw::UiVertex> vertices = state->list->vertices();
+                      mdux::spec::Checks                    checks;
+                      checks.expect(vertices.size() == 12, std::format("two caps and one segment is twelve vertices, got {}", vertices.size()));
+                      if (vertices.size() != 12) {
+                          checks.raise();
+                          return;
+                      }
+                      checks.expect(vertices[4].y < vertices[0].y,
+                                    std::format("the largest sample is higher than the smallest: y {} against {}", vertices[4].y, vertices[0].y));
+                      checks.expect(vertices[0].y == static_cast<float>(band.y + band.height - 1),
+                                    std::format("the smallest sample is on the bottom rail, got y {}", vertices[0].y));
+                      checks.expect(vertices[4].y == static_cast<float>(band.y), std::format("the largest sample is on the top rail, got y {}", vertices[4].y));
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register everyStrokeWidthStaysInside{
     "Every admitted stroke width stays inside the node",
     "evidence-unit",

--- a/tests/verify/GoldenCheckTests.cpp
+++ b/tests/verify/GoldenCheckTests.cpp
@@ -30,6 +30,7 @@ import mdux.draw;
 import mdux.evidence.digest;
 import mdux.evidence.report;
 import mdux.medui.schema;
+import mdux.medui.screen;
 import mdux.verify;
 
 #include "../framework/SpecLabBridge.hpp"
@@ -326,6 +327,60 @@ const mdux::spec::Register everyChannelMustAgreeOnOneCoverage{
                       honest.fill({4, 4, 8, 6}, tint);
                       honest.set(6, 6, mv::blend(ground, tint, 128));
                       checks.expect(mv::colorHash(honest.view(), expectation).held(), "a genuine half-coverage pixel is still a blend");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aDimmedFieldUnderAFullTintStrokeIsAdmitted{
+    "A field at reduced coverage under a full-tint stroke discharges both checks",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-two-coverage-composition")
+            .Given("the composition a bound SignalTrace paints (#257)", [] {})
+            .When("Bounds and ColorHash are run over it", [] {})
+            .Then("both hold, which is what makes that composition available at all",
+                  [] {
+                      // The check behind an argument `mdux.medui.screen` makes rather than proves in
+                      // its own suite. A `SignalTraceSpec` carries one colour token, an additive draw
+                      // list cannot knock a stroke back to the ground, and a third colour fails
+                      // ColorHash - so the only composition left is one tint at two coverages, and
+                      // whether that is admissible is this module's answer to give, not that one's.
+                      //
+                      // The dimmed field is what keeps Bounds true: a stroke alone paints a
+                      // data-dependent box, and `goldenBounds()` asks for the node's whole rectangle
+                      // edge for edge. The full-tint stroke is what keeps ColorHash from reporting
+                      // TintAbsent, which a dimmed field alone would earn.
+                      mdux::spec::Checks checks;
+
+                      const mv::GoldenExpectation expectation = expect(readoutGolden, textlessScreen, mv::RenderScope::localeFree());
+                      const ColorRgba8            tint        = tintOf(readoutToken);
+
+                      // `mdux::medui::boundTraceFieldCoverage` as the runtime quantises it. Written
+                      // as the same arithmetic rather than as 64, so a change to the constant moves
+                      // this scenario with it instead of leaving it testing a number nothing paints.
+                      const auto dimmed = static_cast<std::uint8_t>((255.0F * mdux::medui::boundTraceFieldCoverage) + 0.5F);
+
+                      Canvas canvas{16, 20, ground};
+                      canvas.fill({4, 4, 8, 6}, mv::blend(ground, tint, dimmed));
+                      // A stroke through the field: full tint, and nowhere near filling the box.
+                      for (mdux::core::Px x = 4; x < 12; ++x) {
+                          canvas.set(x, 6 + (x % 3), tint);
+                      }
+
+                      const mv::CheckOutcome bounds = mv::goldenBounds(canvas.view(), expectation);
+                      checks.expect(bounds.held(), std::format("the dimmed field keeps the node's whole rectangle painted: {}", mv::describe(bounds.finding)));
+
+                      const mv::CheckOutcome colour = mv::colorHash(canvas.view(), expectation);
+                      checks.expect(colour.held(), std::format("both coverages are blends of one tint: {}", mv::describe(colour.finding)));
+
+                      // And the half that keeps this from being a scenario that cannot fail: the
+                      // same field with no stroke over it reaches full coverage nowhere, which is
+                      // exactly the TintAbsent the stroke is there to answer.
+                      Canvas fieldOnly{16, 20, ground};
+                      fieldOnly.fill({4, 4, 8, 6}, mv::blend(ground, tint, dimmed));
+                      checks.expect(mv::colorHash(fieldOnly.view(), expectation).finding == mv::Finding::TintAbsent,
+                                    "a dimmed field on its own does not carry its tint");
                       checks.raise();
                   })
             .Execute();


### PR DESCRIPTION
## Summary

A `SignalTrace` now draws the waveform inside the field #255 gave it, expanded on the device from a
**caller-owned ring buffer** into the vertex budget the compiled screen already declares.

Three pieces:

- **`mdux.medui.trace`** (new governed module) — the expansion, split from the screen runtime for the
  reason `mdux.text.draw` is split from it: geometry that can be tested against numbers rather than
  only against a rendered frame. `SampleRing` is a *view* of the producer's storage — never copied,
  never owned, and validated on **every** frame rather than once, because the producer moves `oldest`
  and `count` between them. A `create()`-guarded type would be proving things about a snapshot that
  has already moved.
- **`mdux.draw`** — `addSolidQuad()`, the first primitive here that is not axis-aligned, and
  `Point2F` to carry the one coordinate that cannot be integral: a stroke's normal is irrational for
  all but a handful of slopes, and rounding it makes a 1px stroke alternate between one and two
  pixels wide as its slope changes. `addRect()` and `addSolidQuad()` now share a private
  `appendQuad()`, so "past the checks nothing can fail, so the list never holds a half-recorded
  primitive" lives in one place instead of two.
- **`mdux.medui.screen`** — `SignalBinding`, `TextBinding`'s counterpart for signals and deliberately
  a much cheaper object. There is nothing to hash: samples are produced at run time and no committed
  artifact describes them. What *is* checkable it checks once — every slot names a `SignalTrace` this
  screen carries, no two name the same stream, every slot has a usable ring and style — and it
  retains the screen id, so slots validated for one screen cannot render another.

Segments become quads with square joint caps rather than mitred joins, as the epic's design note
asks. The module comment is exact about what that is rather than letting the name carry a claim the
code does not make: a true round join is a disc and this is the disc's bounding square, which at 1–3
px differ by at most the four corner pixels of a 3×3 block. That is why `maxStrokeWidth` is 3 and a
wider stroke is refused. Mitres were rejected for a different reason: the intersection of two offset
lines is unbounded as the angle between segments closes, so a near-reversal produces a spike of no
fixed length — and a spike is exactly the artefact a waveform must not invent.

Closes #257

## Two decisions worth reviewing rather than skimming

**Refused, never truncated.** A ring past `maxSamplesPerTrace` (256) is `TraceTooLong` and the whole
frame rolls back — enforced at the expansion (`trace-refuses-an-oversized-ring`) and again at the
screen (`screen-oversized-trace-refuses-the-frame`). Showing the newest 256 of 300 samples would draw
a perfectly plausible waveform, in the tint that says it is the window the caller asked for, and
nothing on a monitor distinguishes that from a correct reading of different data.

**One tint at two coverages.** This was the hard part, and `Screen.cppm` records the whole argument
rather than only its conclusion. `SignalTraceSpec` carries **one** colour token; an additive draw
list cannot knock a stroke back to the ground; a third colour fails a `ColorHash` golden. So the two
options that file's #255 paragraph names were both unavailable as written, and what was left is the
third reading of the same rule: a bound trace paints its field at `boundTraceFieldCoverage` (25%)
under a full-tint stroke. Every pixel is then still a blend of ground and tint at one coverage, the
stroke supplies the fully-covered pixels `colorHash()` additionally requires, and the field keeps
`goldenBounds()` seeing the node's whole rectangle as painted — which a stroke alone, whose box is
data-dependent, would not.

Arguments about what a check admits belong to the check, so that is also a scenario:
`verify-golden-two-coverage-composition` in `tests/verify/GoldenCheckTests.cpp` paints exactly this
composition, asserts `goldenBounds()` and `colorHash()` both hold, and asserts that the field *alone*
is the `TintAbsent` the stroke exists to answer — so it is not a scenario that cannot fail.

An **unbound** trace is unchanged. That is why the committed screen's pixel test and its `verify` leg
are unchanged too: both render it without signals, and nothing under `generated/` moved.

## No allocation in the per-frame path, verified the three ways #63 established

1. **Runtime interposition** — a new `medui_noheap_spec` scenario writes a new sample into the ring
   and advances `oldest` *between* frames, so a per-frame scratch for the expanded polyline — the
   obvious implementation of a waveform, and the one this measurement exists to refuse — would show
   up as eight allocations rather than none.
2. **Object-file symbol scan** — needed nothing. `screen.noheap.symbolScan` filters MduXCore's
   objects on `/medui/` and picked up `Trace.cpp.o` and `Trace.cppm.o` on its own; both are in the
   generated object list and the test passes.
3. **Static analysis and a stack bound** — this was the layer genuinely missing for the screen
   runtime. #199 gave it layers 1 and 2 and no `.clang-tidy`; `src/medui/.clang-tidy` adds it, with
   the same checks as `src/ml/.clang-tidy` and a header saying why it is a sibling file rather than a
   shared one. `-Wframe-larger-than=4096` already covers these sources via
   `mdux_enforce_fp_determinism(MduXCore)`.

## The ECG demonstrator is wired, not just referenced

`EcgClassifierExample` binds the **same** `SampleRing` its classifier reads its window out of to
`EndoscopeMonitor`'s `ECG_LEAD_II` trace, and records a frame:

```
Frame from the committed screen 'endoscope-monitor' (1280x720):
  samples bound  : 180 (the window the classifier read, not a copy of it)
  traces expanded: 1
  nodes / drawn  : 6 visited, 362 rectangles, 3 deferred
  budget used    : 1448/4096 vertices, 2172/6144 indices, 1/64 commands
```

Nothing is copied between the two readers — `readWindow()` hands the classifier a contiguous ordered
window and `view()` hands the trace a description of the same storage — so a monitor showing a
waveform beside a classification derived from *different* samples is unspellable rather than
unlikely. That file's own comment had asked for exactly this ("a matter of giving them the same
buffer") and could not yet do it; the paragraph saying so has been replaced by the thing it wanted.

Still no Vulkan and no window in that example: a draw list is geometry.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #257

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [x] `CMakeLists.txt` (root) — `mdux.medui.trace` added to `MduXCore`'s module and source lists
- [x] `FILE_SET CXX_MODULES` lists — `include/mdux/medui/Trace.cppm` added; `examples/CMakeLists.txt`
      gains a second file set on `EcgClassifierExample` for the generated screen module
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [x] `tests/CMakeLists.txt` — `medui/TraceTests.cpp` added to `medui_spec`
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`

Nothing under `generated/` changed, and `ctest -L evidence` confirms it: the unbound render path is
untouched, so the committed screen bundle still re-bakes byte-identically.

## Rebase state

- **Rebased onto:** `180fc01` (current `develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

Run on the verified macOS tuple (upstream LLVM/Clang 21.1.8, `ninja-macos-clang`,
`-DENABLE_CACHE=OFF`) rather than the GCC preset the boxes name, so the GCC lines are left unticked
rather than ticked for a run that did not happen.

- [ ] `cmake --preset ninja-gcc && cmake --build build-gcc` — not run locally, CI covers it
- [ ] `ctest --test-dir build-gcc` — not run locally, CI covers it
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (83 files, 0 findings)
- [x] Other, all on `ninja-macos-clang`:
  - `cmake --build build-macos-clang` — clean, no warnings
  - `ctest` — **698/698 passed**, including `-L noheap` (11), `-L pixel` (2), `-L verify` (1),
    `-L evidence` (7) and `-L determinism` (5)
  - `python3 tools/governed-lint/mdux_governed_lint.py` — OK (36 files, 0 findings)
  - `python3 tools/evidence-lint/mdux_evidence_lint.py` — OK (75 files, 0 findings)
  - `check_file_headers.py` (226 sources), `check_named_mechanisms.py` (78 documents),
    `check_schema_type_drift.py` (7 schemas) — all OK
  - `clang-tidy -p build-macos-clang src/medui/Trace.cpp src/medui/Screen.cpp` — no
    `cppcoreguidelines-no-malloc` or `-owning-memory` findings, which is what the new `.clang-tidy`
    is there to make an error. The `readability-identifier-naming` warnings on enum constants are
    repo-wide and pre-existing (CONTRIBUTING.md's `UpperCamelCase` against the root config), not
    introduced here.
  - `clang-format --dry-run -Werror` clean on every new file and on both `medui` files; the `draw`
    files were left in their existing local style rather than reformatted, which would have been
    unrelated churn.
  - `./build-macos-clang/examples/EcgClassifierExample` — output quoted above

**Not run here:** the Windows/MSVC and Linux/GCC legs, and the lavapipe render legs. The macOS leg
does run `verify.screen.endoscope-monitor` under MoltenVK, and it passes.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next
      dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green.

## Regulatory impact

**Safety-relevant, and the impact is deliberate rather than incidental.** This adds a path by which
live physiological data reaches a rendered frame, which is the first such path in this repository.
Three properties carry that, all of them checks rather than review discipline:

- **Refused, never truncated.** A trace whose sample count exceeds the cap refuses the frame, and the
  frame rolls back whole. A partial frame is the worst outcome available on a medical display,
  because it looks like a reading — the rule the screen runtime already applied to text, applied to a
  waveform.
- **Bounded before the device runs.** Per-node work is `maxSamplesPerTrace`, a constant, exactly as a
  `Label`'s is `maxGlyphsPerRun`; the storage is the screen's declared `DrawBudget`, sized once and
  never grown; and no allocation occurs in the frame, verified the three independent ways #63
  established.
- **Excursions are shown, not refused.** A sample outside the declared display range is pinned to the
  band's rail rather than failing the frame — blanking a monitor at the moment the waveform becomes
  most interesting is the wrong failure direction here, and `trace-clamps-excursions` pins the
  decision. A *non-finite* sample is refused, because it makes a position undefined rather than
  extreme.

No new claim of certification, validation or production readiness is made or implied. The ECG
demonstrator's existing notice — synthetic weights, no training, no clinical validity — is unchanged
and still the first thing it prints.

**Artifacts updated:** `AGENTS.md` § 2 (the parity note said `SignalTrace` remains deferred, which is
no longer true), `docs/architecture.md` (module table, the compiled-screen section, the planned
table), `README.md` (two status rows), and
`.agents/skills/medui-authoring/SKILL.md` (its "one limit" paragraph was stale as of #255 and is now
accurate). No ADR needed a change: ADR-011, ADR-012 and ADR-014 all already say what this
implements, and the one constraint ADR-014 imposed on #257 is met rather than amended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live waveform rendering for `SignalTrace` components using caller-provided sample data.
  - Added signal bindings with validation for stream names, sample ranges, styles, and screen compatibility.
  - Bound traces display a dimmed field beneath a full-color waveform.
  - Added safeguards for oversized or invalid sample data, preserving the frame without partial output.
  - Updated the ECG example to demonstrate classifier data rendered as a trace.

- **Documentation**
  - Updated implementation and architecture documentation to reflect SignalTrace support and deferred components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->