### PR TITLE
Record the shared MedUI syntax baseline with TrustSC (#335)

### DIFF
--- a/docs/adr/ADR-017-sibling-conformance-gate-status.md
+++ b/docs/adr/ADR-017-sibling-conformance-gate-status.md
@@ -177,7 +177,7 @@ re-pin and claim the phases and profiles it implements, gated the same corpus-de
 [#335](https://github.com/ambroise-leclerc/MduX/issues/335), and until it closes the results table
 is a per-consumer statement. MduX's coverage is not lowered to match the narrower claim.
 
-**#335 adoption update, 8 September 2026:** TrustSC `b7fe0e1` adopts MedUI `9a57f64` on its work
+**#335 adoption update, 8 September 2026:** TrustSC `b21c423` adopts MedUI `9a57f64` on its work
 branch and passes all five syntax cases at line-only precision. The
 [paired results](../roadmap.md#335-paired-adoption-results) and
 [behavior reassessment](../parity/behavior-matrix.md#335-adoption-reassessment) record both heads

--- a/docs/adr/ADR-017-sibling-conformance-gate-status.md
+++ b/docs/adr/ADR-017-sibling-conformance-gate-status.md
@@ -70,7 +70,9 @@ The authoritative record of what each consumer demonstrates on its own pin is th
 table in `docs/roadmap.md`: MduX at `183a6da` (MedUI `v0.3.0-rc.1` / `9a57f64`), TrustSC at
 `4f114dd` (MedUI `0.1.0-candidate` / `c8cc45e`). It is not duplicated here or in the behavior
 matrix. The two consumers are on different contract revisions, so the table is a per-consumer
-statement, not a comparison of equivalent results.
+statement, not a comparison of equivalent results. This is the historical #314d pairing;
+the newer [#335 adoption results](../roadmap.md#335-paired-adoption-results) record TrustSC's
+shared-pin syntax candidate without extending this record's rendered/evidence dispositions.
 
 ### 2. PAR-REQ-001 — proposed **Accepted**
 
@@ -169,11 +171,19 @@ out of scope until #335.
 
 ### 5. Cross-implementation parity is not claimed
 
-TrustSC's published head is unchanged at `4f114dd`, pinned to MedUI `0.1.0-candidate`, claiming
-`syntax` only at `line-only` positions and no profiles. A shared baseline requires TrustSC to
+At the #314d assessment, TrustSC's published head was `4f114dd`, pinned to MedUI `0.1.0-candidate`,
+claiming `syntax` only at `line-only` positions and no profiles. A shared baseline requires TrustSC to
 re-pin and claim the phases and profiles it implements, gated the same corpus-derived way. That is
 [#335](https://github.com/ambroise-leclerc/MduX/issues/335), and until it closes the results table
 is a per-consumer statement. MduX's coverage is not lowered to match the narrower claim.
+
+**#335 adoption update, 8 September 2026:** TrustSC `b7fe0e1` adopts MedUI `9a57f64` on its work
+branch and passes all five syntax cases at line-only precision. The
+[paired results](../roadmap.md#335-paired-adoption-results) and
+[behavior reassessment](../parity/behavior-matrix.md#335-adoption-reassessment) record both heads
+and the evidence. Semantics, layout, safety and RENDERED/EVIDENCE remain unclaimed by TrustSC;
+joint sign-off is pending. This syntax result does not discharge the rendered cross-implementation
+condition in decision 3 or establish the derived-observation comparison in decision 4.
 
 ## Alternatives Considered
 

--- a/docs/adr/ADR-017-sibling-conformance-gate-status.md
+++ b/docs/adr/ADR-017-sibling-conformance-gate-status.md
@@ -71,7 +71,7 @@ table in `docs/roadmap.md`: MduX at `183a6da` (MedUI `v0.3.0-rc.1` / `9a57f64`),
 `4f114dd` (MedUI `0.1.0-candidate` / `c8cc45e`). It is not duplicated here or in the behavior
 matrix. The two consumers are on different contract revisions, so the table is a per-consumer
 statement, not a comparison of equivalent results. This is the historical #314d pairing;
-the newer [#335 adoption results](../roadmap.md#335-paired-adoption-results) record TrustSC's
+the newer [#335 paired adoption results](../roadmap.md#335-paired-adoption-results) record TrustSC's
 shared-pin syntax candidate without extending this record's rendered/evidence dispositions.
 
 ### 2. PAR-REQ-001 — proposed **Accepted**
@@ -177,10 +177,10 @@ re-pin and claim the phases and profiles it implements, gated the same corpus-de
 [#335](https://github.com/ambroise-leclerc/MduX/issues/335), and until it closes the results table
 is a per-consumer statement. MduX's coverage is not lowered to match the narrower claim.
 
-**#335 adoption update, 8 September 2026:** TrustSC `b21c423` adopts MedUI `9a57f64` on its work
+**#335 paired adoption results, 8 September 2026:** TrustSC `b21c423` adopts MedUI `9a57f64` on its work
 branch and passes all five syntax cases at line-only precision. The
-[paired results](../roadmap.md#335-paired-adoption-results) and
-[behavior reassessment](../parity/behavior-matrix.md#335-adoption-reassessment) record both heads
+[roadmap results table](../roadmap.md#335-paired-adoption-results) and
+[behavior matrix](../parity/behavior-matrix.md#335-paired-adoption-results) record both heads
 and the evidence. Semantics, layout, safety and RENDERED/EVIDENCE remain unclaimed by TrustSC;
 joint sign-off is pending. This syntax result does not discharge the rendered cross-implementation
 condition in decision 3 or establish the derived-observation comparison in decision 4.

--- a/docs/adr/ADR-017-sibling-conformance-gate-status.md
+++ b/docs/adr/ADR-017-sibling-conformance-gate-status.md
@@ -70,7 +70,7 @@ The authoritative record of what each consumer demonstrates on its own pin is th
 table in `docs/roadmap.md`: MduX at `183a6da` (MedUI `v0.3.0-rc.1` / `9a57f64`), TrustSC at
 `4f114dd` (MedUI `0.1.0-candidate` / `c8cc45e`). It is not duplicated here or in the behavior
 matrix. The two consumers are on different contract revisions, so the table is a per-consumer
-statement, not a comparison of equivalent results. This is the historical #314d pairing;
+statement, not a comparison of equivalent results. This is the historical `#314d` pairing;
 the newer [#335 paired adoption results](../roadmap.md#335-paired-adoption-results) record TrustSC's
 shared-pin syntax candidate without extending this record's rendered/evidence dispositions.
 
@@ -171,7 +171,7 @@ out of scope until #335.
 
 ### 5. Cross-implementation parity is not claimed
 
-At the #314d assessment, TrustSC's published head was `4f114dd`, pinned to MedUI `0.1.0-candidate`,
+At the `#314d` assessment, TrustSC's published head was `4f114dd`, pinned to MedUI `0.1.0-candidate`,
 claiming `syntax` only at `line-only` positions and no profiles. A shared baseline requires TrustSC to
 re-pin and claim the phases and profiles it implements, gated the same corpus-derived way. That is
 [#335](https://github.com/ambroise-leclerc/MduX/issues/335), and until it closes the results table
@@ -199,7 +199,7 @@ condition in decision 3 or establish the derived-observation comparison in decis
   distinct review artifact that maps each requirement to the specific tests that discharge it, and
   they deserve one record a reviewer can ratify or amend as a unit.
 - **Assign the dispositions as Accepted here rather than proposing them.** Rejected: dispositions
-  are the maintainer's and domain reviewer's to assign. This record proposes; the #314d PR review
+  are the maintainer's and domain reviewer's to assign. This record proposes; the `#314d` PR review
   ratifies, and the ratification is linked back into `docs/parity/requirements.md`.
 
 ## Consequences
@@ -207,7 +207,7 @@ condition in decision 3 or establish the derived-observation comparison in decis
 ### Positive
 
 - PAR-REQ-001/002/003 move from "no individual disposition" to a proposed disposition with a test
-  map, so the #314d review is against running code.
+  map, so the `#314d` review is against running code.
 - The RENDERED-subset limitation of the derived envelope is stated once, in a place the reviewer
   and a downstream consumer will both find.
 - The cross-implementation gap has a single owning issue (#335) and the results table has a defined
@@ -225,7 +225,7 @@ condition in decision 3 or establish the derived-observation comparison in decis
 
 - **The dispositions are read as final before the maintainer ratifies.** Mitigation: the status is
   `Proposed`, every disposition says "proposed", and `docs/parity/requirements.md` keeps explicit
-  "ratification pending in the #314d PR" wording.
+  "ratification pending in the `#314d` PR" wording.
 - **The per-consumer results table is read as a parity claim.** Mitigation: decision 1 and the
   table's own header state it is per-consumer; the two contract revisions are printed side by side;
   #335 is named as the completion condition.
@@ -239,7 +239,7 @@ condition in decision 3 or establish the derived-observation comparison in decis
 - `docs/parity/requirements.md` gains the proposed dispositions in its PAR-REQ rows and its Review
   disposition table, each linking here; the decision-map row for "#314 common corpus gate" cites
   this ADR.
-- `docs/parity/behavior-matrix.md` is re-assessed for #314d at the current pins and links the
+- `docs/parity/behavior-matrix.md` is re-assessed for `#314d` at the current pins and links the
   roadmap results table.
 - `docs/adr/README.md` indexes this as ADR-017.
 
@@ -265,7 +265,7 @@ condition in decision 3 or establish the derived-observation comparison in decis
 - **Decision Date**: pending
 - **Approved By**: pending — MduX maintainer, and a domain reviewer for the verifier-area
   dispositions (PAR-REQ-002/003)
-- **Review Date**: to be recorded in the #314d PR, with per-requirement Accepted / amended /
+- **Review Date**: to be recorded in the `#314d` PR, with per-requirement Accepted / amended /
   deferred dispositions linked back into `docs/parity/requirements.md`
 - **Scope**: the per-capability status statement and the proposed PAR-REQ-001/002/003 dispositions.
   The gate architecture stays in ADR-015/016; the cross-implementation baseline is #335.

--- a/docs/parity/behavior-matrix.md
+++ b/docs/parity/behavior-matrix.md
@@ -1,5 +1,9 @@
 # Pinned sibling behavior matrix
 
+**Latest: [#335 adoption reassessment](#335-adoption-reassessment), 8 September 2026.**
+The #314d assessment below is preserved at its original immutable inputs; the adoption section
+records the newer pair and the limited observations they now share.
+
 Assessed **7 September 2026** for [#312](https://github.com/ambroise-leclerc/MduX/issues/312);
 **re-assessed 8 September 2026 for `#314d`** against MduX
 [`183a6da`](https://github.com/ambroise-leclerc/MduX/commit/183a6da3190e673c41edbe9050586d4dc0fa4fa4)
@@ -248,6 +252,63 @@ Offline mode needs the lockfile's dependencies in the local cache. This probe is
 evidence; MduX's own `conformance_spec` is the CI gate. Widget/presentation/dynamic comparisons
 above are source inspection; no cross-sibling pixel or event-replay equivalence was executed or
 established.
+
+## #335 adoption reassessment
+
+Re-assessed **8 September 2026** against MduX
+[`abdf771`](https://github.com/ambroise-leclerc/MduX/commit/abdf77182638735adf47c6d125c53581bc9d4f3d)
+and TrustSC
+[`b7fe0e1`](https://github.com/ambroise-leclerc/TrustSC/commit/b7fe0e18304b2156520b4268e2943d23afb2c77b).
+Both manifests pin MedUI `9a57f6462b6f8dbdf1f0b8b4519674f1c6235dbb` (`v0.3.0-rc.1`).
+The [roadmap's paired results](../roadmap.md#335-paired-adoption-results) are the authoritative
+capability table; this section records the behavioral consequences and reproduction.
+
+MduX's implementation is unchanged from `183a6da`: the intervening commit updates documentation.
+TrustSC's adoption changes the parser/checker and conformance gate; inspection of its diff against
+`4f114dd` found no runtime, renderer, binding, layout or golden-predicate changes. The component,
+interaction, rendering and intentional-difference rows above therefore retain their earlier
+assessment. They have not become cross-implementation tests merely because the pins now agree.
+
+The existing [observation probe](trustsc-observation-probe.rs) was also compiled and re-run against
+TrustSC `b7fe0e1`: `nested-row: MEDUI-E015 line=6 column=absent` and
+`empty golden: GoldenBounds=pass ColorHash=no_baseline`. These remain isolated predicate results,
+not whole-screen conformance, and confirm that the earlier rendering limitations still apply.
+
+| Changed observation | Reassessment |
+|---|---|
+| Contract revision | The adoption branch now reads the same 27 compiler cases as MduX. TrustSC executes the 5 syntax cases and names the remaining 22 as unclaimed; it does not report 27 passes. |
+| Duplicate authored IDs | TrustSC refuses them during parsing across root nodes, Rows and children, at the second declaration's line. Its compiled-node check remains for synthetic panel collisions and edited ASTs. The pinned duplicate-ID source gives E014 at line 11 in both siblings. |
+| Source encoding | TrustSC's production byte parser, file compiler and checker distinguish invalid UTF-8 (E004) from unreadable source (E003). The pinned invalid-UTF-8 source gives E004 at line 1 in both siblings. |
+| Diagnostic precision | The nested-Row source remains E015 at line 6. TrustSC reports no columns for any of the five cases; MduX checks every pinned column. Full-position equivalence remains unestablished. |
+| Closed values and later compiler phases | The new pin includes E033/E034/E035 and the newer layout/safety cases. TrustSC does not execute those phases; acquiring their fixtures supplies no semantic, layout or safety conformance evidence. |
+| Shared observation profiles | TrustSC still has no complete RENDERED/EVIDENCE adapters. Native `ColorHash` and native report shapes retain the differences recorded above. No GPU/capture or derived-envelope comparison was executed. |
+
+The paired local selections passed: MduX **313 tests**, TrustSC **68 tests**. The syntax harness
+reads all expected results from the contract; its negative test inverts an accepted case's
+expected validity and proves the disagreement fails. Another negative proves that adding a phase
+without an adapter is refused. The TrustSC gate runs in a named CI step. CI integration and joint
+review status are recorded in the roadmap rather than inferred from the local totals.
+
+To reproduce, use checkouts at the two implementation SHAs above and the exact contract SHA:
+
+```sh
+# From MduX, with its configured GCC build:
+export MEDUI_CONFORMANCE_DIR=/path/to/MedUI-at-9a57f6462b6f8dbdf1f0b8b4519674f1c6235dbb
+ctest --test-dir build-gcc -R '^(verify_spec|medui_tools_spec|medui_spec|conformance_spec)::' --no-tests=error --output-on-failure
+
+# From TrustSC, retaining the same MEDUI_CONFORMANCE_DIR:
+CI=1 cargo test --locked -p trustsc-ui-dsl-authoring --test shared_conformance -- --nocapture
+cargo test --locked -p trustsc-ui-dsl-authoring -p trustsc-medui-check
+cargo build --locked --workspace
+cargo test --locked --quiet
+```
+
+The local TrustSC run used Rust/Cargo 1.96.0, `--offline`, and a writable copy of the Cargo cache
+under `/tmp`; this resolves the read-only-cache limitation of the historical #314d run. These
+results support common syntax acceptance and diagnostic codes/lines. They do not change
+PAR-REQ-002/003's unverified cross-implementation observations or assign clinical risk controls.
+Impact is **potentially safety-relevant conformance documentation**: only the recorded evidence
+changes in MduX; no runtime code, baked artifact, safety class or certification claim changes.
 
 [m-manifest]: https://github.com/ambroise-leclerc/MduX/blob/183a6da3190e673c41edbe9050586d4dc0fa4fa4/medui-conformance.toml
 [t-manifest]: https://github.com/ambroise-leclerc/TrustSC/blob/4f114dd30c64f61d11edb5941e95f422e189f305/medui-conformance.toml

--- a/docs/parity/behavior-matrix.md
+++ b/docs/parity/behavior-matrix.md
@@ -256,36 +256,40 @@ established.
 ## #335 adoption reassessment
 
 Re-assessed **8 September 2026** against MduX
-[`abdf771`](https://github.com/ambroise-leclerc/MduX/commit/abdf77182638735adf47c6d125c53581bc9d4f3d)
+[`a722784`](https://github.com/ambroise-leclerc/MduX/commit/a722784de5c958cec9ede7903bdf577eb10fe09f)
 and TrustSC
-[`b7fe0e1`](https://github.com/ambroise-leclerc/TrustSC/commit/b7fe0e18304b2156520b4268e2943d23afb2c77b).
+[`b21c423`](https://github.com/ambroise-leclerc/TrustSC/commit/b21c423f590d37c98625e3101ef41787ee4fb13c).
 Both manifests pin MedUI `9a57f6462b6f8dbdf1f0b8b4519674f1c6235dbb` (`v0.3.0-rc.1`).
 The [roadmap's paired results](../roadmap.md#335-paired-adoption-results) are the authoritative
 capability table; this section records the behavioral consequences and reproduction.
 
-MduX's implementation is unchanged from `183a6da`: the intervening commit updates documentation.
-TrustSC's adoption changes the parser/checker and conformance gate; inspection of its diff against
+MduX's implementation is unchanged from `183a6da`: the intervening changes update documentation.
+TrustSC's adoption changes the parser/checker, Studio file loading and conformance gate; inspection
+of its diff against
 `4f114dd` found no runtime, renderer, binding, layout or golden-predicate changes. The component,
 interaction, rendering and intentional-difference rows above therefore retain their earlier
 assessment. They have not become cross-implementation tests merely because the pins now agree.
 
 The existing [observation probe](trustsc-observation-probe.rs) was also compiled and re-run against
-TrustSC `b7fe0e1`: `nested-row: MEDUI-E015 line=6 column=absent` and
+TrustSC `b21c423`: `nested-row: MEDUI-E015 line=6 column=absent` and
 `empty golden: GoldenBounds=pass ColorHash=no_baseline`. These remain isolated predicate results,
 not whole-screen conformance, and confirm that the earlier rendering limitations still apply.
 
 | Changed observation | Reassessment |
 |---|---|
 | Contract revision | The adoption branch now reads the same 27 compiler cases as MduX. TrustSC executes the 5 syntax cases and names the remaining 22 as unclaimed; it does not report 27 passes. |
-| Duplicate authored IDs | TrustSC refuses them during parsing across root nodes, Rows and children, at the second declaration's line. Its compiled-node check remains for synthetic panel collisions and edited ASTs. The pinned duplicate-ID source gives E014 at line 11 in both siblings. |
-| Source encoding | TrustSC's production byte parser, file compiler and checker distinguish invalid UTF-8 (E004) from unreadable source (E003). The pinned invalid-UTF-8 source gives E004 at line 1 in both siblings. |
+| Duplicate authored IDs | TrustSC refuses them during parsing across root nodes, Rows and children, using final IDs and the later effective declaration's line; overwritten values reserve no names. Its compiled-node check remains for synthetic panel collisions and edited ASTs. The pinned duplicate-ID source gives E014 at line 11 in both siblings. |
+| Source encoding | TrustSC's production byte parser, file compiler, checker and Studio file endpoints distinguish invalid UTF-8 (E004) from unreadable source (E003). The pinned invalid-UTF-8 source gives E004 at line 1 in both siblings. |
 | Diagnostic precision | The nested-Row source remains E015 at line 6. TrustSC reports no columns for any of the five cases; MduX checks every pinned column. Full-position equivalence remains unestablished. |
 | Closed values and later compiler phases | The new pin includes E033/E034/E035 and the newer layout/safety cases. TrustSC does not execute those phases; acquiring their fixtures supplies no semantic, layout or safety conformance evidence. |
+| Known safety divergence | An annotation does not promote an optional Button/TextInput requirement to mandatory: E070 is not implemented. This is a behavioral gap in the unclaimed safety phase, not merely a missing diagnostic constant. |
 | Shared observation profiles | TrustSC still has no complete RENDERED/EVIDENCE adapters. Native `ColorHash` and native report shapes retain the differences recorded above. No GPU/capture or derived-envelope comparison was executed. |
 
-The paired local selections passed: MduX **313 tests**, TrustSC **68 tests**. The syntax harness
-reads all expected results from the contract; its negative test inverts an accepted case's
-expected validity and proves the disagreement fails. Another negative proves that adding a phase
+The paired local selections passed: MduX **313 tests**, TrustSC **70 tests**. The syntax harness
+reads all expected results from the contract; its negative test loads the source and runs a positive
+control before inverting validity, then checks the exact assertion message. I/O failures cannot
+satisfy that negative. Studio's **36 tests** also passed, including file endpoint encoding and I/O
+regressions. Another negative proves that adding a phase
 without an adapter is refused. The TrustSC gate runs in a named CI step. CI integration and joint
 review status are recorded in the roadmap rather than inferred from the local totals.
 

--- a/docs/parity/behavior-matrix.md
+++ b/docs/parity/behavior-matrix.md
@@ -1,7 +1,7 @@
 # Pinned sibling behavior matrix
 
 **Latest: [#335 paired adoption results](#335-paired-adoption-results), 8 September 2026.**
-The #314d assessment below is preserved at its original immutable inputs; the adoption section
+The `#314d` assessment below is preserved at its original immutable inputs; the adoption section
 records the newer pair and the limited observations they now share.
 
 Assessed **7 September 2026** for [#312](https://github.com/ambroise-leclerc/MduX/issues/312);
@@ -133,7 +133,7 @@ Sources: [MduX predicates][m-verify], [implementation arithmetic][m-arithmetic],
 the ability to compute/compare a hash is not evidence of a committed image regression gate.
 [MedUI #15](https://github.com/Compliatory/MedUI/issues/15) requests the versioned resolution.
 
-### #314d — the MduX side of the "Proposed treatment" column is delivered and gated
+### `#314d` — the MduX side of the "Proposed treatment" column is delivered and gated
 
 The four merged stages of [#314](https://github.com/ambroise-leclerc/MduX/issues/314) turned the
 proposal above into running code on the MduX side. TrustSC's observations in the table are
@@ -317,7 +317,7 @@ The local TrustSC run used Rust/Cargo 1.96.0, `--offline`, and a writable copy o
 under `/tmp`, as shown above. The source cache must already contain the registry packages required
 by the pinned `Cargo.lock` for the selected host; `--offline` does not download missing dependencies. Copying it to a
 writable directory allows Cargo to unpack cached packages despite the original read-only Cargo
-home, resolving that specific limitation of the historical #314d run. These results support common
+home, resolving that specific limitation of the historical `#314d` run. These results support common
 syntax acceptance and diagnostic codes/lines. They do not change
 PAR-REQ-002/003's unverified cross-implementation observations or assign clinical risk controls.
 Impact is **potentially safety-relevant conformance documentation**: only the recorded evidence

--- a/docs/parity/behavior-matrix.md
+++ b/docs/parity/behavior-matrix.md
@@ -1,6 +1,6 @@
 # Pinned sibling behavior matrix
 
-**Latest: [#335 adoption reassessment](#335-adoption-reassessment), 8 September 2026.**
+**Latest: [#335 paired adoption results](#335-paired-adoption-results), 8 September 2026.**
 The #314d assessment below is preserved at its original immutable inputs; the adoption section
 records the newer pair and the limited observations they now share.
 
@@ -253,7 +253,7 @@ evidence; MduX's own `conformance_spec` is the CI gate. Widget/presentation/dyna
 above are source inspection; no cross-sibling pixel or event-replay equivalence was executed or
 established.
 
-## #335 adoption reassessment
+## #335 paired adoption results
 
 Re-assessed **8 September 2026** against MduX
 [`a722784`](https://github.com/ambroise-leclerc/MduX/commit/a722784de5c958cec9ede7903bdf577eb10fe09f)
@@ -301,15 +301,24 @@ export MEDUI_CONFORMANCE_DIR=/path/to/MedUI-at-9a57f6462b6f8dbdf1f0b8b4519674f1c
 ctest --test-dir build-gcc -R '^(verify_spec|medui_tools_spec|medui_spec|conformance_spec)::' --no-tests=error --output-on-failure
 
 # From TrustSC, retaining the same MEDUI_CONFORMANCE_DIR:
-CI=1 cargo test --locked -p trustsc-ui-dsl-authoring --test shared_conformance -- --nocapture
-cargo test --locked -p trustsc-ui-dsl-authoring -p trustsc-medui-check
-cargo build --locked --workspace
-cargo test --locked --quiet
+# Copy the already populated registry cache into a fresh writable Cargo home.
+mdux335_cargo_source="${CARGO_HOME:-$HOME/.cargo}"
+mdux335_cargo_copy="$(mktemp -d /tmp/mdux-335-cargo.XXXXXX)"
+cp -R "$mdux335_cargo_source/registry" "$mdux335_cargo_copy/"
+chmod -R u+w "$mdux335_cargo_copy"
+export CARGO_HOME="$mdux335_cargo_copy"
+CI=1 cargo test --offline --locked -p trustsc-ui-dsl-authoring --test shared_conformance -- --nocapture
+cargo test --offline --locked -p trustsc-ui-dsl-authoring -p trustsc-medui-check
+cargo build --offline --locked --workspace
+cargo test --offline --locked --quiet
 ```
 
 The local TrustSC run used Rust/Cargo 1.96.0, `--offline`, and a writable copy of the Cargo cache
-under `/tmp`; this resolves the read-only-cache limitation of the historical #314d run. These
-results support common syntax acceptance and diagnostic codes/lines. They do not change
+under `/tmp`, as shown above. The source cache must already contain the registry packages required
+by the pinned `Cargo.lock` for the selected host; `--offline` does not download missing dependencies. Copying it to a
+writable directory allows Cargo to unpack cached packages despite the original read-only Cargo
+home, resolving that specific limitation of the historical #314d run. These results support common
+syntax acceptance and diagnostic codes/lines. They do not change
 PAR-REQ-002/003's unverified cross-implementation observations or assign clinical risk controls.
 Impact is **potentially safety-relevant conformance documentation**: only the recorded evidence
 changes in MduX; no runtime code, baked artifact, safety class or certification claim changes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,10 +12,10 @@
 > **Update, 8 September 2026:** epic #307's child #314 is merged on the MduX side (four stages,
 > through `183a6da`). The [#314 per-capability conformance results](#314-per-capability-conformance-results)
 > table records what each consumer's own pin demonstrates; the cross-implementation baseline is
-> [#335](https://github.com/ambroise-leclerc/MduX/issues/335). TrustSC's head is unchanged at
+> [#335](https://github.com/ambroise-leclerc/MduX/issues/335). TrustSC's published head is unchanged at
 > `4f114dd`, so the Phase-2 comparison below still stands as assessed.
 >
-> **#335 adoption candidate, 8 September 2026:** TrustSC `b21c423` now pins the same MedUI
+> **#335 paired adoption results, 8 September 2026:** TrustSC `b21c423` now pins the same MedUI
 > revision as MduX. The [paired adoption results](#335-paired-adoption-results) below record a
 > shared syntax baseline at line precision. The earlier comparison remains historical;
 > unclaimed phases/profiles and joint sign-off remain explicit gaps.
@@ -136,7 +136,7 @@ dispositions, and the TrustSC-side re-pin tracked as a follow-up issue.
 
 #### #314 per-capability conformance results
 
-**Historical #314 assessment; the [#335 pairing](#335-paired-adoption-results) below is newer.**
+**Historical #314 assessment; the [#335 paired adoption results](#335-paired-adoption-results) below are newer.**
 At these assessed heads the two consumers pin **different** shared-contract revisions, so the table
 records what each demonstrates on its own pin — it is not a cross-implementation parity claim.
 
@@ -202,7 +202,7 @@ MduX `a722784` has successful published
 [macOS](https://github.com/ambroise-leclerc/MduX/actions/runs/34222463456) and
 [sanitizer](https://github.com/ambroise-leclerc/MduX/actions/runs/34222463431) runs.
 Reproduction and the behavioral reassessment are in the
-[behavior matrix](parity/behavior-matrix.md#335-adoption-reassessment).
+[behavior matrix](parity/behavior-matrix.md#335-paired-adoption-results).
 
 **Joint sign-off remains pending.** This removes the pin mismatch for the adoption branch and
 supports the common syntax subset only. TrustSC's semantics/layout/safety adapters and shared

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -191,10 +191,9 @@ selection passed **68 tests** (59 library, 6 CLI, 3 conformance-harness tests), 
 corpus-derived syntax cases, an inverted-expectation negative and refusal of an unsupported phase
 claim. Its full local workspace build and **316 tests with no failures or ignored tests** also
 passed, using Rust/Cargo 1.96.0. The [TrustSC adoption CI run](https://github.com/ambroise-leclerc/TrustSC/actions/runs/34209241880)
-successfully completed its named conformance gate, workspace build/tests, documentation lint,
-artifact verification, headless smoke tests, Studio preview and lavapipe UI verification,
-including evidence upload. These are individual step results; the run's cache cleanup was still
-pending when recorded, so an overall successful run is not asserted here.
+completed successfully, including its named conformance gate, workspace build/tests,
+documentation lint, artifact verification, headless smoke tests, Studio preview, lavapipe UI
+verification and evidence upload.
 MduX `abdf771` has successful published
 [GCC](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432100),
 [MSVC](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432189),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,6 +14,11 @@
 > table records what each consumer's own pin demonstrates; the cross-implementation baseline is
 > [#335](https://github.com/ambroise-leclerc/MduX/issues/335). TrustSC's head is unchanged at
 > `4f114dd`, so the Phase-2 comparison below still stands as assessed.
+>
+> **#335 adoption candidate, 8 September 2026:** TrustSC `b7fe0e1` now pins the same MedUI
+> revision as MduX. The [paired adoption results](#335-paired-adoption-results) below record a
+> shared syntax baseline at line precision. The earlier comparison remains historical;
+> unclaimed phases/profiles and joint sign-off remain explicit gaps.
 
 The original six waves delivered the foundations: trust zones, governance records, baked evidence,
 a real Vulkan renderer, deterministic ML inference, fonts and text, a host-side MedUI compiler,
@@ -131,8 +136,9 @@ dispositions, and the TrustSC-side re-pin tracked as a follow-up issue.
 
 #### #314 per-capability conformance results
 
-The two consumers are pinned to **different** shared-contract revisions, so the table records what
-each demonstrates on its own pin — it is not a cross-implementation parity claim.
+**Historical #314 assessment; the [#335 pairing](#335-paired-adoption-results) below is newer.**
+At these assessed heads the two consumers pin **different** shared-contract revisions, so the table
+records what each demonstrates on its own pin — it is not a cross-implementation parity claim.
 
 | Consumer | Implementation SHA | Pinned MedUI contract | Manifest claims |
 |---|---|---|---|
@@ -155,6 +161,55 @@ profiles stay claimed and gated. A shared baseline requires TrustSC to re-pin to
 claim the phases and profiles it implements — tracked in
 [#335](https://github.com/ambroise-leclerc/MduX/issues/335). The
 [pinned behavior matrix](parity/behavior-matrix.md) links here rather than repeating this table.
+
+#### #335 paired adoption results
+
+Assessed 8 September 2026. Both consumers now select the exact contract commit
+[`9a57f6462b6f8dbdf1f0b8b4519674f1c6235dbb`](https://github.com/Compliatory/MedUI/commit/9a57f6462b6f8dbdf1f0b8b4519674f1c6235dbb)
+(`v0.3.0-rc.1`). TrustSC's adoption is [PR #52](https://github.com/ambroise-leclerc/TrustSC/pull/52),
+on a work branch, not yet integrated into `main`.
+
+| Consumer | Assessed implementation head | Manifest claims |
+|---|---|---|
+| MduX | [`abdf771`](https://github.com/ambroise-leclerc/MduX/commit/abdf77182638735adf47c6d125c53581bc9d4f3d) on `develop`; this record changes documentation only | syntax, semantics, layout, safety; full positions; RENDERED and EVIDENCE |
+| TrustSC | [`b7fe0e1`](https://github.com/ambroise-leclerc/TrustSC/commit/b7fe0e18304b2156520b4268e2943d23afb2c77b) on `335-shared-conformance-baseline` | syntax; line-only positions; no profiles |
+
+| Capability / profile | MduX | TrustSC | Paired conclusion |
+|---|---|---|---|
+| Syntax | All 5 pinned cases pass with full positions. | All 5 pinned cases pass through the production byte parser. | Same corpus and acceptance/rejection codes; lines agree. Columns are asserted only by MduX. |
+| Semantics | All 17 pinned cases pass. | Unclaimed; no complete shared adapter. | MduX-only evidence. |
+| Layout | All 3 pinned cases pass. | Unclaimed; no complete shared adapter. | MduX-only evidence. |
+| Safety | Both pinned cases pass. | Unclaimed; no complete shared adapter. | MduX-only evidence. |
+| Diagnostic positions | Full, including UTF-8 byte columns. | Line-only, with every column required absent. | Precision differs; no full-position equivalence claim. |
+| MEDUI-PROFILE-RENDERED | All 33 vectors pass against MduX's arithmetic. | Unclaimed; native checks are not a complete shared-profile adapter. | MduX-only evidence; no paired pixel/capture result. |
+| MEDUI-PROFILE-EVIDENCE | All 31 aggregate vectors and 29 evidence contract cases pass. | Unclaimed; native reports do not establish the shared aggregate contract. | MduX-only evidence. |
+| Derived RENDERED E01 envelope | Existing GPU CI evidence from #314; not re-run in this local comparison. | No shared envelope claim. | No paired envelope comparison. |
+
+Local verification: MduX's GCC selection of `verify_spec`, `medui_tools_spec`, `medui_spec` and
+`conformance_spec` passed **313 tests** with the pinned checkout supplied. TrustSC's parser/checker
+selection passed **68 tests** (59 library, 6 CLI, 3 conformance-harness tests), including the five
+corpus-derived syntax cases, an inverted-expectation negative and refusal of an unsupported phase
+claim. Its full local workspace build and **316 tests with no failures or ignored tests** also
+passed, using Rust/Cargo 1.96.0. The [TrustSC adoption CI run](https://github.com/ambroise-leclerc/TrustSC/actions/runs/34209241880)
+successfully completed its named conformance gate, workspace build/tests, documentation lint,
+artifact verification, headless smoke tests, Studio preview and lavapipe UI verification,
+including evidence upload. These are individual step results; the run's cache cleanup was still
+pending when recorded, so an overall successful run is not asserted here.
+MduX `abdf771` has successful published
+[GCC](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432100),
+[MSVC](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432189),
+[Linux Clang](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432093),
+[macOS](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432108) and
+[sanitizer](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432061) runs.
+Reproduction and the behavioral reassessment are in the
+[behavior matrix](parity/behavior-matrix.md#335-adoption-reassessment).
+
+**Joint sign-off remains pending.** This removes the pin mismatch for the adoption branch and
+supports the common syntax subset only. TrustSC's semantics/layout/safety adapters and shared
+observation profiles remain unimplemented in the gate; unclaimed coverage is neither a pass nor
+evidence of equivalent behavior. Neither side's coverage was lowered. #335 must not be closed as
+full cross-implementation conformance on this evidence, and ADR-017's rendered-artifact migration
+condition is not discharged by this syntax result.
 
 ### [#308](https://github.com/ambroise-leclerc/MduX/issues/308) — Interactive medical monitor and bounded input handling · planned
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,7 @@
 > [#335](https://github.com/ambroise-leclerc/MduX/issues/335). TrustSC's head is unchanged at
 > `4f114dd`, so the Phase-2 comparison below still stands as assessed.
 >
-> **#335 adoption candidate, 8 September 2026:** TrustSC `b7fe0e1` now pins the same MedUI
+> **#335 adoption candidate, 8 September 2026:** TrustSC `b21c423` now pins the same MedUI
 > revision as MduX. The [paired adoption results](#335-paired-adoption-results) below record a
 > shared syntax baseline at line precision. The earlier comparison remains historical;
 > unclaimed phases/profiles and joint sign-off remain explicit gaps.
@@ -171,8 +171,8 @@ on a work branch, not yet integrated into `main`.
 
 | Consumer | Assessed implementation head | Manifest claims |
 |---|---|---|
-| MduX | [`abdf771`](https://github.com/ambroise-leclerc/MduX/commit/abdf77182638735adf47c6d125c53581bc9d4f3d) on `develop`; this record changes documentation only | syntax, semantics, layout, safety; full positions; RENDERED and EVIDENCE |
-| TrustSC | [`b7fe0e1`](https://github.com/ambroise-leclerc/TrustSC/commit/b7fe0e18304b2156520b4268e2943d23afb2c77b) on `335-shared-conformance-baseline` | syntax; line-only positions; no profiles |
+| MduX | [`a722784`](https://github.com/ambroise-leclerc/MduX/commit/a722784de5c958cec9ede7903bdf577eb10fe09f) on the #335 issue branch; documentation only since `183a6da` | syntax, semantics, layout, safety; full positions; RENDERED and EVIDENCE |
+| TrustSC | [`b21c423`](https://github.com/ambroise-leclerc/TrustSC/commit/b21c423f590d37c98625e3101ef41787ee4fb13c) on `335-shared-conformance-baseline` | syntax; line-only positions; no profiles |
 
 | Capability / profile | MduX | TrustSC | Paired conclusion |
 |---|---|---|---|
@@ -187,19 +187,20 @@ on a work branch, not yet integrated into `main`.
 
 Local verification: MduX's GCC selection of `verify_spec`, `medui_tools_spec`, `medui_spec` and
 `conformance_spec` passed **313 tests** with the pinned checkout supplied. TrustSC's parser/checker
-selection passed **68 tests** (59 library, 6 CLI, 3 conformance-harness tests), including the five
+selection passed **70 tests** (61 library, 6 CLI, 3 conformance-harness tests), including the five
 corpus-derived syntax cases, an inverted-expectation negative and refusal of an unsupported phase
-claim. Its full local workspace build and **316 tests with no failures or ignored tests** also
-passed, using Rust/Cargo 1.96.0. The [TrustSC adoption CI run](https://github.com/ambroise-leclerc/TrustSC/actions/runs/34209241880)
-completed successfully, including its named conformance gate, workspace build/tests,
+claim. The Studio selection passed **36 tests**, including invalid-encoding versus I/O failures
+on detail, frame and proposal endpoints. Its full local workspace build and **319 tests with no failures or ignored tests** also
+passed, using Rust/Cargo 1.96.0. The [TrustSC adoption CI run](https://github.com/ambroise-leclerc/TrustSC/actions/runs/34229297866)
+completed successfully for `b21c423`, including the conformance gate, workspace build/tests,
 documentation lint, artifact verification, headless smoke tests, Studio preview, lavapipe UI
 verification and evidence upload.
-MduX `abdf771` has successful published
-[GCC](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432100),
-[MSVC](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432189),
-[Linux Clang](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432093),
-[macOS](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432108) and
-[sanitizer](https://github.com/ambroise-leclerc/MduX/actions/runs/34197432061) runs.
+MduX `a722784` has successful published
+[GCC](https://github.com/ambroise-leclerc/MduX/actions/runs/34222463527),
+[MSVC](https://github.com/ambroise-leclerc/MduX/actions/runs/34222463504),
+[Linux Clang](https://github.com/ambroise-leclerc/MduX/actions/runs/34222463514),
+[macOS](https://github.com/ambroise-leclerc/MduX/actions/runs/34222463456) and
+[sanitizer](https://github.com/ambroise-leclerc/MduX/actions/runs/34222463431) runs.
 Reproduction and the behavioral reassessment are in the
 [behavior matrix](parity/behavior-matrix.md#335-adoption-reassessment).
 


### PR DESCRIPTION
## Summary

Records the paired MedUI `v0.3.0-rc.1` baseline for MduX `a722784` and TrustSC `b21c423` (https://github.com/ambroise-leclerc/TrustSC/pull/52). TrustSC now passes all five syntax cases on MduX's exact corpus revision. The corrected TrustSC head also handles final-ID overwrites correctly, verifies the exact negative assertion, documents the E070 gap, and uses byte parsing for Studio file reads. The roadmap and behavior matrix preserve the older assessment and distinguish the shared syntax/code/line result from unclaimed semantics, layout, safety and observation profiles. ADR-017's rendered/evidence dispositions remain unchanged.

Part of #335. Joint sign-off remains pending; this does not close #335 or claim full cross-implementation conformance.

## Invitation and contributor agreement

Maintainer-directed work requested for #335. No separate collaborator invitation or CLA acceptance is asserted by this draft.

Invitation / CLA issue: none recorded in this task.

## Dependency

- **Base branch:** `develop`
- **Predecessor PR:** not stacked; sibling adoption is TrustSC PR #52.
- **Merge order:** review alongside TrustSC PR #52; joint integration sign-off follows its merge and successful integration CI.

## Shared registries touched

- [x] None of the above

## Rebase state

- **Rebased onto:** `abdf77182638735adf47c6d125c53581bc9d4f3d`
- **Conflicts resolved as a union:** no conflicts.

## Verification

- MduX: `MEDUI_CONFORMANCE_DIR` points at the exact shared pin; `ctest --test-dir build-gcc -R '^(verify_spec|medui_tools_spec|medui_spec|conformance_spec)::' --no-tests=error --output-on-failure` passed 313 tests. No C++ rebuild was needed for this documentation-only change.
- TrustSC: Rust/Cargo 1.96.0; full `cargo build --offline --locked --workspace` passed; full `cargo test --offline --locked --quiet` passed 319 tests with no failures or ignored tests. Focused parser/checker selection passed 70 tests; Studio passed 36 tests. The explicit `CI=1` conformance gate passed and reported 5 executed / 27 compiler cases.
- Existing TrustSC observation probe recompiled and run against `b21c423`: nested Row E015 at line 6, absent column; isolated empty golden Bounds pass / ColorHash no baseline.
- Both documentation linters passed; MduX's named-mechanism check and `git diff --check` passed. Header lint passed over all 265 tracked C++ sources; its default directory scan also sees a pre-existing ignored `examples/build` compiler-identification file without a Doxygen header.
- Published CI evidence for the assessed heads is linked in the roadmap. No paired GPU capture or derived-envelope comparison was run.

## Post-merge gate

- [x] The `develop` workflow must be green after merge before the next dependent PR may merge.
- **Post-merge `develop` run:** no successor.
- [ ] That run is green.

## Regulatory impact

Potentially safety-relevant conformance documentation. Updates `docs/roadmap.md`, `docs/parity/behavior-matrix.md` and ADR-017, preserving the distinction between implemented evidence and unclaimed behavior. No MduX runtime code, baked artifact, hazard assignment or safety class changes. The syntax result does not discharge ADR-017's rendered-artifact migration condition or PAR-REQ-002/003's cross-implementation observations. Joint maintainer review remains pending; no certification or production-readiness claim is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated conformance records with paired syntax results across MduX and TrustSC.
  * Documented shared revision adoption, parser and checker observations, diagnostic precision, and test outcomes.
  * Clarified that rendering, semantics, layout, safety, evidence, and derived-observation comparisons remain unclaimed or pending joint sign-off.
  * Added reproduction details, comparison limits, and roadmap tracking for the latest paired assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->