### PR TITLE
C2 — Locally versioned observation profiles for rendered checks [#313]

### DIFF
--- a/docs/adr/ADR-014-rendered-truth-verification.md
+++ b/docs/adr/ADR-014-rendered-truth-verification.md
@@ -3,6 +3,18 @@
 ## Status
 Accepted (2026-08-31)
 
+> **Amendment — 2026-09-07, [#313](https://github.com/ambroise-leclerc/MduX/issues/313),
+> [ADR-016](ADR-016-locally-versioned-observation-profiles.md).**
+> [ADR-015](ADR-015-versioned-sibling-observations.md) decision 2 introduces separately versioned
+> observation profiles. ADR-016 gives each of the four checks below an implementation-local
+> `ObservationProfile` (id and version), recorded per outcome in `verification.json`, and implements
+> the RGBA8 SHA-256 raw-image-digest predicate ADR-015 decision 2 names — the observation TrustSC's
+> `ColorHash` actually performs. **Decision 4 is unchanged, and is the reason that predicate is
+> *not* wired as a committed check on any screen**: a committed RGBA8 baseline is exactly the
+> driver-tuple-dependent measured value decision 4 and alternative 6 reject. A profile *identity* is
+> the name of an observation, not a measured value, so recording it per outcome is consistent with
+> decision 4. `schemaVersion` stays `1`.
+
 ## Shared contract
 
 No MedUI shared decision covers verification, so MduX decides it locally and this ADR carries no
@@ -491,6 +503,10 @@ the frame.
 - ADR-011: The deterministic `.medui` compile boundary — the golden predicate and its inputs
 - ADR-012: What a compiled screen emits — decision 4, the sidecar and the single-implementation rule
 - ADR-013: Verified Apple Silicon macOS toolchain — why the pixel-labelled suite may not be skipped
+- ADR-015: Versioned sibling observations — decision 2, why a shared check name is not a shared
+  observation
+- ADR-016: Locally versioned observation profiles — the profile identities added to these checks,
+  the RGBA8 SHA-256 predicate, and why it has no committed baseline (see the amendment above)
 - `tools/medui/Goldens.cppm` — `collectGoldens()` and the closed `CvCheck` set
 - `tests/render/PixelTests.cpp` and `tests/render/ScreenPixelTests.cpp` — the exact comparator, and
   the rendered golden consumer that replaced the tripwire when decision 5 landed
@@ -511,5 +527,8 @@ the frame.
   current screen; and again when #255 added decisions 5 and 6, which turned those three findings into
   `Held` and put the gate on three CI legs; and again when #282 made that four by asserting the gate
   on Windows/MSVC as a named step, which ADR-007 decision 6 records as a gain in diagnosis rather
-  than in coverage — the check already ran there inside the full suite. Review again when #257 and #258 draw a reading inside a field, since
+  than in coverage — the check already ran there inside the full suite. Reviewed again on 2026-09-07
+  for #313: ADR-016 adds a per-outcome observation-profile identity and the RGBA8 SHA-256 predicate
+  without changing any check's semantics, and the amendment at the top of this record confirms
+  decision 4 is unchanged. Review again when #257 and #258 draw a reading inside a field, since
   decision 5's `ColorHash` consequence constrains how they may.

--- a/docs/adr/ADR-015-versioned-sibling-observations.md
+++ b/docs/adr/ADR-015-versioned-sibling-observations.md
@@ -134,6 +134,9 @@ Existing ADR-010/011/012/014 and runtime checks remain authoritative until an ac
 ## References
 
 - [Phase 2 roadmap](../roadmap.md)
+- [ADR-016](ADR-016-locally-versioned-observation-profiles.md) — the local delivery of decision D2:
+  implementation-local observation-profile identities for the four rendered checks and the RGBA8
+  SHA-256 predicate (#313). The shared schema/corpus half remains #314.
 - [Compatibility matrix and evidence](../parity/behavior-matrix.md)
 - [Requirements, review disposition and downstream mapping](../parity/requirements.md)
 - [Pinned MedUI decisions](https://github.com/Compliatory/MedUI/tree/265df1925a672bd556f69123e287215b45cfd210/decisions)

--- a/docs/adr/ADR-016-locally-versioned-observation-profiles.md
+++ b/docs/adr/ADR-016-locally-versioned-observation-profiles.md
@@ -1,0 +1,226 @@
+# ADR-016: Locally versioned observation profiles for rendered checks
+
+## Status
+Proposed (2026-09-07)
+
+## Shared contract
+
+No MedUI shared decision covers verification — [ADR-014](ADR-014-rendered-truth-verification.md)
+says so, and this record inherits that. One thing here is *directional* upstream and delivered
+locally: [MEDUI-DEC-007](https://github.com/Compliatory/MedUI/blob/80961fd7274992d75c8f86016be04b177c581857/decisions/MEDUI-DEC-007-rendered-check-profiles.md)
+accepts that rendered-check observations should be separately named and versioned, but delivers no
+canonical identifiers, no schema and no conformance corpus — its own text says "profile identifiers,
+schemas and the candidate conformance corpus remain delivery work; no consumer support is asserted".
+So every profile id introduced here begins with `mdux.local/`, no `medui-conformance.toml` key or
+pin claims a shared profile, and a later reviewed migration maps these onto the canonical set when
+one exists. The cross-implementation gate is [#314](https://github.com/ambroise-leclerc/MduX/issues/314),
+not this record.
+
+## Context
+
+The [pinned behavior matrix](../parity/behavior-matrix.md) found that `ColorHash` names two
+different observations: in MduX it is a **tint-composition** predicate — every painted pixel is an
+alpha blend of the node's ground and its resolved tint at one coverage, and at least one pixel is
+exactly the tint — while in the Rust sibling TrustSC it is a **SHA-256 over the golden rectangle's
+tightly packed RGBA8**, compared to a committed baseline. A shared spelling is not evidence of a
+shared measurement.
+
+[ADR-015](ADR-015-versioned-sibling-observations.md) decision 2 (Accepted 2026-09-07) requires MduX
+to give each rendered-check predicate a **separately versioned observation-profile identity**, and
+to introduce the RGBA8 SHA-256 predicate as its own profile, so the two implementations can be
+compared honestly in #314 without silently reinterpreting existing MduX evidence. It also requires
+that "adding a common profile must preserve existing required checks unless a reviewed migration
+explicitly replaces them", and states that "ADR-014 is not superseded by this decision".
+
+Three constraints shape the answer:
+
+- **`CvCheck` is a closed, contract-owned set.** `Bounds` and `ColorHash` are the shared language's
+  `safety` capability, pinned in `medui-conformance.toml`, and `MEDUI-E071` rejects a name outside
+  it. Widening it is an upstream change and a re-pin — never an edit to the verifier.
+- **ADR-014 decision 4 keeps measured pixel values out of the committed bundle.** Its alternative 6
+  rejects recording measured samples in `verification.json`, "because it makes a byte-compared file
+  depend on the driver that produced the frame". A committed RGBA8-SHA-256 *baseline* is exactly
+  such a value.
+- **TrustSC commits no hash baselines either.** Its verification guide records the absent committed
+  hash baselines explicitly; the ability to compute a hash is not a committed image-regression gate.
+
+## Medical Device Considerations
+
+Impact: **potentially safety-relevant**. The change touches the governed `mdux.verify` zone and a
+committed evidence artifact. It changes **no check's semantics and no runtime behaviour** — the four
+existing predicates compute exactly what they computed before; only an identity field is added to
+each outcome, and a fifth predicate is added with no production caller.
+
+No hazard, risk control or software safety class in this repository names the failure mode a
+weaker or misidentified verification check would introduce, and this ADR does not invent one. The
+change is flagged for maintainer/domain review per the `mdux-regulated-change` skill. The
+IEC 62304:2006 §5.7 scope limit recorded in `docs/iec62304/03-development-process.md` is unchanged:
+MduX has no assembled software system, and none of this is a certification, validation or
+production-readiness claim. No cross-implementation parity is claimed — #314 owns that, and it
+cannot be discharged from MduX results alone.
+
+## Decision
+
+### 1. Each rendered-check predicate carries an implementation-local observation profile
+
+`mdux.verify` gains an immutable `ObservationProfile` value type — an `id` naming what is observed
+and a `version` that moves only on a reviewed change — and one `inline constexpr` constant per
+predicate:
+
+| Predicate | Profile id | Version | What it observes |
+|---|---|---|---|
+| `goldenBounds()` | `mdux.local/extent-equality` | 1 | the golden node's content occupies exactly its declared rectangle |
+| `colorHash()` | `mdux.local/tint-composition` | 1 | painted pixels are a blend of ground and tint at one coverage, and one is the tint |
+| `inkContainment()` | `mdux.local/ink-containment` | 1 | a text run's placed ink stays inside its node |
+| `localizedTextPresence()` | `mdux.local/ink-coverage` | 1 | the approved locale's run is the shape on screen, per baked coverage |
+| `rawImageDigest()` | `mdux.local/raw-image-digest` | 1 | SHA-256 over a rectangle's tightly packed row-major RGBA8 |
+
+`profileOf(CvCheck)` and `profileOf(TextCheck)` are the mapping; every `CheckOutcome` carries its
+profile, set in the one `opened()` helper so no check can report an outcome without one. This is a
+pure **identity/reporting layer**: the four existing predicates are byte-for-byte the same
+computation, ADR-015 decision 2's "preserve existing required checks" is satisfied by construction,
+and version `1` is the current (`db198c6`-era) arithmetic of each check, including #261's
+two-composite allowance for `colorHash()` and the ground-composite band for the text checks. Earlier
+revisions of these checks are not retro-versioned.
+
+### 2. The RGBA8 SHA-256 predicate is implemented and versioned, but is not a committed check
+
+`mdux.verify::rawImageDigest()` performs TrustSC's `ColorHash` observation — SHA-256 over a region
+of interest's pixels, row by row, four bytes per pixel, no stride padding. It is **not** a `CvCheck`,
+**not** a `.medui` trigger, and **not** wired into the driver's obligation enumeration or the
+committed `verification.json`. That is deliberate, and each half of the reason is load-bearing:
+
+- **It cannot be a `CvCheck`.** That set is closed and contract-owned; a new enumerator is an
+  upstream change and a re-pin, and ADR-014 decision 3 depends on the set being exactly `Bounds`
+  and `ColorHash`.
+- **It must not have a committed baseline.** A committed RGBA8-SHA-256 is a property of the driver
+  tuple that produced the frame — lavapipe on Linux, MoltenVK on macOS, Mesa's lavapipe on Windows
+  — not of the screen's declared inputs. ADR-014 decision 4 and its alternative 6 reject exactly
+  this: it would fail an evidence leg on any rendering change while every check still held, and
+  ADR-007 decision 5 makes the same structural argument about commit SHAs. TrustSC commits none
+  either, so there is no sibling baseline to be compatible with.
+
+So the predicate is **delivered** — implemented, versioned, and exercised by an adversarial fixture
+set (`tests/verify/RawImageDigestTests.cpp`: match, single-channel mismatch, absent baseline,
+region-outside-frame, stride independence, ROI scoping, profile identity, degenerate ROI) — while
+all four required checks are **preserved** unchanged. That is what ADR-015 decision 2 asks for. A
+future consumer that has declared a presentation/backend profile (PAR-REQ-009) can supply a baseline
+through `RawImageExpectation::createWithBaseline()`; there is no such consumer today.
+
+### 3. `NoBaseline` is distinct from a pass
+
+`rawImageDigest()` reports `Finding::NoBaseline` for every call with no baseline. `held()` is false
+for it, so it discharges nothing — the same behaviour as TrustSC's own `NoBaseline`, and consistent
+with ADR-015 decision 3's "only pass discharges a required obligation". `DigestMismatch` is the
+finding for a supplied baseline that does not match; `RegionOutsideFrame` for a region the frame
+does not contain — a failure, not a skip.
+
+### 4. Profile ids and versions are implementation-local and immutable
+
+The `mdux.local/` prefix is the marker: a reader seeing it knows the id is MduX's own, not a
+shared-contract identifier. A profile's `(id, version)` pair never changes meaning — an
+outcome-changing revision takes a new version number, per ADR-015 decision 4's "outcome-changing
+changes require a minor revision". When MEDUI-DEC-007 delivers canonical ids and a schema, a
+reviewed migration maps `mdux.local/*` onto them, keeping the old and candidate identities during
+the transition and preserving existing evidence.
+
+### 5. `verification.json` records the profile per outcome; nothing else changes
+
+Each outcome object gains one nested member:
+
+```json
+{
+  "check": "Bounds",
+  "finding": "Held",
+  "nodeId": "emergency-halt",
+  "observationProfile": { "id": "mdux.local/extent-equality", "version": 1 },
+  "scope": "en-US"
+}
+```
+
+`schemaVersion` stays `1`: `evidence::kSchemaVersion` is shared across every evidence artifact
+(font, text, shader, image, ML, report), and an additive, outcome-preserving field in one artifact
+is not a reason to move it. The file is byte-compared by `evidence.screen.<id>` on four toolchain
+legs, not JSON-schema-validated, and `docs/recipes/screen.schema.json` describes `report.json`'s
+resolved `options`, not `verification.json` — it is unaffected. The regenerated bundle is committed
+through `mdux-bake-update` like any other artifact change.
+
+## Alternatives Considered
+
+- **Add `CvCheck::RawImageDigest`.** Rejected: the set is closed and contract-owned, and ADR-014
+  decision 3 requires it to be exactly `Bounds` and `ColorHash`. A new member is an upstream change.
+- **Commit an RGBA8 baseline for `endoscope-monitor`.** Rejected: ADR-014 decision 4 and
+  alternative 6, and ADR-007 decision 5 — a measured, driver-tuple-dependent value in a
+  byte-compared artifact fails an evidence leg on any rendering change while every check still
+  holds. TrustSC commits none either.
+- **One envelope-level profile id for the whole run.** Rejected: `Bounds` and `ColorHash` are
+  different observations, and a text presence check is a third; a single id would say less than the
+  per-outcome one and could not distinguish them.
+- **Wait for MEDUI-DEC-007's canonical ids before doing anything.** Rejected: ADR-015 permits a
+  labelled implementation-local extension while the upstream discussion is open, and #313's own
+  decision gate (D2/D3/D4, accepted) is met. The migration to canonical ids is mechanical.
+- **A `.medui` trigger for the digest.** Rejected: it is not an authoring concern, and it would
+  widen the grammar to express a check with no committed consumer.
+
+## Consequences
+
+### Positive
+
+- `ColorHash`'s divergence from TrustSC is named and versioned, so #314 compares like with like
+  rather than conflating a tint predicate with a pixel hash.
+- Existing evidence is preserved exactly — no check semantics change, and the regenerated
+  `verification.json` differs only by the additive `observationProfile` member.
+- The RGBA8-digest observation exists for a future declared-profile consumer (PAR-REQ-009) and for
+  #321's dynamic evidence work, without becoming a gate.
+
+### Negative
+
+- `verification.json` grows by one nested object per outcome.
+- A fifth predicate with no committed consumer is carried in the governed module.
+- `mdux.local/*` ids need a future reviewed migration when canonical ids arrive.
+
+### Risks
+
+- **`mdux.local/*` mistaken for a shared-contract identifier.** Mitigation: the prefix, this ADR,
+  the behavior-matrix note, and the PR gate note that no manifest or pin claims a shared profile.
+- **The digest predicate's existence read as a committed image-regression gate.** Mitigation:
+  decision 2, and `rawImageDigest()`'s own documentation — `NoBaseline` for every production call,
+  and no committed baseline by design.
+
+## Implementation Notes
+
+- `mdux.verify` gains `import mdux.evidence.digest;` — both already in `MduXCore`, so no CMake
+  change. `Sha256` is `noexcept`, fixed-buffer and allocation-free; `mdux-governed-lint` and
+  `governed.noThrow.symbolScan` cover the new code with no second registration.
+- New appended `Finding` enumerators `NoBaseline`, `DigestMismatch` and `VerifyError`
+  `DigestRoiDegenerate`; `spell(Finding)` gets two cases (the committed serialisation), `describe()`
+  is free to reword.
+- `tools/verify/Driver.cppm`'s `Outcome` and `Artifact.cpp`'s `outcomeToJson()` carry the profile
+  through; the obligation loop and `writeVerification()`'s pairing invariant are unchanged because
+  `rawImageDigest()` is not an obligation.
+- PAR-REQ-002/003/009 dispositions remain pending; this record delivers the local half of
+  PAR-REQ-002 (four named profiles + the digest predicate + adversarial fixtures) and does not
+  discharge the shared-schema/corpus half.
+
+## References
+
+- [ADR-014](ADR-014-rendered-truth-verification.md) — decision 4 (no measured pixel in the
+  artifact), decision 3 (the closed `CvCheck` set), alternative 6
+- [ADR-015](ADR-015-versioned-sibling-observations.md) — decisions D2, D3, D4
+- [ADR-007](ADR-007-evidence-pipeline-doctrine.md) — decision 5, why environment-dependent data
+  cannot live in a byte-compared artifact
+- [Pinned behavior matrix](../parity/behavior-matrix.md) — the `ColorHash` divergence
+- [Prospective requirements](../parity/requirements.md) — PAR-REQ-002/003/009
+- [MEDUI-DEC-007](https://github.com/Compliatory/MedUI/blob/80961fd7274992d75c8f86016be04b177c581857/decisions/MEDUI-DEC-007-rendered-check-profiles.md)
+- Issues [#313](https://github.com/ambroise-leclerc/MduX/issues/313),
+  [#314](https://github.com/ambroise-leclerc/MduX/issues/314)
+- `include/mdux/verify/Verify.cppm`, `src/verify/Verify.cpp`, `tests/verify/RawImageDigestTests.cpp`
+
+## Approval
+
+- **Proposal date:** 2026-09-07
+- **Decision date:** pending
+- **Approved by:** pending — maintainer/domain review requested (safety-relevant verifier area)
+- **Scope:** the observation-profile identity layer, the `rawImageDigest()` predicate and its
+  uncommitted status, and the `verification.json` per-outcome field. Individual PAR-REQ-002/003/009
+  dispositions and the #314 shared gate are separate.

--- a/docs/adr/ADR-016-locally-versioned-observation-profiles.md
+++ b/docs/adr/ADR-016-locally-versioned-observation-profiles.md
@@ -145,6 +145,15 @@ legs, not JSON-schema-validated, and `docs/recipes/screen.schema.json` describes
 resolved `options`, not `verification.json` — it is unaffected. The regenerated bundle is committed
 through `mdux-bake-update` like any other artifact change.
 
+`writeVerification()` validates the profile before it serialises one, the same way it already checks
+that each outcome pairs with its obligation: an outcome whose profile is missing
+(`{"", 0}`) or is not the one its check reports under is refused with
+`ArtifactError::ObservationProfileInvalid`, not written. `mdux::verify::profileForCheckName()` is the
+single resolver both the driver and the writer use, so the check cannot drift from the value the
+driver set. This is ADR-014 decision 2's "derive, don't trust" applied to the identity: the writer
+is the boundary that turns a `RunResult` into committed evidence, and an unidentified or
+misidentified observation must not cross it.
+
 ## Alternatives Considered
 
 - **Add `CvCheck::RawImageDigest`.** Rejected: the set is closed and contract-owned, and ADR-014
@@ -196,8 +205,11 @@ through `mdux-bake-update` like any other artifact change.
   `DigestRoiDegenerate`; `spell(Finding)` gets two cases (the committed serialisation), `describe()`
   is free to reword.
 - `tools/verify/Driver.cppm`'s `Outcome` and `Artifact.cpp`'s `outcomeToJson()` carry the profile
-  through; the obligation loop and `writeVerification()`'s pairing invariant are unchanged because
-  `rawImageDigest()` is not an obligation.
+  through; the obligation loop is unchanged because `rawImageDigest()` is not an obligation.
+  `writeVerification()` gains one check beside its existing pairing check —
+  `ArtifactError::ObservationProfileInvalid` for a missing or mismatched profile — and
+  `mdux.verify` gains `parseTextCheck()` and `profileForCheckName()` so the writer resolves a
+  check's expected profile through the same code the driver used to set it.
 - PAR-REQ-002/003/009 dispositions remain pending; this record delivers the local half of
   PAR-REQ-002 (four named profiles + the digest predicate + adversarial fixtures) and does not
   discharge the shared-schema/corpus half.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,8 +22,9 @@ in the index below, numbers contiguous from ADR-001.
 | [ADR-013](ADR-013-verified-apple-silicon-macos-toolchain.md) | Verified Apple Silicon macOS toolchain | Accepted | 2026-08-23 |
 | [ADR-014](ADR-014-rendered-truth-verification.md) | What rendered-truth verification checks, and what it cannot | Accepted | 2026-08-31 |
 | [ADR-015](ADR-015-versioned-sibling-observations.md) | Versioned sibling observations | Accepted | 2026-09-07 |
+| [ADR-016](ADR-016-locally-versioned-observation-profiles.md) | Locally versioned observation profiles for rendered checks | Proposed | 2026-09-07 |
 
-Every number from 001 to 015 appears exactly once. A superseded decision keeps its number and its
+Every number from 001 to 016 appears exactly once. A superseded decision keeps its number and its
 file — the trail is only useful if the abandoned turns are still visible.
 
 ## What is not here
@@ -57,7 +58,7 @@ decision record that lists only benefits documents an advertisement rather than 
 ## Writing a new ADR
 
 1. Copy [`template.md`](template.md).
-2. Take the next free number from the index above — currently **ADR-016**.
+2. Take the next free number from the index above — currently **ADR-017**.
 3. Name the file `ADR-NNN-short-description.md`, lowercase and hyphenated.
 4. Add a row to the index in this file. An ADR that is not indexed does not exist.
 5. If it supersedes an earlier decision, set that ADR's status to `Superseded by ADR-NNN`, link

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -403,6 +403,15 @@ consistency rather than truth: the expectation and the frame come from one sourc
 `NothingPainted` findings between #254 and #255, because an artifact that hid them would have been
 worse than none; #255 resolved them by drawing the fields rather than by removing the obligations.
 
+Since #313 each outcome also names an `observationProfile` — an id and version identifying *which*
+observation the check performs (`mdux.local/extent-equality`, `tint-composition`, `ink-containment`,
+`ink-coverage`), so a reader never mistakes MduX's `ColorHash` (a tint-composition predicate) for
+TrustSC's (a raw-pixel digest). That id is an identity rather than a measurement, so it does not
+change what ADR-014 decision 4 keeps out. `mdux.verify` also exposes `rawImageDigest()`, the RGBA8
+SHA-256 predicate ADR-015 decision 2 names; it has no committed baseline by design
+([ADR-016](adr/ADR-016-locally-versioned-observation-profiles.md)), returns `NoBaseline` on every
+production call, and is exercised only by `tests/verify/RawImageDigestTests.cpp`.
+
 Every baker registers through `mdux_bake_artifact()`
 ([`cmake/MduXBake.cmake`](../cmake/MduXBake.cmake)), which creates the bake target, an
 `evidence.<kind>.<id>` test, and membership in `mdux-bake-all` / `mdux-bake-update`.

--- a/docs/parity/behavior-matrix.md
+++ b/docs/parity/behavior-matrix.md
@@ -90,18 +90,30 @@ not an instruction to execute a clinical action or to copy TrustSC's host shutdo
 
 | Check | MduX observation | TrustSC observation | Proposed treatment |
 |---|---|---|---|
-| Bounds / GoldenBounds | Measured content extent must equal golden rectangle; empty fails. Detection is local to the check region and is not proof of no distant overflow. | Ink bbox in a clamped region expanded by 8 pixels must be contained in the expected bounds; no ink passes this check. | Separate extent-equality and containment identities, with explicit empty-content and search policies. |
-| ColorHash | No hash: common-coverage tint/background composition; fully resolved tint must occur. Missing tint fails. | SHA-256 over tightly packed row-major RGBA8 of the golden rectangle. Missing baseline returns NoBaseline, never pass. | Separate tint-composition and RGBA8-digest identities. Never reuse a name to reinterpret old evidence. |
+| Bounds / GoldenBounds | Measured content extent must equal golden rectangle; empty fails. Detection is local to the check region and is not proof of no distant overflow. Named `mdux.local/extent-equality` v1 since #313. | Ink bbox in a clamped region expanded by 8 pixels must be contained in the expected bounds; no ink passes this check. | Separate extent-equality and containment identities, with explicit empty-content and search policies. |
+| ColorHash | No hash: common-coverage tint/background composition; fully resolved tint must occur. Missing tint fails. Named `mdux.local/tint-composition` v1 since #313; the raw-pixel-digest observation is `mdux.local/raw-image-digest` v1, implemented but with no committed baseline. | SHA-256 over tightly packed row-major RGBA8 of the golden rectangle. Missing baseline returns NoBaseline, never pass. | Separate tint-composition and RGBA8-digest identities. Never reuse a name to reinterpret old evidence. |
 | Color tolerance | One UNORM step per modeled composite; existing two-layer fields need two. Channels share a feasible coverage; arbitrary independent channel slack is not permitted. | Exact hash has zero tolerance; ChromeColor uses ±1 per channel in its sampled edge bands. | Profile/check-specific arithmetic and sampling; no global fuzzy tolerance. |
-| TextPresence | Approved atlas coverage and placed glyph checks; ink containment has explicit composite-ground limits. | Glyph-count coverage heuristic (5–70% of estimated glyph area), not a glyph-shape comparison. | Distinct shape/coverage predicates, asset identity and applicability. |
+| TextPresence | Approved atlas coverage and placed glyph checks; ink containment has explicit composite-ground limits. Named `mdux.local/ink-containment` and `mdux.local/ink-coverage`, both v1, since #313. | Glyph-count coverage heuristic (5–70% of estimated glyph area), not a glyph-shape comparison. | Distinct shape/coverage predicates, asset identity and applicability. |
 | Ink/background | Resolved ground/tint and baked placements; bounds and ink checks have documented local limits. | Ink delta threshold 8; containment/search margins 8; local panel/chrome background handling. | Record thresholds, ground resolution and ROI in the profile; do not transfer one sibling's constants into the other silently. |
-| Report scope | Artifact provenance and node/check with explicit locale-free or locale scope; driver enforces complete obligations. | Check IDs such as node::golden_bounds; locale/scenario/clock also carried by the enclosing report. | A common observation key must include scope and provenance, not just the local check ID. |
+| Report scope | Artifact provenance and node/check with explicit locale-free or locale scope; driver enforces complete obligations. Each outcome in `verification.json` now records an `observationProfile` {id, version} (#313). | Check IDs such as node::golden_bounds; locale/scenario/clock also carried by the enclosing report. | A common observation key must include scope and provenance, not just the local check ID. |
 
 Sources: [MduX predicates][m-verify], [implementation arithmetic][m-arithmetic],
 [MduX fixtures][m-tests], [TrustSC checks][t-checks], [report types][t-verify] and
 [TrustSC fixtures][t-tests]. No committed TrustSC hash baselines exist at this assessed head;
 the ability to compute/compare a hash is not evidence of a committed image regression gate.
 [MedUI #15](https://github.com/Compliatory/MedUI/issues/15) requests the versioned resolution.
+
+**Update, 7 September 2026 — [#313](https://github.com/ambroise-leclerc/MduX/issues/313) delivered
+the local half of the "Proposed treatment" column above.** MduX's four rendered checks each carry an
+implementation-local `ObservationProfile` (id + version), recorded per outcome in `verification.json`,
+and `mdux.verify::rawImageDigest()` implements the RGBA8 SHA-256 observation TrustSC's `ColorHash`
+performs — as its own profile, so the two `ColorHash` results are never conflated. Per
+[ADR-016](../adr/ADR-016-locally-versioned-observation-profiles.md) and ADR-014 decision 4 it has
+**no committed baseline** (a driver-tuple-dependent digest cannot live in a byte-compared artifact),
+still returns `NoBaseline` on every production call, and is fixture-tested only. The profile ids are
+`mdux.local/*` until MEDUI-DEC-007 delivers canonical identifiers; the shared schema/corpus and the
+cross-implementation gate remain [#314](https://github.com/ambroise-leclerc/MduX/issues/314). This is
+not a parity claim.
 
 ## Intentional differences
 

--- a/docs/parity/requirements.md
+++ b/docs/parity/requirements.md
@@ -46,7 +46,7 @@ allocate profile identifiers or establish consumer capabilities.
 
 | Work | Decisions needed before dependent behavior lands |
 |---|---|
-| #313 verifier semantics | D2/D3/D4; [MedUI #15](https://github.com/Compliatory/MedUI/issues/15), reviewed PAR-REQ-002/003/009. |
+| #313 verifier semantics | D2/D3/D4 (accepted); [MedUI #15](https://github.com/Compliatory/MedUI/issues/15), reviewed PAR-REQ-002/003/009. **Local half delivered** by [ADR-016](../adr/ADR-016-locally-versioned-observation-profiles.md): implementation-local observation-profile identities for the four rendered checks and the RGBA8 SHA-256 predicate, per-outcome in `verification.json`, no committed baseline. The shared schema/corpus half and the PAR-REQ dispositions remain open. |
 | #314 common corpus gate | D1–D4 and #313; MedUI #15 plus diagnostic/safety cases from existing #2/#3/#4/#8. Only claim phases with complete applicable passing cases. |
 | #315 input design | D5; [MedUI #16](https://github.com/Compliatory/MedUI/issues/16), PAR-REQ-004–008. Resolve event vocabulary, coordinate rounding, paste/repeat/focus and host action policy here. |
 | #316 queue/editing; #317 presentation adapter | Accepted #315 requirements; D5; PAR-REQ-004–007. |
@@ -81,7 +81,8 @@ their profile/schema/corpus delivery and consumer adoption gates remain in force
 | Record | Requested reviewer | State |
 |---|---|---|
 | ADR-015 D1–D5 | MduX maintainer | Accepted by Ambroise Leclerc, 2026-09-07 |
-| PAR-REQ-001–010 | MduX maintainer; domain reviewer for any device action/risk-control interpretation | Individual dispositions pending |
+| ADR-016 (local observation profiles) | MduX maintainer; domain reviewer (safety-relevant verifier area) | Proposed 2026-09-07 (#313); no check semantics or runtime behaviour changed |
+| PAR-REQ-001–010 | MduX maintainer; domain reviewer for any device action/risk-control interpretation | Individual dispositions pending. #313 delivers the **local** half of PAR-REQ-002 (four named profiles + the RGBA8 digest predicate + adversarial fixtures); the shared-schema/corpus half and the disposition itself remain open. |
 | Shared rendered profiles | MedUI #15 participants/maintainer | MEDUI-DEC-007 accepted, 2026-09-07; profile delivery pending |
 | Shared interaction/presentation profiles | MedUI #16 participants/maintainer | MEDUI-DEC-008 accepted, 2026-09-07; profile delivery pending |
 

--- a/docs/parity/requirements.md
+++ b/docs/parity/requirements.md
@@ -81,7 +81,7 @@ their profile/schema/corpus delivery and consumer adoption gates remain in force
 | Record | Requested reviewer | State |
 |---|---|---|
 | ADR-015 D1–D5 | MduX maintainer | Accepted by Ambroise Leclerc, 2026-09-07 |
-| ADR-016 (local observation profiles) | MduX maintainer; domain reviewer (safety-relevant verifier area) | Proposed 2026-09-07 (#313); no check semantics or runtime behaviour changed |
+| ADR-016 (local observation profiles) | MduX maintainer; domain reviewer (safety-relevant verifier area) | Proposed 2026-09-07 (#313). The four required rendered checks (`Bounds`, `ColorHash`, `InkContainment`, `LocalizedTextPresence`) keep their exact semantics; each gains an implementation-local `ObservationProfile` id recorded per outcome. `mdux.verify::rawImageDigest()` is an exported, fixture-tested predicate with a defined `NoBaseline` outcome that never discharges an obligation — it is **not** a `CvCheck`, has **no production caller**, and is **outside driver obligation enumeration**. Production-driver behaviour is unchanged; the committed `verification.json` differs only by the additive `observationProfile` member. |
 | PAR-REQ-001–010 | MduX maintainer; domain reviewer for any device action/risk-control interpretation | Individual dispositions pending. #313 delivers the **local** half of PAR-REQ-002 (four named profiles + the RGBA8 digest predicate + adversarial fixtures); the shared-schema/corpus half and the disposition itself remain open. |
 | Shared rendered profiles | MedUI #15 participants/maintainer | MEDUI-DEC-007 accepted, 2026-09-07; profile delivery pending |
 | Shared interaction/presentation profiles | MedUI #16 participants/maintainer | MEDUI-DEC-008 accepted, 2026-09-07; profile delivery pending |

--- a/generated/screen/endoscope-monitor/report.json
+++ b/generated/screen/endoscope-monitor/report.json
@@ -80,7 +80,7 @@
     },
     {
       "path": "verification.json",
-      "sha256": "e4ebf65e4384e7dd8c12679de5d24d2223d442bd0fd673a7b448f332800c02c7"
+      "sha256": "2abc6c8a9680e2176ceb8e5f454b7ef1807bb3dbd08447cd158b9ad787638019"
     }
   ],
   "recipe": {

--- a/generated/screen/endoscope-monitor/verification.json
+++ b/generated/screen/endoscope-monitor/verification.json
@@ -40,54 +40,90 @@
       "check": "Bounds",
       "finding": "Held",
       "nodeId": "emergency-halt",
+      "observationProfile": {
+        "id": "mdux.local/extent-equality",
+        "version": 1
+      },
       "scope": "en-US"
     },
     {
       "check": "ColorHash",
       "finding": "Held",
       "nodeId": "emergency-halt",
+      "observationProfile": {
+        "id": "mdux.local/tint-composition",
+        "version": 1
+      },
       "scope": "en-US"
     },
     {
       "check": "Bounds",
       "finding": "Held",
       "nodeId": "insufflation-pressure",
+      "observationProfile": {
+        "id": "mdux.local/extent-equality",
+        "version": 1
+      },
       "scope": "en-US"
     },
     {
       "check": "ColorHash",
       "finding": "Held",
       "nodeId": "insufflation-pressure",
+      "observationProfile": {
+        "id": "mdux.local/tint-composition",
+        "version": 1
+      },
       "scope": "en-US"
     },
     {
       "check": "Bounds",
       "finding": "Held",
       "nodeId": "ecg-lead-ii",
+      "observationProfile": {
+        "id": "mdux.local/extent-equality",
+        "version": 1
+      },
       "scope": "en-US"
     },
     {
       "check": "InkContainment",
       "finding": "Held",
       "nodeId": "screen-title",
+      "observationProfile": {
+        "id": "mdux.local/ink-containment",
+        "version": 1
+      },
       "scope": "en-US"
     },
     {
       "check": "LocalizedTextPresence",
       "finding": "Held",
       "nodeId": "screen-title",
+      "observationProfile": {
+        "id": "mdux.local/ink-coverage",
+        "version": 1
+      },
       "scope": "en-US"
     },
     {
       "check": "InkContainment",
       "finding": "Held",
       "nodeId": "emergency-halt",
+      "observationProfile": {
+        "id": "mdux.local/ink-containment",
+        "version": 1
+      },
       "scope": "en-US"
     },
     {
       "check": "LocalizedTextPresence",
       "finding": "Held",
       "nodeId": "emergency-halt",
+      "observationProfile": {
+        "id": "mdux.local/ink-coverage",
+        "version": 1
+      },
       "scope": "en-US"
     }
   ],

--- a/include/mdux/verify/Verify.cppm
+++ b/include/mdux/verify/Verify.cppm
@@ -1,6 +1,6 @@
 /**
  * @file Verify.cppm
- * @brief Rendered-truth checks: four pure functions over a CPU framebuffer and an artifact-derived
+ * @brief Rendered-truth checks: pure functions over a CPU framebuffer and an artifact-derived
  *        expectation, answering whether a frame shows what the compiled screen said it would.
  *
  * @compliance ADR-004 Trust zones in C++ (governed zone: std only, no Vulkan, no windowing)
@@ -8,6 +8,8 @@
  * @compliance ADR-011 The deterministic `.medui` compile boundary
  * @compliance ADR-012 What a compiled screen emits, and which parts are committed
  * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ * @compliance ADR-015 Versioned sibling observations (decision 2: name the predicate, not its alias)
+ * @compliance ADR-016 Locally versioned observation profiles for rendered checks
  *
  * Part of MduXCore, and that placement is ADR-014 decision 1 rather than an inheritance: the checks
  * have the same shape as the screen runtime - bounded arithmetic over caller-owned storage, no
@@ -17,14 +19,15 @@
  *
  * **The driver is not here.** Rendering a frame, reading `goldens.json`, enumerating obligations and
  * writing `verification.json` are what ADR-004 and ADR-005 keep out of this zone; they are #253's
- * and #254's, and they call in. What this module owns is the four questions themselves.
+ * and #254's, and they call in. What this module owns is the questions themselves.
  *
- * ## The four checks, and which are opt-in
+ * ## The checks, and which are opt-in
  *
  * - **`goldenBounds()`** - the golden node's rendered content occupies the declared rectangle;
  * - **`colorHash()`** - that content carries the tint its colour token resolves to;
  * - **`inkContainment()`** - a compiled text node's run stays inside its node bounds;
- * - **`localizedTextPresence()`** - the approved locale's bound run is the one on screen.
+ * - **`localizedTextPresence()`** - the approved locale's bound run is the one on screen;
+ * - **`rawImageDigest()`** - a region's tightly packed RGBA8 hashes to a committed baseline.
  *
  * The first two are `Bounds` and `ColorHash`, the closed `CvCheck` set an author opts into per node.
  * That set belongs to the shared language's `safety` capability, pinned in `medui-conformance.toml`,
@@ -33,11 +36,28 @@
  * `mdux.tools.medui.goldens` rather than declared twice, for the reason ADR-012 decision 4 gives
  * about the golden predicate: two implementations of one closed set agree until the day they matter.
  *
- * The last two are **not** opt-in and are deliberately not `CvCheck` enumerators. They apply to
- * every compiled node whose spec carries a `textKey`, in every approved locale, whether or not that
- * node has a golden entry. A glyph run leaving the box that was budgeted for it is a defect however
- * the author annotated the node, and #195 already measured that box at compile time - these are the
- * same claim, verified against pixels.
+ * `inkContainment()` and `localizedTextPresence()` are **not** opt-in and are deliberately not
+ * `CvCheck` enumerators. They apply to every compiled node whose spec carries a `textKey`, in every
+ * approved locale, whether or not that node has a golden entry. A glyph run leaving the box that was
+ * budgeted for it is a defect however the author annotated the node, and #195 already measured that
+ * box at compile time - these are the same claim, verified against pixels.
+ *
+ * `rawImageDigest()` is neither opt-in nor mandatory: it has **no committed baseline and no
+ * production caller**. It exists so that the observation TrustSC's `ColorHash` actually performs -
+ * a raw-pixel digest - has a name of its own here (ADR-015 decision 2), and so #314 can compare the
+ * two implementations without conflating a tint predicate with a pixel hash. ADR-014 decision 4
+ * keeps a driver-tuple-dependent digest out of the byte-compared bundle; ADR-016 records why that
+ * makes this a fixture-and-future-consumer tool rather than a gate, and why `Finding::NoBaseline`
+ * (its answer for every production call) is distinct from a pass.
+ *
+ * ## Observation profiles
+ *
+ * ADR-015 decision 2: a shared check *name* is not evidence of a shared *observation*. Every
+ * `CheckOutcome` therefore carries an `ObservationProfile` - an id naming what was measured and a
+ * version that moves only on a reviewed change - and `verification.json` records it beside each
+ * outcome. `profileOf()` maps a `CvCheck` or `TextCheck` to its profile; `rawImageDigest()` carries
+ * `rawImageDigestProfile`. The ids are implementation-local (`localProfilePrefix`) until
+ * MEDUI-DEC-007 delivers a canonical set (ADR-016).
  *
  * ## What a check is given, and what it may never be given
  *
@@ -156,6 +176,7 @@ export module mdux.verify;
 import std;
 import mdux.core.result;
 import mdux.core.units;
+import mdux.evidence.digest;
 import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.medui.screen;
@@ -198,6 +219,7 @@ enum class VerifyError : std::uint8_t {
     UnknownTextKey,             ///< the bound package carries no run for this node's text key
     AtlasSizeMismatch,          ///< the coverage sheet is not the size the font package declares
     GlyphOutsideAtlas,          ///< a glyph's slot leaves the coverage sheet
+    DigestRoiDegenerate,        ///< a raw-image-digest ROI has a non-positive width or height
 };
 
 [[nodiscard]] std::string_view describe(VerifyError error) noexcept;
@@ -304,6 +326,64 @@ private:
 static_assert(!std::is_aggregate_v<FramebufferView>, "a FramebufferView must only be obtainable through create()");
 
 /**
+ * @brief The identity of one rendered-check observation: what it measures, at which revision.
+ *
+ * [ADR-015](../../../docs/adr/ADR-015-versioned-sibling-observations.md) decision 2 is the reason
+ * this type exists: `ColorHash` is one name for two different observations - a tint-composition
+ * predicate here, a raw-pixel digest in TrustSC - and a shared spelling is not evidence of a shared
+ * measurement. Each predicate in this module therefore carries a profile whose `id` names *what* it
+ * observes and whose `version` moves only when a reviewed migration changes the answer it can give.
+ * `verification.json` records the profile beside every outcome, so a reader (and #314's
+ * cross-implementation gate) compares like with like.
+ *
+ * The ids are **implementation-local** - see [ADR-016](../../../docs/adr/ADR-016-locally-versioned-observation-profiles.md).
+ * MEDUI-DEC-007 accepts the *direction* of shared rendered-check profiles but delivers no canonical
+ * identifiers, schema or corpus, so every id here begins with `localProfilePrefix` and no manifest
+ * or pin claims a shared profile. A later reviewed migration maps these onto the canonical set.
+ *
+ * A value type with a string view and an integer: `constexpr`, no allocation, trivially comparable.
+ * The `id` is a pointer into a string literal that outlives every use.
+ */
+class ObservationProfile {
+public:
+    constexpr ObservationProfile() noexcept = default;
+    constexpr ObservationProfile(std::string_view id, std::uint32_t version) noexcept : id_{id}, version_{version} {}
+
+    [[nodiscard]] constexpr std::string_view id() const noexcept {
+        return id_;
+    }
+    [[nodiscard]] constexpr std::uint32_t version() const noexcept {
+        return version_;
+    }
+    /// Whether this names a profile at all. False for a default-constructed one.
+    [[nodiscard]] constexpr bool valid() const noexcept {
+        return !id_.empty();
+    }
+
+    [[nodiscard]] constexpr bool operator==(const ObservationProfile&) const noexcept = default;
+
+private:
+    std::string_view id_{};
+    std::uint32_t    version_{0};
+};
+
+/// The prefix every profile id in this module carries until MEDUI-DEC-007 delivers canonical ids
+/// (ADR-016). A reader seeing it knows the id is MduX's own, not a shared-contract identifier.
+inline constexpr std::string_view localProfilePrefix = "mdux.local/";
+
+/// `goldenBounds()`: the golden node's content occupies exactly its declared rectangle.
+inline constexpr ObservationProfile extentEqualityProfile{"mdux.local/extent-equality", 1};
+/// `colorHash()`: painted pixels are a blend of ground and tint at one coverage, and one is the tint.
+inline constexpr ObservationProfile tintCompositionProfile{"mdux.local/tint-composition", 1};
+/// `inkContainment()`: a text run's placed ink stays inside the node that names it.
+inline constexpr ObservationProfile inkContainmentProfile{"mdux.local/ink-containment", 1};
+/// `localizedTextPresence()`: the approved locale's run is the shape on screen, per baked coverage.
+inline constexpr ObservationProfile inkCoverageProfile{"mdux.local/ink-coverage", 1};
+/// `rawImageDigest()`: SHA-256 over tightly packed row-major RGBA8 of a rectangle. Uncommitted;
+/// see ADR-016 for why it exists without a committed baseline.
+inline constexpr ObservationProfile rawImageDigestProfile{"mdux.local/raw-image-digest", 1};
+
+/**
  * @brief A verification the shared language lets an author opt a node into.
  *
  * The closed set, defined here and aliased by `mdux.tools.medui.goldens` so that the compiler that
@@ -367,6 +447,30 @@ enum class TextCheck : std::uint8_t {
             return "InkContainment";
         case TextCheck::LocalizedTextPresence:
             return "LocalizedTextPresence";
+    }
+    return {};
+}
+
+/// The observation profile the golden check `check` reports under (ADR-015 D2 / ADR-016). A pure
+/// mapping: `Bounds` observes extent equality, `ColorHash` observes tint composition. The verifier
+/// and any reader of `verification.json` resolve a check's profile the same way.
+[[nodiscard]] constexpr ObservationProfile profileOf(CvCheck check) noexcept {
+    switch (check) {
+        case CvCheck::Bounds:
+            return extentEqualityProfile;
+        case CvCheck::ColorHash:
+            return tintCompositionProfile;
+    }
+    return {};
+}
+
+/// The observation profile the mandatory text check `check` reports under (ADR-015 D2 / ADR-016).
+[[nodiscard]] constexpr ObservationProfile profileOf(TextCheck check) noexcept {
+    switch (check) {
+        case TextCheck::InkContainment:
+            return inkContainmentProfile;
+        case TextCheck::LocalizedTextPresence:
+            return inkCoverageProfile;
     }
     return {};
 }
@@ -600,6 +704,72 @@ private:
 };
 
 static_assert(!std::is_aggregate_v<GoldenExpectation>, "a GoldenExpectation must only be obtainable through create()");
+
+/**
+ * @brief A rectangle to hash, and the baseline digest to compare it against - if there is one.
+ *
+ * The expectation `rawImageDigest()` consumes, and the whole of what the `raw-rgba8-sha256` profile
+ * (ADR-016) needs: a region of interest, and optionally a committed SHA-256 to check it against.
+ * This is TrustSC's `ColorHash` observation - a raw-pixel digest - given a name of its own so the
+ * two implementations' `ColorHash` results are never mistaken for each other.
+ *
+ * **There is no production caller that supplies a baseline**, and there is deliberately no committed
+ * one. [ADR-014](../../../docs/adr/ADR-014-rendered-truth-verification.md) decision 4 and its
+ * alternative 6 keep measured pixel values out of the byte-compared bundle: a committed RGBA8
+ * digest is a property of the driver tuple that produced the frame - lavapipe, MoltenVK, Mesa's
+ * Windows build - not of the screen's declared inputs, so it would fail an evidence leg on any
+ * rendering change while every check still held. TrustSC commits none either. So `createWithBaseline()`
+ * exists for the unit suite and for a future consumer that has declared a presentation/backend
+ * profile (PAR-REQ-009); `create()` is the shape everything else uses, and it resolves to
+ * `Finding::NoBaseline`, which never discharges an obligation.
+ *
+ * Obtainable only through a factory, and not an aggregate, so a `roi` that was never bounded cannot
+ * reach the check.
+ */
+class RawImageExpectation {
+public:
+    /// A region to hash with no baseline to compare it to. The result is `Finding::NoBaseline`.
+    ///
+    /// Refuses a non-positive `roi` extent - `VerifyError::DigestRoiDegenerate` - so the check's
+    /// own bounds walk is over a rectangle by construction.
+    [[nodiscard]] static mdux::core::Result<RawImageExpectation, VerifyError>
+    create(std::string_view nodeId, RenderScope scope, mdux::medui::NodeRect roi) noexcept;
+
+    /// A region to hash and the committed digest it must equal. For the unit suite and a future
+    /// declared-profile consumer; there is no such consumer today. Same `roi` refusal as `create()`.
+    [[nodiscard]] static mdux::core::Result<RawImageExpectation, VerifyError>
+    createWithBaseline(std::string_view nodeId, RenderScope scope, mdux::medui::NodeRect roi, mdux::evidence::Digest baseline) noexcept;
+
+    [[nodiscard]] std::string_view nodeId() const noexcept {
+        return nodeId_;
+    }
+    [[nodiscard]] RenderScope scope() const noexcept {
+        return scope_;
+    }
+    [[nodiscard]] mdux::medui::NodeRect roi() const noexcept {
+        return roi_;
+    }
+    /// Whether a baseline was supplied. When false, `rawImageDigest()` reports `NoBaseline`.
+    [[nodiscard]] bool hasBaseline() const noexcept {
+        return hasBaseline_;
+    }
+    /// The committed digest. Meaningless unless `hasBaseline()`.
+    [[nodiscard]] const mdux::evidence::Digest& baseline() const noexcept {
+        return baseline_;
+    }
+
+private:
+    RawImageExpectation(std::string_view nodeId, RenderScope scope, mdux::medui::NodeRect roi, bool hasBaseline, const mdux::evidence::Digest& baseline) noexcept
+        : nodeId_{nodeId}, scope_{scope}, roi_{roi}, baseline_{baseline}, hasBaseline_{hasBaseline} {}
+
+    std::string_view       nodeId_{};
+    RenderScope            scope_{RenderScope::localeFree()};
+    mdux::medui::NodeRect  roi_{};
+    mdux::evidence::Digest baseline_{};
+    bool                   hasBaseline_{false};
+};
+
+static_assert(!std::is_aggregate_v<RawImageExpectation>, "a RawImageExpectation must only be obtainable through a factory");
 
 /**
  * @brief The colour a coverage value paints when the tint is composited over the ground.
@@ -879,6 +1049,8 @@ enum class Finding : std::uint8_t {
     GlyphMissing,        ///< a non-blank record of the approved run painted nothing
     CoverageDiffers,     ///< a glyph's pixels are not what its baked coverage would produce
     InkOutsideTheRun,    ///< the node shows ink where this locale's run paints none
+    NoBaseline,          ///< `rawImageDigest()` had no committed digest to compare against
+    DigestMismatch,      ///< the region's SHA-256 is not the committed baseline's
 };
 
 [[nodiscard]] std::string_view describe(Finding finding) noexcept;
@@ -917,6 +1089,10 @@ enum class Finding : std::uint8_t {
             return "CoverageDiffers";
         case Finding::InkOutsideTheRun:
             return "InkOutsideTheRun";
+        case Finding::NoBaseline:
+            return "NoBaseline";
+        case Finding::DigestMismatch:
+            return "DigestMismatch";
     }
     return {};
 }
@@ -942,6 +1118,7 @@ struct CheckOutcome {
     std::string_view       nodeId{};
     std::string_view       scope{};     ///< the locale tag, or `localeFreeScopeName`
     std::string_view       check{};     ///< the check's spelling, e.g. `Bounds`
+    ObservationProfile     profile{};   ///< which observation this outcome is: id and version (ADR-016)
     mdux::medui::NodeRect  expected{};  ///< the rectangle the expectation named
     mdux::medui::NodeRect  found{};     ///< what the frame showed, when the finding measured it
     bool                   foundValid{false};
@@ -1032,5 +1209,24 @@ struct CheckOutcome {
  * misses by far more, and a wrong tint by more still.
  */
 [[nodiscard]] CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpectation& expectation) noexcept;
+
+/**
+ * @brief `raw-rgba8-sha256`: the region's tightly packed RGBA8 hashes to a committed baseline.
+ *
+ * TrustSC's `ColorHash` observation, named separately here so that the two implementations'
+ * `ColorHash` results are never compared as though they measured the same thing (ADR-015 D2). The
+ * digest is SHA-256 over the region of interest's pixels, row by row, four bytes per pixel, with no
+ * stride padding - the same "tightly packed row-major RGBA8" TrustSC hashes.
+ *
+ * **It reports `Finding::NoBaseline` for every production call**, because there is no committed
+ * baseline and deliberately never will be: ADR-014 decision 4 keeps a driver-tuple-dependent
+ * measurement out of the byte-compared bundle, and ADR-016 records why that makes this profile a
+ * fixture-and-future-consumer tool rather than a committed gate. `NoBaseline` never discharges an
+ * obligation - it is distinct from a pass, the way TrustSC's own `NoBaseline` is. With a baseline
+ * (a unit test, or a consumer that has declared a presentation profile) it reports `Held` on a
+ * match and `Finding::DigestMismatch` otherwise. A region outside the frame is
+ * `Finding::RegionOutsideFrame`, a failure rather than a skip.
+ */
+[[nodiscard]] CheckOutcome rawImageDigest(const FramebufferView& frame, const RawImageExpectation& expectation) noexcept;
 
 }  // namespace mdux::verify

--- a/include/mdux/verify/Verify.cppm
+++ b/include/mdux/verify/Verify.cppm
@@ -1154,7 +1154,6 @@ struct CheckOutcome {
     std::string_view       nodeId{};
     std::string_view       scope{};     ///< the locale tag, or `localeFreeScopeName`
     std::string_view       check{};     ///< the check's spelling, e.g. `Bounds`
-    ObservationProfile     profile{};   ///< which observation this outcome is: id and version (ADR-016)
     mdux::medui::NodeRect  expected{};  ///< the rectangle the expectation named
     mdux::medui::NodeRect  found{};     ///< what the frame showed, when the finding measured it
     bool                   foundValid{false};
@@ -1162,6 +1161,9 @@ struct CheckOutcome {
     mdux::core::ColorRgba8 foundColor{};
     bool                   foundColorValid{false};
     std::size_t            glyphIndex{0};  ///< which record, for a glyph-level finding
+    // Appended rather than slotted beside `check`: this is an aggregate a caller may initialise
+    // positionally (see the same note on `Invocation` in the driver), so a new field goes last.
+    ObservationProfile     profile{};  ///< which observation this outcome is: id and version (ADR-016)
 
     [[nodiscard]] constexpr bool held() const noexcept {
         return finding == Finding::Held;

--- a/include/mdux/verify/Verify.cppm
+++ b/include/mdux/verify/Verify.cppm
@@ -451,6 +451,20 @@ enum class TextCheck : std::uint8_t {
     return {};
 }
 
+/// The mandatory text check `name` spells, or nothing when the name is not one of the two.
+///
+/// The counterpart of `parseCvCheck` for the checks that have no `CvCheck` enumerator, so a reader
+/// of `verification.json` can resolve any recorded check name back to its kind and its profile.
+[[nodiscard]] constexpr std::optional<TextCheck> parseTextCheck(std::string_view name) noexcept {
+    if (name == spell(TextCheck::InkContainment)) {
+        return TextCheck::InkContainment;
+    }
+    if (name == spell(TextCheck::LocalizedTextPresence)) {
+        return TextCheck::LocalizedTextPresence;
+    }
+    return std::nullopt;
+}
+
 /// The observation profile the golden check `check` reports under (ADR-015 D2 / ADR-016). A pure
 /// mapping: `Bounds` observes extent equality, `ColorHash` observes tint composition. The verifier
 /// and any reader of `verification.json` resolve a check's profile the same way.
@@ -473,6 +487,27 @@ enum class TextCheck : std::uint8_t {
             return inkCoverageProfile;
     }
     return {};
+}
+
+/// The observation profile a check *spelled* `name` must report under, or nothing when `name` is
+/// not a check this module defines.
+///
+/// One resolver for every consumer, so the driver that sets a profile and the artifact writer that
+/// checks one before committing it cannot disagree about which profile a check name implies. A name
+/// outside the closed set - anything but the four `spell()` strings and `RawImageDigest` - returns
+/// nothing, which the writer treats as a reason to refuse rather than to serialise an
+/// unidentifiable observation.
+[[nodiscard]] constexpr std::optional<ObservationProfile> profileForCheckName(std::string_view name) noexcept {
+    if (const auto cv = parseCvCheck(name); cv.has_value()) {
+        return profileOf(*cv);
+    }
+    if (const auto text = parseTextCheck(name); text.has_value()) {
+        return profileOf(*text);
+    }
+    if (name == "RawImageDigest") {
+        return rawImageDigestProfile;
+    }
+    return std::nullopt;
 }
 
 /// How a locale-free render scope names itself in a report.

--- a/include/mdux/verify/Verify.cppm
+++ b/include/mdux/verify/Verify.cppm
@@ -743,8 +743,9 @@ static_assert(!std::is_aggregate_v<GoldenExpectation>, "a GoldenExpectation must
 /**
  * @brief A rectangle to hash, and the baseline digest to compare it against - if there is one.
  *
- * The expectation `rawImageDigest()` consumes, and the whole of what the `raw-rgba8-sha256` profile
- * (ADR-016) needs: a region of interest, and optionally a committed SHA-256 to check it against.
+ * The expectation `rawImageDigest()` consumes, and the whole of what the `raw-image-digest` profile
+ * (`mdux.local/raw-image-digest`, ADR-016) needs: a region of interest, and optionally a committed
+ * SHA-256 to check it against.
  * This is TrustSC's `ColorHash` observation - a raw-pixel digest - given a name of its own so the
  * two implementations' `ColorHash` results are never mistaken for each other.
  *
@@ -1246,7 +1247,7 @@ struct CheckOutcome {
 [[nodiscard]] CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpectation& expectation) noexcept;
 
 /**
- * @brief `raw-rgba8-sha256`: the region's tightly packed RGBA8 hashes to a committed baseline.
+ * @brief `raw-image-digest`: the region's tightly packed RGBA8 hashes to a committed baseline.
  *
  * TrustSC's `ColorHash` observation, named separately here so that the two implementations'
  * `ColorHash` results are never compared as though they measured the same thing (ADR-015 D2). The

--- a/src/verify/Verify.cpp
+++ b/src/verify/Verify.cpp
@@ -245,7 +245,7 @@ struct Box {
 /// `profile` names the observation this check performs (ADR-015 D2 / ADR-016), and it is set here
 /// rather than by each check so that no check can report an outcome without one.
 [[nodiscard]] CheckOutcome opened(std::string_view nodeId, RenderScope scope, std::string_view check, ObservationProfile profile, NodeRect expected) noexcept {
-    return CheckOutcome{.finding = Finding::Held, .nodeId = nodeId, .scope = scope.name(), .check = check, .profile = profile, .expected = expected};
+    return CheckOutcome{.finding = Finding::Held, .nodeId = nodeId, .scope = scope.name(), .check = check, .expected = expected, .profile = profile};
 }
 
 [[nodiscard]] CheckOutcome failed(CheckOutcome outcome, Finding finding) noexcept {

--- a/src/verify/Verify.cpp
+++ b/src/verify/Verify.cpp
@@ -16,6 +16,7 @@ module mdux.verify;
 import std;
 import mdux.core.result;
 import mdux.core.units;
+import mdux.evidence.digest;
 import mdux.font.schema;
 import mdux.medui.schema;
 import mdux.medui.screen;
@@ -240,8 +241,11 @@ struct Box {
 }
 
 /// The outcome every check starts from, so the reporting fields are filled in one place.
-[[nodiscard]] CheckOutcome opened(std::string_view nodeId, RenderScope scope, std::string_view check, NodeRect expected) noexcept {
-    return CheckOutcome{.finding = Finding::Held, .nodeId = nodeId, .scope = scope.name(), .check = check, .expected = expected};
+///
+/// `profile` names the observation this check performs (ADR-015 D2 / ADR-016), and it is set here
+/// rather than by each check so that no check can report an outcome without one.
+[[nodiscard]] CheckOutcome opened(std::string_view nodeId, RenderScope scope, std::string_view check, ObservationProfile profile, NodeRect expected) noexcept {
+    return CheckOutcome{.finding = Finding::Held, .nodeId = nodeId, .scope = scope.name(), .check = check, .profile = profile, .expected = expected};
 }
 
 [[nodiscard]] CheckOutcome failed(CheckOutcome outcome, Finding finding) noexcept {
@@ -303,6 +307,8 @@ std::string_view describe(VerifyError error) noexcept {
             return "the coverage sheet is not the size the font package declares";
         case VerifyError::GlyphOutsideAtlas:
             return "a glyph's slot leaves the coverage sheet";
+        case VerifyError::DigestRoiDegenerate:
+            return "the raw-image-digest region has a non-positive width or height";
     }
     return "unknown verification error";
 }
@@ -333,6 +339,10 @@ std::string_view describe(Finding finding) noexcept {
             return "a glyph's pixels are not what its baked coverage would paint in this tint";
         case Finding::InkOutsideTheRun:
             return "the node shows ink where this locale's run paints none";
+        case Finding::NoBaseline:
+            return "there is no committed digest to compare this region against";
+        case Finding::DigestMismatch:
+            return "the region's SHA-256 is not the committed baseline digest";
     }
     return "unknown verification finding";
 }
@@ -663,7 +673,7 @@ std::uint8_t TextExpectation::coverage(const PlacedGlyph& placed, Px dx, Px dy) 
 }
 
 CheckOutcome goldenBounds(const FramebufferView& frame, const GoldenExpectation& expectation) noexcept {
-    CheckOutcome outcome = opened(expectation.nodeId(), expectation.scope(), spell(CvCheck::Bounds), expectation.bounds());
+    CheckOutcome outcome = opened(expectation.nodeId(), expectation.scope(), spell(CvCheck::Bounds), profileOf(CvCheck::Bounds), expectation.bounds());
     if (!frame.contains(expectation.bounds())) {
         return failed(outcome, Finding::RegionOutsideFrame);
     }
@@ -687,7 +697,7 @@ CheckOutcome goldenBounds(const FramebufferView& frame, const GoldenExpectation&
 }
 
 CheckOutcome colorHash(const FramebufferView& frame, const GoldenExpectation& expectation) noexcept {
-    CheckOutcome outcome  = opened(expectation.nodeId(), expectation.scope(), spell(CvCheck::ColorHash), expectation.bounds());
+    CheckOutcome outcome  = opened(expectation.nodeId(), expectation.scope(), spell(CvCheck::ColorHash), profileOf(CvCheck::ColorHash), expectation.bounds());
     outcome.expectedColor = expectation.tint();
     if (!expectation.hasTint()) {
         return failed(outcome, Finding::NoTintToCompare);
@@ -734,7 +744,7 @@ CheckOutcome colorHash(const FramebufferView& frame, const GoldenExpectation& ex
 }
 
 CheckOutcome inkContainment(const FramebufferView& frame, const TextExpectation& expectation) noexcept {
-    CheckOutcome outcome = opened(expectation.nodeId(), expectation.scope(), spell(TextCheck::InkContainment), expectation.bounds());
+    CheckOutcome outcome = opened(expectation.nodeId(), expectation.scope(), spell(TextCheck::InkContainment), profileOf(TextCheck::InkContainment), expectation.bounds());
     if (!inside(expectation.ink(), expectation.bounds())) {
         // The compile-time claim, failing before a pixel is read. #195 proved this box fits this
         // rectangle for the package it measured; a run that overflows here was bound from a package
@@ -784,7 +794,7 @@ CheckOutcome inkContainment(const FramebufferView& frame, const TextExpectation&
 }
 
 CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpectation& expectation) noexcept {
-    CheckOutcome outcome  = opened(expectation.nodeId(), expectation.scope(), spell(TextCheck::LocalizedTextPresence), expectation.bounds());
+    CheckOutcome outcome  = opened(expectation.nodeId(), expectation.scope(), spell(TextCheck::LocalizedTextPresence), profileOf(TextCheck::LocalizedTextPresence), expectation.bounds());
     outcome.expectedColor = expectation.tint();
     if (!frame.contains(expectation.bounds())) {
         return failed(outcome, Finding::RegionOutsideFrame);
@@ -929,6 +939,56 @@ CheckOutcome localizedTextPresence(const FramebufferView& frame, const TextExpec
     outcome.expectedColor = tint;
     outcome.found         = ink;
     outcome.foundValid    = true;
+    return outcome;
+}
+
+Result<RawImageExpectation, VerifyError> RawImageExpectation::create(std::string_view nodeId, RenderScope scope, NodeRect roi) noexcept {
+    if (roi.width <= 0 || roi.height <= 0) {
+        return err(VerifyError::DigestRoiDegenerate);
+    }
+    return RawImageExpectation{nodeId, scope, roi, false, mdux::evidence::Digest{}};
+}
+
+Result<RawImageExpectation, VerifyError>
+RawImageExpectation::createWithBaseline(std::string_view nodeId, RenderScope scope, NodeRect roi, mdux::evidence::Digest baseline) noexcept {
+    if (roi.width <= 0 || roi.height <= 0) {
+        return err(VerifyError::DigestRoiDegenerate);
+    }
+    return RawImageExpectation{nodeId, scope, roi, true, baseline};
+}
+
+CheckOutcome rawImageDigest(const FramebufferView& frame, const RawImageExpectation& expectation) noexcept {
+    CheckOutcome outcome = opened(expectation.nodeId(), expectation.scope(), "RawImageDigest", rawImageDigestProfile, expectation.roi());
+    if (!frame.contains(expectation.roi())) {
+        return failed(outcome, Finding::RegionOutsideFrame);
+    }
+
+    // SHA-256 over the region's pixels row by row, four bytes per pixel, no stride padding - the
+    // "tightly packed row-major RGBA8" TrustSC hashes. Streamed a pixel at a time into the fixed
+    // 64-byte block buffer `Sha256` owns, so nothing here allocates.
+    const NodeRect        roi = expectation.roi();
+    mdux::evidence::Sha256 hasher;
+    for (Px y = roi.y; y < roi.y + roi.height; ++y) {
+        for (Px x = roi.x; x < roi.x + roi.width; ++x) {
+            // `contains()` above bounds the walk, so `pixelAt()` is never empty here; the ground
+            // colour is a safe stand-in that cannot arise for an in-range pixel.
+            const ColorRgba8 pixel = frame.pixelAt(x, y).value_or(ColorRgba8{});
+            const std::array<std::byte, 4> bytes{
+                std::byte{pixel.r}, std::byte{pixel.g}, std::byte{pixel.b}, std::byte{pixel.a}};
+            hasher.update(bytes);
+        }
+    }
+    const mdux::evidence::Digest digest = hasher.finish();
+
+    if (!expectation.hasBaseline()) {
+        // The production answer, and distinct from a pass: ADR-016 keeps a committed baseline out of
+        // the byte-compared bundle, so there is nothing to check against and the obligation stays
+        // undischarged. TrustSC's `NoBaseline` behaves the same way.
+        return failed(outcome, Finding::NoBaseline);
+    }
+    if (digest != expectation.baseline()) {
+        return failed(outcome, Finding::DigestMismatch);
+    }
     return outcome;
 }
 

--- a/src/verify/Verify.cpp
+++ b/src/verify/Verify.cpp
@@ -970,8 +970,8 @@ CheckOutcome rawImageDigest(const FramebufferView& frame, const RawImageExpectat
     mdux::evidence::Sha256 hasher;
     for (Px y = roi.y; y < roi.y + roi.height; ++y) {
         for (Px x = roi.x; x < roi.x + roi.width; ++x) {
-            // `contains()` above bounds the walk, so `pixelAt()` is never empty here; the ground
-            // colour is a safe stand-in that cannot arise for an in-range pixel.
+            // `contains()` above has already bounded the walk to the frame, so every `pixelAt()`
+            // here is engaged; the `value_or` is defensive and its argument is never reached.
             const ColorRgba8 pixel = frame.pixelAt(x, y).value_or(ColorRgba8{});
             const std::array<std::byte, 4> bytes{
                 std::byte{pixel.r}, std::byte{pixel.g}, std::byte{pixel.b}, std::byte{pixel.a}};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -876,6 +876,7 @@ add_executable(verify_spec
     verify/FramebufferTests.cpp
     verify/GoldenCheckTests.cpp
     verify/TextCheckTests.cpp
+    verify/RawImageDigestTests.cpp
 )
 
 target_link_libraries(verify_spec PRIVATE MduX::Core speclab::speclab)

--- a/tests/verify/GoldenCheckTests.cpp
+++ b/tests/verify/GoldenCheckTests.cpp
@@ -685,3 +685,37 @@ const mdux::spec::Register aTintClaimNeedsATintToMake{
                   })
             .Execute();
     }};
+
+const mdux::spec::Register eachGoldenCheckNamesItsOwnObservation{
+    "Bounds and ColorHash carry distinct, versioned observation profiles",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-golden-observation-profile")
+            .Given("a golden opted into both checks, and a frame that draws its node", [] {})
+            .When("goldenBounds and colorHash run over it", [] {})
+            .Then("each outcome names the profile its check reports under, and the two differ",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // ADR-015 decision 2: MduX's `ColorHash` is a tint-composition predicate, not
+                      // the raw-pixel digest TrustSC's `ColorHash` is. The profile on the outcome is
+                      // what keeps the two from being compared as one observation.
+                      checks.expect(mv::profileOf(mv::CvCheck::Bounds) == mv::extentEqualityProfile, "Bounds maps to extent-equality");
+                      checks.expect(mv::profileOf(mv::CvCheck::ColorHash) == mv::tintCompositionProfile, "ColorHash maps to tint-composition");
+                      checks.expect(mv::profileOf(mv::CvCheck::Bounds) != mv::profileOf(mv::CvCheck::ColorHash), "and the two are not the same observation");
+                      checks.expect(mv::extentEqualityProfile.id().starts_with(mv::localProfilePrefix), "the ids are implementation-local (ADR-016)");
+                      checks.expect(mv::tintCompositionProfile.version() == 1, "at version 1");
+
+                      Canvas canvas{16, 20, ground};
+                      canvas.fill({4, 4, 8, 6}, tintOf(readoutToken));
+
+                      const mv::GoldenExpectation expectation = expect(readoutGolden, textlessScreen, mv::RenderScope::localeFree());
+                      const mv::CheckOutcome      bounds      = mv::goldenBounds(canvas.view(), expectation);
+                      const mv::CheckOutcome      colour      = mv::colorHash(canvas.view(), expectation);
+
+                      checks.expect(bounds.profile == mv::extentEqualityProfile, "the goldenBounds outcome carries extent-equality");
+                      checks.expect(colour.profile == mv::tintCompositionProfile, "the colorHash outcome carries tint-composition");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/verify/RawImageDigestTests.cpp
+++ b/tests/verify/RawImageDigestTests.cpp
@@ -1,0 +1,327 @@
+/**
+ * @file RawImageDigestTests.cpp
+ * @brief BDD scenarios for `rawImageDigest()` and the `RawImageExpectation` that feeds it.
+ *
+ * @compliance ADR-004 Trust zones in C++ (governed zone: this suite links MduX::Core only)
+ * @compliance ADR-014 What rendered-truth verification checks, and what it cannot
+ * @compliance ADR-015 Versioned sibling observations (decision 2)
+ * @compliance ADR-016 Locally versioned observation profiles for rendered checks
+ *
+ * `rawImageDigest()` is the observation TrustSC's `ColorHash` actually performs - a SHA-256 over a
+ * rectangle's tightly packed row-major RGBA8 - named separately here so the two implementations'
+ * `ColorHash` results are never compared as though they measured the same thing (ADR-015 D2).
+ *
+ * Three things these scenarios establish.
+ *
+ * **Every production call reports `NoBaseline`, and that is not a pass.** ADR-016 keeps a committed
+ * baseline out of the byte-compared bundle, so `create()` (no baseline) resolves to `NoBaseline`,
+ * which `held()` is false for - the way TrustSC's own `NoBaseline` behaves.
+ *
+ * **With a baseline the digest is exact.** A hand-computed SHA-256 over the ROI holds; a single
+ * flipped channel is `DigestMismatch` - the smallest wrong answer, the one a tolerance would wave
+ * through, which is the same discipline `tests/render/PixelTests.cpp` applies to a whole frame.
+ *
+ * **The digest is over tightly packed row-major RGBA8, scoped to the ROI.** It does not depend on
+ * the framebuffer's row stride, and a pixel changed outside the ROI does not change the result.
+ *
+ * The frames are painted by hand with `SyntheticFrame.hpp`'s `Canvas`; no GPU is involved, which is
+ * ADR-014 decision 1's first consequence made mechanical.
+ */
+
+import std;
+import speclab;
+import mdux.core.result;
+import mdux.core.units;
+import mdux.evidence.digest;
+import mdux.medui.schema;
+import mdux.verify;
+
+#include "../framework/SpecLabBridge.hpp"
+#include "SyntheticFrame.hpp"
+
+namespace {
+
+namespace ms = mdux::medui;
+namespace mv = mdux::verify;
+
+using mdux::core::ColorRgba8;
+using mdux::core::Px;
+using mdux::test::verify::Canvas;
+
+/// What a fixture clears to.
+constexpr ColorRgba8 ground{.r = 10, .g = 10, .b = 10, .a = 255};
+
+/// SHA-256 over `rect`'s pixels of `canvas`, row by row, four bytes per pixel, no stride padding -
+/// the same "tightly packed row-major RGBA8" `rawImageDigest()` hashes, computed independently here
+/// so a scenario checks the check rather than a shared helper.
+[[nodiscard]] mdux::evidence::Digest digestOf(const Canvas& canvas, ms::NodeRect rect) {
+    std::vector<std::byte> packed;
+    packed.reserve(static_cast<std::size_t>(rect.width) * static_cast<std::size_t>(rect.height) * 4U);
+    for (Px y = rect.y; y < rect.y + rect.height; ++y) {
+        for (Px x = rect.x; x < rect.x + rect.width; ++x) {
+            const ColorRgba8 pixel = canvas.at(x, y);
+            packed.push_back(std::byte{pixel.r});
+            packed.push_back(std::byte{pixel.g});
+            packed.push_back(std::byte{pixel.b});
+            packed.push_back(std::byte{pixel.a});
+        }
+    }
+    return mdux::evidence::sha256(packed);
+}
+
+/// Builds the expectation or fails the scenario, so a `Then` reads as the claim.
+[[nodiscard]] mv::RawImageExpectation withBaseline(ms::NodeRect roi, mdux::evidence::Digest baseline) {
+    auto made = mv::RawImageExpectation::createWithBaseline("readout", mv::RenderScope::localeFree(), roi, baseline);
+    if (!made.has_value()) {
+        throw speclab::core::AssertionFailure(std::string{"the expectation was refused: "} + std::string{mv::describe(made.error())},
+                                              std::source_location::current());
+    }
+    return *made;
+}
+
+[[nodiscard]] mv::RawImageExpectation noBaseline(ms::NodeRect roi) {
+    auto made = mv::RawImageExpectation::create("readout", mv::RenderScope::localeFree(), roi);
+    if (!made.has_value()) {
+        throw speclab::core::AssertionFailure(std::string{"the expectation was refused: "} + std::string{mv::describe(made.error())},
+                                              std::source_location::current());
+    }
+    return *made;
+}
+
+constexpr ms::NodeRect roi{.x = 4, .y = 4, .width = 8, .height = 6};
+
+}  // namespace
+
+const mdux::spec::Register aMatchingBaselineHolds{
+    "A region whose SHA-256 is the committed baseline holds, and names the raw-image-digest profile",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-rawdigest-matches-baseline")
+            .Given("a painted frame and the digest of its ROI computed by hand", [] {})
+            .When("rawImageDigest runs with that digest as the baseline", [] {})
+            .Then("it holds, and the outcome carries mdux.local/raw-image-digest v1",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Canvas canvas{16, 20, ground};
+                      canvas.fill(roi, ColorRgba8{.r = 33, .g = 184, .b = 107, .a = 255});
+                      canvas.set(6, 6, ColorRgba8{.r = 200, .g = 12, .b = 40, .a = 255});
+
+                      const mv::CheckOutcome outcome = mv::rawImageDigest(canvas.view(), withBaseline(roi, digestOf(canvas, roi)));
+
+                      checks.expect(outcome.held(), std::format("the digest matches: {}", mv::describe(outcome.finding)));
+                      checks.expect(outcome.check == "RawImageDigest", "the outcome names the check");
+                      checks.expect(outcome.profile == mv::rawImageDigestProfile, "and its observation profile");
+                      checks.expect(outcome.profile.id() == "mdux.local/raw-image-digest", "which is the raw-image-digest id");
+                      checks.expect(outcome.profile.version() == 1, "at version 1");
+                      checks.expect(outcome.nodeId == "readout" && outcome.scope == mv::localeFreeScopeName, "and the node and scope");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register oneFlippedChannelIsAMismatch{
+    "A single flipped channel in the region is a DigestMismatch, not a pass",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-rawdigest-mismatch")
+            .Given("a baseline taken from one frame", [] {})
+            .When("one channel of one ROI pixel is changed and the check runs", [] {})
+            .Then("it reports DigestMismatch",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Canvas original{16, 20, ground};
+                      original.fill(roi, ColorRgba8{.r = 33, .g = 184, .b = 107, .a = 255});
+                      const mdux::evidence::Digest baseline = digestOf(original, roi);
+
+                      Canvas altered{16, 20, ground};
+                      altered.fill(roi, ColorRgba8{.r = 33, .g = 184, .b = 107, .a = 255});
+                      altered.set(7, 7, ColorRgba8{.r = 34, .g = 184, .b = 107, .a = 255});  // +1 on red
+
+                      const mv::CheckOutcome outcome = mv::rawImageDigest(altered.view(), withBaseline(roi, baseline));
+                      checks.expect(outcome.finding == mv::Finding::DigestMismatch, std::format("smallest wrong answer is a mismatch: {}", mv::describe(outcome.finding)));
+                      checks.expect(!outcome.held(), "which is a failure");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register anAbsentBaselineNeverPasses{
+    "With no committed baseline the region cannot discharge anything: NoBaseline, never Held",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-rawdigest-absent-baseline")
+            .Given("a painted frame and an expectation built without a baseline", [] {})
+            .When("rawImageDigest runs", [] {})
+            .Then("it reports NoBaseline, which is not a pass, and still names the node, scope and profile",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Canvas canvas{16, 20, ground};
+                      canvas.fill(roi, ColorRgba8{.r = 60, .g = 107, .b = 44, .a = 255});
+
+                      const mv::CheckOutcome outcome = mv::rawImageDigest(canvas.view(), noBaseline(roi));
+                      checks.expect(outcome.finding == mv::Finding::NoBaseline, std::format("no baseline to compare against: {}", mv::describe(outcome.finding)));
+                      checks.expect(!outcome.held(), "and NoBaseline never discharges an obligation");
+                      checks.expect(outcome.nodeId == "readout", "the outcome still names the node");
+                      checks.expect(outcome.scope == mv::localeFreeScopeName, "and the scope");
+                      checks.expect(outcome.profile == mv::rawImageDigestProfile, "and the observation profile");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aRegionOffTheFrameFails{
+    "A region that is not inside the frame fails rather than reading past it",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-rawdigest-region-outside-frame")
+            .Given("an ROI wider than the frame handed in", [] {})
+            .When("rawImageDigest runs", [] {})
+            .Then("it fails as a region outside the frame",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Canvas small{8, 8, ground};
+                      const mv::CheckOutcome outcome = mv::rawImageDigest(small.view(), noBaseline(roi));
+                      checks.expect(outcome.finding == mv::Finding::RegionOutsideFrame, "the rectangle leaves the frame");
+                      checks.expect(!outcome.held(), "which is a failure, not a skip");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theDigestIsRowMajorAndStrideIndependent{
+    "The digest is over tightly packed RGBA8: the framebuffer's row stride does not change it",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-rawdigest-row-major-independent-of-stride")
+            .Given("one image as a packed view and as a padded-stride view", [] {})
+            .When("rawImageDigest runs over each against the packed image's own digest", [] {})
+            .Then("both hold: padding between rows is not part of the observation",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      constexpr Px          width   = 6;
+                      constexpr Px          height  = 4;
+                      constexpr std::size_t widthSz = static_cast<std::size_t>(width);
+                      std::vector<ColorRgba8> pixels(widthSz * static_cast<std::size_t>(height), ground);
+                      for (std::size_t y = 0; y < static_cast<std::size_t>(height); ++y) {
+                          for (std::size_t x = 0; x < widthSz; ++x) {
+                              pixels[y * widthSz + x] = ColorRgba8{.r = static_cast<std::uint8_t>(x * 8),
+                                                                  .g = static_cast<std::uint8_t>(y * 8),
+                                                                  .b = 42,
+                                                                  .a = 255};
+                          }
+                      }
+
+                      const auto packed = mv::FramebufferView::createPacked(pixels, width, height);
+                      if (!packed.has_value()) {
+                          throw speclab::core::AssertionFailure("the packed view was refused", std::source_location::current());
+                      }
+
+                      // The same pixels with 8 padding bytes per row.
+                      constexpr std::size_t paddedStride = widthSz * 4 + 8;
+                      std::vector<std::byte> paddedBytes(paddedStride * static_cast<std::size_t>(height), std::byte{0xEE});
+                      for (std::size_t y = 0; y < static_cast<std::size_t>(height); ++y) {
+                          for (std::size_t x = 0; x < widthSz; ++x) {
+                              const ColorRgba8  pixel = pixels[y * widthSz + x];
+                              const std::size_t base  = y * paddedStride + x * 4;
+                              paddedBytes[base + 0]   = std::byte{pixel.r};
+                              paddedBytes[base + 1]   = std::byte{pixel.g};
+                              paddedBytes[base + 2]   = std::byte{pixel.b};
+                              paddedBytes[base + 3]   = std::byte{pixel.a};
+                          }
+                      }
+                      const auto padded = mv::FramebufferView::create(paddedBytes, width, height, paddedStride, mv::PixelFormat::Rgba8Unorm);
+                      if (!padded.has_value()) {
+                          throw speclab::core::AssertionFailure(std::string{"the padded view was refused: "} + std::string{mv::describe(padded.error())},
+                                                                std::source_location::current());
+                      }
+
+                      // The digest of the whole image, packed.
+                      std::vector<std::byte> tight;
+                      for (const ColorRgba8& pixel : pixels) {
+                          tight.push_back(std::byte{pixel.r});
+                          tight.push_back(std::byte{pixel.g});
+                          tight.push_back(std::byte{pixel.b});
+                          tight.push_back(std::byte{pixel.a});
+                      }
+                      const mdux::evidence::Digest baseline = mdux::evidence::sha256(tight);
+                      const ms::NodeRect whole{.x = 0, .y = 0, .width = width, .height = height};
+
+                      checks.expect(mv::rawImageDigest(*packed, withBaseline(whole, baseline)).held(), "the packed view matches");
+                      checks.expect(mv::rawImageDigest(*padded, withBaseline(whole, baseline)).held(), "and so does the padded one");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theDigestIsScopedToTheRoi{
+    "The digest covers only the ROI: a pixel changed outside it does not change the result",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-rawdigest-roi-scoped")
+            .Given("a baseline for a sub-rectangle of the frame", [] {})
+            .When("a pixel outside that rectangle is changed", [] {})
+            .Then("the ROI digest still holds, and the whole-frame digest would not",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      Canvas canvas{16, 20, ground};
+                      canvas.fill(roi, ColorRgba8{.r = 33, .g = 184, .b = 107, .a = 255});
+                      const mdux::evidence::Digest roiBaseline   = digestOf(canvas, roi);
+                      const ms::NodeRect           whole{.x = 0, .y = 0, .width = 16, .height = 20};
+                      const mdux::evidence::Digest wholeBaseline = digestOf(canvas, whole);
+
+                      canvas.set(0, 0, ColorRgba8{.r = 255, .g = 255, .b = 255, .a = 255});  // outside the ROI
+
+                      checks.expect(mv::rawImageDigest(canvas.view(), withBaseline(roi, roiBaseline)).held(), "the ROI digest is unchanged");
+                      checks.expect(mv::rawImageDigest(canvas.view(), withBaseline(whole, wholeBaseline)).finding == mv::Finding::DigestMismatch,
+                                    "while the whole-frame digest is not");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register theProfileIsImplementationLocalAndVersioned{
+    "The raw-image-digest profile is implementation-local and immutably versioned",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-rawdigest-profile-identity")
+            .Given("the rawImageDigestProfile constant", [] {})
+            .When("its id and version are read", [] {})
+            .Then("the id carries the implementation-local prefix and the version is 1",
+                  [] {
+                      mdux::spec::Checks checks;
+                      checks.expect(mv::rawImageDigestProfile.id() == "mdux.local/raw-image-digest", "the id is mdux.local/raw-image-digest");
+                      checks.expect(mv::rawImageDigestProfile.id().starts_with(mv::localProfilePrefix), "which is implementation-local (ADR-016)");
+                      checks.expect(mv::rawImageDigestProfile.version() == 1, "at version 1");
+                      checks.expect(mv::rawImageDigestProfile.valid(), "and it names a profile");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register aDegenerateRoiIsRefused{
+    "An expectation over a non-positive rectangle is refused before any check runs",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-rawdigest-roi-degenerate-refused")
+            .Given("a region of interest with zero width", [] {})
+            .When("an expectation is built from it", [] {})
+            .Then("it is refused as a degenerate ROI",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      const auto made = mv::RawImageExpectation::create("readout", mv::RenderScope::localeFree(),
+                                                                        ms::NodeRect{.x = 4, .y = 4, .width = 0, .height = 6});
+                      checks.expect(!made.has_value(), "the expectation is not built");
+                      if (!made.has_value()) {
+                          checks.expect(made.error() == mv::VerifyError::DigestRoiDegenerate, "and the reason names the degenerate ROI");
+                      }
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/verify/TextCheckTests.cpp
+++ b/tests/verify/TextCheckTests.cpp
@@ -857,3 +857,35 @@ const mdux::spec::Register aProductionExpectationIsAuthorisedByArtifacts{
                 })
             .Execute();
     }};
+
+const mdux::spec::Register eachTextCheckNamesItsOwnObservation{
+    "InkContainment and LocalizedTextPresence carry distinct, versioned observation profiles",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-text-observation-profile")
+            .Given("a label whose approved run is drawn where the runtime would draw it", [] {})
+            .When("both mandatory text checks run", [] {})
+            .Then("each outcome names the profile its check reports under (ADR-015 D2 / ADR-016)",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      checks.expect(mv::profileOf(mv::TextCheck::InkContainment) == mv::inkContainmentProfile, "InkContainment maps to ink-containment");
+                      checks.expect(mv::profileOf(mv::TextCheck::LocalizedTextPresence) == mv::inkCoverageProfile, "LocalizedTextPresence maps to ink-coverage");
+                      checks.expect(mv::profileOf(mv::TextCheck::InkContainment) != mv::profileOf(mv::TextCheck::LocalizedTextPresence), "and the two are distinct observations");
+                      checks.expect(mv::inkContainmentProfile.id().starts_with(mv::localProfilePrefix), "the ids are implementation-local");
+                      checks.expect(mv::inkCoverageProfile.version() == 1, "at version 1");
+
+                      const mdux::font::FontPackage font    = twoGlyphFont();
+                      const std::vector<std::byte>  atlas   = syntheticAtlas();
+                      const std::vector<std::byte>  records = abRun();
+                      const mv::TextExpectation     title   = expect(titleNode(), records, font, atlas);
+
+                      Canvas canvas{64, 48, ground};
+                      paintRun(canvas, title, tintOf(titleToken));
+
+                      checks.expect(mv::inkContainment(canvas.view(), title).profile == mv::inkContainmentProfile, "the InkContainment outcome carries ink-containment");
+                      checks.expect(mv::localizedTextPresence(canvas.view(), title).profile == mv::inkCoverageProfile, "the LocalizedTextPresence outcome carries ink-coverage");
+                      checks.raise();
+                  })
+            .Execute();
+    }};

--- a/tests/verify_ui/ArtifactTests.cpp
+++ b/tests/verify_ui/ArtifactTests.cpp
@@ -32,8 +32,8 @@ namespace vu  = mdux::tools::verify;
         {  .kind = vu::ObligationKind::Text, .nodeId = "title", .scope = "en-US", .check = "InkContainment"}
     };
     result.outcomes = {
-        {.finding = mv::Finding::NothingPainted,  .nodeId = "dial", .scope = "en-US",         .check = "Bounds"},
-        {          .finding = mv::Finding::Held, .nodeId = "title", .scope = "en-US", .check = "InkContainment"}
+        {.finding = mv::Finding::NothingPainted, .nodeId = "dial", .scope = "en-US", .check = "Bounds", .profile = mv::profileOf(mv::CvCheck::Bounds)},
+        {.finding = mv::Finding::Held, .nodeId = "title", .scope = "en-US", .check = "InkContainment", .profile = mv::profileOf(mv::TextCheck::InkContainment)}
     };
     result.inputs = {
         {.role = "screenPackage",       .id = "demo",      .locale = {}, .sha256 = std::string(64, 'a')},
@@ -107,7 +107,14 @@ const mdux::spec::Register noMeasurementReachesTheArtifact{
                       }
                       checks.expect(!text->contains("found"), "no measured rectangle or colour is recorded");
                       checks.expect(!text->contains("expected"), "not even the expectation's own numbers, which goldens.json already carries");
-                      checks.expect(!text->contains("/") && !text->contains("\\\\"), "no path, absolute or otherwise");
+                      // No filesystem path: not an absolute one, not a relative one, and not a
+                      // committed-artifact filename or the build tree it is baked into. The `/` in a
+                      // `mdux.local/...` profile id is a namespace separator, not a path, so the
+                      // check names what a path actually looks like rather than banning the byte.
+                      checks.expect(!text->contains("\"/") && !text->contains("\"./") && !text->contains("\"../") && !text->contains("\\\\"),
+                                    "no path value, absolute or otherwise");
+                      checks.expect(!text->contains("generated") && !text->contains("mdux_bake") && !text->contains(".json"),
+                                    "and no artifact filename or build-tree location");
                       checks.expect(!text->contains("duration") && !text->contains("elapsed"), "no duration");
                       checks.raise();
                   })
@@ -164,6 +171,52 @@ const mdux::spec::Register aRunThatCouldNotBeMadeIsNotWritable{
                       vu::RunResult wrongCheck     = completedRun();
                       wrongCheck.outcomes[0].check = "ColorHash";
                       checks.expect(!vu::writeVerification(wrongCheck, "demo").has_value(), "and one that would turn a bounds obligation into a tint claim");
+                      checks.raise();
+                  })
+            .Execute();
+    }};
+
+const mdux::spec::Register everyOutcomeMustCarryItsOwnObservationProfile{
+    "An outcome with no observation profile, or the wrong one, is refused rather than serialized",
+    "evidence-unit",
+    [] {
+        return speclab::Test("verify-artifact-observation-profile")
+            .Given("a completed run, and copies of it whose outcomes carry a wrong or missing profile", [] {})
+            .When("each is offered to the writer", [] {})
+            .Then("the coherent one records each outcome's profile, and the incoherent ones are refused",
+                  [] {
+                      mdux::spec::Checks checks;
+
+                      // The happy path: every outcome carries the profile its check reports under,
+                      // and the writer records it (ADR-016).
+                      const auto text = vu::writeVerification(completedRun(), "demo");
+                      checks.expect(text.has_value(), "a run whose profiles match its checks is written");
+                      if (text.has_value()) {
+                          checks.expect(text->contains("mdux.local/extent-equality"), "the Bounds outcome records the extent-equality profile");
+                          checks.expect(text->contains("mdux.local/ink-containment"), "the InkContainment outcome records the ink-containment profile");
+                          checks.expect(text->contains("\"version\""), "with a version beside the id");
+                      }
+
+                      // A default-constructed profile - what an outcome built without one carries -
+                      // names no observation, so the writer cannot say what was measured.
+                      vu::RunResult unidentified            = completedRun();
+                      unidentified.outcomes[0].profile      = mv::ObservationProfile{};
+                      const auto refusedUnidentified        = vu::writeVerification(unidentified, "demo");
+                      checks.expect(!refusedUnidentified.has_value() && refusedUnidentified.error() == vu::ArtifactError::ObservationProfileInvalid,
+                                    "an outcome with no profile is refused");
+
+                      // A profile that belongs to a different check - here the raw-pixel digest on a
+                      // tint predicate's outcome - is the misidentification the field exists to stop.
+                      vu::RunResult misidentified           = completedRun();
+                      misidentified.outcomes[0].profile     = mv::rawImageDigestProfile;
+                      const auto refusedMisidentified       = vu::writeVerification(misidentified, "demo");
+                      checks.expect(!refusedMisidentified.has_value() && refusedMisidentified.error() == vu::ArtifactError::ObservationProfileInvalid,
+                                    "and one carrying another check's profile is refused too");
+
+                      // Even the right id at an unrecognised version is not this build's observation.
+                      vu::RunResult wrongVersion            = completedRun();
+                      wrongVersion.outcomes[1].profile      = mv::ObservationProfile{"mdux.local/ink-containment", 99};
+                      checks.expect(!vu::writeVerification(wrongVersion, "demo").has_value(), "and so is a known id at a version this build does not produce");
                       checks.raise();
                   })
             .Execute();

--- a/tools/verify/Artifact.cpp
+++ b/tools/verify/Artifact.cpp
@@ -44,17 +44,31 @@ using mdux::core::err;
 }
 
 /**
- * @brief One outcome as the file records it: the obligation, and whether it held.
+ * @brief One outcome as the file records it: the obligation, which observation performed it, and
+ *        whether it held.
  *
- * Four members and no fifth. `check` and `scope` are what keep a claim scoped to the obligation it
- * came from - a node verified in `en-US` and not in `de-DE` shows up as two entries with different
- * findings rather than as one summary - and `finding` is a named reason rather than a boolean so
- * that "nothing was drawn there" and "it was drawn in the wrong colour" stay distinguishable.
+ * `check` and `scope` are what keep a claim scoped to the obligation it came from - a node verified
+ * in `en-US` and not in `de-DE` shows up as two entries with different findings rather than as one
+ * summary - and `finding` is a named reason rather than a boolean so that "nothing was drawn there"
+ * and "it was drawn in the wrong colour" stay distinguishable.
+ *
+ * `observationProfile` is an **identity, not a measurement**: it names *what* the check observed and
+ * at which revision (ADR-015 decision 2, ADR-016), so a reader - and #314's cross-implementation
+ * gate - never mistakes MduX's `ColorHash` (a tint predicate) for TrustSC's (a pixel digest). It is
+ * a fixed property of the check, so it does not turn this file into the driver-tuple-dependent
+ * artifact ADR-014 decision 4 forbids; no measured pixel value is recorded here.
  */
 [[nodiscard]] std::optional<evj::Value> outcomeToJson(const Outcome& outcome) {
+    evj::Value profile = evj::Value::emptyObject();
+    if (!put(profile, "id", evj::Value::string(std::string{outcome.profile.id()}))
+        || !put(profile, "version", evj::Value::unsignedInteger(outcome.profile.version()))) {
+        return std::nullopt;
+    }
+
     evj::Value entry = evj::Value::emptyObject();
     if (!put(entry, "check", evj::Value::string(outcome.check)) || !put(entry, "finding", evj::Value::string(std::string{mdux::verify::spell(outcome.finding)}))
-        || !put(entry, "nodeId", evj::Value::string(outcome.nodeId)) || !put(entry, "scope", evj::Value::string(outcome.scope))) {
+        || !put(entry, "nodeId", evj::Value::string(outcome.nodeId)) || !put(entry, "observationProfile", std::move(profile))
+        || !put(entry, "scope", evj::Value::string(outcome.scope))) {
         return std::nullopt;
     }
     return entry;

--- a/tools/verify/Artifact.cpp
+++ b/tools/verify/Artifact.cpp
@@ -101,6 +101,8 @@ std::string_view describe(ArtifactError error) noexcept {
             return "the run discharged no obligations, and a verification of nothing is not evidence";
         case ArtifactError::OutcomeMismatch:
             return "the run produced a different number of outcomes than it enumerated obligations";
+        case ArtifactError::ObservationProfileInvalid:
+            return "an outcome carries no observation profile, or one that is not the profile its check reports under";
         case ArtifactError::MalformedReport:
             return "the screen bundle's report.json is not a bake report";
         case ArtifactError::ReportRewriteFailed:
@@ -135,6 +137,16 @@ mdux::core::Result<std::string, ArtifactError> writeVerification(const RunResult
         const Outcome&    outcome    = result.outcomes[index];
         if (outcome.nodeId != obligation.nodeId || outcome.scope != obligation.scope || outcome.check != obligation.check) {
             return err(ArtifactError::OutcomeMismatch);
+        }
+        // The same "derive, don't trust" rule ADR-014 decision 2 states for expectations, applied to
+        // the identity ADR-016 adds: the profile the driver attached must be exactly the one this
+        // check reports under. A missing profile (`{"", 0}`) or a digest profile on a `ColorHash`
+        // outcome would put an unidentified or misidentified observation into a byte-compared file,
+        // which is the guarantee this field exists to make. `profileForCheckName()` is the same
+        // resolver the driver used, so this cannot disagree with it by construction.
+        const std::optional<mdux::verify::ObservationProfile> expected = mdux::verify::profileForCheckName(outcome.check);
+        if (!expected.has_value() || !outcome.profile.valid() || outcome.profile != *expected) {
+            return err(ArtifactError::ObservationProfileInvalid);
         }
     }
 

--- a/tools/verify/Artifact.cppm
+++ b/tools/verify/Artifact.cppm
@@ -53,13 +53,14 @@ inline constexpr std::string_view verificationFileName = "verification.json";
 inline constexpr std::string_view artifactToolName = "mdux-verify-bake";
 
 enum class ArtifactError : std::uint8_t {
-    NotRun,               ///< the run could not be made, so there is no outcome set to serialize
-    NoObligations,        ///< a run that verified nothing is not evidence (ADR-014 decision 3)
-    OutcomeMismatch,      ///< outcomes and obligations disagree; the driver's own invariant broke
-    MalformedReport,      ///< the bundle's `report.json` did not parse as a bake report
-    ReportRewriteFailed,  ///< the extended report failed its own validation
-    SerializationFailed,  ///< canonical JSON refused a member this writer built
-    PublishFailed,        ///< a bundle file could not be staged or promoted; the bundle is unchanged
+    NotRun,                    ///< the run could not be made, so there is no outcome set to serialize
+    NoObligations,             ///< a run that verified nothing is not evidence (ADR-014 decision 3)
+    OutcomeMismatch,           ///< outcomes and obligations disagree; the driver's own invariant broke
+    ObservationProfileInvalid, ///< an outcome carries no observation profile, or one that is not its check's (ADR-016)
+    MalformedReport,           ///< the bundle's `report.json` did not parse as a bake report
+    ReportRewriteFailed,       ///< the extended report failed its own validation
+    SerializationFailed,       ///< canonical JSON refused a member this writer built
+    PublishFailed,             ///< a bundle file could not be staged or promoted; the bundle is unchanged
 };
 
 [[nodiscard]] std::string_view describe(ArtifactError error) noexcept;

--- a/tools/verify/Driver.cpp
+++ b/tools/verify/Driver.cpp
@@ -783,6 +783,7 @@ private:
             .nodeId          = std::string{outcome.nodeId},
             .scope           = std::string{outcome.scope},
             .check           = std::string{outcome.check},
+            .profile         = outcome.profile,
             .expected        = outcome.expected,
             .found           = outcome.found,
             .foundValid      = outcome.foundValid,

--- a/tools/verify/Driver.cpp
+++ b/tools/verify/Driver.cpp
@@ -783,14 +783,14 @@ private:
             .nodeId          = std::string{outcome.nodeId},
             .scope           = std::string{outcome.scope},
             .check           = std::string{outcome.check},
-            .profile         = outcome.profile,
             .expected        = outcome.expected,
             .found           = outcome.found,
             .foundValid      = outcome.foundValid,
             .expectedColor   = outcome.expectedColor,
             .foundColor      = outcome.foundColor,
             .foundColorValid = outcome.foundColorValid,
-            .glyphIndex      = outcome.glyphIndex};
+            .glyphIndex      = outcome.glyphIndex,
+            .profile         = outcome.profile};
 }
 
 [[nodiscard]] std::string rectangle(mdux::medui::NodeRect value) {

--- a/tools/verify/Driver.cppm
+++ b/tools/verify/Driver.cppm
@@ -65,17 +65,18 @@ struct PlanResult {
 
 /// An owning copy of the governed outcome, suitable for #254's later serialization stage.
 struct Outcome {
-    mdux::verify::Finding  finding{mdux::verify::Finding::Held};
-    std::string            nodeId;
-    std::string            scope;
-    std::string            check;
-    mdux::medui::NodeRect  expected{};
-    mdux::medui::NodeRect  found{};
-    bool                   foundValid{false};
-    mdux::core::ColorRgba8 expectedColor{};
-    mdux::core::ColorRgba8 foundColor{};
-    bool                   foundColorValid{false};
-    std::size_t            glyphIndex{0};
+    mdux::verify::Finding            finding{mdux::verify::Finding::Held};
+    std::string                     nodeId;
+    std::string                     scope;
+    std::string                     check;
+    mdux::verify::ObservationProfile profile{};  ///< which observation produced this outcome (ADR-016)
+    mdux::medui::NodeRect            expected{};
+    mdux::medui::NodeRect            found{};
+    bool                            foundValid{false};
+    mdux::core::ColorRgba8          expectedColor{};
+    mdux::core::ColorRgba8          foundColor{};
+    bool                            foundColorValid{false};
+    std::size_t                     glyphIndex{0};
 
     [[nodiscard]] bool held() const noexcept {
         return finding == mdux::verify::Finding::Held;

--- a/tools/verify/Driver.cppm
+++ b/tools/verify/Driver.cppm
@@ -65,18 +65,20 @@ struct PlanResult {
 
 /// An owning copy of the governed outcome, suitable for #254's later serialization stage.
 struct Outcome {
-    mdux::verify::Finding            finding{mdux::verify::Finding::Held};
-    std::string                     nodeId;
-    std::string                     scope;
-    std::string                     check;
+    mdux::verify::Finding   finding{mdux::verify::Finding::Held};
+    std::string             nodeId;
+    std::string             scope;
+    std::string             check;
+    mdux::medui::NodeRect   expected{};
+    mdux::medui::NodeRect   found{};
+    bool                    foundValid{false};
+    mdux::core::ColorRgba8  expectedColor{};
+    mdux::core::ColorRgba8  foundColor{};
+    bool                    foundColorValid{false};
+    std::size_t             glyphIndex{0};
+    // Appended, not slotted beside `check`: this is an exported aggregate a caller may initialise
+    // positionally, the same reason `Invocation`'s `frameImageDirectory` is last.
     mdux::verify::ObservationProfile profile{};  ///< which observation produced this outcome (ADR-016)
-    mdux::medui::NodeRect            expected{};
-    mdux::medui::NodeRect            found{};
-    bool                            foundValid{false};
-    mdux::core::ColorRgba8          expectedColor{};
-    mdux::core::ColorRgba8          foundColor{};
-    bool                            foundColorValid{false};
-    std::size_t                     glyphIndex{0};
 
     [[nodiscard]] bool held() const noexcept {
         return finding == mdux::verify::Finding::Held;


### PR DESCRIPTION
## Summary

ADR-015 decision 2: a shared check *name* is not evidence of a shared *observation*. `ColorHash` is a tint-composition predicate in MduX and a raw-pixel SHA-256 digest in TrustSC, so #314 cannot compare the two implementations without a way to tell them apart.

This gives each `mdux.verify` rendered-check predicate an implementation-local `ObservationProfile` (an `id` naming what is observed, a `version` that moves only on a reviewed change), recorded per outcome in `verification.json`, and implements `rawImageDigest()` — the observation TrustSC's `ColorHash` performs — as its own profile.

| Predicate | Profile | Version |
|---|---|---|
| `goldenBounds()` | `mdux.local/extent-equality` | 1 |
| `colorHash()` | `mdux.local/tint-composition` | 1 |
| `inkContainment()` | `mdux.local/ink-containment` | 1 |
| `localizedTextPresence()` | `mdux.local/ink-coverage` | 1 |
| `rawImageDigest()` (new) | `mdux.local/raw-image-digest` | 1 |

**Pure identity/reporting layer.** The four existing predicates compute exactly what they computed before — ADR-015 D2's "preserve existing required checks" holds by construction. `verification.json` gains one nested `observationProfile: {id, version}` per outcome; `schemaVersion` stays `1` (the shared `evidence::kSchemaVersion` is not moved for one artifact's additive, outcome-preserving field).

**`rawImageDigest()` has no committed baseline, by design.** It is not a `CvCheck` (that set is closed and contract-owned) and ADR-014 decision 4 / alternative 6 keep a driver-tuple-dependent digest out of the byte-compared bundle — TrustSC commits none either. It reports `Finding::NoBaseline` for every production call (never a pass, matching TrustSC's own `NoBaseline`), is not wired into the driver's obligation loop, and is exercised only by fixtures. [ADR-016](https://github.com/ambroise-leclerc/MduX/blob/313-c2-implement-agreed-verification-semantics-without-weakening-existing-evidence/docs/adr/ADR-016-locally-versioned-observation-profiles.md) records the reasoning.

**Not claimed here, and recorded as open:**
- PAR-REQ-002/003/009 dispositions remain pending (this delivers the *local* half of PAR-REQ-002).
- MEDUI-DEC-007's canonical profile ids/schema/corpus are not delivered — every id is `mdux.local/*`, and no manifest or pin claims a shared profile.
- The #314 cross-implementation gate and a linked TrustSC adoption. **This is not a parity claim.**

Part of #307. Addresses #313; issue closure follows maintainer/domain review of ADR-016 and the PAR-REQ dispositions.

## Invitation and contributor agreement

- [x] I was invited by a maintainer to contribute this change. *(Repository owner.)*
- [x] I accepted the repository's Contributor Licence Agreement. *(Repository owner.)*

Invitation / CLA issue: #313

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked
- **Merge order:** mergeable now (its only prerequisite, #312 / PR #329, is merged)

## Shared registries touched

- [x] `tests/CMakeLists.txt` — `verify/RawImageDigestTests.cpp` added to `verify_spec`
- [x] Committed artifacts under `generated/` — `generated/screen/endoscope-monitor/{verification,report}.json` regenerated via `mdux-bake-update`
- [ ] `CMakeLists.txt` (root)
- [ ] `FILE_SET CXX_MODULES` lists
- [ ] `tools/CMakeLists.txt`
- [ ] Schemas under `docs/*/schemas/`
- [ ] Generated indexes

## Rebase state

- **Rebased onto:** `a209b000911fb323c03b0cc8147a8378b53b6d81` (`develop` head)
- **Conflicts resolved as a union:** no conflicts

## Verification

Local, GCC 16 + lavapipe/RADV, `MEDUI_CONFORMANCE_DIR` pointed at the pinned MedUI checkout (`265df19…`):

- [x] `cmake --build build-gcc` — clean, no warnings
- [x] `ctest --test-dir build-gcc` — **810/810 passed**, incl. `evidence` (byte-comparison of the regenerated `verification.json`), `verify` (`verify.screen.endoscope-monitor` over the committed bundle), `governed`, `noheap`, `pixel`
- [x] `verify_spec` — 36/36 (26 existing + 10 new)
- [x] `python3 tools/docs-lint/mdux_docs_lint.py` — OK (87 files)
- [x] Other: `mdux-governed-lint`, `check_schema_type_drift.py`, `check_documented_test_selectors.py` — all OK; `verification.json` diff is additive `observationProfile` only
- [ ] Clang/libc++, MSVC, MoltenVK — not run locally; the four CI legs cover them (plain C++23, no compiler-specific constructs)

One unrelated pre-existing local-only failure: `test_check_file_headers.py::test_the_tree_itself_conforms` flags a stale `examples/build/` CMake tree (gitignored, absent in CI's out-of-source builds) — the same failure #304's PR #306 recorded.

## Post-merge gate

- [x] I understand that the `develop` workflow must be green after this merges before the next dependent PR may merge.
- **Post-merge `develop` run:** pending merge
- [ ] That run is green. *(#314 is the successor; it must wait for this and the post-merge `develop` run.)*

## Regulatory impact

**Potentially safety-relevant.** The change touches the governed `mdux.verify` zone and a committed evidence artifact, but **no check semantics change and no runtime behaviour change** — the four existing predicates are byte-for-byte the same computation; only an identity field is added per outcome, and the new predicate has no production caller.

Affected records: ADR-014 (amendment note — decision 4 unchanged), ADR-015 (reference), new ADR-016 (Proposed). No hazard, risk control or software safety class names the failure mode a misidentified verification check would introduce, and this PR does not invent one — flagged for maintainer/domain review per `mdux-regulated-change`. The IEC 62304:2006 §5.7 scope limit is unchanged. No certification, validation or production-readiness claim; no cross-implementation parity claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added raw-image digest verification for RGBA8 regions using SHA-256, including baseline comparison and clear mismatch, missing-baseline, and invalid-region results.
  - Verification outcomes now include a versioned observation profile identifying the check performed.
  - Verification artifacts record each outcome’s observation profile ID and version.

- **Documentation**
  - Added and updated architecture, parity, and decision records covering observation profiles and raw-image verification.

- **Tests**
  - Added coverage for digest accuracy, regions, row padding, mismatches, and observation-profile reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->