### PR TITLE
S5 follow-on — a TextInput's charset bounds what the device displays [#297]

### DIFF
--- a/.agents/skills/medui-authoring/SKILL.md
+++ b/.agents/skills/medui-authoring/SKILL.md
@@ -86,15 +86,21 @@ before you write one:
 - **`max_length` is measured against your box**, since this issue: `max_length` cells of the font's
   widest glyph plus the caret's column must fit, or the screen fails to compile with `MEDUI-E050`.
   A `max_length` past `maxFieldCells` (64) is `MEDUI-E053` instead, because no box makes it drawable.
-- **Your `charset:` is a compile-time claim about the *source*, not a runtime filter.** It says which
-  code points this field's data can produce, and the compiler checks that the font package can draw
-  all of them (`MEDUI-E053`). It does not reach the device: a compiled node carries the charset's
-  *name*, not its set, so what the runtime refuses is a character the **font package's** charset does
-  not admit — which is wider than yours whenever you narrowed it. A host that sends a letter to a
-  digits-only field gets a letter on screen. The box is measured against the font's charset too, for
-  the same reason, which is conservative in the only safe direction. Narrowing enforcement to the
-  node's own set needs the compiled screen to carry resolved ranges, which is
-  [#297](https://github.com/ambroise-leclerc/MduX/issues/297).
+- **Your `charset:` bounds what the device displays, since [#297](https://github.com/ambroise-leclerc/MduX/issues/297).**
+  It says which code points this field's data can produce; the compiler checks the font package can
+  draw all of them (`MEDUI-E053`) *and* writes the resolved ranges into the compiled node, so the
+  runtime holds the field to your set and not only to the font's. A host that sends a letter to a
+  digits-only field is refused. Before #297 the node carried the charset's *name* and nothing else,
+  so the letter went on screen.
+  - The refusal has its own name. `CharacterOutsideFieldCharset` is a character the package draws
+    perfectly well that **this node never declared**; `GlyphNotInPackage` is one the font cannot draw
+    at all. If you see the second, re-bake the font; if you see the first, either the host is sending
+    the wrong data or your `charset:` is narrower than the field's real alphabet.
+  - It is checked when a value is **bound**, not only when a frame is drawn.
+    `TextInputBinding::create()` refuses the slot, which leaves the previous frame on screen and
+    hands your host an error; a violation that reaches `render()` refuses the whole screen instead.
+  - The box is still measured against the **font's** charset, not yours, which is conservative in the
+    only safe direction: a box sized for the widest glyph the font admits holds every narrower one.
 - **Display and caret only.** No composition, no candidate window, no key handling. The host edits
   the value; the screen shows it. A value longer than the field, or a character the font package's
   restricted charset does not admit, refuses the frame rather than truncating or substituting — the
@@ -234,10 +240,26 @@ compiler knows a `TimeSeconds` clock draws eight glyphs and checks them against 
 There is no product-supplied table to configure, and a box too narrow for the format is a compile
 error.
 
-`charset:` on `TextInput` stays an open name — it resolves against the character sets a build bakes,
-which the contract does not enumerate. It bounds what the field may *display*; what its box must
-*hold* is measured against the font package's own charset, for the reason the `TextInput` notes
-above give.
+`charset:` on `TextInput` stays an open **name in the source** — it resolves against the character
+sets a build bakes, which the contract does not enumerate. What the *compiled node* carries is the
+resolved set as well as the name (#297), so the device enforces it without a table shipped beside the
+screen. Write the sets in your screen recipe's `[dynamicText]` table, repeating a name to give it
+more than one run of code points:
+
+```toml
+[dynamicText]
+names           = ["PATIENT-ID", "PATIENT-ID"]
+# Decimal: the TOML subset has no hex. 48..57 is U+0030..U+0039, 65..90 is U+0041..U+005A.
+firstCodePoints = [48, 65]
+lastCodePoints  = [57, 90]
+```
+
+The ranges must not overlap, and the compiler refuses the recipe naming the entry if they do. The
+resolved set lands in the committed `package.json`, so widening what a field will accept is a re-bake
+and a reviewable diff rather than a change in a table nobody reads.
+
+What the field's box must *hold* is still measured against the font package's own charset, for the
+reason the `TextInput` notes above give.
 
 ## `@safety_critical` — when it's mandatory, and when it's automatic
 

--- a/docs/adr/ADR-012-compiled-screen-artifacts.md
+++ b/docs/adr/ADR-012-compiled-screen-artifacts.md
@@ -84,9 +84,47 @@ values is also what makes the package readable in a diff: a reviewer sees
 (MEDUI-DEC-006) and a name outside one is `MEDUI-E034`. The distinction matters here rather than
 being a typing detail. A validated *name* is proved to resolve against a table a build supplies, so
 what it means is configuration; a *member* means one thing everywhere, which is what lets the
-compiler measure a clock's rendering against its bounds instead of looking it up. `charset` stays a
-name, because the character sets it resolves against are baked per build and the contract does not
-enumerate them.
+compiler measure a clock's rendering against its bounds instead of looking it up.
+
+**Amended by #297: a `TextInput` carries its `charset` name *and* the code points that name resolved
+to.** This record previously said "`charset` stays a name, because the character sets it resolves
+against are baked per build and the contract does not enumerate them", and the second half of that
+sentence is still true — it is the conclusion drawn from it that was wrong. A device handed only the
+name has nothing to compare a character against but the font package, so a field declared `charset:
+DIGITS` on a font admitting all of Latin-1 displayed the `A` a host handed it: the narrowing stopped
+at the compiler and an author reading the field could not tell.
+
+There are three kinds of thing a compiled node can carry, not two, and `charset` is the third:
+
+- a **member**, which means one thing everywhere, because the contract enumerates it;
+- a **name**, which resolves against a table a *build* supplies, and which a device therefore cannot
+  resolve without that table shipped beside the artifact — the exposure `ReadingSlot` documents at
+  length, and the reason #258 left `NumericDisplay`'s `templateId` a name: what a template stands for
+  is a *rendering the host supplies at run time*;
+- a **resolved value**, which the compiler derived from such a table at build time and wrote down.
+  `bounds` is one. `charsetRanges` is one. Nothing ships beside the screen and nothing is looked up:
+  the device tests membership in a set that is in the file.
+
+That third category is what makes this different from `templateId` rather than a reversal of it. A
+charset name stands for a set the compiler has already resolved and already validated against the
+font (`MEDUI-E053`); resolving it twice, once into a compile-time check and once into a table a
+product hands the runtime, is precisely how the two would come to disagree.
+
+**This is not a widening of the shared contract**, and the reason is worth stating because the
+opposite is arguable. MEDUI-DEC-006 assigns the character sets themselves to the implementation —
+"`charset` stays an open name resolved against the implementation's baked character sets" — so what
+lands in `package.json` is the resolution of a table the contract has already delegated.
+MEDUI-DEC-003 characterises a compiled screen as *locale-free layout data* and closes by assigning
+"committed artifact layouts" to implementations, with conformance comparing "observable meaning, not
+output encoding"; the ranges are locale-free, are not glyph data, and are integers the compiler
+computed. And it is checkable rather than only arguable: the four claimed capabilities are `syntax`,
+`semantics`, `layout` and `safety`, none of which reads a compiled package, and all eighteen pinned
+cases at `265df19` pass unchanged.
+
+What it *is* is a portability difference worth recording rather than discovering: the same `.medui`
+source compiled by an implementation that does not carry the ranges will display a character this one
+refuses. That belongs upstream, and this record is where MduX says what it did and why, not a
+substitute for asking.
 
 **All three files spell their members in camelCase**, as the committed font, shader and model
 packages do (`byteLength`, `occupancyPercent`, `advanceWidth`). The one file that could have differed is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,11 +261,17 @@ the compiled node carried the charset's *name*, so a device had nothing to compa
 against but the font package, and a field declared for digits displayed the letter a host sent it.
 The node now carries the code points that name resolved to, and the two bounds stay distinguishable —
 `GlyphNotInPackage` is a character the package cannot draw, `CharacterOutsideFieldCharset` is one it
-draws perfectly well that this node never declared. This is the one field where a *name* becomes a
-*value* in a compiled screen besides a colour token, and ADR-012 says why that is carrying a resolved
-value rather than shipping a product table: what a `NumericDisplay`'s `templateId` stands for is a
-rendering the host supplies at run time, while what a charset stands for is a set the compiler has
-already resolved and already checked the font against.
+draws perfectly well that this node never declared.
+
+`charsetRanges` is the **only** place a compiled screen carries a resolved value where it could have
+carried a name, and the contrast with its neighbours is the point rather than an exception to it. A
+`colorToken` and a `textKey` stay names: ADR-011 fixes that boundary and the device resolves each by
+a bounded lookup in a governed table it already holds, which is also what keeps the package readable
+in a diff. A `templateId` stays a name for a stronger reason — what it stands for is a *rendering the
+host supplies at run time*, so resolving it would mean shipping a product table beside the screen.
+What a charset stands for is neither: a set the compiler has already resolved and already checked the
+font against, with nothing left for a device to look up. ADR-012 names the three cases and says why
+this one is carrying a resolved value rather than baking configuration.
 
 Display and caret is the whole of the component. #17 cuts input-method editing and ADR-004 is the
 reason — an IME needs the platform, graphics and OS headers a governed module is compiled without —

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,6 +256,17 @@ deliberately does not check" in `TextBudget.cppm`. And a value longer than its f
 the package cannot draw, refuses the frame rather than truncating or substituting: a shortened
 patient identifier is a different identifier that looks like a whole one.
 
+#297 added the second bound. A `TextInput`'s `charset:` used to reach the compiler and stop there:
+the compiled node carried the charset's *name*, so a device had nothing to compare a character
+against but the font package, and a field declared for digits displayed the letter a host sent it.
+The node now carries the code points that name resolved to, and the two bounds stay distinguishable —
+`GlyphNotInPackage` is a character the package cannot draw, `CharacterOutsideFieldCharset` is one it
+draws perfectly well that this node never declared. This is the one field where a *name* becomes a
+*value* in a compiled screen besides a colour token, and ADR-012 says why that is carrying a resolved
+value rather than shipping a product table: what a `NumericDisplay`'s `templateId` stands for is a
+rendering the host supplies at run time, while what a charset stands for is a set the compiler has
+already resolved and already checked the font against.
+
 Display and caret is the whole of the component. #17 cuts input-method editing and ADR-004 is the
 reason — an IME needs the platform, graphics and OS headers a governed module is compiled without —
 so the host owns the keystrokes and what crosses the boundary is what to display.

--- a/docs/recipes/screen.schema.json
+++ b/docs/recipes/screen.schema.json
@@ -90,7 +90,7 @@
     },
     "dynamicText": {
       "type": "array",
-      "description": "The product's governed dynamic-text table, resolved. A report that named a table without recording its contents would say which table a screen was checked against and not what that check was of.",
+      "description": "The product's governed dynamic-text table, resolved. A report that named a table without recording its contents would say which table a screen was checked against and not what that check was of. One entry per name: the recipe's positional arrays may repeat a name to add a range to its set, and the entries here are those sets, sorted and disjoint.",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -105,7 +105,7 @@
           },
           "produces": {
             "type": "array",
-            "description": "The code points this source can produce, as closed ranges. The compiler checks the font package can draw all of them.",
+            "description": "The code points this source can produce, as closed ranges, sorted and non-overlapping. The compiler checks the font package can draw all of them, and - for a `TextInput`'s `charset:` - carries the resolved set into the compiled node so the device can hold a field to it too (#297).",
             "items": {
               "type": "object",
               "additionalProperties": false,
@@ -117,12 +117,14 @@
                 "first": {
                   "type": "integer",
                   "description": "First code point, inclusive.",
-                  "minimum": 0
+                  "minimum": 0,
+                  "maximum": 1114111
                 },
                 "last": {
                   "type": "integer",
-                  "description": "Last code point, inclusive.",
-                  "minimum": 0
+                  "description": "Last code point, inclusive. Bounded at U+10FFFF, the last Unicode scalar value: above it is not a character, so a table naming one describes something no text can contain.",
+                  "minimum": 0,
+                  "maximum": 1114111
                 }
               }
             }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -432,6 +432,8 @@ display and caret and nothing else.
 - #258 S3 `NumericDisplay` and `Clock` — **blocked by #219**
 - #259 S4 `StatusIndicator` — **shipped**; the ECG demonstrator binds its classifier's class to one
 - #260 S5 `TextInput` (display and caret only) — **shipped**; a fixed-pitch grid, measured at compile time
+  - #297 — **shipped**; the follow-on that made `charset:` a bound on what the *device* displays and
+    not only a claim about the source, by carrying the resolved code-point ranges in the compiled node
 - #261 S6 Buttons with requirement binding — **shipped**; a face, a closed action, and the requirement it is traced to
 
 Largely independent of one another, unlike #16's, which is why they landed in that order rather than

--- a/generated/screen/endoscope-monitor/package.json
+++ b/generated/screen/endoscope-monitor/package.json
@@ -114,6 +114,17 @@
       "id": "patient-id",
       "kind": "TextInput",
       "spec": {
+        "charset": "PATIENT-ID",
+        "charsetRanges": [
+          {
+            "first": 48,
+            "last": 57
+          },
+          {
+            "first": 65,
+            "last": 90
+          }
+        ],
         "colorToken": "Theme.Colors.Title",
         "maxLength": 12,
         "source": "PATIENT_ID"

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -2,7 +2,7 @@
   "inputs": [
     {
       "path": "recipes/screen/endoscope-monitor/EndoscopeMonitor.medui",
-      "sha256": "e112c36bf155193817f0617542d2c65bb71ba3ad4499273bb10b140bc8256f77"
+      "sha256": "1af81df848711c180b6bf09d91372b616d90e92b4ebf07d5c654c04658bff448"
     },
     {
       "path": "generated/font/dejavu-ui/package.json",
@@ -31,7 +31,21 @@
       "maxIndices": 6144,
       "maxVertices": 4096
     },
-    "dynamicText": [],
+    "dynamicText": [
+      {
+        "name": "PATIENT-ID",
+        "produces": [
+          {
+            "first": 48,
+            "last": 57
+          },
+          {
+            "first": 65,
+            "last": 90
+          }
+        ]
+      }
+    ],
     "fontPackage": "generated/font/dejavu-ui/package.json",
     "id": "endoscope-monitor",
     "imagePackages": [
@@ -62,16 +76,16 @@
     },
     {
       "path": "package.json",
-      "sha256": "7d76632e0750df04370209ae6010ae81777890cc4a8a4015449e421e84260229"
+      "sha256": "6be56d5be1c7bcb11570bb4cedc170458d0b0c2e7a8e0f4d21ff1e7c051a2d74"
     },
     {
       "path": "verification.json",
-      "sha256": "5e49e42b14d9591e528859086687d73860535105aa3c08e9b0d9a53ab42dc080"
+      "sha256": "e4ebf65e4384e7dd8c12679de5d24d2223d442bd0fd673a7b448f332800c02c7"
     }
   ],
   "recipe": {
     "path": "recipes/screen/endoscope-monitor.toml",
-    "sha256": "53a2ef140fb7be0cab37a9fc40ebc114d78f9c2c9c3927706a50523cb6fc285f"
+    "sha256": "7207c95d4cf45a57179886e9f2e86a9ab89493f2ff9678406bda38e9da2ca26a"
   },
   "schemaVersion": 1,
   "stages": [

--- a/generated/screen/endoscope-monitor/verification.json
+++ b/generated/screen/endoscope-monitor/verification.json
@@ -4,7 +4,7 @@
     {
       "id": "endoscope-monitor",
       "role": "screenPackage",
-      "sha256": "7d76632e0750df04370209ae6010ae81777890cc4a8a4015449e421e84260229"
+      "sha256": "6be56d5be1c7bcb11570bb4cedc170458d0b0c2e7a8e0f4d21ff1e7c051a2d74"
     },
     {
       "id": "endoscope-monitor",

--- a/include/mdux/font/Schema.cppm
+++ b/include/mdux/font/Schema.cppm
@@ -126,12 +126,12 @@ enum class SchemaError : std::uint8_t {
 /// only in `report.json` so a runtime that loads a package can check the sidecar it was given
 /// belongs to it, without needing the bake report.
 struct AtlasMetrics {
-    std::string   path{};              ///< bare filename, resolved beside `package.json`
+    std::string   path{};  ///< bare filename, resolved beside `package.json`
     std::uint32_t width{0};
     std::uint32_t height{0};
-    std::uint64_t byteLength{0};       ///< exactly `width * height`; the sheet is R8
-    std::string   sha256{};            ///< 64 lowercase hex characters
-    std::uint32_t occupancyPercent{0}; ///< recorded for the report, not load-bearing
+    std::uint64_t byteLength{0};        ///< exactly `width * height`; the sheet is R8
+    std::string   sha256{};             ///< 64 lowercase hex characters
+    std::uint32_t occupancyPercent{0};  ///< recorded for the report, not load-bearing
 };
 
 /// One baked glyph: where it sits in the sheet, and what it does to the pen.
@@ -146,12 +146,14 @@ struct GlyphRecord {
     std::int16_t  leftSideBearing{0};
     std::uint32_t x{0};
     std::uint32_t y{0};
-    std::uint32_t width{0};   ///< zero for a blank such as the space, which still has an advance
+    std::uint32_t width{0};  ///< zero for a blank such as the space, which still has an advance
     std::uint32_t height{0};
     std::int32_t  bitmapOriginX{0};
     std::int32_t  bitmapOriginY{0};
 
-    [[nodiscard]] bool isBlank() const noexcept { return width == 0 || height == 0; }
+    [[nodiscard]] bool isBlank() const noexcept {
+        return width == 0 || height == 0;
+    }
 };
 
 /// One kerning adjustment the baker chose to bake, in font units.
@@ -165,12 +167,36 @@ struct KerningPair {
     std::int16_t adjustment{0};
 };
 
-/// One run of code points the package is allowed to draw.
+/// The largest Unicode scalar value. Above this is not a character at all, so a table naming one is
+/// describing something no text can contain.
+///
+/// Exported rather than kept in this module's implementation because a `TextInput`'s own narrowed
+/// charset is checked against the same three bounds by `mdux.medui.schema`, and Unicode's limits are
+/// not a fact each table gets to spell for itself. They live beside `CharsetRange` because that is
+/// the type they bound, not because they belong to fonts.
+inline constexpr char32_t maxCodePoint = 0x10FFFF;
+
+/// The surrogate block. Not scalar values: a lone surrogate is a UTF-16 encoding artefact, never a
+/// character, so a charset admitting one admits something no glyph can correspond to.
+inline constexpr char32_t surrogateFirst = 0xD800;
+inline constexpr char32_t surrogateLast  = 0xDFFF;
+
+/// One run of code points a table admits, inclusive at both ends.
+///
+/// Shared by a font package's `restrictedCharset` - the set the *package can draw* - and by a
+/// `TextInput`'s narrowed `charsetRanges` - the set that *node may display*. One type rather than
+/// two of the same shape, because the check `recordField()` makes is a comparison between them: the
+/// node's set is the narrower of the two by construction, and comparing like with like is what makes
+/// that sentence checkable rather than a claim about two spellings.
 struct CharsetRange {
     char32_t first{0};
     char32_t last{0};
 
-    [[nodiscard]] bool contains(char32_t point) const noexcept { return point >= first && point <= last; }
+    [[nodiscard]] constexpr bool contains(char32_t point) const noexcept {
+        return point >= first && point <= last;
+    }
+
+    [[nodiscard]] constexpr bool operator==(const CharsetRange&) const noexcept = default;
 };
 
 /**
@@ -181,13 +207,13 @@ struct CharsetRange {
  * caller holds a `FontPackage` that has not been checked.
  */
 struct FontPackage {
-    std::string              id{};
-    std::uint16_t            unitsPerEm{0};
-    std::uint32_t            pixelSize{0};
-    std::vector<std::string> locales{};
-    AtlasMetrics             atlas{};
-    std::vector<GlyphRecord> glyphs{};       ///< sorted by code point
-    std::vector<KerningPair> kerning{};
+    std::string               id{};
+    std::uint16_t             unitsPerEm{0};
+    std::uint32_t             pixelSize{0};
+    std::vector<std::string>  locales{};
+    AtlasMetrics              atlas{};
+    std::vector<GlyphRecord>  glyphs{};             ///< sorted by code point
+    std::vector<KerningPair>  kerning{};
     std::vector<CharsetRange> restrictedCharset{};  ///< sorted, non-overlapping
 
     /// Every structural rule this module enforces, including the tabular-figure requirement and

--- a/include/mdux/medui/Field.cppm
+++ b/include/mdux/medui/Field.cppm
@@ -53,12 +53,25 @@
  * derive the same number.
  *
  * A `TextInput`'s `charset:` field could in principle narrow it - a field restricted to digits would
- * fit in a tighter grid than one that admits `@` - and that is deliberately *not* done. The
- * compiled node carries `charset` as a validated name rather than as a set (ADR-011), so a runtime
- * that wanted the narrower pitch would need a product table shipped beside the screen, which is the
- * exposure `ReadingSlot` documents at length for a `templateId`. The conservative direction is free
- * here: a box sized for the font's widest glyph holds every narrower one, so an author who narrows
- * the charset gets a box larger than they strictly need and never one too small.
+ * fit in a tighter grid than one that admits `@` - and that is deliberately *not* done.
+ *
+ * The reason changed with #297 and the decision did not, which is worth separating because the old
+ * reason is now false. It used to be that a runtime *could not*: the compiled node carried the
+ * charset's name and nothing else, so a narrower pitch would have needed a product table shipped
+ * beside the screen. The node now carries the resolved set, so this function could take it. It does
+ * not, because narrowing buys nothing and costs a dependency:
+ *
+ * - **The direction is safe as it stands.** The node's set is proved a subset of the font's at
+ *   compile time (`MEDUI-E053`), so the font-wide pitch is never *smaller* than a node-wide one
+ *   would be. An author who narrows a charset gets a box larger than they strictly need and never
+ *   one too small.
+ * - **A pitch is a property of one artifact both sides hold.** `cellWidth(font)` has one answer per
+ *   font package, derived from the same bytes on the host and on the device, and neither can be told
+ *   a different one. Adding the node as a second input gives it an answer per *node* and a way for
+ *   two callers to disagree, for a few pixels.
+ * - **It would couple what a field may show to where its ink lands.** Widening a `charset:` reads as
+ *   a permissions edit; under a narrowed pitch it would move every cell of that field, changing
+ *   measured extents and pinned pixels. Those are two independent facts and they stay independent.
  *
  * ## What is bounded, and by what
  *

--- a/include/mdux/medui/Field.cppm
+++ b/include/mdux/medui/Field.cppm
@@ -82,19 +82,38 @@
  * identifier is a different identifier. The compile-time counterpart is the charset check the budget
  * stage already performs, which is what makes this refusal the second line rather than the first.
  *
- * ## The limit that leaves, stated rather than left to be found
+ * ## The node's own charset, and why it is a second bound rather than the same one
  *
- * A `TextInput`'s own `charset:` is **not** enforced here, and cannot be: a compiled node carries
- * the charset's *name* and not its set (ADR-011), so this module has nothing to compare a character
- * against but the font package. A field declared `charset: DIGITS` against a font that also admits
- * letters will therefore display a letter the host sends it.
+ * A `TextInput`'s `charset:` is enforced here too, since #297. It was not before, and could not be:
+ * a compiled node carried the charset's *name* and nothing else, so this module had nothing to
+ * compare a character against but the font package, and a field declared `charset: DIGITS` against a
+ * font that also admits letters displayed the letter a host sent it. `TextInputSpec::charsetRanges`
+ * now carries what that name resolved to, and `narrowed` is that set arriving here.
  *
- * That is a narrower guarantee than an author might read into the field, so it is written down. The
- * compiler does check the declared set - every code point it can produce must be one the font can
- * draw - which is what the narrowing is *for*: proving a source cannot escape the package. Enforcing
- * it on device needs the compiled screen to carry the resolved ranges, which is a schema change and
- * therefore a change to the shared contract's compiled-screen semantics; #297 is where that is
- * argued, not here.
+ * The two bounds answer two different questions and both are asked, in that order:
+ *
+ * - **`GlyphNotInPackage`** - the font package will not draw this character. A physical limit: there
+ *   is no glyph, no fallback (ADR-010 leaves the runtime none), and no cell was ever sized for it.
+ * - **`CharacterOutsideFieldCharset`** - the package draws it perfectly well, and *this node never
+ *   said it would show it*. A policy limit, and a different fact, which is why it is a different
+ *   error rather than the same one reported twice. A caller told "no glyph" would go and re-bake a
+ *   font; a caller told this one has a host sending a field data the screen was not designed for.
+ *
+ * The font's set is asked first because it is the one that admits no argument. A character failing
+ * both is reported as the physical limit, which is the more actionable of the two.
+ *
+ * ## Where a charset violation is meant to be caught, and why it is checked twice
+ *
+ * Here is the second line, not the first. `TextInputBinding::create()` asks the same question when a
+ * value is *bound*, which is where a host can still act on the answer: a refusal there leaves the
+ * previous frame on screen and hands the caller a named error. A refusal here rolls back the frame,
+ * and `mdux.medui.screen` turns that into a screen that does not render - the right outcome for a
+ * disagreement nobody caught earlier, and a poor one to rely on, because a blank display tells an
+ * operator less than a stale one does.
+ *
+ * That is `TextInputBinding`'s existing arrangement for `max_length` and the caret extended to the
+ * charset, for its stated reason: one place reports at start-up where a caller can act on it, and
+ * one holds when the two disagree.
  */
 module;
 
@@ -130,17 +149,48 @@ inline constexpr std::int64_t caretWidth = 1;
 
 /// Why a field was refused. Every one leaves the draw list exactly as it was found.
 enum class FieldError : std::uint8_t {
-    NoCells,            ///< the field has no cells, so there is nowhere to display anything
-    TooManyCells,       ///< the field has more cells than `maxFieldCells`
-    TextTooLong,        ///< the value has more characters than the field has cells
-    CaretOutOfRange,    ///< the caret is not a position in the field, nor just past its last cell
-    GlyphNotInPackage,  ///< a character the value needs is one the font package cannot draw
-    EmptyCharset,       ///< the font package admits no code point, so no cell width can be derived
-    CharsetHasNoInk,    ///< every code point it admits is blank, so no field could show anything
-    ListRejected,       ///< `DrawList` refused a rectangle - budget, or a degenerate extent
+    NoCells,                       ///< the field has no cells, so there is nowhere to display anything
+    TooManyCells,                  ///< the field has more cells than `maxFieldCells`
+    TextTooLong,                   ///< the value has more characters than the field has cells
+    CaretOutOfRange,               ///< the caret is not a position in the field, nor just past its last cell
+    GlyphNotInPackage,             ///< a character the value needs is one the font package cannot draw
+    CharacterOutsideFieldCharset,  ///< a character the package can draw, that this node never declared
+    EmptyCharset,                  ///< the font package admits no code point, so no cell width can be derived
+    CharsetHasNoInk,               ///< every code point it admits is blank, so no field could show anything
+    ListRejected,                  ///< `DrawList` refused a rectangle - budget, or a degenerate extent
 };
 
 [[nodiscard]] std::string_view describe(FieldError error) noexcept;
+
+/**
+ * @brief Whether a node whose narrowed charset is `narrowed` may display `point`.
+ *
+ * The one definition of that question (#297), used by `recordField()` when a frame is drawn and by
+ * `TextInputBinding::create()` when a value is bound.
+ *
+ * **Empty admits everything.** A node that declared no `charset:` carries no ranges, and that is
+ * "this field narrows nothing" rather than "this field admits nothing" - the fail-closed reading of
+ * an empty set, and the wrong one here, since it would refuse every character of every field that
+ * does not narrow. What keeps that safe rather than convenient is `ScreenPackage::validate()`, which
+ * refuses a node carrying a `charset` name with no ranges: a narrowing that reached a device with its
+ * set lost is a compile error in the generated screen, so an empty set here is always a node that
+ * asked for no bound and never one whose bound went missing.
+ *
+ * Linear over a handful of ranges rather than a binary search. A node's set is the narrow one by
+ * construction - `FontPackage::permits()` searches the wide one - and validation has already
+ * established the ordering a search would need.
+ */
+[[nodiscard]] constexpr bool admits(std::span<const mdux::font::CharsetRange> narrowed, char32_t point) noexcept {
+    if (narrowed.empty()) {
+        return true;
+    }
+    for (const mdux::font::CharsetRange& range : narrowed) {
+        if (range.contains(point)) {
+            return true;
+        }
+    }
+    return false;
+}
 
 /**
  * @brief The width of one cell, in pixels: the widest advance the font package can produce.
@@ -207,6 +257,7 @@ struct FieldExtent {
  *
  * @param list  the destination; rectangles are appended in cell order, the caret last
  * @param font  the font package the glyphs come from
+ * @param narrowed the node's own `charsetRanges`, or empty for a node that narrows nothing
  * @param node  the node's resolved rectangle, in surface pixels
  * @param cells the field's `max_length`: how many cells the grid has
  * @param text  the value, as code points - decoded by the host, never parsed here
@@ -233,12 +284,13 @@ struct FieldExtent {
  * Allocation-free, `noexcept`, and all-or-nothing: on any refusal the list is rolled back to where
  * it stood on entry.
  */
-[[nodiscard]] mdux::core::ResultVoid<FieldError> recordField(mdux::draw::DrawList&          list,
-                                                             const mdux::font::FontPackage& font,
-                                                             const mdux::core::Rect&        node,
-                                                             std::size_t                    cells,
-                                                             std::span<const char32_t>      text,
-                                                             std::optional<std::size_t>     caret,
-                                                             mdux::core::ColorRgba8         color) noexcept;
+[[nodiscard]] mdux::core::ResultVoid<FieldError> recordField(mdux::draw::DrawList&                     list,
+                                                             const mdux::font::FontPackage&            font,
+                                                             std::span<const mdux::font::CharsetRange> narrowed,
+                                                             const mdux::core::Rect&                   node,
+                                                             std::size_t                               cells,
+                                                             std::span<const char32_t>                 text,
+                                                             std::optional<std::size_t>                caret,
+                                                             mdux::core::ColorRgba8                    color) noexcept;
 
 }  // namespace mdux::medui

--- a/include/mdux/medui/Schema.cppm
+++ b/include/mdux/medui/Schema.cppm
@@ -95,6 +95,12 @@ import mdux.draw;
 import mdux.evidence.digest;
 import mdux.evidence.report;
 
+// Re-exported, not merely imported. `TextInputSpec::charsetRanges` is a span of
+// `mdux::font::CharsetRange`, so the type is part of this contract rather than an implementation
+// detail behind it: a consumer holding a compiled screen has to be able to name what a field admits,
+// and the generated translation unit that owns the storage has to be able to declare the array.
+export import mdux.font.schema;
+
 export namespace mdux::medui {
 
 /// The `<kind>` component of `generated/<kind>/<id>/`, and the value of a package's `kind` member.
@@ -136,10 +142,28 @@ enum class SchemaError : std::uint8_t {
     MissingImagePackageApproval,  ///< an Image names no approved image package
     UnspecifiedNamedValue,        ///< a closed-set field left at its `Unspecified` sentinel
     NamedValueOutOfRange,         ///< a closed-set field holding no enumerator of its type
+    NarrowedCharsetIsEmpty,       ///< a node names a charset but carries no set, so nothing narrows
+    UnnamedCharsetRanges,         ///< a node carries a charset set that no `charset:` asked for
+    CharsetRangeDescending,       ///< a range ending before it begins, which admits nothing
+    CharsetRangesOverlap,         ///< ranges out of order or overlapping, so the set is ambiguous
+    CodePointOutOfRange,          ///< a range naming something past the last Unicode scalar value
+    SurrogateCodePoint,           ///< a range admitting a lone surrogate, which is no character
 };
 
 [[nodiscard]] constexpr std::string_view describe(SchemaError error) noexcept {
     switch (error) {
+        case SchemaError::NarrowedCharsetIsEmpty:
+            return "a text input names a charset but carries no resolved set";
+        case SchemaError::UnnamedCharsetRanges:
+            return "a text input carries a resolved charset it never named";
+        case SchemaError::CharsetRangeDescending:
+            return "a charset range ends before it begins";
+        case SchemaError::CharsetRangesOverlap:
+            return "the charset ranges are not sorted and disjoint";
+        case SchemaError::CodePointOutOfRange:
+            return "a charset range names a value past the last Unicode scalar value";
+        case SchemaError::SurrogateCodePoint:
+            return "a charset range admits a surrogate, which is not a character";
         case SchemaError::UnspecifiedNamedValue:
             return "a field whose value must come from a closed set was left unspecified";
         case SchemaError::NamedValueOutOfRange:
@@ -605,6 +629,27 @@ struct StatusIndicatorSpec {
     }
 };
 
+/**
+ * @brief A text input's source, its cell count, and the set of characters it may display.
+ *
+ * `charset` is the name the source wrote and `charsetRanges` is what that name resolved to, and the
+ * pair is the point of #297. A name alone is a claim about the *source*: the compiler proves every
+ * code point the named set can produce is one the font package can draw (`MEDUI-E053`), which stops
+ * a screen escaping its font. It is not a bound on what a *device* displays, because a device
+ * handed only a name has nothing to compare a character against - so a field declared `charset:
+ * DIGITS`, on a font that also admits letters, displayed the `A` a host handed it.
+ *
+ * The ranges close that. They are resolved by the compiler from the build's own character-set table
+ * and carried here, so the device tests membership against data in the artifact and needs no table
+ * shipped beside it. That is what distinguishes this from `NumericDisplaySpec::templateId`, which
+ * #258 deliberately left a name: a template stands for a *rendering the host supplies at run time*
+ * (`ReadingSlot::rendering`), while a charset stands for a set the compiler has already resolved and
+ * already validated. Carrying it is closer to carrying resolved `bounds` than to carrying a product
+ * table.
+ *
+ * Both or neither. `validate()` refuses a name with no ranges - a narrowing nothing can enforce -
+ * and ranges with no name, which would be a set no source asked for.
+ */
 struct TextInputSpec {
     std::string_view source{};
     std::string_view colorToken{};
@@ -612,7 +657,19 @@ struct TextInputSpec {
     std::string_view charset{};      ///< empty when the component narrows nothing
     std::string_view requirement{};  ///< optional on a TextInput
 
-    [[nodiscard]] constexpr bool operator==(const TextInputSpec&) const noexcept = default;
+    /// The code points `charset` resolved to: sorted, non-overlapping, scalar values. Empty exactly
+    /// when `charset` is, and spanning storage the generated translation unit owns, as
+    /// `StatusIndicatorSpec`'s parallel lists do.
+    std::span<const mdux::font::CharsetRange> charsetRanges{};
+
+    [[nodiscard]] constexpr bool operator==(const TextInputSpec& other) const noexcept {
+        return source == other.source && colorToken == other.colorToken && maxLength == other.maxLength && charset == other.charset
+               && requirement == other.requirement && std::ranges::equal(charsetRanges, other.charsetRanges);
+    }
+
+    // The membership test lives in `mdux.medui.field` as `admits()`, not here as an accessor. One
+    // definition: an empty set means "this node narrows nothing" rather than "this node admits
+    // nothing", and a rule with two spellings is a rule two readers can disagree about.
 };
 
 /**
@@ -1050,6 +1107,31 @@ template <typename Member>
     }
     if (spec->maxLength <= 0) {
         return mdux::core::err(SchemaError::NonPositiveMaxLength);
+    }
+    // Both or neither (#297). A name with no set is a narrowing the device cannot enforce, which is
+    // the state this whole member exists to leave; a set with no name is one no source asked for.
+    // Refusing both directions is what makes `narrows()` answerable from either field.
+    if (spec->charset.empty() != spec->charsetRanges.empty()) {
+        return mdux::core::err(spec->charset.empty() ? SchemaError::UnnamedCharsetRanges : SchemaError::NarrowedCharsetIsEmpty);
+    }
+    // The same four rules `FontPackage::validate()` applies to `restrictedCharset`, in the same
+    // order and under the same names, because they are the same rules about the same type. Sorted
+    // and disjoint is not tidiness: `permits()` reads the set as a union, so an overlapping pair
+    // describes a set two readers could enumerate differently.
+    for (std::size_t index = 0; index < spec->charsetRanges.size(); ++index) {
+        const mdux::font::CharsetRange& range = spec->charsetRanges[index];
+        if (range.last < range.first) {
+            return mdux::core::err(SchemaError::CharsetRangeDescending);
+        }
+        if (range.last > mdux::font::maxCodePoint) {
+            return mdux::core::err(SchemaError::CodePointOutOfRange);
+        }
+        if (range.first <= mdux::font::surrogateLast && range.last >= mdux::font::surrogateFirst) {
+            return mdux::core::err(SchemaError::SurrogateCodePoint);
+        }
+        if (index > 0 && range.first <= spec->charsetRanges[index - 1].last) {
+            return mdux::core::err(SchemaError::CharsetRangesOverlap);
+        }
     }
     return requireColor(spec->colorToken);
 }

--- a/include/mdux/medui/Screen.cppm
+++ b/include/mdux/medui/Screen.cppm
@@ -292,42 +292,43 @@ struct ButtonFace {
 
 /// Why a frame was refused. Every one leaves the draw list exactly as it was found.
 enum class ScreenError : std::uint8_t {
-    MalformedColorToken,      ///< a node's colour is not of the form `Theme.Colors.<Token>`
-    UnknownColorToken,        ///< well-formed, and the governed table does not define it
-    BudgetExhausted,          ///< a write would exceed a `DrawBudget` this frame is held to
-    UnknownTextKey,           ///< a bound text package carries no run for a node's `textKey`
-    MalformedTextRun,         ///< a run's range leaves the sidecar, or its bytes are not whole records
-    RunTooLong,               ///< a run holds more than `maxGlyphsPerRun` records
-    AtlasMismatch,            ///< the text package was baked against a different font package
-    SidecarMismatch,          ///< the sidecar is not the one the text package describes
-    PackageNotApproved,       ///< the screen was not compiled against this locale/package/digest
-    TextOverflowsNode,        ///< a run's ink is wider or taller than the node that names it
-    ImageSidecarMismatch,     ///< RGBA bytes differ from the baked image package
-    ImageNotApproved,         ///< the screen did not approve this image id/digest/extent
-    UnknownStreamSource,      ///< a signal slot names a stream no `SignalTrace` on this screen carries
-    DuplicateStream,          ///< two signal slots name the same stream
-    MissingSampleRing,        ///< a signal slot carries no ring, so its trace could never draw a sample
-    UnknownReadingNode,       ///< a reading slot names no `NumericDisplay` on this screen
-    DuplicateReading,         ///< two reading slots name the same node
-    MalformedPattern,         ///< a reading slot's rendering is empty or longer than `maxPatternLength`
-    ReadingRefused,           ///< a reading could not be drawn - see `ReadingError` for which way
-    ReadingOverflowsNode,     ///< a drawn reading's ink is wider or taller than the node that holds it
-    UnknownStatusNode,        ///< a status slot names no `StatusIndicator` on this screen
-    DuplicateStatus,          ///< two status slots name the same node
-    StateOutOfRange,          ///< a slot's state is not a position in that node's closed `states` list
-    StatusHasNoTint,          ///< a bound indicator declares no per-state colours, so its states look alike
-    UnknownTextInputNode,     ///< a text-input slot names no `TextInput` on this screen
-    DuplicateTextInput,       ///< two text-input slots name the same node
-    FieldRefused,             ///< a field could not be drawn - see `FieldError` for which way
-    FieldOverflowsNode,       ///< a drawn field's ink is wider or taller than the node that holds it
-    MalformedTraceStyle,      ///< a slot's sample range is empty or not finite, or its stroke is not 1-3px
-    MalformedSampleRing,      ///< a bound ring's oldest index or live count is not a position in it
-    NonFiniteSample,          ///< a live sample is a NaN or an infinity
-    TraceTooLong,             ///< a bound ring holds more than `maxSamplesPerTrace` samples
-    TraceBandTooSmall,        ///< a bound trace's node is too small to hold its stroke
-    ScreenNotApproved,        ///< a signal binding built for one screen was offered to another
-    UnimplementedEvent,       ///< a pressed `CriticalButton` names no member of the closed `SystemEvent` set
-    UntracedCriticalControl,  ///< a pressed `CriticalButton` declares no requirement to trace it to
+    MalformedColorToken,           ///< a node's colour is not of the form `Theme.Colors.<Token>`
+    UnknownColorToken,             ///< well-formed, and the governed table does not define it
+    BudgetExhausted,               ///< a write would exceed a `DrawBudget` this frame is held to
+    UnknownTextKey,                ///< a bound text package carries no run for a node's `textKey`
+    MalformedTextRun,              ///< a run's range leaves the sidecar, or its bytes are not whole records
+    RunTooLong,                    ///< a run holds more than `maxGlyphsPerRun` records
+    AtlasMismatch,                 ///< the text package was baked against a different font package
+    SidecarMismatch,               ///< the sidecar is not the one the text package describes
+    PackageNotApproved,            ///< the screen was not compiled against this locale/package/digest
+    TextOverflowsNode,             ///< a run's ink is wider or taller than the node that names it
+    ImageSidecarMismatch,          ///< RGBA bytes differ from the baked image package
+    ImageNotApproved,              ///< the screen did not approve this image id/digest/extent
+    UnknownStreamSource,           ///< a signal slot names a stream no `SignalTrace` on this screen carries
+    DuplicateStream,               ///< two signal slots name the same stream
+    MissingSampleRing,             ///< a signal slot carries no ring, so its trace could never draw a sample
+    UnknownReadingNode,            ///< a reading slot names no `NumericDisplay` on this screen
+    DuplicateReading,              ///< two reading slots name the same node
+    MalformedPattern,              ///< a reading slot's rendering is empty or longer than `maxPatternLength`
+    ReadingRefused,                ///< a reading could not be drawn - see `ReadingError` for which way
+    ReadingOverflowsNode,          ///< a drawn reading's ink is wider or taller than the node that holds it
+    UnknownStatusNode,             ///< a status slot names no `StatusIndicator` on this screen
+    DuplicateStatus,               ///< two status slots name the same node
+    StateOutOfRange,               ///< a slot's state is not a position in that node's closed `states` list
+    StatusHasNoTint,               ///< a bound indicator declares no per-state colours, so its states look alike
+    UnknownTextInputNode,          ///< a text-input slot names no `TextInput` on this screen
+    DuplicateTextInput,            ///< two text-input slots name the same node
+    FieldRefused,                  ///< a field could not be drawn - see `FieldError` for which way
+    CharacterOutsideFieldCharset,  ///< a value carries a character its `TextInput`'s `charset:` excludes
+    FieldOverflowsNode,            ///< a drawn field's ink is wider or taller than the node that holds it
+    MalformedTraceStyle,           ///< a slot's sample range is empty or not finite, or its stroke is not 1-3px
+    MalformedSampleRing,           ///< a bound ring's oldest index or live count is not a position in it
+    NonFiniteSample,               ///< a live sample is a NaN or an infinity
+    TraceTooLong,                  ///< a bound ring holds more than `maxSamplesPerTrace` samples
+    TraceBandTooSmall,             ///< a bound trace's node is too small to hold its stroke
+    ScreenNotApproved,             ///< a signal binding built for one screen was offered to another
+    UnimplementedEvent,            ///< a pressed `CriticalButton` names no member of the closed `SystemEvent` set
+    UntracedCriticalControl,       ///< a pressed `CriticalButton` declares no requirement to trace it to
 };
 
 // The two token failures are kept apart because the schema keeps them apart, and for its reason: a

--- a/recipes/screen/endoscope-monitor.toml
+++ b/recipes/screen/endoscope-monitor.toml
@@ -59,6 +59,25 @@ maxCommands = 64
 names      = ["TPL-PRESSURE-MMHG"]
 renderings = ["##.# mmHg"]
 
+# What each `charset:` a TextInput names actually admits (#297). The product's table, exactly as
+# `[numericTemplates]` is: `PATIENT-ID` is this device's rule for what a patient identifier may
+# contain, not the language's.
+#
+# The arrays are positional, and a name repeated across entries adds a range to its set - which is
+# how `PATIENT-ID` is digits *and* uppercase letters rather than one contiguous run. Lowercase,
+# punctuation and space are all drawable by the committed font and none of them is here, which is the
+# whole point: the compiler proves the set cannot escape the font, and the device refuses a character
+# the set does not contain.
+#
+# Widening this is a re-bake and a review of the diff: the resolved ranges are in the committed
+# `package.json`, so what a field will display changes visibly rather than in a table nobody reads.
+[dynamicText]
+names           = ["PATIENT-ID", "PATIENT-ID"]
+# Decimal, as `recipes/font/dejavu-ui.toml` says and for its reason: mdux.tools.toml's subset has no
+# hexadecimal literals. 48..57 is U+0030..U+0039, the digits; 65..90 is U+0041..U+005A, A to Z.
+firstCodePoints = [48, 65]
+lastCodePoints  = [57, 90]
+
 # The packages this screen's text is validated against (#235). `fontPackage` supplies the glyph
 # metrics every box is measured with; `packages` lists one committed text package per locale the
 # font approves, which today is `en-US` alone.

--- a/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
+++ b/recipes/screen/endoscope-monitor/EndoscopeMonitor.medui
@@ -100,6 +100,7 @@ Screen EndoscopeMonitor {
             source: "PATIENT_ID";
             max_length: 12;
             color: Theme.Colors.Title;
+            charset: PATIENT-ID;
         }
     }
 

--- a/src/font/Schema.cpp
+++ b/src/font/Schema.cpp
@@ -28,16 +28,9 @@ using mdux::core::ResultVoid;
 
 namespace {
 
-constexpr char32_t surrogateFirst = 0xD800;
-constexpr char32_t surrogateLast  = 0xDFFF;
-
 [[nodiscard]] bool isPowerOfTwo(std::uint32_t value) noexcept {
     return value != 0 && (value & (value - 1)) == 0;
 }
-
-/// The largest Unicode scalar value. Above this is not a character at all, so a package naming
-/// one is describing a glyph for something no text can contain.
-constexpr char32_t maxCodePoint = 0x10FFFF;
 
 /// Reads a required integer member, or fails with the error the caller names.
 [[nodiscard]] Result<std::int64_t, SchemaError> requireInt(const json::Value& object, std::string_view key) noexcept {

--- a/src/medui/Field.cpp
+++ b/src/medui/Field.cpp
@@ -127,6 +127,8 @@ std::string_view describe(FieldError error) noexcept {
             return "the caret is not a position in the field";
         case FieldError::GlyphNotInPackage:
             return "the value needs a character the font package cannot draw";
+        case FieldError::CharacterOutsideFieldCharset:
+            return "the value needs a character this field's charset does not admit";
         case FieldError::EmptyCharset:
             return "the font package admits no code point, so no cell width can be derived";
         case FieldError::CharsetHasNoInk:
@@ -187,13 +189,14 @@ mdux::core::Result<FieldExtent, FieldError> measureField(const mdux::font::FontP
     return FieldExtent{.inked = true, .width = inkRight + overhangOf(cell), .height = cell.bottom - cell.top};
 }
 
-mdux::core::ResultVoid<FieldError> recordField(mdux::draw::DrawList&          list,
-                                               const mdux::font::FontPackage& font,
-                                               const mdux::core::Rect&        node,
-                                               std::size_t                    cells,
-                                               std::span<const char32_t>      text,
-                                               std::optional<std::size_t>     caret,
-                                               mdux::core::ColorRgba8         color) noexcept {
+mdux::core::ResultVoid<FieldError> recordField(mdux::draw::DrawList&                     list,
+                                               const mdux::font::FontPackage&            font,
+                                               std::span<const mdux::font::CharsetRange> narrowed,
+                                               const mdux::core::Rect&                   node,
+                                               std::size_t                               cells,
+                                               std::span<const char32_t>                 text,
+                                               std::optional<std::size_t>                caret,
+                                               mdux::core::ColorRgba8                    color) noexcept {
     if (const auto accepted = fieldAccepts(cells, text.size(), caret); !accepted.has_value()) {
         return mdux::core::err(accepted.error());
     }
@@ -239,6 +242,17 @@ mdux::core::ResultVoid<FieldError> recordField(mdux::draw::DrawList&          li
             // carry. Same refusal as an absent glyph, because from a caller's side it is the same
             // fact: this package will not display that character.
             return refuse(FieldError::GlyphNotInPackage);
+        }
+        // The node's own set, asked second and only when the package already said yes (#297). A
+        // character failing both is the font's refusal, which is the more actionable of the two: no
+        // re-declaration of a charset can make a package draw a glyph it does not have.
+        //
+        // An empty `narrowed` is a node that declared no `charset:`, not a node that admits nothing.
+        // `admits()` says so rather than the loop reading an empty set as a union of no ranges,
+        // which is the fail-*closed* reading of a set and the wrong one here: it would refuse every
+        // character of every field that narrows nothing, which is most of them.
+        if (!admits(narrowed, text[index])) {
+            return refuse(FieldError::CharacterOutsideFieldCharset);
         }
         const mdux::font::GlyphRecord* glyph = font.find(text[index]);
         if (glyph == nullptr) {

--- a/src/medui/Screen.cpp
+++ b/src/medui/Screen.cpp
@@ -145,6 +145,12 @@ struct InkBox {
     if (error == FieldError::ListRejected) {
         return ScreenError::BudgetExhausted;
     }
+    // Named rather than flattened into `FieldRefused`, because it is the one field refusal a caller
+    // can act on without reading `FieldError`: the character is drawable and the *node* excluded it,
+    // so what is wrong is the value a host supplied and not the screen, the font or the budget.
+    if (error == FieldError::CharacterOutsideFieldCharset) {
+        return ScreenError::CharacterOutsideFieldCharset;
+    }
     return ScreenError::FieldRefused;
 }
 
@@ -403,6 +409,21 @@ mdux::core::Result<TextInputBinding, ScreenError> TextInputBinding::create(const
         if (const auto fits = fieldAccepts(cells, slot.text.size(), slot.caret); !fits.has_value()) {
             return mdux::core::err(asScreenError(fits.error()));
         }
+
+        // The node's declared charset, checked where a host can still do something about it (#297).
+        // This is the *first* line: `recordField()` asks the same question per frame, and a refusal
+        // there rolls back the whole screen, so a value that was never going to be displayable is
+        // much better refused when it is offered than when it is drawn.
+        //
+        // Not checked here: whether the font package can draw the character. That needs a
+        // `FontPackage`, which a text-input binding is deliberately not given - the value and the
+        // glyphs are joined by `TextBinding`, and asking a caller for a second artifact to build
+        // this one would couple two bindings that are independent by design. The frame asks it.
+        for (const char32_t point : slot.text) {
+            if (!admits(input->charsetRanges, point)) {
+                return mdux::core::err(ScreenError::CharacterOutsideFieldCharset);
+            }
+        }
     }
 
     return TextInputBinding{screen.id, slots};
@@ -476,6 +497,8 @@ std::string_view describe(ScreenError error) noexcept {
             return "two text-input slots name the same node";
         case ScreenError::FieldRefused:
             return "a field could not be drawn from the value, caret and length it was given";
+        case ScreenError::CharacterOutsideFieldCharset:
+            return "a value carries a character the node's own charset does not admit";
         case ScreenError::FieldOverflowsNode:
             return "a drawn field's ink is larger than the node that holds it";
         case ScreenError::UnimplementedEvent:
@@ -887,7 +910,8 @@ mdux::core::Result<FrameStats, ScreenError> render(const ScreenPackage&    scree
             const auto cells = input->maxLength <= 0 ? std::size_t{0} : static_cast<std::size_t>(input->maxLength);
 
             const std::size_t verticesBefore = list.vertices().size();
-            if (const auto recorded = recordField(list, *text.font(), toRect(node.bounds), cells, slot->text, slot->caret, quantise(*colour));
+            if (const auto recorded =
+                    recordField(list, *text.font(), input->charsetRanges, toRect(node.bounds), cells, slot->text, slot->caret, quantise(*colour));
                 !recorded.has_value()) {
                 // Forwarded rather than flattened, unlike the label path's: every way `recordField()`
                 // refuses is a distinct thing the caller can act on, and none of them was already

--- a/tests/medui/CompileTests.cpp
+++ b/tests/medui/CompileTests.cpp
@@ -22,6 +22,7 @@ import mdux.draw;
 import mdux.evidence.digest;
 import mdux.evidence.report;
 import mdux.font.schema;
+import mdux.medui.field;
 import mdux.medui.schema;
 import mdux.medui.screen;
 import mdux.text.schema;
@@ -373,6 +374,138 @@ const mdux::spec::Register theIrDescribesTheCompileThatProducedIt{
                       std::vector<cli::Diagnostic> second;
                       const auto                   again = md::run(*recipe, "recipes/screen/endoscope-monitor.toml", asBytes(recipeText), repoRoot(), second);
                       checks.expect(again.has_value() && again->irJson == outputs->irJson, "two compiles of one recipe produce one IR");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aCharsetNameIsResolvedIntoTheCompiledNode{
+    "A TextInput's charset is compiled into the node as a set, from a table one name may repeat in",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-compile-charset-is-resolved")
+            .Given("a recipe naming one charset over two entries, and a screen that uses it", [] {})
+            .When("the screen is compiled", [] {})
+            .Then("the node carries both ranges, sorted, and an overlapping table is refused instead",
+                  [] {
+                      // #297. The compiled node used to carry the charset's *name*, which a device
+                      // could only look up in a table shipped beside the screen - so the narrowing
+                      // stopped at the compiler and a field declared for digits displayed the letter
+                      // a host sent it. This is the resolution that closes it, checked end to end
+                      // from the recipe rather than from a hand-built spec.
+                      //
+                      // The repeated name is the other half: one entry carries one contiguous run,
+                      // and a patient identifier is digits *and* uppercase letters. Repeating a name
+                      // used to create a second rule that `checkDynamicText()`'s `find` never
+                      // reached, so the budget stage checked one range and ignored the rest - a
+                      // charset could escape its font while the compile stayed green.
+                      mdux::spec::Checks             checks;
+                      mdux::test::TemporaryDirectory root{"mdux-meduic-charset"};
+
+                      const auto copy = [&](std::string_view relative) {
+                          const std::filesystem::path destination = root.path() / relative;
+                          std::filesystem::create_directories(destination.parent_path());
+                          std::filesystem::copy_file(repoRoot() / relative, destination, std::filesystem::copy_options::overwrite_existing);
+                      };
+                      copy("generated/font/dejavu-ui/package.json");
+                      copy("generated/text/endoscope-monitor-en-us/package.json");
+                      copy("generated/text/endoscope-monitor-en-us/runs.bin");
+
+                      const std::filesystem::path source = root.path() / "recipes/screen/badge/Badge.medui";
+                      std::filesystem::create_directories(source.parent_path());
+                      {
+                          std::ofstream out{source, std::ios::binary};
+                          out << "Screen Badge {\n"
+                                 "    layout: Vertical { spacing: 0px; padding: 0px; }\n"
+                                 "    surface: 400px, 200px;\n"
+                                 "\n"
+                                 "    TextInput {\n"
+                                 "        id: badge;\n"
+                                 "        width: 240px;\n"
+                                 "        height: 40px;\n"
+                                 "        source: \"BADGE\";\n"
+                                 "        max_length: 6;\n"
+                                 "        color: Theme.Colors.Title;\n"
+                                 "        charset: BADGE-ID;\n"
+                                 "    }\n"
+                                 "}\n";
+                      }
+
+                      // 48..57 is U+0030..U+0039 and 65..90 is U+0041..U+005A. Decimal because
+                      // mdux.tools.toml's subset has no hexadecimal literals.
+                      const auto recipeWith = [](std::string_view firsts, std::string_view lasts) {
+                          return std::format("[package]\n"
+                                             "id            = \"badge\"\n"
+                                             "source        = \"recipes/screen/badge/Badge.medui\"\n"
+                                             "surfaceWidth  = 400\n"
+                                             "surfaceHeight = 200\n"
+                                             "\n"
+                                             "[budget]\n"
+                                             "maxVertices = 1024\n"
+                                             "maxIndices  = 1536\n"
+                                             "maxCommands = 16\n"
+                                             "\n"
+                                             "[dynamicText]\n"
+                                             "names           = [\"BADGE-ID\", \"BADGE-ID\"]\n"
+                                             "firstCodePoints = [{}]\n"
+                                             "lastCodePoints  = [{}]\n"
+                                             "\n"
+                                             "[text]\n"
+                                             "fontPackage = \"generated/font/dejavu-ui/package.json\"\n"
+                                             "packages    = [\"generated/text/endoscope-monitor-en-us/package.json\"]\n",
+                                             firsts,
+                                             lasts);
+                      };
+
+                      // Deliberately given out of order, so the sort is exercised rather than
+                      // agreed with: the compiled set has to be sorted whatever order it was written
+                      // in, because `ScreenPackage::validate()` refuses one that is not.
+                      const std::string            recipeText = recipeWith("65, 48", "90, 57");
+                      std::vector<cli::Diagnostic> diagnostics;
+                      const auto                   recipe = md::parseRecipe(recipeText, "recipes/screen/badge.toml", diagnostics);
+                      if (!recipe.has_value()) {
+                          checks.expect(false, std::format("the recipe parses, first diagnostic '{}'", firstCode(diagnostics)));
+                          checks.raise();
+                          return;
+                      }
+
+                      const auto outputs = md::run(*recipe, "recipes/screen/badge.toml", asBytes(recipeText), root.path(), diagnostics);
+                      if (!outputs.has_value()) {
+                          checks.expect(false, std::format("the screen compiles, first diagnostic '{}'", firstCode(diagnostics)));
+                          checks.raise();
+                          return;
+                      }
+
+                      const md::PackageReadResult reread = md::readPackage(outputs->packageJson, "package.json");
+                      checks.expect(reread.ok(), "the compiled package reads back");
+                      if (!reread.ok()) {
+                          checks.raise();
+                          return;
+                      }
+                      const ms::ScreenPackage  package = reread.document.package();
+                      const ms::CompiledNode*  node    = package.find("badge");
+                      const ms::TextInputSpec* input   = node == nullptr ? nullptr : std::get_if<ms::TextInputSpec>(&node->payload);
+                      checks.expect(input != nullptr, "the compiled screen carries the TextInput");
+                      if (input != nullptr) {
+                          checks.expect(input->charset == "BADGE-ID", std::format("the name the source wrote, got '{}'", input->charset));
+                          const std::array expected{
+                              mdux::font::CharsetRange{.first = U'0', .last = U'9'},
+                              mdux::font::CharsetRange{.first = U'A', .last = U'Z'}
+                          };
+                          checks.expect(std::ranges::equal(input->charsetRanges, expected),
+                                        std::format("both ranges, in order, got {}", input->charsetRanges.size()));
+                          // The set is the narrower of the two by construction, which is what makes
+                          // `recordField()`'s second question worth asking at all.
+                          checks.expect(!ms::admits(input->charsetRanges, U'a'), "a lowercase letter the font draws is outside the node's set");
+                      }
+
+                      // And an author who writes two runs that overlap is told which entry, at the
+                      // recipe, rather than through a schema failure that names no line.
+                      std::vector<cli::Diagnostic> overlapping;
+                      const std::string            bad     = recipeWith("48, 55", "57, 90");
+                      const auto                   refused = md::parseRecipe(bad, "recipes/screen/badge.toml", overlapping);
+                      checks.expect(!refused.has_value(), "a table whose ranges overlap is refused");
+                      checks.expect(firstCode(overlapping) == "MEDUI-E002", std::format("reported at the recipe, got '{}'", firstCode(overlapping)));
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/EmitTests.cpp
+++ b/tests/medui/EmitTests.cpp
@@ -21,7 +21,9 @@ import mdux.medui.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.emit;
 import mdux.tools.medui.layout;
+import mdux.font.schema;
 import mdux.tools.medui.package;
+import mdux.tools.medui.textbudget;
 import mdux.tools.medui.parser;
 
 #include "../framework/SpecLabBridge.hpp"
@@ -42,6 +44,20 @@ constexpr std::array fixtureImageApprovals{
 
 /// The budget the fixture package declares, and therefore the one a rebuild must reproduce.
 constexpr mdux::draw::DrawBudget fixtureBudget{.maxVertices = 4096, .maxIndices = 6144, .maxCommands = 256};
+
+/// The build's dynamic-text table, as a compile has one. The fixture's `TextInput` declares
+/// `charset: Ascii`, and since #297 the compiler resolves that name into the node rather than
+/// carrying it - so a package builder without this table cannot compile the fixture at all, which
+/// is the fail-closed direction and the point of the change.
+///
+/// U+0020..U+007E, the same range the committed `dejavu-ui` package declares, because a charset that
+/// escaped its font is what `MEDUI-E053` refuses upstream of here.
+constexpr std::array fixtureAscii{
+    mdux::font::CharsetRange{.first = 0x20, .last = 0x7E}
+};
+const std::array fixtureCharsets{
+    md::DynamicTextRule{.name = "Ascii", .produces = fixtureAscii}
+};
 
 [[nodiscard]] std::filesystem::path fixturePath(std::string_view name) {
     return std::filesystem::path{MDUX_REPO_ROOT} / "tests" / "medui" / "fixtures" / name;
@@ -102,7 +118,8 @@ const mdux::spec::Register theEmittedFixtureIsWhatTheCompilerProduces{
                                                                                      {.id                    = "every-component",
                                                                                       .budget                = fixtureBudget,
                                                                                       .approvedTextPackages  = fixtureApprovals,
-                                                                                      .approvedImagePackages = fixtureImageApprovals})
+                                                                                      .approvedImagePackages = fixtureImageApprovals,
+                                                                                      .charsets              = fixtureCharsets})
                                                                         .package());
                       checks.expect(produced == fixture("every-component-package.json"), std::format("the committed package is current, got:\n{}", produced));
                       checks.raise();
@@ -352,7 +369,9 @@ const mdux::spec::Register aDecodedControlCharacterCannotEndTheLiteral{
                       }
 
                       const std::string json = md::writePackage(
-                          md::buildPackage(layout, {.id = "escapes", .budget = fixtureBudget, .approvedTextPackages = fixtureApprovals}).package());
+                          md::buildPackage(layout,
+                                           {.id = "escapes", .budget = fixtureBudget, .approvedTextPackages = fixtureApprovals, .charsets = fixtureCharsets})
+                              .package());
                       const std::filesystem::path path = scratch.path() / "package.json";
                       std::ofstream               out{path, std::ios::binary | std::ios::trunc};
                       out.write(json.data(), static_cast<std::streamsize>(json.size()));

--- a/tests/medui/FieldTests.cpp
+++ b/tests/medui/FieldTests.cpp
@@ -322,7 +322,7 @@ const mdux::spec::Register theGridDoesNotMoveWithTheValue{
                       const auto secondCellLeft = [&checks](std::array<char32_t, 2> value) {
                           Scratch    scratch;
                           auto       list     = scratch.list();
-                          const auto recorded = ms::recordField(list, theFont(), node, 4, value, std::nullopt, ink);
+                          const auto recorded = ms::recordField(list, theFont(), {}, node, 4, value, std::nullopt, ink);
                           checks.expect(recorded.has_value(), "the value is recorded");
                           if (!recorded.has_value()) {
                               return mdux::core::Px{0};
@@ -394,7 +394,7 @@ const mdux::spec::Register theEnvelopeBoundsEveryValue{
                           for (const std::optional<std::size_t> caret : {std::optional<std::size_t>{}, std::optional<std::size_t>{4}}) {
                               Scratch    scratch;
                               auto       list     = scratch.list();
-                              const auto recorded = ms::recordField(list, theFont(), node, 4, value, caret, ink);
+                              const auto recorded = ms::recordField(list, theFont(), {}, node, 4, value, caret, ink);
                               checks.expect(recorded.has_value(), "the value is recorded");
                               if (!recorded.has_value()) {
                                   continue;
@@ -437,7 +437,7 @@ const mdux::spec::Register aNegativeBearingStaysInsideTheNode{
 
                       Scratch    scratch;
                       auto       list     = scratch.list();
-                      const auto recorded = ms::recordField(list, theFont(), node, 4, value, std::optional<std::size_t>{2}, ink);
+                      const auto recorded = ms::recordField(list, theFont(), {}, node, 4, value, std::optional<std::size_t>{2}, ink);
                       checks.expect(recorded.has_value(), "the value is recorded");
 
                       const Box box = boxOf(list);
@@ -486,7 +486,7 @@ const mdux::spec::Register anOversizedValueIsRefused{
 
                       Scratch    scratch;
                       auto       list     = scratch.list();
-                      const auto recorded = ms::recordField(list, theFont(), node, 3, tooLong, std::nullopt, ink);
+                      const auto recorded = ms::recordField(list, theFont(), {}, node, 3, tooLong, std::nullopt, ink);
 
                       checks.expect(!recorded.has_value(), "the value is refused");
                       if (!recorded.has_value()) {
@@ -515,7 +515,7 @@ const mdux::spec::Register aGlyphThePackageLacksIsRefused{
 
                       Scratch    scratch;
                       auto       list     = scratch.list();
-                      const auto recorded = ms::recordField(list, theFont(), node, 4, unknown, std::nullopt, ink);
+                      const auto recorded = ms::recordField(list, theFont(), {}, node, 4, unknown, std::nullopt, ink);
 
                       checks.expect(!recorded.has_value(), "the value is refused");
                       if (!recorded.has_value()) {
@@ -559,7 +559,7 @@ const mdux::spec::Register aGlyphOutsideTheCharsetIsRefused{
                       constexpr std::array<char32_t, 1> outside{U'W'};
                       Scratch                           scratch;
                       auto                              list     = scratch.list();
-                      const auto                        recorded = ms::recordField(list, narrowed, node, 4, outside, std::nullopt, ink);
+                      const auto                        recorded = ms::recordField(list, narrowed, {}, node, 4, outside, std::nullopt, ink);
 
                       checks.expect(!recorded.has_value(), "the value is refused");
                       if (!recorded.has_value()) {
@@ -567,6 +567,97 @@ const mdux::spec::Register aGlyphOutsideTheCharsetIsRefused{
                                         std::format("reported as GlyphNotInPackage, got '{}'", ms::describe(recorded.error())));
                       }
                       checks.expect(list.vertices().empty(), "and nothing is left recorded");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theNodesOwnCharsetBoundsWhatItDisplays{
+    "A field displays only what its own charset admits, not everything its font can draw",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-field-node-charset-is-enforced")
+            .Given("a node narrowed to one letter, on a package that draws several", [] {})
+            .When("the declared letter and an undeclared one are each recorded into it", [] {})
+            .Then("the declared one is drawn, the other is refused, and the refusal is not the font's",
+                  [] {
+                      // #297. Before it, a compiled node carried the charset's *name* and not its
+                      // set, so this module had nothing to compare a character against but the font
+                      // package - and a field declared for digits displayed the letter a host sent.
+                      //
+                      // The two bounds are deliberately distinguishable. `W` here is a character the
+                      // package draws perfectly well; what refuses it is the *node*, and a caller
+                      // told `GlyphNotInPackage` would go and re-bake a font that is not the problem.
+                      mdux::spec::Checks checks;
+
+                      static constexpr std::array onlyI{
+                          font::CharsetRange{.first = U'i', .last = U'i'}
+                      };
+                      checks.expect(theFont().permits(U'W') && theFont().find(U'W') != nullptr, "the package can draw the letter the node excludes");
+
+                      const auto record = [&](std::array<char32_t, 1> value, std::span<const font::CharsetRange> narrowed) {
+                          Scratch scratch;
+                          auto    list = scratch.list();
+                          auto    done = ms::recordField(list, theFont(), narrowed, node, 4, value, std::nullopt, ink);
+                          return std::pair{done, list.vertices().empty()};
+                      };
+
+                      const auto [declared, declaredEmpty] = record({U'i'}, onlyI);
+                      checks.expect(declared.has_value(), "the declared letter is inside the set and is drawn");
+                      checks.expect(!declaredEmpty, "and left something recorded");
+
+                      const auto [letter, letterEmpty] = record({U'W'}, onlyI);
+                      checks.expect(!letter.has_value(), "the undeclared one is outside it and is refused");
+                      if (!letter.has_value()) {
+                          checks.expect(letter.error() == ms::FieldError::CharacterOutsideFieldCharset,
+                                        std::format("reported as CharacterOutsideFieldCharset, got '{}'", ms::describe(letter.error())));
+                      }
+                      checks.expect(letterEmpty, "and nothing is left recorded, as every field refusal leaves nothing");
+
+                      // The counterweight, and the half that keeps an empty set from becoming a
+                      // field that displays nothing: a node declaring no `charset:` carries no
+                      // ranges, and that is "narrows nothing" rather than "admits nothing".
+                      const auto [unnarrowed, unnarrowedEmpty] = record({U'W'}, {});
+                      checks.expect(unnarrowed.has_value(), "a node that narrows nothing draws the same letter");
+                      checks.expect(!unnarrowedEmpty, "having recorded it");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theFontsRefusalIsReportedBeforeTheNodes{
+    "A character neither the font nor the node admits is reported as the font's refusal",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-field-charset-refusals-are-ordered")
+            .Given("a package and a node both narrowed to one letter", [] {})
+            .When("a letter the package no longer draws is recorded", [] {})
+            .Then("it is GlyphNotInPackage, because no re-declaration could make that character drawable",
+                  [] {
+                      // Which of two true refusals a caller is told about is a decision, so it is
+                      // pinned. The font's is the more actionable: widening a node's `charset:`
+                      // cannot conjure a glyph, while re-baking the font can - and a caller told
+                      // "this node never declared it" would edit the screen and see no change.
+                      mdux::spec::Checks checks;
+
+                      font::FontPackage narrowedFont = fixtureFont();
+                      narrowedFont.restrictedCharset = {
+                          {.first = U' ', .last = U' '},
+                          {.first = U'i', .last = U'i'}
+                      };
+                      static constexpr std::array onlyI{
+                          font::CharsetRange{.first = U'i', .last = U'i'}
+                      };
+
+                      constexpr std::array<char32_t, 1> letter{U'W'};
+                      Scratch                           scratch;
+                      auto                              list     = scratch.list();
+                      const auto                        recorded = ms::recordField(list, narrowedFont, onlyI, node, 4, letter, std::nullopt, ink);
+                      checks.expect(!recorded.has_value(), "the value is refused");
+                      if (!recorded.has_value()) {
+                          checks.expect(recorded.error() == ms::FieldError::GlyphNotInPackage,
+                                        std::format("reported as GlyphNotInPackage, got '{}'", ms::describe(recorded.error())));
+                      }
                       checks.raise();
                   })
             .Execute();
@@ -599,7 +690,7 @@ const mdux::spec::Register anInkFreeCharsetIsRefusedByBoth{
                       Scratch                           scratch;
                       auto                              list = scratch.list();
                       constexpr std::array<char32_t, 1> blank{U' '};
-                      const auto                        recorded = ms::recordField(list, blanks, node, 4, blank, std::optional<std::size_t>{1}, ink);
+                      const auto                        recorded = ms::recordField(list, blanks, {}, node, 4, blank, std::optional<std::size_t>{1}, ink);
                       checks.expect(!recorded.has_value() && recorded.error() == ms::FieldError::CharsetHasNoInk,
                                     "and the placement refuses it in the same words");
                       checks.expect(list.vertices().empty(), "with nothing left recorded");
@@ -623,7 +714,7 @@ const mdux::spec::Register theCaretStandsOnACellBoundary{
                       const auto caretLeft = [&](std::size_t caret) {
                           Scratch    scratch;
                           auto       list     = scratch.list();
-                          const auto recorded = ms::recordField(list, theFont(), node, 4, value, caret, ink);
+                          const auto recorded = ms::recordField(list, theFont(), {}, node, 4, value, caret, ink);
                           checks.expect(recorded.has_value(), std::format("a caret at {} is drawn", caret));
                           if (!recorded.has_value()) {
                               return mdux::core::Px{-1};
@@ -655,7 +746,7 @@ const mdux::spec::Register theCaretStandsOnACellBoundary{
 
                       Scratch    scratch;
                       auto       list    = scratch.list();
-                      const auto refused = ms::recordField(list, theFont(), node, 4, value, std::optional<std::size_t>{5}, ink);
+                      const auto refused = ms::recordField(list, theFont(), {}, node, 4, value, std::optional<std::size_t>{5}, ink);
                       checks.expect(!refused.has_value() && refused.error() == ms::FieldError::CaretOutOfRange,
                                     "a caret past the field's end is CaretOutOfRange");
                       checks.expect(list.vertices().empty(), "and nothing is left recorded");
@@ -689,7 +780,7 @@ const mdux::spec::Register aFieldTheRuntimeWillNotDrawIsRefused{
 
                       Scratch    scratch;
                       auto       list  = scratch.list();
-                      const auto drawn = ms::recordField(list, theFont(), node, 0, {}, std::nullopt, ink);
+                      const auto drawn = ms::recordField(list, theFont(), {}, node, 0, {}, std::nullopt, ink);
                       checks.expect(!drawn.has_value() && drawn.error() == ms::FieldError::NoCells, "recordField() refuses zero cells");
                       checks.raise();
                   })
@@ -765,6 +856,72 @@ const mdux::spec::Register slotsAreCheckedAgainstTheScreen{
                           ms::TextInputSlot{.nodeId = "entry", .text = value, .caret = std::optional<std::size_t>{5}}
                       };
                       checks.expect(refusalOf(inputScreen, caretPastEnd) == ms::ScreenError::FieldRefused, "a caret past the field is FieldRefused");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aValueOutsideTheNodesCharsetIsRefusedAtTheJoin{
+    "A value carrying a character the node's charset excludes is refused when it is bound",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-field-charset-is-checked-at-the-join")
+            .Given("a screen whose input is narrowed to one letter", [] {})
+            .When("a value carrying another letter is offered to create()", [] {})
+            .Then("it is refused there, so no frame ever has to be rolled back for it",
+                  [] {
+                      // The first of the two lines #297 adds, and the one that matters in practice.
+                      // `recordField()` asks the same question per frame and rolls the whole screen
+                      // back when the answer is no; a blank display tells an operator less than a
+                      // stale one does, so a value that could never be displayed is much better
+                      // refused where a host still has somewhere to put the error.
+                      mdux::spec::Checks checks;
+
+                      static constexpr std::array onlyI{
+                          font::CharsetRange{.first = U'i', .last = U'i'}
+                      };
+                      static constexpr ms::TextInputSpec               narrowedEntry{.source        = "PATIENT_ID",
+                                                                                     .colorToken    = "Theme.Colors.Title",
+                                                                                     .maxLength     = 4,
+                                                                                     .charset       = "OnlyI",
+                                                                                     .requirement   = {},
+                                                                                     .charsetRanges = onlyI};
+                      static constexpr std::array<ms::CompiledNode, 2> narrowedNodes{
+                          ms::CompiledNode{.id = "ground",  .bounds = {0, 0, 200, 100},        .payload = ground},
+                          ms::CompiledNode{ .id = "entry", .bounds = {20, 30, 100, 40}, .payload = narrowedEntry}
+                      };
+                      static constexpr ms::ScreenPackage narrowedScreen{.id                   = "field",
+                                                                        .schemaVersion        = mdux::evidence::kSchemaVersion,
+                                                                        .surfaceWidth         = 200,
+                                                                        .surfaceHeight        = 100,
+                                                                        .approvedTextPackages = placeholderApprovals,
+                                                                        .nodes                = narrowedNodes,
+                                                                        .budget               = testBudget};
+                      static_assert(narrowedScreen.validate().has_value(), "a node carrying a charset and its resolved set is a valid screen");
+
+                      constexpr std::array<char32_t, 1> inside{U'i'};
+                      const std::array                  accepted{
+                          ms::TextInputSlot{.nodeId = "entry", .text = inside, .caret = std::nullopt}
+                      };
+                      checks.expect(!refusalOf(narrowedScreen, accepted).has_value(), "a value inside the declared set binds");
+
+                      constexpr std::array<char32_t, 2> outside{U'i', U'W'};
+                      const std::array                  refused{
+                          ms::TextInputSlot{.nodeId = "entry", .text = outside, .caret = std::nullopt}
+                      };
+                      checks.expect(refusalOf(narrowedScreen, refused) == ms::ScreenError::CharacterOutsideFieldCharset,
+                                    "and one carrying a character it excludes is CharacterOutsideFieldCharset");
+
+                      // Named rather than folded into `FieldRefused`, because it is the one refusal
+                      // here that says the *value* is wrong rather than the screen or the font - and
+                      // an integrator reading `FieldRefused` would go looking at `max_length`.
+                      checks.expect(refusalOf(narrowedScreen, refused) != ms::ScreenError::FieldRefused, "and distinguishable from a length or caret refusal");
+
+                      // The same node's set does not travel: the unnarrowed screen still takes `W`.
+                      const std::array wide{
+                          ms::TextInputSlot{.nodeId = "entry", .text = outside, .caret = std::nullopt}
+                      };
+                      checks.expect(!refusalOf(inputScreen, wide).has_value(), "a screen whose input narrows nothing accepts the same value");
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -425,6 +425,29 @@ const mdux::spec::Register aHandEditedCharsetIsRefusedWhereItCanBeNamed{
                                         std::format("reported as SCP002, a member with a wrong value, got '{}'", firstCode(result)));
                       }
 
+                      // A surrogate is the other shape, and it fails differently. It survives the
+                      // cast to `char32_t` intact, so nothing is lost quietly - what would be lost
+                      // is the diagnostic: `validate()` refuses it as SCP005, "the screen the file
+                      // describes is not valid", which names neither the member nor the value.
+                      //
+                      // Both a range *inside* the block and one that merely *spans* it, because the
+                      // test is an overlap rather than one on each endpoint: `0..65535` contains the
+                      // whole block while neither of its ends is in it, and an endpoint-wise check
+                      // would wave it through to the weaker diagnostic.
+                      const std::array<std::pair<std::string_view, std::string_view>, 2> surrogates{
+                          std::pair{"55296", "57343"},
+                          std::pair{    "0", "65535"}
+                      };
+                      for (const auto& [first, last] : surrogates) {
+                          const std::string           edited = editing(editing(written, "\"first\": 32", std::format("\"first\": {}", first)),
+                                                             "\"last\": 126",
+                                                             std::format("\"last\": {}", last));
+                          const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                          checks.expect(!result.ok(), std::format("the range {}..{} admits a surrogate and is refused", first, last));
+                          checks.expect(firstCode(result) == "SCP002",
+                                        std::format("named at the member rather than as a schema failure, got '{}'", firstCode(result)));
+                      }
+
                       // A member inside a range is closed too, for `anUndefinedMemberIsRefused`'s
                       // reason: a silently ignored `firts` is a range a reviewer believes is pinned.
                       const std::string           misspelt = editing(written, "\"first\": 32", "\"firts\": 32");

--- a/tests/medui/PackageTests.cpp
+++ b/tests/medui/PackageTests.cpp
@@ -23,7 +23,9 @@ import mdux.tools.cli;
 import mdux.tools.medui.ast;
 import mdux.tools.medui.goldens;
 import mdux.tools.medui.layout;
+import mdux.font.schema;
 import mdux.tools.medui.package;
+import mdux.tools.medui.textbudget;
 import mdux.tools.medui.parser;
 
 #include "../framework/SpecLabBridge.hpp"
@@ -69,11 +71,24 @@ constexpr std::array fixtureImageApprovals{
     return resolved;
 }
 
+/// The build's charset table. The every-component fixture declares `charset: Ascii`, which the
+/// package builder resolves rather than carries (#297), so a compile without a table naming it is
+/// a compile that cannot produce this screen.
+constexpr std::array everyComponentAscii{
+    mdux::font::CharsetRange{.first = 0x20, .last = 0x7E}
+};
+const std::array everyComponentCharsets{
+    md::DynamicTextRule{.name = "Ascii", .produces = everyComponentAscii}
+};
+
 /// The screen carrying all eleven payloads, compiled.
 [[nodiscard]] md::ScreenDocument everyComponent() {
-    return md::buildPackage(
-        layoutOf(fixture("accepted-every-component.medui"), 800, 700),
-        {.id = "every-component", .budget = testBudget, .approvedTextPackages = fixtureApprovals, .approvedImagePackages = fixtureImageApprovals});
+    return md::buildPackage(layoutOf(fixture("accepted-every-component.medui"), 800, 700),
+                            {.id                    = "every-component",
+                             .budget                = testBudget,
+                             .approvedTextPackages  = fixtureApprovals,
+                             .approvedImagePackages = fixtureImageApprovals,
+                             .charsets              = everyComponentCharsets});
 }
 
 /// One Label on a small surface: the screen the byte-exact scenario spells out.
@@ -212,6 +227,13 @@ const mdux::spec::Register fieldsReachTheirOwnSpecMembers{
                       if (const auto* input = std::get_if<ms::TextInputSpec>(&node(package, "patient-id").payload)) {
                           checks.expect(input->maxLength == 16, std::format("the TextInput's length bound, got {}", input->maxLength));
                           checks.expect(input->charset == "Ascii", std::format("the TextInput's charset, got '{}'", input->charset));
+                          // And what that name resolved to (#297), which is the half a device can
+                          // act on: a name it cannot look up bounds nothing.
+                          checks.expect(input->charsetRanges.size() == 1, std::format("one resolved range, got {}", input->charsetRanges.size()));
+                          if (input->charsetRanges.size() == 1) {
+                              checks.expect(input->charsetRanges[0] == mdux::font::CharsetRange{.first = 0x20, .last = 0x7E},
+                                            "the range the build's table gave that name");
+                          }
                       } else {
                           checks.expect(false, "the patient-id node holds a TextInput spec");
                       }
@@ -372,6 +394,43 @@ const mdux::spec::Register theBytesAreExactlyDetermined{
                       // A screen package holds no float, so ADR-007's `{"bits": N}` encoding - the
                       // one thing that makes a float portable - never appears in one.
                       checks.expect(written.find("\"bits\"") == std::string::npos, "no floating-point value appears in a screen package");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aHandEditedCharsetIsRefusedWhereItCanBeNamed{
+    "A resolved charset edited out of range is refused by the reader, not by the device",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-package-charset-ranges-are-checked")
+            .Given("a committed screen whose TextInput carries its resolved charset", [] {})
+            .When("a code point is edited to something that is not a character", [] {})
+            .Then("the read fails naming the file, rather than the value reaching a char32_t",
+                  [] {
+                      // `char32_t` is unsigned, so a negative code point cast into one arrives as a
+                      // range near the top of the plane: a set the node never declared, silently, in
+                      // the one file that exists to make the set reviewable. `ScreenPackage::
+                      // validate()` would refuse the result, but as a schema failure with no file
+                      // and no member attached - which is the difference this scenario pins.
+                      mdux::spec::Checks checks;
+                      const std::string  written = md::writePackage(everyComponent().package());
+                      checks.expect(written.find("\"charsetRanges\"") != std::string::npos, "the committed bytes carry the resolved set");
+
+                      for (const std::string_view point : {"-1", "1114112"}) {
+                          const std::string           edited = editing(written, "\"first\": 32", std::format("\"first\": {}", point));
+                          const md::PackageReadResult result = md::readPackage(edited, "package.json");
+                          checks.expect(!result.ok(), std::format("'{}' is not a code point and is refused", point));
+                          checks.expect(firstCode(result) == "SCP002",
+                                        std::format("reported as SCP002, a member with a wrong value, got '{}'", firstCode(result)));
+                      }
+
+                      // A member inside a range is closed too, for `anUndefinedMemberIsRefused`'s
+                      // reason: a silently ignored `firts` is a range a reviewer believes is pinned.
+                      const std::string           misspelt = editing(written, "\"first\": 32", "\"firts\": 32");
+                      const md::PackageReadResult refused  = md::readPackage(misspelt, "package.json");
+                      checks.expect(!refused.ok(), "a misspelt member inside a range is refused");
+                      checks.expect(firstCode(refused) == "SCP003", std::format("reported as SCP003, an undefined member, got '{}'", firstCode(refused)));
                       checks.raise();
                   })
             .Execute();

--- a/tests/medui/SchemaTests.cpp
+++ b/tests/medui/SchemaTests.cpp
@@ -816,6 +816,93 @@ const mdux::spec::Register statesAndTheirTintsPairUp{
             .Execute();
     }};
 
+const mdux::spec::Register aNarrowedCharsetIsCheckedAsASet{
+    "A text input's resolved charset is a set, and every way it could not be is refused",
+    "evidence-unit",
+    [] {
+        return speclab::Test("medui-schema-charset-ranges")
+            .Given("a TextInput carrying a charset name and the ranges it resolved to", [] {})
+            .When("each way the pair could be wrong is validated", [] {})
+            .Then("each has its own error, so a screen a device cannot enforce is a compile failure",
+                  [] {
+                      // #297 puts the resolved set in the artifact, and this is what keeps that set
+                      // meaning one thing. `admits()` reads the ranges as a union and an empty span
+                      // as "narrows nothing", so both halves of that reading have to be guaranteed
+                      // here: a name with no set would be a narrowing silently gone - the state
+                      // before #297 - and overlapping ranges are a set two readers could enumerate
+                      // differently.
+                      mdux::spec::Checks checks;
+
+                      static constexpr std::array digits{
+                          mdux::font::CharsetRange{.first = U'0', .last = U'9'}
+                      };
+                      static constexpr std::array descending{
+                          mdux::font::CharsetRange{.first = U'9', .last = U'0'}
+                      };
+                      static constexpr std::array overlapping{
+                          mdux::font::CharsetRange{.first = U'0', .last = U'9'},
+                          mdux::font::CharsetRange{.first = U'5', .last = U'A'}
+                      };
+                      static constexpr std::array pastUnicode{
+                          mdux::font::CharsetRange{.first = 0x30, .last = mdux::font::maxCodePoint + 1}
+                      };
+                      static constexpr std::array surrogates{
+                          mdux::font::CharsetRange{.first = 0xD800, .last = 0xDFFF}
+                      };
+
+                      const auto verdict = [&](std::string_view charset, std::span<const mdux::font::CharsetRange> ranges) {
+                          const std::array<ms::CompiledNode, 1> nodes{
+                              ms::CompiledNode{.id      = "entry",
+                                               .bounds  = {0, 0, 100, 20},
+                                               .payload = ms::TextInputSpec{.source        = "NOTE",
+                                                                            .colorToken    = "Theme.Colors.Title",
+                                                                            .maxLength     = 16,
+                                                                            .charset       = charset,
+                                                                            .requirement   = {},
+                                                                            .charsetRanges = ranges}}
+                          };
+                          const ms::ScreenPackage package{
+                              .id                   = "screen",
+                              .schemaVersion        = mdux::evidence::kSchemaVersion,
+                              .surfaceWidth         = 400,
+                              .surfaceHeight        = 300,
+                              .approvedTextPackages = constApprovals,
+                              .nodes                = nodes,
+                              .budget               = mdux::draw::DrawBudget{.maxVertices = 64, .maxIndices = 96, .maxCommands = 4}
+                          };
+                          const auto result = package.validate();
+                          return result.has_value() ? std::optional<ms::SchemaError>{} : std::optional{result.error()};
+                      };
+
+                      checks.expect(!verdict("DIGITS", digits).has_value(), "a name with the set it resolved to is valid");
+                      checks.expect(!verdict({}, {}).has_value(), "and so is a node that narrows nothing, carrying neither");
+
+                      // The pair, in both directions. Neither half alone is a state `admits()` could
+                      // read correctly.
+                      checks.expect(verdict("DIGITS", {}) == ms::SchemaError::NarrowedCharsetIsEmpty, "a name with no set is NarrowedCharsetIsEmpty");
+                      checks.expect(verdict({}, digits) == ms::SchemaError::UnnamedCharsetRanges, "a set with no name is UnnamedCharsetRanges");
+
+                      // The four rules the font package's own charset is held to, under the same
+                      // names, because they are the same rules about the same type.
+                      checks.expect(verdict("DIGITS", descending) == ms::SchemaError::CharsetRangeDescending, "a range ending before it begins is refused");
+                      checks.expect(verdict("DIGITS", overlapping) == ms::SchemaError::CharsetRangesOverlap, "overlapping ranges are refused");
+                      checks.expect(verdict("DIGITS", pastUnicode) == ms::SchemaError::CodePointOutOfRange, "a range past the last scalar value is refused");
+                      checks.expect(verdict("DIGITS", surrogates) == ms::SchemaError::SurrogateCodePoint, "a range admitting a surrogate is refused");
+
+                      // Every one of them has a description, as every other schema error does.
+                      for (const ms::SchemaError error : {ms::SchemaError::NarrowedCharsetIsEmpty,
+                                                          ms::SchemaError::UnnamedCharsetRanges,
+                                                          ms::SchemaError::CharsetRangeDescending,
+                                                          ms::SchemaError::CharsetRangesOverlap,
+                                                          ms::SchemaError::CodePointOutOfRange,
+                                                          ms::SchemaError::SurrogateCodePoint}) {
+                          checks.expect(!ms::describe(error).empty(), "the error names itself");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
 const mdux::spec::Register unknownPayloadsAreRefused{
     "A payload this module cannot name is refused rather than accepted",
     "evidence-unit",

--- a/tests/medui/fixtures/every-component-package.json
+++ b/tests/medui/fixtures/every-component-package.json
@@ -183,6 +183,12 @@
       "kind": "TextInput",
       "spec": {
         "charset": "Ascii",
+        "charsetRanges": [
+          {
+            "first": 32,
+            "last": 126
+          }
+        ],
         "colorToken": "Theme.Colors.Neutral",
         "maxLength": 16,
         "requirement": "REQ-EC-005",

--- a/tools/docs-lint/check_schema_type_drift.py
+++ b/tools/docs-lint/check_schema_type_drift.py
@@ -320,7 +320,8 @@ def validate(value, schema: dict, where: str) -> list[str]:
     Deliberately a subset, and deliberately written here rather than taken as a dependency - the
     same reasoning ADR-007 applies to SHA-256 and canonical JSON, and ADR-009 to the test framework.
     What the recipe schemas use is `type`, `required`, `properties`, `additionalProperties`, `items`,
-    `enum`, `minimum`, `minLength`, `minItems`, `pattern` and `uniqueItems`, and a validator for that
+    `enum`, `minimum`, `maximum`, `minLength`, `minItems`, `pattern` and `uniqueItems`, and a
+    validator for that
     is fifty lines. `pattern` and `uniqueItems` were in the supported set before they were
     implemented, which is exactly the hole `check_recipe_schema_keywords` exists to close and which
     it could not close about itself - a schema could claim either and the checker would accept a
@@ -343,6 +344,8 @@ def validate(value, schema: dict, where: str) -> list[str]:
         problems.append(f"{where}: {value!r} is not one of {schema['enum']}")
     if "minimum" in schema and isinstance(value, (int, float)) and value < schema["minimum"]:
         problems.append(f"{where}: {value} is below the minimum {schema['minimum']}")
+    if "maximum" in schema and isinstance(value, (int, float)) and value > schema["maximum"]:
+        problems.append(f"{where}: {value} is above the maximum {schema['maximum']}")
     if "minLength" in schema and isinstance(value, str) and len(value) < schema["minLength"]:
         problems.append(f"{where}: shorter than minLength {schema['minLength']}")
     if "minItems" in schema and isinstance(value, list) and len(value) < schema["minItems"]:
@@ -380,7 +383,7 @@ def validate(value, schema: dict, where: str) -> list[str]:
 
 SUPPORTED_KEYWORDS = {
     "$schema", "$id", "title", "description", "type", "required", "properties",
-    "additionalProperties", "items", "enum", "minimum", "minLength", "minItems",
+    "additionalProperties", "items", "enum", "minimum", "maximum", "minLength", "minItems",
     "uniqueItems", "pattern", "examples",
 }
 

--- a/tools/docs-lint/test_check_schema_type_drift.py
+++ b/tools/docs-lint/test_check_schema_type_drift.py
@@ -348,6 +348,7 @@ class ValidatorTests(unittest.TestCase):
             "type": ({"type": "string"}, 1),
             "enum": ({"enum": ["a"]}, 1),
             "minimum": ({"minimum": 5}, 4),
+            "maximum": ({"maximum": 5}, 6),
             "minLength": ({"minLength": 2}, "a"),
             "minItems": ({"minItems": 2}, ["a"]),
             "pattern": ({"pattern": "^z"}, "a"),

--- a/tools/medui/Compile.cpp
+++ b/tools/medui/Compile.cpp
@@ -415,10 +415,43 @@ std::optional<Recipe> parseRecipe(std::string_view text, std::string_view recipe
                        "an inverted range checks nothing, so it is refused rather than read as empty");
                 return std::nullopt;
             }
-            DynamicText rule;
-            rule.name = names[index];
+            // A name repeated across entries **accumulates** its ranges rather than starting a
+            // second rule, which is how a charset says more than one run of code points: a patient
+            // identifier is digits *and* uppercase letters, and one entry can only carry one run.
+            //
+            // Accumulating is also the fail-closed direction, and the reason is a hole this closes.
+            // `checkDynamicText()` resolves a name with `std::ranges::find`, which stops at the
+            // first match - so two rules of one name meant the budget stage checked one range and
+            // ignored the other, and a screen could produce a character the font cannot draw while
+            // the compile stayed green. Two entries are now one set, and the set is what is checked.
+            const auto   existing = std::ranges::find(recipe.dynamicText, names[index], &DynamicText::name);
+            DynamicText& rule     = existing != recipe.dynamicText.end() ? *existing
+                                                                         : recipe.dynamicText.emplace_back(DynamicText{.name = names[index], .produces = {}});
             rule.produces.push_back(mdux::font::CharsetRange{.first = static_cast<char32_t>(first), .last = static_cast<char32_t>(last)});
-            recipe.dynamicText.push_back(std::move(rule));
+        }
+
+        // Sorted and disjoint, checked here where a recipe line can be named. The compiled screen's
+        // own `validate()` requires both of a `TextInput`'s `charsetRanges` - a set two readers could
+        // enumerate differently is not a set - but it would report them as a schema failure with no
+        // recipe and no entry attached, which tells an author nothing about the table they wrote.
+        for (DynamicText& rule : recipe.dynamicText) {
+            std::ranges::sort(rule.produces, {}, &mdux::font::CharsetRange::first);
+            for (std::size_t index = 1; index < rule.produces.size(); ++index) {
+                if (rule.produces[index].first <= rule.produces[index - 1].last) {
+                    report(diagnostics,
+                           Code::RecipeMissingMember,
+                           std::string{recipePath},
+                           namesLine,
+                           std::format("[dynamicText] entry '{}' names overlapping ranges U+{:04X}..U+{:04X} and U+{:04X}..U+{:04X}",
+                                       rule.name,
+                                       static_cast<std::uint32_t>(rule.produces[index - 1].first),
+                                       static_cast<std::uint32_t>(rule.produces[index - 1].last),
+                                       static_cast<std::uint32_t>(rule.produces[index].first),
+                                       static_cast<std::uint32_t>(rule.produces[index].last)),
+                           "one name may be repeated to add a range to its set, and the ranges must not overlap");
+                    return std::nullopt;
+                }
+            }
         }
     }
 
@@ -950,18 +983,22 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
         return std::nullopt;
     }
 
+    // The build's charset table, as views. Hoisted out of the budget block below because the package
+    // builder resolves the same names through the same table (#297): the compile-time check that a
+    // charset cannot escape the font and the run-time bound the artifact carries are two readings of
+    // one table, and two tables is precisely how they would come to disagree.
+    std::vector<DynamicTextRule> dynamicRules;
+    dynamicRules.reserve(recipe.dynamicText.size());
+    for (const DynamicText& rule : recipe.dynamicText) {
+        dynamicRules.push_back(DynamicTextRule{.name = rule.name, .produces = rule.produces});
+    }
+
     // 5. Text budgets, when there is anything to measure.
     if (measurable) {
         std::vector<LocaleText> localeTexts;
         localeTexts.reserve(locales.size());
         for (const LoadedLocale& locale : locales) {
             localeTexts.push_back(LocaleText{.package = &locale.package, .sidecar = locale.sidecar});
-        }
-
-        std::vector<DynamicTextRule> dynamicRules;
-        dynamicRules.reserve(recipe.dynamicText.size());
-        for (const DynamicText& rule : recipe.dynamicText) {
-            dynamicRules.push_back(DynamicTextRule{.name = rule.name, .produces = rule.produces});
         }
 
         std::vector<NumericTemplateRule> templateRules;
@@ -1005,7 +1042,7 @@ std::optional<CompileOutputs> run(const Recipe&                 recipe,
     // 7. The compiled screen and its bytes.
     const ScreenDocument document = buildPackage(
         layout,
-        {.id = recipe.id, .budget = recipe.budget, .approvedTextPackages = approvals, .approvedImagePackages = imageApprovals});
+        {.id = recipe.id, .budget = recipe.budget, .approvedTextPackages = approvals, .approvedImagePackages = imageApprovals, .charsets = dynamicRules});
     const ms::ScreenPackage package = document.package();
 
     CompileOutputs outputs;

--- a/tools/medui/Emit.cpp
+++ b/tools/medui/Emit.cpp
@@ -148,10 +148,27 @@ void appendSpan(std::string& out, bool& first, std::string_view member, std::str
     return std::format("{}OfNode{}", what, index);
 }
 
-/// The `StatusIndicator` arrays a screen needs, declared before the node table that views them.
+/// The `StatusIndicator` and `TextInput` arrays a screen needs, declared before the node table that
+/// views them. Both are spans in the schema, so both need storage the generated translation unit
+/// owns - which is what makes a compiled screen a value in `.rodata` rather than something built.
 [[nodiscard]] std::string renderStateArrays(const ms::ScreenPackage& package) {
     std::string out;
     for (std::size_t index = 0; index < package.nodes.size(); ++index) {
+        if (const auto* input = std::get_if<ms::TextInputSpec>(&package.nodes[index].payload); input != nullptr && !input->charsetRanges.empty()) {
+            // The set node '<id>' may display, resolved from its `charset:` name at compile time
+            // (#297). Emitted as the ranges rather than the name because a device given the name
+            // could only look it up in a table shipped beside the screen, which is the exposure the
+            // whole boundary exists to avoid.
+            out += std::format("/// The characters node '{}' may display: '{}', resolved.\n", escape(package.nodes[index].id), escape(input->charset));
+            out += std::format("inline constexpr mdux::font::CharsetRange {}[] = {{", arrayName("charsetRanges", index));
+            for (std::size_t range = 0; range < input->charsetRanges.size(); ++range) {
+                out += std::format("{}{{.first = {}, .last = {}}}",
+                                   range == 0 ? "" : ", ",
+                                   static_cast<std::uint32_t>(input->charsetRanges[range].first),
+                                   static_cast<std::uint32_t>(input->charsetRanges[range].last));
+            }
+            out += "};\n\n";
+        }
         const auto* status = std::get_if<ms::StatusIndicatorSpec>(&package.nodes[index].payload);
         if (status == nullptr) {
             continue;
@@ -281,6 +298,9 @@ void appendSpan(std::string& out, bool& first, std::string_view member, std::str
         first = false;
         appendName(out, first, "charset", input->charset);
         appendName(out, first, "requirement", input->requirement);
+        if (!input->charsetRanges.empty()) {
+            appendSpan(out, first, "charsetRanges", arrayName("charsetRanges", index));
+        }
     } else {
         // Unreachable for a package that validated, which is the only kind that reaches here.
         throw std::logic_error("a node carries a payload this emitter does not know");

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -690,11 +690,19 @@ private:
 /// Reads a resolved charset back, or nothing when the member is absent - which is a node that
 /// narrowed nothing, exactly as an absent name is a name it does not have.
 ///
-/// Every code point is checked against the type that will hold it *before* it becomes one. `char32_t`
-/// is unsigned, so a negative `first` cast into it would arrive as a range near the top of the plane
-/// - a set the node never declared, silently, in the one file that is supposed to make the set
-/// reviewable. `ScreenPackage::validate()` would then refuse it as `CodePointOutOfRange`, but with no
-/// file name and no member attached; caught here it names both.
+/// Every range is checked against what a code point *is*, before one becomes a `char32_t`. Two
+/// shapes, and they fail differently:
+///
+/// - A value outside 0..U+10FFFF. `char32_t` is unsigned, so a negative `first` cast into one would
+///   arrive as a range near the top of the plane - a set the node never declared, silently, in the
+///   one file that is supposed to make the set reviewable.
+/// - A range admitting a surrogate. Those survive the cast intact, so nothing is lost quietly; what
+///   is lost is the diagnostic. `ScreenPackage::validate()` refuses both shapes, but as `SCP005`
+///   "the screen the file describes is not valid" - which names neither the member nor the value,
+///   and this function's whole reason for existing is that it can name both.
+///
+/// The surrogate test is the *overlap* `validate()` uses rather than a test on each endpoint, and
+/// the difference is not pedantic: `0..65535` contains the whole block while neither end is in it.
 [[nodiscard]] std::optional<std::vector<mdux::font::CharsetRange>>
 readRanges(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
     const json::Value* member = object.find(key);
@@ -719,9 +727,15 @@ readRanges(const json::Value& object, std::string_view key, std::string_view wha
         }
         for (const std::int64_t point : {*first, *last}) {
             if (point < 0 || point > static_cast<std::int64_t>(mdux::font::maxCodePoint)) {
-                sink.fail(memberWrong, std::format("{} member '{}' names {}, which is not a Unicode scalar value", what, key, point));
+                sink.fail(memberWrong, std::format("{} member '{}' names {}, which is past the last Unicode scalar value", what, key, point));
                 return std::nullopt;
             }
+        }
+        if (*first <= static_cast<std::int64_t>(mdux::font::surrogateLast) && *last >= static_cast<std::int64_t>(mdux::font::surrogateFirst)) {
+            sink.fail(
+                memberWrong,
+                std::format("{} member '{}' names the range {}..{}, which admits a surrogate and so is not a set of characters", what, key, *first, *last));
+            return std::nullopt;
         }
         ranges.push_back(mdux::font::CharsetRange{.first = static_cast<char32_t>(*first), .last = static_cast<char32_t>(*last)});
     }

--- a/tools/medui/Package.cpp
+++ b/tools/medui/Package.cpp
@@ -10,6 +10,7 @@ module mdux.tools.medui.package;
 import std;
 import mdux.draw;
 import mdux.evidence.digest;
+import mdux.font.schema;
 import mdux.evidence.json;
 import mdux.evidence.report;
 import mdux.medui.schema;
@@ -17,6 +18,7 @@ import mdux.tools.cli;
 import mdux.tools.medui.ast;
 import mdux.tools.medui.goldens;
 import mdux.tools.medui.layout;
+import mdux.tools.medui.textbudget;
 
 namespace mdux::tools::medui {
 
@@ -111,6 +113,33 @@ constexpr std::string_view schemaRefused = "SCP005";
 }
 
 /**
+ * @brief The code points a `TextInput`'s `charset:` name stands for (#297).
+ *
+ * Resolved here rather than carried as a name, which is the whole of what #297 changes: a device
+ * handed a name has nothing to compare a character against, while a device handed the ranges needs
+ * no table shipped beside the screen.
+ *
+ * An unresolvable name **throws**, as every other bypassed gate in this file does. The budget stage
+ * refuses one with `MEDUI-E053` - "'{}' is not in the governed dynamic-text table, so what '{}' can
+ * produce is not bounded" - and a screen carrying a `TextInput` always reaches that stage, because
+ * `needsTextBudget()` includes the component. So a name arriving here unresolved means the compile
+ * ran without its gates, and the one thing this must not do is quietly emit an empty set: that is a
+ * node whose narrowing is silently gone, which is the state before #297 rather than a diagnostic.
+ */
+[[nodiscard]] std::span<const mdux::font::CharsetRange>
+resolveCharset(std::string_view declared, std::span<const DynamicTextRule> charsets, std::string_view nodeId) {
+    if (declared.empty()) {
+        return {};
+    }
+    const auto found = std::ranges::find(charsets, declared, &DynamicTextRule::name);
+    if (found == charsets.end()) {
+        throw std::logic_error(
+            std::format("'{}' names charset '{}', which the dynamic-text table does not define: the text-budget stage is a required gate", nodeId, declared));
+    }
+    return found->produces;
+}
+
+/**
  * @brief The typed payload for one resolved node.
  *
  * The mapping from a dictionary field to a spec member is the whole content of this function, and
@@ -118,7 +147,7 @@ constexpr std::string_view schemaRefused = "SCP005";
  * `Button` are both a `textKey`, while `source` means a data stream on one component and an image
  * package on another. A table keyed by field name could not express that.
  */
-[[nodiscard]] ms::NodePayload payloadFor(const ResolvedNode& resolved, ScreenDocument& document) {
+[[nodiscard]] ms::NodePayload payloadFor(const ResolvedNode& resolved, ScreenDocument& document, std::span<const DynamicTextRule> charsets) {
     const ast::Node& source = resolved.source;
     const auto       name   = [&](std::string_view field) {
         return document.intern(textOf(source, field));
@@ -175,11 +204,13 @@ constexpr std::string_view schemaRefused = "SCP005";
                                        .colorTokens = document.internList(listOf(source, "colors"))};
     }
     if (resolved.component == "TextInput") {
-        return ms::TextInputSpec{.source      = name("source"),
-                                 .colorToken  = name("color"),
-                                 .maxLength   = numberOf(source, "max_length"),
-                                 .charset     = name("charset"),
-                                 .requirement = name("requirement")};
+        const std::string_view declared = name("charset");
+        return ms::TextInputSpec{.source        = name("source"),
+                                 .colorToken    = name("color"),
+                                 .maxLength     = numberOf(source, "max_length"),
+                                 .charset       = declared,
+                                 .requirement   = name("requirement"),
+                                 .charsetRanges = document.internRanges(resolveCharset(declared, charsets, resolved.id))};
     }
     // `Row` reaches here only if the solver stopped flattening: a Row contributes its children and
     // at most one synthetic background, never itself. Anything else is a component semantic
@@ -239,6 +270,21 @@ template <typename Rect>
     elements.reserve(names.size());
     for (const std::string_view name : names) {
         elements.push_back(json::Value::string(std::string{name}));
+    }
+    return json::Value::array(std::move(elements));
+}
+
+/// A resolved charset, as the font package's own `restrictedCharset` is written: `first` and `last`
+/// per range, and the ranges in the order the set is read in. One spelling for one shape, so a
+/// reader of either file needs one reader.
+[[nodiscard]] json::Value writeRanges(std::span<const mdux::font::CharsetRange> ranges) {
+    std::vector<json::Value> elements;
+    elements.reserve(ranges.size());
+    for (const mdux::font::CharsetRange& range : ranges) {
+        json::Value entry = json::Value::emptyObject();
+        put(entry, "first", json::Value::unsignedInteger(static_cast<std::uint64_t>(range.first)));
+        put(entry, "last", json::Value::unsignedInteger(static_cast<std::uint64_t>(range.last)));
+        elements.push_back(std::move(entry));
     }
     return json::Value::array(std::move(elements));
 }
@@ -317,6 +363,12 @@ template <typename Rect>
         put(spec, "stateKeys", writeNames(status->stateKeys));
     } else if (const auto* input = std::get_if<ms::TextInputSpec>(&payload)) {
         putName(spec, "charset", input->charset);
+        // Omitted with the name rather than written empty, for `putName()`'s reason and one more:
+        // `validate()` refuses a node carrying one of the pair without the other, so an artifact in
+        // which they could disagree is one this writer must not be able to produce.
+        if (!input->charsetRanges.empty()) {
+            put(spec, "charsetRanges", writeRanges(input->charsetRanges));
+        }
         putName(spec, "colorToken", input->colorToken);
         put(spec, "maxLength", json::Value::integer(input->maxLength));
         putName(spec, "requirement", input->requirement);
@@ -340,6 +392,17 @@ std::string_view ScreenDocument::intern(std::string_view text) {
         return {};
     }
     return text_.emplace_back(text);
+}
+
+std::span<const mdux::font::CharsetRange> ScreenDocument::internRanges(std::span<const mdux::font::CharsetRange> ranges) {
+    if (ranges.empty()) {
+        // A node that narrows nothing owns no set, exactly as `intern()` stores nothing for an
+        // absent name. `admits()` reads the empty span as "this node declared no charset", which is
+        // the reading `ScreenPackage::validate()` keeps honest.
+        return {};
+    }
+    std::vector<mdux::font::CharsetRange>& stored = charsets_.emplace_back(ranges.begin(), ranges.end());
+    return stored;
 }
 
 std::span<const std::string_view> ScreenDocument::internList(std::span<const std::string> items) {
@@ -420,7 +483,7 @@ ScreenDocument buildPackage(const LayoutResult& layout, PackageInputs inputs) {
                                     .y      = narrow(resolved.bounds.y, "node y"),
                                     .width  = narrow(resolved.bounds.width, "node width"),
                                     .height = narrow(resolved.bounds.height, "node height")},
-            .payload = payloadFor(resolved, document)
+            .payload = payloadFor(resolved, document, inputs.charsets)
         });
     }
 
@@ -624,6 +687,47 @@ private:
 }
 
 /// A list-valued spec member, absent meaning empty.
+/// Reads a resolved charset back, or nothing when the member is absent - which is a node that
+/// narrowed nothing, exactly as an absent name is a name it does not have.
+///
+/// Every code point is checked against the type that will hold it *before* it becomes one. `char32_t`
+/// is unsigned, so a negative `first` cast into it would arrive as a range near the top of the plane
+/// - a set the node never declared, silently, in the one file that is supposed to make the set
+/// reviewable. `ScreenPackage::validate()` would then refuse it as `CodePointOutOfRange`, but with no
+/// file name and no member attached; caught here it names both.
+[[nodiscard]] std::optional<std::vector<mdux::font::CharsetRange>>
+readRanges(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
+    const json::Value* member = object.find(key);
+    if (member == nullptr) {
+        return std::vector<mdux::font::CharsetRange>{};
+    }
+    if (member->kind() != json::Value::Kind::Array) {
+        sink.fail(memberWrong, std::format("{} member '{}' is not an array", what, key));
+        return std::nullopt;
+    }
+    std::vector<mdux::font::CharsetRange> ranges;
+    ranges.reserve(member->elements().size());
+    for (const json::Value& element : member->elements()) {
+        static constexpr std::array<std::string_view, 2> allowed{"first", "last"};
+        if (!expectObject(element, std::format("{} member '{}'", what, key), allowed, sink)) {
+            return std::nullopt;
+        }
+        const auto first = readInteger(element, "first", what, sink);
+        const auto last  = readInteger(element, "last", what, sink);
+        if (!first.has_value() || !last.has_value()) {
+            return std::nullopt;
+        }
+        for (const std::int64_t point : {*first, *last}) {
+            if (point < 0 || point > static_cast<std::int64_t>(mdux::font::maxCodePoint)) {
+                sink.fail(memberWrong, std::format("{} member '{}' names {}, which is not a Unicode scalar value", what, key, point));
+                return std::nullopt;
+            }
+        }
+        ranges.push_back(mdux::font::CharsetRange{.first = static_cast<char32_t>(*first), .last = static_cast<char32_t>(*last)});
+    }
+    return ranges;
+}
+
 [[nodiscard]] std::optional<std::vector<std::string>> readNames(const json::Value& object, std::string_view key, std::string_view what, const Sink& sink) {
     const json::Value* member = object.find(key);
     if (member == nullptr) {
@@ -695,7 +799,7 @@ readSpec(const json::Value& node, std::string_view kind, std::string_view what, 
     static constexpr std::array<std::string_view, 4> criticalMembers{"colorToken", "labelKey", "onPress", "requirement"};
     static constexpr std::array<std::string_view, 4> numericMembers{"colorToken", "requirement", "source", "templateId"};
     static constexpr std::array<std::string_view, 4> statusMembers{"colorTokens", "requirement", "source", "stateKeys"};
-    static constexpr std::array<std::string_view, 5> inputMembers{"charset", "colorToken", "maxLength", "requirement", "source"};
+    static constexpr std::array<std::string_view, 6> inputMembers{"charset", "charsetRanges", "colorToken", "maxLength", "requirement", "source"};
 
     // Interns one spec name. The member set has already been checked by `expectObject()` on the
     // branch that calls this, so what remains is reading the names the kind admits.
@@ -854,10 +958,17 @@ readSpec(const json::Value& node, std::string_view kind, std::string_view what, 
         const auto maxLength   = readInteger(*spec, "maxLength", where, sink);
         const auto charset     = name("charset");
         const auto requirement = name("requirement");
-        if (!source.has_value() || !colorToken.has_value() || !maxLength.has_value() || !charset.has_value() || !requirement.has_value()) {
+        const auto ranges      = readRanges(*spec, "charsetRanges", where, sink);
+        if (!source.has_value() || !colorToken.has_value() || !maxLength.has_value() || !charset.has_value() || !requirement.has_value()
+            || !ranges.has_value()) {
             return false;
         }
-        payload = ms::TextInputSpec{.source = *source, .colorToken = *colorToken, .maxLength = *maxLength, .charset = *charset, .requirement = *requirement};
+        payload = ms::TextInputSpec{.source        = *source,
+                                    .colorToken    = *colorToken,
+                                    .maxLength     = *maxLength,
+                                    .charset       = *charset,
+                                    .requirement   = *requirement,
+                                    .charsetRanges = document.internRanges(*ranges)};
         return true;
     }
     return sink.fail(kindUnknown,

--- a/tools/medui/Package.cppm
+++ b/tools/medui/Package.cppm
@@ -95,10 +95,12 @@ export module mdux.tools.medui.package;
 
 import std;
 import mdux.draw;
+import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.tools.cli;
 import mdux.tools.medui.goldens;
 import mdux.tools.medui.layout;
+import mdux.tools.medui.textbudget;
 
 export namespace mdux::tools::medui {
 
@@ -120,6 +122,16 @@ struct PackageInputs {
     mdux::draw::DrawBudget                             budget{};
     std::span<const mdux::medui::TextPackageApproval>  approvedTextPackages;
     std::span<const mdux::medui::ImagePackageApproval> approvedImagePackages{};
+
+    /// The build's dynamic-text table, so a `TextInput`'s `charset:` can be *resolved* into the
+    /// compiled node rather than carried into it as a name (#297).
+    ///
+    /// `DynamicTextRule` borrowed from the budget stage rather than restated: it is the same table,
+    /// read for a second purpose, and the budget stage's question - "can this name produce something
+    /// the font cannot draw" - is only answerable about the same ranges this one writes down. Two
+    /// stages resolving one name through two tables is exactly the drift that would make a screen's
+    /// compile-time check and its run-time check disagree.
+    std::span<const DynamicTextRule> charsets{};
 };
 
 /**
@@ -168,16 +180,21 @@ public:
     /// parallel `stateKeys` and `colorTokens`.
     [[nodiscard]] std::span<const std::string_view> internList(std::span<const std::string> items);
 
+    /// Interns a resolved charset and returns a stable span of it, for a `TextInput`'s
+    /// `charsetRanges`. Empty interns to an empty span: a node that narrows nothing owns no set.
+    [[nodiscard]] std::span<const mdux::font::CharsetRange> internRanges(std::span<const mdux::font::CharsetRange> ranges);
+
 private:
-    std::deque<std::string>                        text_;
-    std::deque<std::vector<std::string_view>>      lists_;
-    std::vector<mdux::medui::TextPackageApproval>  approvedTextPackages_;
-    std::vector<mdux::medui::ImagePackageApproval> storedImagePackages;
-    std::vector<mdux::medui::CompiledNode>         nodes_;
-    std::string_view                               id_;
-    std::int32_t                                   surfaceWidth_{0};
-    std::int32_t                                   surfaceHeight_{0};
-    mdux::draw::DrawBudget                         budget_{};
+    std::deque<std::string>                           text_;
+    std::deque<std::vector<std::string_view>>         lists_;
+    std::deque<std::vector<mdux::font::CharsetRange>> charsets_;
+    std::vector<mdux::medui::TextPackageApproval>     approvedTextPackages_;
+    std::vector<mdux::medui::ImagePackageApproval>    storedImagePackages;
+    std::vector<mdux::medui::CompiledNode>            nodes_;
+    std::string_view                                  id_;
+    std::int32_t                                      surfaceWidth_{0};
+    std::int32_t                                      surfaceHeight_{0};
+    mdux::draw::DrawBudget                            budget_{};
 };
 
 /**


### PR DESCRIPTION
## Summary

A `TextInput`'s `charset:` reached the compiler and stopped there. The compiled node carried the charset's **name**, so a device had nothing to compare a character against but the font package: a field declared `charset: DIGITS`, on a font admitting all of Latin-1, displayed the `A` a host handed it. The narrowing was a claim about the *source*, and an author reading the field could not tell.

The node now carries the code points that name resolved to. The device tests membership against data in the artifact rather than a table shipped beside it.

**The decision the issue asked for, and the argument.** #258 left `NumericDisplay`'s `templateId` a name, and the question was whether a charset is the same case. It is not, and the difference is sharp: what a template name stands for is a *rendering the host supplies at run time* (`ReadingSlot::rendering`), while what a charset name stands for is a *set the compiler has already resolved and already validated against the font* (`MEDUI-E053`). Carrying it is closer to carrying resolved `bounds` than to carrying a product table — a compiled node has three kinds of thing in it, not two, and ADR-012 now names the third.

**Why this is not a widening of the shared contract.** MEDUI-DEC-006 (Accepted) assigns the character sets themselves to the implementation — "`charset` stays an open name resolved against the implementation's baked character sets" — so what lands in `package.json` is the resolution of a table the contract has already delegated. MEDUI-DEC-003 characterises a compiled screen as locale-free layout data and assigns "committed artifact layouts" to implementations, with conformance comparing "observable meaning, not output encoding". And it is checkable rather than only arguable: the four claimed capabilities are `syntax`, `semantics`, `layout` and `safety`, none of which reads a compiled package, and **all eighteen pinned cases pass unchanged at `265df19`**.

What it *is* is a portability difference, recorded rather than left to be discovered: the same source compiled by an implementation that does not carry the ranges will display a character this one refuses. ADR-012 says so and says it belongs upstream.

**The refusal is its own fact.** `CharacterOutsideFieldCharset` is a character the package draws perfectly well that *this node never declared*; `GlyphNotInPackage` is one the font cannot draw at all. A caller told the second goes and re-bakes a font, and would have got nowhere told it about the first. The font's refusal wins when both apply, because no re-declaration makes a glyph exist.

**It is asked twice**, which is `TextInputBinding`'s existing arrangement for `max_length` extended to the charset: `create()` refuses the slot where a host can still act on it, and `recordField()` holds when the two disagree. A refusal at the frame rolls the whole screen back, and a blank display tells an operator less than a stale one does.

**Two things fell out of doing it.**

- `[dynamicText]` could express one contiguous run per name, and a repeated name silently started a second rule that `checkDynamicText()`'s `find` never reached — so the budget stage checked one range and ignored the rest, and **a charset could escape its font while the compile stayed green**. A repeated name now accumulates, the set is sorted, and an overlapping pair is refused at the recipe line rather than as a schema failure naming nothing.
- `docs/recipes/screen.schema.json` bounds a code point at U+10FFFF, which needed `maximum` implementing in the drift checker's subset validator. The checker refused the keyword rather than ignoring it — which is exactly what #301 taught it to do.

The demonstrator screen uses the feature, so it is in the committed evidence rather than only in fixtures: `patient-id` declares `charset: PATIENT-ID`, digits and uppercase, and the resolved ranges are in the committed `package.json` and in the generated C++.

Closes #297

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #297

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
- [x] Schemas under `docs/*/schemas/` or `docs/governance/schemas/` — `docs/recipes/screen.schema.json`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [x] Committed artifacts under `generated/` — `generated/screen/endoscope-monitor/` re-baked
- [ ] None of the above

No module was added, moved or removed: `mdux.medui.schema` gained `export import mdux.font.schema`, because `TextInputSpec::charsetRanges` is a span of `mdux::font::CharsetRange` and the type is therefore part of this contract rather than an implementation detail behind it.

## Rebase state

- **Rebased onto:** `4e1150c6bc8aa664fa13ad02871c09329b36269a` (`origin/develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [x] `cmake --preset ninja-gcc && cmake --build build-gcc`
- [x] `ctest --test-dir build-gcc` — 800/800 passed, under **both** `radv` and `lavapipe` (`VK_DRIVER_FILES`), since testing one GPU is what let #298's ColorHash defect through
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 83 files, 0 findings
- [x] Other:
  - `check_schema_type_drift.py` — 7 schemas, 2 vocabularies, 6 recipe schemas against 8 reports
  - `generate_tool_manifest.py --check`, `generate_ai_reference.py --check`, `check_file_headers.py`
  - `tools/docs-lint` unit tests — 186 tests, 1 pre-existing failure unrelated to this branch (`test_the_tree_itself_conforms` walks a git-ignored `examples/build/` CMake probe directory)
  - Pinned MedUI conformance at `265df19`: 18 cases, none unclaimed, all pass
  - Evidence re-bake: `mdux-bake-update`, diff reviewed — the resolved ranges in `package.json`, the table in `report.json`, one digest in `verification.json`
  - Mutation-checked: neutering the `admits()` call in `recordField()` fails `medui-field-node-charset-is-enforced`

Six new scenarios: the node's set enforced at the frame, the two refusals ordered, the set enforced at the join, every way `validate()` refuses a set that is not one, a hand-edited range refused by the reader where it can be named, and the compile end to end from a recipe whose table repeats a name.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** no successor
- [ ] That run is green.

## Regulatory impact

**Yes — this changes safety behaviour, and the change is a risk control becoming enforceable rather than advisory.**

A `charset:` declaration is a constraint on what a field may show an operator. Until now it constrained only what the *compiler would accept*, so a host defect that put a letter into a digits-only patient-identifier field produced a plausible-looking wrong value on screen with nothing to say it was wrong. The declaration now bounds the device too, and a violation is refused rather than displayed — at bind time where a host can act on it, and at the frame as a second line.

The narrowing is fail-closed in both directions it could have gone wrong: `ScreenPackage::validate()` refuses a node carrying a charset name whose resolved set is missing (a narrowing silently gone), and refuses a set carrying no name. Both are `static_assert`s in generated code, so such a screen is a build failure rather than a device that quietly stopped enforcing.

The fail-open path in `[dynamicText]` closed here is the one worth flagging to a reviewer: a table repeating a charset name had its later ranges checked by nothing, so a screen could produce a character its font cannot draw with the compile reporting success. That is ADR-010's on-device-shaping commitment being unenforced for that screen.

Artifacts updated: ADR-012 (amended — the record that said `charset` stays a name), `docs/architecture.md`, `docs/roadmap.md`, the `medui-authoring` skill, `docs/recipes/screen.schema.json`, and the committed `generated/screen/endoscope-monitor/` bundle. `requirement:` tracing and the golden set are unchanged — a `TextInput` carries no golden, and none was added or removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text inputs now enforce their declared character sets when values are bound and displayed.
  * Compiled screen data includes the resolved character ranges for each restricted text input.
  * Character-set errors now distinguish undeclared characters from glyphs missing in the font.
  * Screen recipes support repeated character-set names and validate sorted, non-overlapping Unicode ranges.
  * The endoscope monitor’s patient ID field now accepts only digits and uppercase letters.

* **Documentation**
  * Updated architecture, recipe, roadmap, and decision-record documentation to describe the behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->