### PR TITLE
S7 — Refresh agent instructions and reject empty documented test selections [#304]

### DIFF
--- a/.agents/skills/mdux-build-and-test/SKILL.md
+++ b/.agents/skills/mdux-build-and-test/SKILL.md
@@ -67,9 +67,9 @@ know will fail or guessing at results.
 
 3. **Test**, focused before broad:
    ```bash
-   ctest --test-dir build --output-on-failure                              # full suite
-   ctest --test-dir build -R '^unit_tests::' --output-on-failure           # one target's cases
-   ctest --test-dir build -L evidence --no-tests=error --output-on-failure # one label
+   ctest --test-dir build --output-on-failure                                             # full suite
+   ctest --test-dir build -R '^unit_tests::' --no-tests=error --output-on-failure          # one target's cases
+   ctest --test-dir build -L evidence --no-tests=error --output-on-failure                 # one label
    ```
    `mdux_discover_tests()` registers one CTest entry per `TEST_CASE`, named `<target>::<case>` -
    not a hand-written suite name. There is no fixed list to quote here that would not go stale the
@@ -79,15 +79,16 @@ know will fail or guessing at results.
    already wired up (`evidence`, `determinism`, `noheap`, `pixel`, `regulatory`, `verify`, …) and
    what each one answers.
 
-   **Add `--no-tests=error` to any selection you are using as verification evidence.** Without it,
+   **`--no-tests=error` is not decoration above — carry it into any selection you use as
+   verification evidence, including one you write yourself and not only these three.** Without it,
    a selector that matches nothing exits 0 and prints "0 tests failed out of 0" - a command that
    reads as a passing check and asserted nothing. This is not hypothetical: an earlier revision of
-   this skill recommended exactly such a selector (issue #304), and it was found by running it, not
-   by reading it. A CI regression check
+   this skill recommended exactly such a selector with no flag to catch it (issue #304), and it was
+   found by running the command, not by reading it. A CI regression check
    (`tools/docs-lint/check_documented_test_selectors.py`) now asks a built CTest configuration
    whether every `-R`/`--tests-regex` example in this file, `AGENTS.md` and
-   `docs/getting-started.md` still matches something, so a selector going stale here again is a
-   build failure rather than a second reader's discovery.
+   `docs/getting-started.md` still matches something - which checks that *these* examples stay
+   live, not that a selection you construct from them at the terminal carries the flag too.
 
 4. **Run an example** directly once built, e.g. `./build/examples/MedicalUiExample`.
 

--- a/.agents/skills/mdux-build-and-test/SKILL.md
+++ b/.agents/skills/mdux-build-and-test/SKILL.md
@@ -67,11 +67,27 @@ know will fail or guessing at results.
 
 3. **Test**, focused before broad:
    ```bash
-   ctest --test-dir build -R MduXUnitTests --output-on-failure  # one suite
-   ctest --test-dir build --output-on-failure                   # full suite
+   ctest --test-dir build --output-on-failure                              # full suite
+   ctest --test-dir build -R '^unit_tests::' --output-on-failure           # one target's cases
+   ctest --test-dir build -L evidence --no-tests=error --output-on-failure # one label
    ```
-   Registered CTest names: `MduXUnitTests`, `MduXComplianceTests`, `VulkanSCMemoryPoolTests`,
-   `VulkanSCDeviceObjectTests`.
+   `mdux_discover_tests()` registers one CTest entry per `TEST_CASE`, named `<target>::<case>` -
+   not a hand-written suite name. There is no fixed list to quote here that would not go stale the
+   next time a case is added or renamed; find the live one with `ctest --test-dir build -N` (lists
+   every registered name) or `ctest --test-dir build -N -R <pattern>` (narrows first). See
+   [`docs/getting-started.md`](../../../docs/getting-started.md#selecting-suites) for the labels
+   already wired up (`evidence`, `determinism`, `noheap`, `pixel`, `regulatory`, `verify`, …) and
+   what each one answers.
+
+   **Add `--no-tests=error` to any selection you are using as verification evidence.** Without it,
+   a selector that matches nothing exits 0 and prints "0 tests failed out of 0" - a command that
+   reads as a passing check and asserted nothing. This is not hypothetical: an earlier revision of
+   this skill recommended exactly such a selector (issue #304), and it was found by running it, not
+   by reading it. A CI regression check
+   (`tools/docs-lint/check_documented_test_selectors.py`) now asks a built CTest configuration
+   whether every `-R`/`--tests-regex` example in this file, `AGENTS.md` and
+   `docs/getting-started.md` still matches something, so a selector going stale here again is a
+   build failure rather than a second reader's discovery.
 
 4. **Run an example** directly once built, e.g. `./build/examples/MedicalUiExample`.
 

--- a/.agents/skills/mdux-regulated-change/SKILL.md
+++ b/.agents/skills/mdux-regulated-change/SKILL.md
@@ -83,10 +83,16 @@ the fact — flag it for maintainer/domain-expert review instead (see Step 5).
   named standard's requirements for real-world use.
 
 Never let the second or third category be described using language that implies the first. In
-particular, `README.md`'s "Completed" status for the ISO 14971/13485 risk and quality-management
-frameworks is project intent, not implemented evidence (see `AGENTS.md` § 2) — do not cite it as
-proof that a compliance requirement is already satisfied, and do not introduce new claims of that
-kind for the change you are making.
+particular, ADR-014's rendered-truth verification is implemented evidence — `verify.screen.<id>`
+exists, runs in CI, and passes — but it is not a certification claim, and the project's own
+documents say so rather than leaving it implied: `docs/iec62304/03-development-process.md` records
+that MduX has no software *system* in IEC 62304 §5.7's sense, and the CHANGELOG states "no IEC
+62304 §5.7 system claim" beside every release the mechanism ships in. A passing rendered-truth gate
+is evidence a future system-level argument could rest on, not the argument itself — do not cite it
+as proof such an argument is already made, and do not introduce a new claim of that kind for the
+change you are making. (An earlier revision of this skill used README.md's ISO 14971/13485
+"Completed" status for the same point; issue `#111` removed the claim it referred to, and issue
+`#304` replaced the example rather than leave it citing text that no longer exists.)
 
 ## Handoff checklist
 

--- a/.github/workflows/linux-gcc16-build.yml
+++ b/.github/workflows/linux-gcc16-build.yml
@@ -92,7 +92,8 @@ jobs:
           libxi-dev \
           xvfb \
           wget \
-          gnupg
+          gnupg \
+          python3
 
     - name: Install latest CMake
       run: |
@@ -202,6 +203,16 @@ jobs:
       shell: bash
       run: ctest --preset ninja-gcc -L verify -V --no-tests=error
 
+    # Issue #304: a documented `ctest -R <selector>` example that matches nothing reads as
+    # verification evidence and produces none - `.agents/skills/mdux-build-and-test/SKILL.md`
+    # recommended one until this found it. Run here rather than in Documentation Lint because the
+    # question needs a *built* CTest configuration to ask (`--show-only=json-v1` against the tree
+    # `mdux_discover_tests()` actually populated); Documentation Lint runs on ubuntu-latest with no
+    # C++ toolchain at all, by design, so a docs-only PR keeps its fast feedback. One leg is
+    # proportionate: the documented names are toolchain-independent, so GCC 16 - the project's
+    # floor and the leg this exact defect was found on - is asked once rather than on all four.
+    - name: Verify documented test selectors are live
+      run: python3 tools/docs-lint/check_documented_test_selectors.py --build-dir build-gcc
 
     - name: Verify no source-tree writes
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,12 @@ Three decisions from that programme apply repository-wide:
    closed) — see `regulatory-citations` in § 7 and [ADR-006](docs/adr/ADR-006-no-reproduction-of-normative-standard-text.md).
    Do not add new material that reproduces or closely paraphrases a standard's wording.
    `mdux-docs-lint` enforces this in CI.
-4. **Evidence is baked and committed** (issue `#12`, closed). Five artifacts live under
-   `generated/`: two shader packages, two ML model packages and one font package. A normal build never writes into
+4. **Evidence is baked and committed** (issue `#12`, closed). Eight artifacts live under
+   `generated/` today — see the `evidence-pipeline` skill's own status line for the current count
+   and kinds rather than a second copy of it here. A normal build never writes into
    the source tree — `mdux-bake-update` is the only path that does, run deliberately by an author
-   who commits the diff. CI asserts byte-identity on both toolchain legs.
+   who commits the diff. CI asserts byte-identity on every toolchain leg that runs the evidence
+   label.
 5. **Zero-SOUP ML inference has landed** (issue `#18`, closed). `mdux.ml.kernels` is imported by
    both the device runtime and the host baker, and `Classifier1D::create()` fails closed on a
    digest or golden-vector mismatch. See [ADR-008](docs/adr/ADR-008-zero-soup-ml-inference.md).
@@ -395,7 +397,7 @@ is one of the things that would have caught that earlier.
 | [`mdux-regulated-change`](.agents/skills/mdux-regulated-change/SKILL.md) | A change can affect safety behavior, risk controls, compliance metadata, traceability, auditability, lifecycle documents, or claims about medical-device standards. | Impact classification, affected-artifact identification, proportionate documentation updates, traceability, review/escalation triggers, evidence-vs-intent-vs-certification distinctions. |
 | [`regulatory-citations`](.agents/skills/regulatory-citations/SKILL.md) | Writing or reviewing anything that claims alignment with IEC 62304, ISO 13485, ISO 14971, IEC 62366-1, or IEC 81001-5-1. | Citation-key format, the `Justification` object, the prohibition on reproducing normative text. **Target convention** — see § 2's parity-programme note. |
 | [`evidence-pipeline`](.agents/skills/evidence-pipeline/SKILL.md) | Adding or modifying a baked asset (font, shader, image, `.medui` screen, ML model) or anything under `generated/`. | Recipe→baker→committed-artifact doctrine, canonical-JSON rules, why `generated/` is never hand-edited. Each kind's **resolved** option set is published as `docs/recipes/<kind>.schema.json` (#264) and checked against every committed report. **Live** — `mdux-shaderbake` and `mdux-mlbake` both register through `mdux_bake_artifact()`, and `generated/shader/` and `generated/model/` are committed and byte-verified. |
-| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. The machine-readable form of all of it is `docs/medui/grammar.json`, emitted by `mdux-meduic --grammar` from the compiler's own tables (#263) — read that for the *set* of anything, and `mdux-meduic --explain MEDUI-EXXX` for one diagnostic. **Live** — a `.medui` file compiles to a committed artifact, emits `constexpr` C++, and reaches compared pixels; what it cannot yet carry is text (issue `#235`). |
+| [`medui-authoring`](.agents/skills/medui-authoring/SKILL.md) | Authoring or discussing a `.medui` screen. | Grammar, component dictionary, theme tokens, text budgets, `@safety_critical`. The machine-readable form of all of it is `docs/medui/grammar.json`, emitted by `mdux-meduic --grammar` from the compiler's own tables (#263) — read that for the *set* of anything, and `mdux-meduic --explain MEDUI-EXXX` for one diagnostic. **Live** — a `.medui` file compiles to a committed artifact, emits `constexpr` C++, and reaches compared pixels; every component the dictionary names draws (epic `#17`, closed). |
 | [`sdf-documents`](.agents/skills/sdf-documents/SKILL.md) | Filling in or reviewing a `software_development_file/` document. | Structure, the summarize-don't-duplicate rule, citing into the corpus. **Live** — `software_development_file/` exists with templates and records (issue `#9`). |
 
 Detailed procedures live in the skill files, not here — this table only routes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,10 @@ Three decisions from that programme apply repository-wide:
    closed) — see `regulatory-citations` in § 7 and [ADR-006](docs/adr/ADR-006-no-reproduction-of-normative-standard-text.md).
    Do not add new material that reproduces or closely paraphrases a standard's wording.
    `mdux-docs-lint` enforces this in CI.
-4. **Evidence is baked and committed** (issue `#12`, closed). Eight artifacts live under
-   `generated/` today — see the `evidence-pipeline` skill's own status line for the current count
-   and kinds rather than a second copy of it here. A normal build never writes into
+4. **Evidence is baked and committed** (issue `#12`, closed). Artifacts live under `generated/` —
+   see the `evidence-pipeline` skill's own status line for the current count and kinds rather than
+   a second copy of it here, which is exactly the number this sentence used to restate and go
+   stale by. A normal build never writes into
    the source tree — `mdux-bake-update` is the only path that does, run deliberately by an author
    who commits the diff. CI asserts byte-identity on every toolchain leg that runs the evidence
    label.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -527,8 +527,17 @@ because closing an epic issue is a separate, manual step from closing its last c
 - #263 S4 Machine-readable `.medui` grammar and `--explain` — **shipped**; `docs/medui/grammar.json`, emitted from the compiler's own tables
 - #264 S5 JSON Schemas for every recipe kind — **shipped**; `docs/recipes/*.schema.json`, checked against every committed report
 - #265 S6 `--dump-ir` JSON and a generated tool manifest — **shipped**; the resolved IR, and a manifest generated from the build's own registration
+- #304 S7 Refresh agent instructions and reject empty documented test selections — **shipped**;
+  a follow-up to #65/#66 rather than a seventh grammar/schema/IR feature. An assessment of
+  `develop` found agent-facing instructions that disagreed with the implementation - a
+  `ctest -R <name>` example naming a suite registration `mdux_discover_tests()` had already
+  replaced with `<target>::<case>` entries, a "five artifacts" count where eight now exist, and two
+  references to issues since closed. Fixed, and closed mechanically rather than left to the next
+  audit to rediscover by hand: `tools/docs-lint/check_documented_test_selectors.py` asks a built
+  CTest configuration whether every documented `-R` example still matches something, wired into
+  the GCC 16 build leg since the question needs a build to ask.
 
-_S1–S6 closed. #19 has no open child._
+_S1–S7 closed. #19 has no open child._
 
 ---
 

--- a/tools/docs-lint/check_documented_test_selectors.py
+++ b/tools/docs-lint/check_documented_test_selectors.py
@@ -119,10 +119,40 @@ def fenced_code_lines(text: str) -> list[tuple[int, str]]:
     return lines
 
 
+def join_shell_continuations(lines: list[tuple[int, str]]) -> list[tuple[int, str]]:
+    """Merges a line ending in a shell continuation backslash with the line(s) that follow it, so
+    a `ctest` invocation split across lines is matched as the one command it is rather than as two
+    lines neither of which contains both `ctest` and `-R`. The merged result keeps the *first*
+    physical line's number - a citation still points at the line a reader looks for the command on,
+    not at whichever continuation line happened to carry the flag.
+
+    Applies within one fenced block at a time. `fenced_code_lines()` numbers its lines with no gap
+    while a fence stays open and at least one gap (the delimiter lines it drops) between two
+    fences, so a break in the sequence is a fence boundary - a continuation must never be read
+    across it, or a line ending a block coincidentally with a trailing `\\` could absorb the next
+    block's first line.
+    """
+    joined: list[tuple[int, str]] = []
+    index = 0
+    while index < len(lines):
+        start_line, buffer = lines[index]
+        current_line = start_line
+        while buffer.rstrip().endswith("\\") and index + 1 < len(lines):
+            next_line, next_text = lines[index + 1]
+            if next_line != current_line + 1:
+                break
+            buffer = buffer.rstrip()[:-1].rstrip() + " " + next_text.strip()
+            current_line = next_line
+            index += 1
+        joined.append((start_line, buffer))
+        index += 1
+    return joined
+
+
 def find_citations(path: Path) -> list[Citation]:
     text = path.read_text(encoding="utf-8", errors="replace")
     citations = []
-    for line_number, line in fenced_code_lines(text):
+    for line_number, line in join_shell_continuations(fenced_code_lines(text)):
         for match in CTEST_SELECTOR_PATTERN.finditer(line):
             selector = match.group("quoted") if match.group("quoted") is not None else match.group("bare")
             citations.append(Citation(path, line_number, selector))
@@ -213,8 +243,8 @@ def main(argv: list[str]) -> int:
 
     if not (build_dir / "CTestTestfile.cmake").is_file():
         print(
-            f"mdux-doc-selectors: '{build_dir}' has no CTestTestfile.cmake - configure and build "
-            "first, or pass --build-dir at the tree that was",
+            f"mdux-doc-selectors: '{build_dir}' has no CTestTestfile.cmake - pass --build-dir at "
+            "an already configured and built CMake binary directory (e.g. build-gcc)",
             file=sys.stderr,
         )
         return 1

--- a/tools/docs-lint/check_documented_test_selectors.py
+++ b/tools/docs-lint/check_documented_test_selectors.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -60,13 +60,10 @@ from pathlib import Path
 
 FENCE_PATTERN_CHARS = ("```", "~~~")
 
-# Mirrors CTEST_LABEL_PATTERN in check_named_mechanisms.py, for `-R`/`--tests-regex` instead of
-# `-L`/`--label-regex`. The gap between `ctest` and the flag may hold options and a preset name,
-# bounded so a sentence rather than a command line cannot be captured across a bracket or comma.
-CTEST_SELECTOR_PATTERN = re.compile(
-    r"\bctest\b(?P<gap>[^\n(),]{0,60}?)(?:-R\b|--tests-regex\b)(?:\s+|=)"
-    r"(?:(?P<quote>[\"'])(?P<quoted>[^\n]*?)(?P=quote)|(?P<bare>[^\s,\])`]+))"
-)
+# Long-form `--tests-regex=<value>`. Not `-R=<value>`: CTest's own CLI does not accept `=` on the
+# short spelling, and inventing an accepted form here would recognise something no shell would
+# actually pass through.
+TESTS_REGEX_EQUALS_PREFIX = "--tests-regex="
 
 
 @dataclass(frozen=True)
@@ -149,12 +146,53 @@ def join_shell_continuations(lines: list[tuple[int, str]]) -> list[tuple[int, st
     return joined
 
 
+def selectors_in_line(line: str) -> list[str]:
+    """Every `-R`/`--tests-regex` value on one already-joined logical line, read by tokenizing it
+    as a shell would rather than by pattern-matching the text.
+
+    This replaced a regex bounding the gap between `ctest` and the flag to 60 characters and
+    excluding punctuation from an unquoted value - both wrong, found by reproduction rather than
+    inspection: a realistic option list before `-R` is longer than 60 characters
+    (`--test-dir build --output-on-failure --no-tests=error --parallel 4 -R ObsoleteSuite` matched
+    nothing at all), and a selector containing a comma is an ordinary CTest regex
+    (`^unit_tests::Version,obsolete$` truncated to `^unit_tests::Version`, which then reported the
+    *wrong* selector as live). `shlex` has neither problem: it tokenizes the whole line regardless
+    of length, and a quoted or unquoted token is returned whole, punctuation included - the shell
+    property this line is actually being read for.
+
+    `#` starts a comment exactly as it does in the shells these examples are written for, which is
+    what lets a trailing `# one suite` annotation fall away without a second rule for it.
+
+    Returns nothing for a line `shlex` cannot tokenize (unbalanced quotes) rather than guessing -
+    the same "ask, don't reconstruct" choice `matching_test_count()` makes about a `ctest` failure.
+    """
+    try:
+        tokens = shlex.split(line, comments=True)
+    except ValueError:
+        return []
+    if "ctest" not in tokens:
+        return []
+
+    found = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in ("-R", "--tests-regex"):
+            if index + 1 < len(tokens):
+                found.append(tokens[index + 1])
+            index += 2
+            continue
+        if token.startswith(TESTS_REGEX_EQUALS_PREFIX):
+            found.append(token[len(TESTS_REGEX_EQUALS_PREFIX) :])
+        index += 1
+    return found
+
+
 def find_citations(path: Path) -> list[Citation]:
     text = path.read_text(encoding="utf-8", errors="replace")
     citations = []
     for line_number, line in join_shell_continuations(fenced_code_lines(text)):
-        for match in CTEST_SELECTOR_PATTERN.finditer(line):
-            selector = match.group("quoted") if match.group("quoted") is not None else match.group("bare")
+        for selector in selectors_in_line(line):
             citations.append(Citation(path, line_number, selector))
     return citations
 

--- a/tools/docs-lint/check_documented_test_selectors.py
+++ b/tools/docs-lint/check_documented_test_selectors.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Fails when a documented `ctest -R <selector>` example matches no registered test.
+
+Host-only tool (ADR-004): standard library only, no third-party dependencies.
+
+Issue #304's finding, made mechanical rather than left to the next reader to rediscover:
+`.agents/skills/mdux-build-and-test/SKILL.md` recommended
+`ctest --test-dir build -R MduXUnitTests --output-on-failure`, a name from before
+`mdux_discover_tests()` replaced hand-written suite registrations with one CTest entry per
+`TEST_CASE`, named `<target>::<case>`. Running the documented command against the tree it
+describes returned `Total Tests: 0` - a command that reads as verification evidence and produces
+none, silently, because CTest treats an empty selection as a successful run of nothing unless
+`--no-tests=error` says otherwise.
+
+This tool asks a real, built CTest configuration whether a documented selector still selects
+anything - `ctest --show-only=json-v1 -R <selector>` - rather than keeping a second list of
+expected names in this file for the documentation to drift away from. That second list is
+exactly what issue #304 asks not to be built: the source of truth for "does this selector match a
+test" is the test tree itself, on the day the check runs, not a snapshot of it copied in here.
+
+## What is scanned, and why this set
+
+`AGENTS.md`, every `.agents/skills/*/SKILL.md`, and `docs/getting-started.md` - the documents an
+agent reads to learn *how to run tests*, which is the same set issue #304 audited by hand. Not all
+of `docs/`: `check_named_mechanisms.py` already resolves `ctest -L <label>` citations there
+statically (a label is a literal string attached in CMake or a `TEST_CASE`, so no build is
+needed), and a changelog or roadmap entry quoting a historical command is describing what a past
+release did, not instructing a reader what to run today.
+
+Only fenced code blocks are scanned, which is the opposite convention from
+`check_named_mechanisms.py` and deliberately so: that checker treats a fence as an illustrative
+example exempt from checking prose claims, while a `ctest` invocation in one of these documents
+*is* the claim - it is presented as the command to run, and #304 is exactly the case of a fenced
+example nobody could run correctly.
+
+## What "obsolete" means here, precisely
+
+A selector that CTest's `--show-only=json-v1` reports zero tests for, against the build directory
+given. That is the one fact this tool proves: it does not check that the prose around the command
+is otherwise accurate, that the build directory itself is current, or that a selector matching one
+stale test is the *right* test - see #304's own acceptance criteria for why a mechanical checker
+does not stand in for reading the surrounding text.
+
+Usage:
+    python3 tools/docs-lint/check_documented_test_selectors.py --build-dir PATH [--repo-root PATH]
+
+Exit status 0 when every documented selector matches at least one registered test, 1 otherwise -
+including when `--build-dir` holds no CTest configuration to ask, which would otherwise make an
+empty scan look identical to a clean one.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+FENCE_PATTERN_CHARS = ("```", "~~~")
+
+# Mirrors CTEST_LABEL_PATTERN in check_named_mechanisms.py, for `-R`/`--tests-regex` instead of
+# `-L`/`--label-regex`. The gap between `ctest` and the flag may hold options and a preset name,
+# bounded so a sentence rather than a command line cannot be captured across a bracket or comma.
+CTEST_SELECTOR_PATTERN = re.compile(
+    r"\bctest\b(?P<gap>[^\n(),]{0,60}?)(?:-R\b|--tests-regex\b)(?:\s+|=)"
+    r"(?:(?P<quote>[\"'])(?P<quoted>[^\n]*?)(?P=quote)|(?P<bare>[^\s,\])`]+))"
+)
+
+
+@dataclass(frozen=True)
+class Citation:
+    path: Path
+    line: int
+    selector: str
+
+
+@dataclass(frozen=True)
+class Finding:
+    citation: Citation
+    reason: str
+
+
+def documents_to_scan(root: Path) -> list[Path]:
+    """The fixed set of "how to run tests" documents - see the module docstring for why this set
+    and not all of `docs/`. Skills are discovered by glob rather than named individually, so a
+    skill added later is scanned without editing this function - the one place a hardcoded list
+    would have been tempting and is not needed.
+    """
+    paths = []
+    agents_md = root / "AGENTS.md"
+    if agents_md.is_file():
+        paths.append(agents_md)
+    getting_started = root / "docs" / "getting-started.md"
+    if getting_started.is_file():
+        paths.append(getting_started)
+    skills_root = root / ".agents" / "skills"
+    if skills_root.is_dir():
+        paths.extend(sorted(skills_root.glob("*/SKILL.md")))
+    return paths
+
+
+def fenced_code_lines(text: str) -> list[tuple[int, str]]:
+    """Lines strictly inside a fenced code block, 1-indexed, excluding the fence delimiters
+    themselves. An unterminated fence is treated as open to the end of the file - the same
+    fail-open-to-scanning choice `check_named_mechanisms.py` makes for the opposite case, applied
+    here so a malformed document still gets its fenced content checked rather than none of it.
+    """
+    lines: list[tuple[int, str]] = []
+    in_fence = False
+    for index, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith(FENCE_PATTERN_CHARS):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            lines.append((index, line))
+    return lines
+
+
+def find_citations(path: Path) -> list[Citation]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    citations = []
+    for line_number, line in fenced_code_lines(text):
+        for match in CTEST_SELECTOR_PATTERN.finditer(line):
+            selector = match.group("quoted") if match.group("quoted") is not None else match.group("bare")
+            citations.append(Citation(path, line_number, selector))
+    return citations
+
+
+def matching_test_count(ctest_command: str, build_dir: Path, selector: str) -> int:
+    """How many tests `--show-only=json-v1 -R <selector>` reports against `build_dir`.
+
+    `--show-only` applies the same `-R` filtering a real run would (checked empirically: a
+    selector matching zero tests returns an empty `tests` array rather than the whole inventory),
+    so this asks the identical question the documented command would answer, without running
+    anything a test binary does.
+
+    Raises `RuntimeError` for anything that is not "the selector matched N tests" - a missing
+    `ctest`, a build directory with no test configuration, or output this tool does not
+    understand - so a caller can tell "the selector is stale" apart from "the question could not
+    be asked", which is the distinction issue #304's own acceptance criteria ask for.
+    """
+    try:
+        completed = subprocess.run(
+            [ctest_command, "--test-dir", str(build_dir), "--show-only=json-v1", "-R", selector],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as error:
+        raise RuntimeError(f"'{ctest_command}' could not be run: {error}") from error
+
+    if completed.returncode != 0 or not completed.stdout.strip():
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit status {completed.returncode}"
+        raise RuntimeError(f"'{ctest_command} --test-dir {build_dir} --show-only=json-v1' failed: {detail}")
+
+    try:
+        document = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"'{ctest_command} --show-only=json-v1' did not print JSON: {error}") from error
+
+    tests = document.get("tests")
+    if not isinstance(tests, list):
+        raise RuntimeError("'--show-only=json-v1' output has no 'tests' array - unexpected CTest version or format")
+    return len(tests)
+
+
+def check_repository(root: Path, build_dir: Path, ctest_command: str) -> tuple[list[Finding], int, int]:
+    """Returns (findings, documents checked, citations checked)."""
+    findings: list[Finding] = []
+    citations_checked = 0
+    documents = documents_to_scan(root)
+    for document in documents:
+        for citation in find_citations(document):
+            citations_checked += 1
+            try:
+                count = matching_test_count(ctest_command, build_dir, citation.selector)
+            except RuntimeError as error:
+                findings.append(Finding(citation, str(error)))
+                continue
+            if count == 0:
+                findings.append(
+                    Finding(citation, f"'-R {citation.selector}' matches 0 registered tests in {build_dir}")
+                )
+    return findings, len(documents), citations_checked
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (default: inferred from this script's location)",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        required=True,
+        help="a configured and built CMake binary directory to ask CTest about",
+    )
+    parser.add_argument(
+        "--ctest-command",
+        default="ctest",
+        help="the ctest executable to invoke (default: 'ctest', resolved via PATH)",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.repo_root.resolve()
+    build_dir = args.build_dir.resolve()
+
+    if not (build_dir / "CTestTestfile.cmake").is_file():
+        print(
+            f"mdux-doc-selectors: '{build_dir}' has no CTestTestfile.cmake - configure and build "
+            "first, or pass --build-dir at the tree that was",
+            file=sys.stderr,
+        )
+        return 1
+
+    findings, documents_checked, citations_checked = check_repository(root, build_dir, args.ctest_command)
+
+    if findings:
+        for finding in findings:
+            path = finding.citation.path
+            relative = path.relative_to(root) if path.is_relative_to(root) else path
+            print(f"mdux-doc-selectors: {relative}:{finding.citation.line}: {finding.reason}", file=sys.stderr)
+        print(f"mdux-doc-selectors: {len(findings)} finding(s)", file=sys.stderr)
+        print(
+            "mdux-doc-selectors: update the documented selector to a name or pattern "
+            "'ctest --test-dir <build> -N' actually lists",
+            file=sys.stderr,
+        )
+        return 1
+
+    if documents_checked == 0:
+        # The same vacuous-success guard check_named_mechanisms.py applies: a scan of nothing
+        # printing "OK" is indistinguishable from a scan that found everything correct.
+        print(
+            f"mdux-doc-selectors: no documents found under '{root}' - --repo-root is wrong or the layout moved",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"mdux-doc-selectors: OK ({documents_checked} document(s), {citations_checked} selector(s) checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/docs-lint/test_check_documented_test_selectors.py
+++ b/tools/docs-lint/test_check_documented_test_selectors.py
@@ -133,6 +133,48 @@ class CitationExtractionTests(unittest.TestCase):
             # `ctest` itself appears - not the continuation line the flag happened to land on.
             self.assertEqual(citations[0].line, 2)
 
+    def test_a_long_option_list_before_the_flag_does_not_hide_it(self) -> None:
+        # A regex once bounded the gap between `ctest` and `-R` to 60 characters - shorter than a
+        # realistic option list, so this exact line matched nothing at all and the selector inside
+        # it was never checked.
+        text = (
+            "```bash\n"
+            "ctest --test-dir build --output-on-failure --no-tests=error --parallel 4 -R ObsoleteSuite\n"
+            "```\n"
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            citations = selectors.find_citations(path)
+            self.assertEqual([c.selector for c in citations], ["ObsoleteSuite"])
+
+    def test_an_unquoted_selector_keeps_its_punctuation(self) -> None:
+        # A regex once excluded `,` (and `)`, `]`) from an unquoted selector's characters, so
+        # `^unit_tests::Version,obsolete$` was read as `^unit_tests::Version` - a *different*,
+        # actually-live selector silently substituted for the one the document names, which is
+        # worse than missing it: the check would have reported this citation live.
+        text = "```bash\nctest --test-dir build -R ^unit_tests::Version,obsolete$\n```\n"
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            citations = selectors.find_citations(path)
+            self.assertEqual([c.selector for c in citations], ["^unit_tests::Version,obsolete$"])
+
+    def test_a_trailing_comment_does_not_become_part_of_the_selector(self) -> None:
+        text = "```bash\nctest --test-dir build -R MduXUnitTests --output-on-failure  # one suite\n```\n"
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            citations = selectors.find_citations(path)
+            self.assertEqual([c.selector for c in citations], ["MduXUnitTests"])
+
+    def test_a_line_with_unbalanced_quotes_is_skipped_rather_than_guessed_at(self) -> None:
+        text = "```bash\nctest --test-dir build -R 'unterminated\n```\n"
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            self.assertEqual(selectors.find_citations(path), [])
+
     def test_a_continuation_is_not_read_across_a_fence_boundary(self) -> None:
         # A line ending a fenced block in a trailing backslash - unusual, but not this tool's to
         # assume can't happen - must not absorb the next block's first line as if it were the

--- a/tools/docs-lint/test_check_documented_test_selectors.py
+++ b/tools/docs-lint/test_check_documented_test_selectors.py
@@ -23,13 +23,19 @@ CTEST_AVAILABLE = shutil.which("ctest") is not None
 def write_ctest_testfile(build_dir: Path, test_names: list[str]) -> None:
     """A minimal real CTest configuration: one always-passing test per name given.
 
-    `add_test(<name> "true")` is the old-style positional form `cmake/MduXBake.cmake` and
+    `add_test("<name>" "true")` is the old-style positional form `cmake/MduXBake.cmake` and
     `MduXTestDiscoveryImpl.cmake` both use for the same reason documented there - it is what
     `mdux_discover_tests()` actually writes, so a hand-written fixture here matches production
     shape rather than an idealised one.
+
+    The name is quoted, which is not decoration: every discovered case name contains a space
+    (`"unit_tests::Version Test"`), and CTest reads an *unquoted* `add_test(unit_tests::Version
+    Test "true")` as name `unit_tests::Version`, command `Test`, argument `"true"` - confirmed
+    empirically, and exactly the gap between this fixture and production shape that would have
+    let every test here pass against a name CTest was never asked to register.
     """
     build_dir.mkdir(parents=True, exist_ok=True)
-    lines = [f'add_test({name} "true")\n' for name in test_names]
+    lines = [f'add_test("{name}" "true")\n' for name in test_names]
     (build_dir / "CTestTestfile.cmake").write_text("".join(lines), encoding="utf-8")
 
 
@@ -113,6 +119,31 @@ class CitationExtractionTests(unittest.TestCase):
             citations = selectors.find_citations(path)
             self.assertEqual([c.selector for c in citations], ["Stale"])
 
+    def test_a_selector_on_a_shell_continuation_line_is_still_found(self) -> None:
+        # `ctest` and `-R` on different physical lines used to produce no citation at all - a
+        # command that reads as documented verification and is silently never checked, which is
+        # the exact failure shape this whole tool exists to close.
+        text = "```bash\nctest --test-dir build \\\n    -R MduXUnitTests --output-on-failure\n```\n"
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            citations = selectors.find_citations(path)
+            self.assertEqual([c.selector for c in citations], ["MduXUnitTests"])
+            # The line a reader would look for the command on - the first of the two, where
+            # `ctest` itself appears - not the continuation line the flag happened to land on.
+            self.assertEqual(citations[0].line, 2)
+
+    def test_a_continuation_is_not_read_across_a_fence_boundary(self) -> None:
+        # A line ending a fenced block in a trailing backslash - unusual, but not this tool's to
+        # assume can't happen - must not absorb the next block's first line as if it were the
+        # same command.
+        text = "```bash\necho done \\\n```\n```bash\nctest --test-dir build -R Live\n```\n"
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            citations = selectors.find_citations(path)
+            self.assertEqual([c.selector for c in citations], ["Live"])
+
 
 @unittest.skipUnless(CTEST_AVAILABLE, "ctest is not on PATH in this environment")
 class LiveCTestQueryTests(unittest.TestCase):
@@ -123,6 +154,19 @@ class LiveCTestQueryTests(unittest.TestCase):
             build_dir = Path(raw)
             write_ctest_testfile(build_dir, ["sample::CaseOne", "sample::CaseTwo", "other::CaseOne"])
             self.assertEqual(selectors.matching_test_count("ctest", build_dir, "^sample::"), 2)
+
+    def test_a_name_containing_a_space_is_registered_whole_rather_than_split(self) -> None:
+        # Every discovered case name contains a space (`unit_tests::Version Test`), and an
+        # unquoted `add_test(unit_tests::Version Test "true")` is read by CTest as name
+        # `unit_tests::Version`, command `Test` - a fixture bug that would have let every test
+        # here pass against a name that was never actually registered. Pinned directly, rather
+        # than relying on the other scenarios happening to use a prefix selector that cannot tell
+        # the difference.
+        with tempfile.TemporaryDirectory() as raw:
+            build_dir = Path(raw)
+            write_ctest_testfile(build_dir, ["unit_tests::Version Test"])
+            self.assertEqual(selectors.matching_test_count("ctest", build_dir, "^unit_tests::Version$"), 0)
+            self.assertEqual(selectors.matching_test_count("ctest", build_dir, "^unit_tests::Version Test$"), 1)
 
     def test_a_selector_matching_nothing_returns_zero_rather_than_raising(self) -> None:
         with tempfile.TemporaryDirectory() as raw:

--- a/tools/docs-lint/test_check_documented_test_selectors.py
+++ b/tools/docs-lint/test_check_documented_test_selectors.py
@@ -1,0 +1,240 @@
+"""Tests for check_documented_test_selectors.
+
+The property under test is issue #304's own acceptance criterion, stated directly: an obsolete
+`-R` selector must fail and a valid one must pass, against a *real* CTest inventory rather than a
+second list of names this suite would have to keep in step with the checker. Every test that
+asks "does this selector match" builds a hand-written `CTestTestfile.cmake` and asks the real
+`ctest` binary about it - `CTestTestfile.cmake` is a plain script `ctest` reads directly, so this
+needs no CMake configure, only the same tool the checker itself shells out to.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_documented_test_selectors as selectors
+
+CTEST_AVAILABLE = shutil.which("ctest") is not None
+
+
+def write_ctest_testfile(build_dir: Path, test_names: list[str]) -> None:
+    """A minimal real CTest configuration: one always-passing test per name given.
+
+    `add_test(<name> "true")` is the old-style positional form `cmake/MduXBake.cmake` and
+    `MduXTestDiscoveryImpl.cmake` both use for the same reason documented there - it is what
+    `mdux_discover_tests()` actually writes, so a hand-written fixture here matches production
+    shape rather than an idealised one.
+    """
+    build_dir.mkdir(parents=True, exist_ok=True)
+    lines = [f'add_test({name} "true")\n' for name in test_names]
+    (build_dir / "CTestTestfile.cmake").write_text("".join(lines), encoding="utf-8")
+
+
+class DocumentDiscoveryTests(unittest.TestCase):
+    def test_finds_agents_md_getting_started_and_every_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "AGENTS.md").write_text("", encoding="utf-8")
+            (root / "docs").mkdir()
+            (root / "docs" / "getting-started.md").write_text("", encoding="utf-8")
+            (root / ".agents" / "skills" / "zeta-skill").mkdir(parents=True)
+            (root / ".agents" / "skills" / "zeta-skill" / "SKILL.md").write_text("", encoding="utf-8")
+            (root / ".agents" / "skills" / "alpha-skill").mkdir(parents=True)
+            (root / ".agents" / "skills" / "alpha-skill" / "SKILL.md").write_text("", encoding="utf-8")
+            # A skill directory with no SKILL.md is not a document to scan - the glob is on the
+            # filename, not the directory, so this cannot silently start reading the wrong file.
+            (root / ".agents" / "skills" / "no-skill-file").mkdir(parents=True)
+
+            found = selectors.documents_to_scan(root)
+
+            self.assertEqual(
+                found,
+                [
+                    root / "AGENTS.md",
+                    root / "docs" / "getting-started.md",
+                    root / ".agents" / "skills" / "alpha-skill" / "SKILL.md",
+                    root / ".agents" / "skills" / "zeta-skill" / "SKILL.md",
+                ],
+            )
+
+    def test_a_repository_missing_every_document_scans_nothing_rather_than_failing(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            self.assertEqual(selectors.documents_to_scan(Path(raw)), [])
+
+
+class CitationExtractionTests(unittest.TestCase):
+    def test_extracts_a_bare_selector_only_inside_a_fence(self) -> None:
+        text = (
+            "Mention `-R MduXUnitTests` in prose names nothing to check.\n"
+            "```bash\n"
+            "ctest --test-dir build -R MduXUnitTests --output-on-failure\n"
+            "```\n"
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            citations = selectors.find_citations(path)
+            self.assertEqual(len(citations), 1)
+            self.assertEqual(citations[0].selector, "MduXUnitTests")
+            self.assertEqual(citations[0].line, 3)
+
+    def test_extracts_a_quoted_selector_and_the_long_flag_spelling(self) -> None:
+        text = (
+            "```console\n"
+            "ctest --test-dir build -R '^unit_tests::' --output-on-failure\n"
+            "ctest --test-dir build --tests-regex \"^medui_tools_spec::\"\n"
+            "```\n"
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            citations = selectors.find_citations(path)
+            self.assertEqual([c.selector for c in citations], ["^unit_tests::", "^medui_tools_spec::"])
+
+    def test_a_label_selector_is_not_mistaken_for_a_name_selector(self) -> None:
+        # `-L`/`--label-regex` is a different, already-checked mechanism
+        # (check_named_mechanisms.py, against the static CMake/TEST_CASE index rather than a
+        # built tree) - this checker's whole reason to exist is that a `-R` name cannot be
+        # validated that way, so it must not silently absorb `-L` citations too.
+        text = "```bash\nctest --test-dir build -L evidence --output-on-failure\n```\n"
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            self.assertEqual(selectors.find_citations(path), [])
+
+    def test_an_unterminated_fence_still_has_its_content_checked(self) -> None:
+        text = "```bash\nctest --test-dir build -R Stale\n"
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "doc.md"
+            path.write_text(text, encoding="utf-8")
+            citations = selectors.find_citations(path)
+            self.assertEqual([c.selector for c in citations], ["Stale"])
+
+
+@unittest.skipUnless(CTEST_AVAILABLE, "ctest is not on PATH in this environment")
+class LiveCTestQueryTests(unittest.TestCase):
+    """`matching_test_count()` against a real, hand-written CTest configuration."""
+
+    def test_a_selector_matching_registered_tests_returns_their_count(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            build_dir = Path(raw)
+            write_ctest_testfile(build_dir, ["sample::CaseOne", "sample::CaseTwo", "other::CaseOne"])
+            self.assertEqual(selectors.matching_test_count("ctest", build_dir, "^sample::"), 2)
+
+    def test_a_selector_matching_nothing_returns_zero_rather_than_raising(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            build_dir = Path(raw)
+            write_ctest_testfile(build_dir, ["sample::CaseOne"])
+            self.assertEqual(selectors.matching_test_count("ctest", build_dir, "DoesNotExist"), 0)
+
+    def test_an_unresolvable_ctest_command_raises_rather_than_reporting_zero(self) -> None:
+        # Distinct from "matched zero tests": "could not be asked" is a different fact, and
+        # collapsing the two would report an infrastructure problem as a documentation defect.
+        with tempfile.TemporaryDirectory() as raw:
+            build_dir = Path(raw)
+            write_ctest_testfile(build_dir, ["sample::CaseOne"])
+            with self.assertRaises(RuntimeError):
+                selectors.matching_test_count("mdux-ctest-does-not-exist", build_dir, "sample")
+
+
+@unittest.skipUnless(CTEST_AVAILABLE, "ctest is not on PATH in this environment")
+class CheckRepositoryTests(unittest.TestCase):
+    """The end-to-end property: an obsolete selector fails, a valid one passes."""
+
+    def make_repository(self, root: Path, skill_text: str) -> Path:
+        skill_dir = root / ".agents" / "skills" / "sample-skill"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text(skill_text, encoding="utf-8")
+        return skill_path
+
+    def test_an_obsolete_selector_is_a_finding_and_a_live_one_is_not(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            build_dir = root / "build"
+            write_ctest_testfile(build_dir, ["unit_tests::Version Test"])
+
+            self.make_repository(
+                root,
+                "```bash\n"
+                "ctest --test-dir build -R MduXUnitTests --output-on-failure\n"
+                "```\n",
+            )
+            findings, documents, citations = selectors.check_repository(root, build_dir, "ctest")
+            self.assertEqual(documents, 1)
+            self.assertEqual(citations, 1)
+            self.assertEqual(len(findings), 1)
+            self.assertIn("MduXUnitTests", findings[0].reason)
+            self.assertIn("0 registered tests", findings[0].reason)
+
+    def test_a_selector_that_matches_is_not_a_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            build_dir = root / "build"
+            write_ctest_testfile(build_dir, ["unit_tests::Version Test"])
+
+            self.make_repository(
+                root,
+                "```bash\n"
+                "ctest --test-dir build -R '^unit_tests::' --output-on-failure\n"
+                "```\n",
+            )
+            findings, documents, citations = selectors.check_repository(root, build_dir, "ctest")
+            self.assertEqual(citations, 1)
+            self.assertEqual(findings, [])
+
+
+@unittest.skipUnless(CTEST_AVAILABLE, "ctest is not on PATH in this environment")
+class MainEntryPointTests(unittest.TestCase):
+    """Literal exit-status proof of #304's acceptance criterion, via the script as a subprocess -
+    the same way CI invokes it."""
+
+    SCRIPT = Path(__file__).resolve().with_name("check_documented_test_selectors.py")
+
+    def run_script(self, root: Path, build_dir: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(self.SCRIPT), "--repo-root", str(root), "--build-dir", str(build_dir)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_exits_nonzero_for_an_obsolete_selector(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            build_dir = root / "build"
+            write_ctest_testfile(build_dir, ["unit_tests::Version Test"])
+            (root / ".agents" / "skills" / "s").mkdir(parents=True)
+            (root / ".agents" / "skills" / "s" / "SKILL.md").write_text(
+                "```bash\nctest -R MduXUnitTests\n```\n", encoding="utf-8"
+            )
+            result = self.run_script(root, build_dir)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("MduXUnitTests", result.stderr)
+
+    def test_exits_zero_for_a_live_selector(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            build_dir = root / "build"
+            write_ctest_testfile(build_dir, ["unit_tests::Version Test"])
+            (root / ".agents" / "skills" / "s").mkdir(parents=True)
+            (root / ".agents" / "skills" / "s" / "SKILL.md").write_text(
+                "```bash\nctest -R '^unit_tests::'\n```\n", encoding="utf-8"
+            )
+            result = self.run_script(root, build_dir)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+    def test_a_build_directory_with_no_ctest_configuration_is_reported_distinctly(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            result = self.run_script(root, root / "not-a-build-dir")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("CTestTestfile.cmake", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Issue #304's own assessment, reproduced rather than taken on trust, then fixed at each citation:

- `.agents/skills/mdux-build-and-test/SKILL.md` recommended `ctest --test-dir build -R MduXUnitTests`, a name from before `mdux_discover_tests()` replaced hand-written suite registrations with one CTest entry per `TEST_CASE`, named `<target>::<case>`. Running it against the current build: `Total Tests: 0`. `-R '^unit_tests::'` runs 3.
- `AGENTS.md` said five artifacts live under `generated/`; eight do, and the `evidence-pipeline` skill's own status line already says which — pointed there instead of a second count.
- `AGENTS.md`'s `medui-authoring` row said a compiled screen "cannot yet carry text" and cited #235 (closed). #17, which closed since this session started, means every component in the dictionary draws.
- `mdux-regulated-change/SKILL.md`'s evidence-vs-intent-vs-certification example cited `README.md`'s ISO 14971/13485 "Completed" status; #111 removed the claim it referred to, and `README.md` carries no such status at all today.

Each fix replaces the citation with something current rather than deleting the point it was illustrating. The build-and-test fix also removes the "Registered CTest names" inventory itself, per the issue's own instruction not to trade one stale list for another — it now points to `ctest -N` for the live names and `docs/getting-started.md` for the wired-up labels. The regulated-change fix keeps the same "evidence is not a certification claim" lesson, re-grounded in ADR-014's rendered-truth verification and the CHANGELOG's own "no IEC 62304 §5.7 system claim" language, which still exists to check the claim against.

**The mechanical regression check.** `tools/docs-lint/check_documented_test_selectors.py` asks a real, built CTest configuration (`ctest --show-only=json-v1 -R <selector>`) whether every documented `-R`/`--tests-regex` example still matches something — no second list of expected names in the checker for the documentation to drift away from, which is exactly what the issue asks not to be built. It scans `AGENTS.md`, every `.agents/skills/*/SKILL.md` and `docs/getting-started.md` — the "how to run tests" surface an agent actually reads — for a selector inside a fenced code block. That is the opposite convention from `check_named_mechanisms.py`, deliberately: that checker treats a fence as an illustrative example exempt from checking, while a `ctest` invocation in one of these documents *is* the claim being made.

Wired into the GCC 16 build leg (`.github/workflows/linux-gcc16-build.yml`) rather than Documentation Lint: that workflow runs on `ubuntu-latest` with no C++ toolchain by design, so a docs-only PR keeps its fast feedback, and this check genuinely needs a built, discovered test tree to ask. One leg is proportionate — the documented names do not vary by toolchain, and GCC 16 is the leg issue #304 itself found the defect on.

`docs/roadmap.md` updated per the issue's own acceptance item: #304 added under #19 as S7, distinguished from the S1–S6 grammar/schema/IR work as a guidance correction rather than a new feature.

Closes #304

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change.
- [x] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.

Invitation / CLA issue: #304

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now

## Shared registries touched

- [ ] `CMakeLists.txt` (root) — targets, trust-zone declarations, install/export set
- [ ] `FILE_SET CXX_MODULES` lists — a module interface added, removed or moved
- [ ] `tools/CMakeLists.txt` — host-tool targets and their sources
- [ ] `tests/CMakeLists.txt` — test source lists and suite membership
- [ ] Schemas under `docs/*/schemas/` or `docs/governance/schemas/`
- [ ] Generated indexes (`AI-Reference.{md,json}`, per-clause indexes)
- [ ] Committed artifacts under `generated/`
- [x] None of the above — a new host-only docs-lint script (`tools/docs-lint/`) and one new CI step, neither of which is a registry the checklist above tracks

## Rebase state

- **Rebased onto:** `1beac12` (`origin/develop`)
- **Conflicts resolved as a union:** no conflicts

## Verification

- [x] `cmake --preset ninja-gcc && cmake --build build-gcc`
- [x] `ctest --test-dir build-gcc` — 800/800 passed, unaffected by this branch (no C++ changed)
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — 83 files, 0 findings
- [x] Other:
  - `python3 -m unittest discover -s tools/docs-lint -p 'test_*.py'` — 200/200 (186 existing + 14 new for the checker), the one pre-existing failure being the unrelated `examples/build/` ignored-directory issue in `test_check_file_headers.py`
  - `check_documented_test_selectors.py --build-dir build-gcc` — reproduces the defect before the SKILL.md fix (`0 registered tests` for `MduXUnitTests`) and passes after
  - `check_named_mechanisms.py` — 79 documents/workflows, unaffected
  - New checker's 14 tests all run against a real hand-written `CTestTestfile.cmake` and the real `ctest` binary rather than mocked subprocess output — the literal proof of the issue's acceptance criterion: an obsolete selector fails, a valid one passes

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** pending merge
- [ ] That run is green.

## Regulatory impact

**Potentially safety-relevant, matching the issue's own classification: incorrect verification instructions can cause evidence to be silently omitted, even though nothing here touches device behavior, an artifact format, or a safety control.**

The concrete risk closed: a selector that matches nothing exits 0 and reports "0 tests failed out of 0" unless `--no-tests=error` is given — a command that reads as a passing check and asserts nothing. An agent or reviewer following the old `SKILL.md` example would have believed a suite ran when it did not. The fix is documentation plus a CI-mechanical check that this exact defect class cannot recur silently; it does not change what any test verifies, only whether the instructions for invoking verification are followed correctly.

Artifacts updated: `AGENTS.md`, `.agents/skills/mdux-build-and-test/SKILL.md`, `.agents/skills/mdux-regulated-change/SKILL.md`, `docs/roadmap.md`, `.github/workflows/linux-gcc16-build.yml`. No ADR, schema, or committed artifact changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Added support for running tests by discovered test names, regular expressions, and labels.
  * Added validation to ensure documented test selectors continue matching available tests.
  * Added automated coverage for selector scanning, matching, error handling, and missing build configurations.

* **Documentation**
  * Updated testing guidance, evidence documentation, roadmap status, and compliance examples.
  * Clarified current evidence and IEC 62304 scope statements.

* **CI**
  * Added selector validation to the GCC 16 build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->